### PR TITLE
chore: add gemini provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,20 @@
 # Copy this file to .env.local and fill in all values before running the app.
 # Never commit .env.local — it is gitignored.
 
-# ─── Anthropic ────────────────────────────────────────────────────────────────
-# Required for AI verse connections (/api/connections)
+# ─── AI Provider ──────────────────────────────────────────────────────────────
+# Which LLM provider to use. Set to "gemini" for dev to save costs.
+# Default: claude (production-grade theological reasoning)
+AI_PROVIDER=claude           # claude | gemini
+
+# Anthropic — required when AI_PROVIDER=claude
 # Get your key at: https://console.anthropic.com/
 ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=             # optional override, default: claude-opus-4-7
+
+# Google Gemini — required when AI_PROVIDER=gemini
+# Get your key at: https://aistudio.google.com/apikey
+GEMINI_API_KEY=
+GEMINI_MODEL=                # optional override, default: gemini-2.0-flash
 
 # ─── Quran Foundation — User API (OAuth2 PKCE) ────────────────────────────────
 # Request access at: https://api-docs.quran.foundation/request-access/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     # Actual secrets are set in Vercel project settings for deployments.
     env:
       ANTHROPIC_API_KEY: sk-ant-placeholder
+      AI_PROVIDER: claude
+      GEMINI_API_KEY: placeholder-gemini-key
+      GEMINI_MODEL: gemini-2.0-flash
       NEXT_PUBLIC_QF_CLIENT_ID: placeholder-client-id
       QF_API_BASE: https://placeholder.example.com
       QF_AUTH_BASE: https://placeholder.example.com

--- a/__tests__/api/connections.test.ts
+++ b/__tests__/api/connections.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+  const mockText = JSON.stringify([
+    { ref: "2:255", reason: "The Throne Verse manifests divine sovereignty." },
+    { ref: "3:18", reason: "Allah witnesses His own oneness directly." },
+    { ref: "112:1", reason: "Pure tawhid — the essence of divine singularity." },
+  ]);
+
+  class MockAnthropic {
+    messages = {
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: mockText }],
+      }),
+    };
+  }
+
+  return { default: MockAnthropic };
+});
+
+import { POST } from "@/app/api/connections/route";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function arabicResp(text = "آية كريمة") {
+  return { ok: true, json: async () => ({ data: { text } }) };
+}
+function transResp(text = "A noble verse.") {
+  return { ok: true, json: async () => ({ data: { text } }) };
+}
+
+function makeRequest(body: Record<string, string>) {
+  return new NextRequest("http://localhost/api/connections", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/connections", () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it("returns 400 when fromRef is missing", async () => {
+    const req = makeRequest({ kind: "thematic", arabicText: "text", translation: "trans" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when kind is missing", async () => {
+    const req = makeRequest({ fromRef: "1:1", arabicText: "text", translation: "trans" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid kind", async () => {
+    const req = makeRequest({ fromRef: "1:1", kind: "bogus", arabicText: "text", translation: "trans" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with 3 ConnectionResult objects for a valid request", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url !== "string") return { ok: false };
+      if (url.includes("ar.alafasy")) return arabicResp("نص عربي");
+      if (url.includes("en.sahih")) return transResp("English translation");
+      return { ok: false };
+    });
+
+    const req = makeRequest({
+      fromRef: "1:1",
+      kind: "thematic",
+      arabicText: "بِسْمِ اللَّهِ الرَّحْمَنِ الرَّحِيمِ",
+      translation: "In the name of Allah, the Most Gracious, the Most Merciful.",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(3);
+  });
+
+  it("each result has ref, arabicText, translation, surahName, reason, and kind", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url !== "string") return { ok: false };
+      if (url.includes("ar.alafasy")) return arabicResp("نص عربي");
+      if (url.includes("en.sahih")) return transResp("English translation");
+      return { ok: false };
+    });
+
+    const req = makeRequest({
+      fromRef: "2:255",
+      kind: "contrast",
+      arabicText: "اللَّهُ لَا إِلَهَ إِلَّا هُوَ",
+      translation: "Allah — there is no deity except Him.",
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    for (const item of body) {
+      expect(item).toHaveProperty("ref");
+      expect(item).toHaveProperty("arabicText");
+      expect(item).toHaveProperty("translation");
+      expect(item).toHaveProperty("surahName");
+      expect(item).toHaveProperty("reason");
+      expect(item).toHaveProperty("kind", "contrast");
+    }
+  });
+});

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -1,9 +1,8 @@
-import Anthropic from "@anthropic-ai/sdk";
+import { unstable_cache } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
+import { callAI } from "@/lib/ai";
 import type { ConnectionResult, EdgeKind, VerseRef } from "@/types/quran";
 import { getSurahName } from "@/lib/surah-names";
-
-const client = new Anthropic();
 
 const KIND_INSTRUCTIONS: Record<EdgeKind, string> = {
   thematic:
@@ -60,14 +59,8 @@ async function fetchVerseData(ref: string): Promise<{
 
   try {
     const [arabicRes, translationRes] = await Promise.all([
-      fetch(
-        `https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/ar.alafasy`,
-        { next: { revalidate: 86400 } }
-      ),
-      fetch(
-        `https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/en.sahih`,
-        { next: { revalidate: 86400 } }
-      ),
+      fetch(`https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/ar.alafasy`),
+      fetch(`https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/en.sahih`),
     ]);
 
     if (!arabicRes.ok || !translationRes.ok) return null;
@@ -90,6 +83,53 @@ async function fetchVerseData(ref: string): Promise<{
   }
 }
 
+const getCachedConnections = unstable_cache(
+  async (
+    fromRef: string,
+    arabicText: string,
+    translation: string,
+    kind: EdgeKind
+  ): Promise<ConnectionResult[]> => {
+    const text = await callAI(buildPrompt(fromRef, arabicText, translation, kind));
+
+    let rawConnections: Array<{ ref: string; reason: string }>;
+    try {
+      const jsonMatch = text.match(/\[[\s\S]*\]/);
+      if (!jsonMatch) throw new Error("No JSON array found");
+      rawConnections = JSON.parse(jsonMatch[0]);
+    } catch {
+      return [];
+    }
+
+    const verseDataResults = await Promise.all(
+      rawConnections.slice(0, 3).map((c) => fetchVerseData(c.ref))
+    );
+
+    return rawConnections
+      .slice(0, 3)
+      .map((c, i) => {
+        const verseData = verseDataResults[i];
+        if (!verseData) return null;
+        const [surahStr, ayahStr] = c.ref.split(":");
+        const result: ConnectionResult = {
+          surah: parseInt(surahStr, 10),
+          ayah: parseInt(ayahStr, 10),
+          ref: c.ref as VerseRef,
+          arabicText: verseData.arabicText,
+          translation: verseData.translation,
+          surahName: verseData.surahName,
+          surahNameArabic: verseData.surahNameArabic,
+          reason: c.reason,
+          kind,
+        };
+        return result;
+      })
+      .filter((c): c is ConnectionResult => c !== null);
+  },
+  ["connections-v1"],
+  { revalidate: 86400 * 30 }
+);
+
 export async function POST(req: NextRequest) {
   let body: { fromRef?: string; kind?: string; arabicText?: string; translation?: string };
   try {
@@ -111,60 +151,7 @@ export async function POST(req: NextRequest) {
   const edgeKind = kind as EdgeKind;
 
   try {
-    const message = await client.messages.create({
-      model: "claude-opus-4-7",
-      max_tokens: 16000,
-      thinking: { type: "adaptive" },
-      messages: [
-        {
-          role: "user",
-          content: buildPrompt(fromRef, arabicText, translation, edgeKind),
-        },
-      ],
-    });
-
-    const textContent = message.content.find((b) => b.type === "text");
-    if (!textContent || textContent.type !== "text") {
-      return NextResponse.json({ error: "No response from AI" }, { status: 500 });
-    }
-
-    let rawConnections: Array<{ ref: string; reason: string }>;
-    try {
-      const jsonMatch = textContent.text.match(/\[[\s\S]*\]/);
-      if (!jsonMatch) throw new Error("No JSON array found");
-      rawConnections = JSON.parse(jsonMatch[0]);
-    } catch {
-      return NextResponse.json(
-        { error: "Failed to parse AI response" },
-        { status: 500 }
-      );
-    }
-
-    const verseDataResults = await Promise.all(
-      rawConnections.slice(0, 3).map((c) => fetchVerseData(c.ref))
-    );
-
-    const connections: ConnectionResult[] = rawConnections
-      .slice(0, 3)
-      .map((c, i) => {
-        const verseData = verseDataResults[i];
-        if (!verseData) return null;
-
-        const [surahStr, ayahStr] = c.ref.split(":");
-        const result: ConnectionResult = {
-          surah: parseInt(surahStr, 10),
-          ayah: parseInt(ayahStr, 10),
-          ref: c.ref as VerseRef,
-          arabicText: verseData.arabicText,
-          translation: verseData.translation,
-          surahName: verseData.surahName,
-          surahNameArabic: verseData.surahNameArabic,
-          reason: c.reason,
-          kind: edgeKind,
-        };
-        return result;
-      })
-      .filter((c): c is ConnectionResult => c !== null);
+    const connections = await getCachedConnections(fromRef, arabicText, translation, edgeKind);
 
     if (connections.length === 0) {
       return NextResponse.json({ error: "Could not resolve any verses" }, { status: 500 });

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -1,11 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
 import { unstable_cache } from "next/cache";
+import { callAI } from "@/lib/ai";
 import { getNameBySlug } from "@/lib/divine-names";
 import { getSurahName } from "@/lib/surah-names";
 import type { VerseRef } from "@/types/quran";
-
-const client = new Anthropic();
 
 interface NameVerse {
   ref: VerseRef;
@@ -76,26 +74,13 @@ const getVersesBySlug = unstable_cache(
     const name = getNameBySlug(slug);
     if (!name) return [];
 
-    const message = await client.messages.create({
-      model: "claude-opus-4-7",
-      max_tokens: 8000,
-      thinking: { type: "adaptive" },
-      messages: [
-        {
-          role: "user",
-          content: buildPrompt(name.arabic, name.transliteration, name.meaning, name.description),
-        },
-      ],
-    });
-
-    const textBlock = message.content.find((b) => b.type === "text");
-    if (!textBlock || textBlock.type !== "text") return [];
+    const text = await callAI(buildPrompt(name.arabic, name.transliteration, name.meaning, name.description));
 
     let rawItems: Array<{ ref: string; reason: string }>;
     try {
-      const match = textBlock.text.match(/\[[\s\S]*\]/);
+      const match = text.match(/\[[\s\S]*\]/);
       if (!match) return [];
-      rawItems = JSON.parse(match[0]);
+      rawItems = JSON.parse(match[0]) as Array<{ ref: string; reason: string }>;
     } catch {
       return [];
     }

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -1,0 +1,39 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+type Provider = "claude" | "gemini";
+
+const provider = (process.env.AI_PROVIDER ?? "claude") as Provider;
+
+/**
+ * Calls the configured LLM provider and returns the raw text response.
+ * Provider is selected by AI_PROVIDER env var ("claude" | "gemini", default: "claude").
+ */
+export async function callAI(prompt: string): Promise<string> {
+  if (provider === "gemini") return callGemini(prompt);
+  return callClaude(prompt);
+}
+
+async function callClaude(prompt: string): Promise<string> {
+  const client = new Anthropic();
+  const model = process.env.ANTHROPIC_MODEL ?? "claude-opus-4-7";
+  const message = await client.messages.create({
+    model,
+    max_tokens: 4096,
+    thinking: { type: "adaptive" },
+    messages: [{ role: "user", content: prompt }],
+  });
+  const block = message.content.find((b) => b.type === "text");
+  if (!block || block.type !== "text") throw new Error("No text block in Claude response");
+  return block.text;
+}
+
+async function callGemini(prompt: string): Promise<string> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error("GEMINI_API_KEY is not set");
+  const model = process.env.GEMINI_MODEL ?? "gemini-2.0-flash";
+  const ai = new GoogleGenerativeAI(apiKey);
+  const genModel = ai.getGenerativeModel({ model });
+  const result = await genModel.generateContent(prompt);
+  return result.response.text();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.96.0",
+        "@google/generative-ai": "^0.24.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-popover": "^1.1.15",
@@ -774,6 +775,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.96.0",
+    "@google/generative-ai": "^0.24.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -8,3 +8,6 @@ process.env.QF_CLIENT_SECRET = "test-client-secret";
 process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
 process.env.NEXT_PUBLIC_QF_AUTH_BASE = "https://auth.test.qf.com";
 process.env.ANTHROPIC_API_KEY ??= "test-anthropic-key";
+process.env.AI_PROVIDER ??= "claude";
+process.env.GEMINI_API_KEY ??= "test-gemini-key-placeholder";
+process.env.GEMINI_MODEL ??= "gemini-2.0-flash";


### PR DESCRIPTION
This pull request introduces provider-agnostic AI support for verse connections and divine name lookups, allowing the application to use either Anthropic Claude or Google Gemini as the LLM backend. The AI provider is now configurable via environment variables, and all AI calls are routed through a new abstraction layer. Related tests, environment files, and workflow configs are updated to support both providers.

**AI Provider Abstraction and Integration**

* Added a new `callAI` function in `lib/ai.ts` that selects between Anthropic Claude and Google Gemini based on the `AI_PROVIDER` environment variable. This function handles all LLM calls and abstracts provider-specific logic. (`[lib/ai.tsR1-R39](diffhunk://#diff-cd66d1f97679af093b98759ae8201b158de480beac9beb44dd88da2ea83bc849R1-R39)`)
* Updated `app/api/connections/route.ts` and `app/api/names/[slug]/verses/route.ts` to use the new `callAI` abstraction, removing direct Anthropic SDK usage and making the endpoints provider-agnostic. (`[[1]](diffhunk://#diff-eea4475f992685a5aa9410d2f5a6d4f3ec0bd2f9e68b9034f5bff9e79131446dL1-L7)`, `[[2]](diffhunk://#diff-eea4475f992685a5aa9410d2f5a6d4f3ec0bd2f9e68b9034f5bff9e79131446dL93-L152)`, `[app/api/names/[slug]/verses/route.tsL2-L9](diffhunk://#diff-1d490fb1892a3faa47881e765352a807fecf110a54adf8a002e36659d1ded9b8L2-L9)`, `[app/api/names/[slug]/verses/route.tsL79-R83](diffhunk://#diff-1d490fb1892a3faa47881e765352a807fecf110a54adf8a002e36659d1ded9b8L79-R83)`)

**Configuration and Environment Updates**

* Updated `.env.example`, workflow config (`.github/workflows/ci.yml`), and test setup (`vitest.setup.ts`) to support and document both Claude and Gemini API keys and models, and to set the AI provider for different environments. (`[[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL4-R17)`, `[[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR40-R42)`, `[[3]](diffhunk://#diff-0a7996d580fb7938335496ed892e3c0a70af5770fdce11c375de28b9ec7b43cdR11-R13)`)

**Dependencies**

* Added `@google/generative-ai` to `package.json` to enable Google Gemini support. (`[package.jsonR15](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R15)`)

**Testing**

* Added comprehensive tests for the `/api/connections` endpoint, mocking both the AI and fetch layers to ensure correct behavior regardless of provider. (`[__tests__/api/connections.test.tsR1-R113](diffhunk://#diff-ee40edfd0a2b4388caeff10036a564453b667fa827894b4690247a17d4b15046R1-R113)`)