### PR TITLE
Fix/canvas sharing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,6 @@ __tests__
 .github
 .agents
 scripts
+!scripts/migrate.mjs
 hosting.md
 plan.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,10 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# Migration runner — node scripts/migrate.mjs (uses drizzle-orm, no drizzle-kit needed)
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/migrate.mjs ./scripts/migrate.mjs
+COPY --from=builder --chown=nextjs:nodejs /app/lib/db/migrations ./lib/db/migrations
+
 USER nextjs
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/app/api/share/[id]/route.ts
+++ b/app/api/share/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { sharedCanvases } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  if (!/^[a-f0-9]{10}$/.test(id)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const rows = await db
+    .select()
+    .from(sharedCanvases)
+    .where(eq(sharedCanvases.id, id))
+    .limit(1);
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(JSON.parse(rows[0].data));
+}

--- a/app/api/share/[id]/route.ts
+++ b/app/api/share/[id]/route.ts
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   const { id } = await params;
 
-  if (!/^[a-f0-9]{10}$/.test(id)) {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(id)) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { sharedCanvases } from "@/lib/db/schema";
+
+const MAX_BYTES = 512 * 1024; // 512 KB
+
+function generateId(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 10);
+}
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    const text = await req.text();
+    if (Buffer.byteLength(text, "utf8") > MAX_BYTES) {
+      return NextResponse.json({ error: "Canvas too large" }, { status: 413 });
+    }
+    body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    (body as { v?: unknown }).v !== 1 ||
+    !Array.isArray((body as { nodes?: unknown }).nodes) ||
+    (body as { nodes: unknown[] }).nodes.length === 0
+  ) {
+    return NextResponse.json({ error: "Invalid canvas" }, { status: 400 });
+  }
+
+  const id = generateId();
+  await db.insert(sharedCanvases).values({ id, data: JSON.stringify(body) });
+  return NextResponse.json({ id });
+}

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,14 +1,35 @@
 import { NextResponse } from "next/server";
+import { lt } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { sharedCanvases } from "@/lib/db/schema";
 
 const MAX_BYTES = 512 * 1024; // 512 KB
+const RATE_LIMIT = 10;
+const WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
-function generateId(): string {
-  return crypto.randomUUID().replace(/-/g, "").slice(0, 10);
+const ipBuckets = new Map<string, { count: number; windowStart: number }>();
+
+function getIp(req: Request): string {
+  return (
+    (req.headers.get("x-forwarded-for") ?? "").split(",")[0].trim() ||
+    req.headers.get("x-real-ip") ||
+    "unknown"
+  );
 }
 
 export async function POST(req: Request) {
+  const ip = getIp(req);
+  const now = Date.now();
+  const bucket = ipBuckets.get(ip);
+  if (!bucket || now - bucket.windowStart > WINDOW_MS) {
+    ipBuckets.set(ip, { count: 1, windowStart: now });
+  } else {
+    bucket.count += 1;
+    if (bucket.count > RATE_LIMIT) {
+      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    }
+  }
   let body: unknown;
   try {
     const text = await req.text();
@@ -30,7 +51,13 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid canvas" }, { status: 400 });
   }
 
-  const id = generateId();
+  if (Math.random() < 0.05) {
+    db.delete(sharedCanvases)
+      .where(lt(sharedCanvases.createdAt, new Date(now - TTL_MS)))
+      .catch(() => {});
+  }
+
+  const id = crypto.randomUUID();
   await db.insert(sharedCanvases).values({ id, data: JSON.stringify(body) });
   return NextResponse.json({ id });
 }

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -47,12 +47,21 @@ export function Header({ onSearchOpen }: HeaderProps) {
     if (verses.length > 0) playGraph(verses);
   };
 
-  const handleShare = () => {
-    const url = buildShareUrl(serializeCanvas(nodes, edges));
-    navigator.clipboard.writeText(url).then(() => {
+  const [sharing, setSharing] = useState(false);
+
+  const handleShare = async () => {
+    if (sharing) return;
+    setSharing(true);
+    try {
+      const url = await buildShareUrl(serializeCanvas(nodes, edges));
+      await navigator.clipboard.writeText(url);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    });
+    } catch {
+      // Share API or clipboard failed — silent
+    } finally {
+      setSharing(false);
+    }
   };
 
   const handleSignIn = async () => {
@@ -95,9 +104,10 @@ export function Header({ onSearchOpen }: HeaderProps) {
         {nodeCount > 0 && (
           <button
             onClick={handleShare}
-            title="Copy shareable link"
+            disabled={sharing}
+            title={sharing ? "Generating link…" : "Copy shareable link"}
             aria-label="Copy shareable canvas link"
-            className="w-7 h-7 rounded border flex items-center justify-center transition-colors cursor-pointer"
+            className="w-7 h-7 rounded border flex items-center justify-center transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-wait"
             style={{
               borderColor: copied ? "var(--color-teal)" : "var(--color-border)",
               color: copied ? "var(--color-teal)" : "var(--color-text-muted)",

--- a/hooks/useCanvasPersistence.ts
+++ b/hooks/useCanvasPersistence.ts
@@ -5,23 +5,19 @@ import { useCanvasStore, serializeCanvas, type SavedCanvas } from "@/store/canva
 
 const LS_KEY = "open-hikmah-canvas";
 
-function encode(canvas: SavedCanvas): string {
-  return btoa(unescape(encodeURIComponent(JSON.stringify(canvas))));
-}
-
-function decode(s: string): SavedCanvas | null {
-  try {
-    return JSON.parse(decodeURIComponent(escape(atob(s)))) as SavedCanvas;
-  } catch {
-    return null;
-  }
-}
-
-export function buildShareUrl(canvas: SavedCanvas): string {
+export async function buildShareUrl(canvas: SavedCanvas): Promise<string> {
+  const res = await fetch("/api/share", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(canvas),
+  });
+  if (!res.ok) throw new Error("Share failed");
+  const { id } = await res.json() as { id: string };
   const url = new URL(window.location.href);
   url.pathname = "/";
-  url.searchParams.delete("verse");
-  url.hash = `canvas=${encode(canvas)}`;
+  url.search = "";
+  url.hash = "";
+  url.searchParams.set("share", id);
   return url.toString();
 }
 
@@ -32,24 +28,29 @@ export function useCanvasPersistence() {
   const hydratedRef = useRef(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // On mount: restore from URL hash first, then localStorage
+  // On mount: restore from ?share=<id> first, then localStorage
   useEffect(() => {
     if (hydratedRef.current) return;
     hydratedRef.current = true;
 
-    // Check URL hash for shared canvas
-    const hash = window.location.hash;
-    const match = hash.match(/canvas=([^&]+)/);
-    if (match) {
-      const saved = decode(match[1]);
-      if (saved?.v === 1 && saved.nodes.length > 0) {
-        restoreCanvas(saved);
-        // Clean the hash from URL without reload
-        const url = new URL(window.location.href);
-        url.hash = "";
-        window.history.replaceState(null, "", url.toString());
-        return;
-      }
+    const params = new URLSearchParams(window.location.search);
+    const shareId = params.get("share");
+
+    if (shareId && /^[a-f0-9]{10}$/.test(shareId)) {
+      // Clean the share param from URL immediately so refreshing doesn't re-fetch
+      const cleanUrl = new URL(window.location.href);
+      cleanUrl.searchParams.delete("share");
+      window.history.replaceState(null, "", cleanUrl.toString());
+
+      fetch(`/api/share/${shareId}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((saved: SavedCanvas | null) => {
+          if (saved?.v === 1 && saved.nodes.length > 0) {
+            restoreCanvas(saved);
+          }
+        })
+        .catch(() => {});
+      return;
     }
 
     // Fall back to localStorage

--- a/hooks/useCanvasPersistence.ts
+++ b/hooks/useCanvasPersistence.ts
@@ -28,32 +28,7 @@ export function useCanvasPersistence() {
   const hydratedRef = useRef(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // On mount: restore from ?share=<id> first, then localStorage
-  useEffect(() => {
-    if (hydratedRef.current) return;
-    hydratedRef.current = true;
-
-    const params = new URLSearchParams(window.location.search);
-    const shareId = params.get("share");
-
-    if (shareId && /^[a-f0-9]{10}$/.test(shareId)) {
-      // Clean the share param from URL immediately so refreshing doesn't re-fetch
-      const cleanUrl = new URL(window.location.href);
-      cleanUrl.searchParams.delete("share");
-      window.history.replaceState(null, "", cleanUrl.toString());
-
-      fetch(`/api/share/${shareId}`)
-        .then((r) => (r.ok ? r.json() : null))
-        .then((saved: SavedCanvas | null) => {
-          if (saved?.v === 1 && saved.nodes.length > 0) {
-            restoreCanvas(saved);
-          }
-        })
-        .catch(() => {});
-      return;
-    }
-
-    // Fall back to localStorage
+  function tryRestoreFromLocalStorage() {
     try {
       const raw = localStorage.getItem(LS_KEY);
       if (raw) {
@@ -65,6 +40,38 @@ export function useCanvasPersistence() {
     } catch {
       // Corrupt localStorage — ignore
     }
+  }
+
+  // On mount: restore from ?share=<id> first, then localStorage
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    hydratedRef.current = true;
+
+    const params = new URLSearchParams(window.location.search);
+    const shareId = params.get("share");
+
+    if (shareId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(shareId)) {
+      fetch(`/api/share/${shareId}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((saved: SavedCanvas | null) => {
+          if (saved?.v === 1 && saved.nodes.length > 0) {
+            restoreCanvas(saved);
+            // Only clean the URL once we've successfully restored — preserves the
+            // share link for retry if the fetch fails or returns invalid data.
+            const cleanUrl = new URL(window.location.href);
+            cleanUrl.searchParams.delete("share");
+            window.history.replaceState(null, "", cleanUrl.toString());
+          } else {
+            tryRestoreFromLocalStorage();
+          }
+        })
+        .catch(() => {
+          tryRestoreFromLocalStorage();
+        });
+      return;
+    }
+
+    tryRestoreFromLocalStorage();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/lib/db/migrations/0000_spooky_vivisector.sql
+++ b/lib/db/migrations/0000_spooky_vivisector.sql
@@ -1,0 +1,70 @@
+CREATE TABLE "activity_log" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"activity_type" text NOT NULL,
+	"verse_ref" text,
+	"activity_date" date NOT NULL,
+	"occurred_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "challenges" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"challenger_id" integer NOT NULL,
+	"challenged_id" integer NOT NULL,
+	"verse_ref" text NOT NULL,
+	"activity_type" text DEFAULT 'connection_made' NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"starts_at" timestamp with time zone NOT NULL,
+	"ends_at" timestamp with time zone NOT NULL,
+	"winner_id" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "no_self_challenge" CHECK ("challenges"."challenger_id" != "challenges"."challenged_id")
+);
+--> statement-breakpoint
+CREATE TABLE "friendships" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"requester_id" integer NOT NULL,
+	"addressee_id" integer NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "no_self_friendship" CHECK ("friendships"."requester_id" != "friendships"."addressee_id")
+);
+--> statement-breakpoint
+CREATE TABLE "shared_canvases" (
+	"id" text PRIMARY KEY NOT NULL,
+	"data" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"qf_id" text NOT NULL,
+	"username" text NOT NULL,
+	"display_name" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_active_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"current_streak" integer DEFAULT 0 NOT NULL,
+	"longest_streak" integer DEFAULT 0 NOT NULL,
+	"last_activity_date" date,
+	CONSTRAINT "users_qf_id_unique" UNIQUE("qf_id"),
+	CONSTRAINT "users_username_unique" UNIQUE("username")
+);
+--> statement-breakpoint
+ALTER TABLE "activity_log" ADD CONSTRAINT "activity_log_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "challenges" ADD CONSTRAINT "challenges_challenger_id_users_id_fk" FOREIGN KEY ("challenger_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "challenges" ADD CONSTRAINT "challenges_challenged_id_users_id_fk" FOREIGN KEY ("challenged_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "challenges" ADD CONSTRAINT "challenges_winner_id_users_id_fk" FOREIGN KEY ("winner_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "friendships" ADD CONSTRAINT "friendships_requester_id_users_id_fk" FOREIGN KEY ("requester_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "friendships" ADD CONSTRAINT "friendships_addressee_id_users_id_fk" FOREIGN KEY ("addressee_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "activity_user_date_idx" ON "activity_log" USING btree ("user_id","activity_date");--> statement-breakpoint
+CREATE INDEX "activity_user_type_date_idx" ON "activity_log" USING btree ("user_id","activity_type","activity_date");--> statement-breakpoint
+CREATE INDEX "challenges_challenger_status_idx" ON "challenges" USING btree ("challenger_id","status");--> statement-breakpoint
+CREATE INDEX "challenges_challenged_status_idx" ON "challenges" USING btree ("challenged_id","status");--> statement-breakpoint
+CREATE INDEX "challenges_ends_at_idx" ON "challenges" USING btree ("ends_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "friendships_pair_idx" ON "friendships" USING btree ("requester_id","addressee_id");--> statement-breakpoint
+CREATE INDEX "friendships_addressee_status_idx" ON "friendships" USING btree ("addressee_id","status");--> statement-breakpoint
+CREATE INDEX "friendships_requester_status_idx" ON "friendships" USING btree ("requester_id","status");--> statement-breakpoint
+CREATE UNIQUE INDEX "users_qf_id_idx" ON "users" USING btree ("qf_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "users_username_idx" ON "users" USING btree ("username");--> statement-breakpoint
+CREATE INDEX "users_last_active_idx" ON "users" USING btree ("last_active_at");

--- a/lib/db/migrations/meta/0000_snapshot.json
+++ b/lib/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,623 @@
+{
+  "id": "c42ffb45-51f7-4e55-9297-6ce3f36a6f8d",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_date": {
+          "name": "activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_date_idx": {
+          "name": "activity_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_type_date_idx": {
+          "name": "activity_user_type_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_user_id_users_id_fk": {
+          "name": "activity_log_user_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenger_id": {
+          "name": "challenger_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenged_id": {
+          "name": "challenged_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_challenger_status_idx": {
+          "name": "challenges_challenger_status_idx",
+          "columns": [
+            {
+              "expression": "challenger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_challenged_status_idx": {
+          "name": "challenges_challenged_status_idx",
+          "columns": [
+            {
+              "expression": "challenged_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_ends_at_idx": {
+          "name": "challenges_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_challenger_id_users_id_fk": {
+          "name": "challenges_challenger_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_challenged_id_users_id_fk": {
+          "name": "challenges_challenged_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenged_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_winner_id_users_id_fk": {
+          "name": "challenges_winner_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_challenge": {
+          "name": "no_self_challenge",
+          "value": "\"challenges\".\"challenger_id\" != \"challenges\".\"challenged_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "friendships_pair_idx": {
+          "name": "friendships_pair_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_addressee_status_idx": {
+          "name": "friendships_addressee_status_idx",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_requester_status_idx": {
+          "name": "friendships_requester_status_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_requester_id_users_id_fk": {
+          "name": "friendships_requester_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_addressee_id_users_id_fk": {
+          "name": "friendships_addressee_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_friendship": {
+          "name": "no_self_friendship",
+          "value": "\"friendships\".\"requester_id\" != \"friendships\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shared_canvases": {
+      "name": "shared_canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qf_id": {
+          "name": "qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_qf_id_idx": {
+          "name": "users_qf_id_idx",
+          "columns": [
+            {
+              "expression": "qf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_active_idx": {
+          "name": "users_last_active_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_qf_id_unique": {
+          "name": "users_qf_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qf_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1779273899692,
+      "tag": "0000_spooky_vivisector",
+      "breakpoints": true
+    }
+  ]
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -109,6 +109,14 @@ export const challenges = pgTable(
   ]
 );
 
+// ─── Shared Canvases ──────────────────────────────────────────────────────────
+
+export const sharedCanvases = pgTable("shared_canvases", {
+  id: text("id").primaryKey(),
+  data: text("data").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 // ─── Exported types ───────────────────────────────────────────────────────────
 
 export type User = typeof users.$inferSelect;
@@ -116,3 +124,4 @@ export type NewUser = typeof users.$inferInsert;
 export type Friendship = typeof friendships.$inferSelect;
 export type ActivityLogEntry = typeof activityLog.$inferSelect;
 export type Challenge = typeof challenges.$inferSelect;
+export type SharedCanvas = typeof sharedCanvases.$inferSelect;

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -1,0 +1,22 @@
+// Standalone migration runner — safe to execute in the production container.
+// Uses drizzle-orm's migrate() directly; does not need drizzle-kit or drizzle.config.ts.
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = join(__dirname, "../lib/db/migrations");
+
+if (!process.env.DATABASE_URL) {
+  console.error("DATABASE_URL is not set");
+  process.exit(1);
+}
+
+const sql = postgres(process.env.DATABASE_URL, { max: 1 });
+const db = drizzle(sql);
+
+await migrate(db, { migrationsFolder });
+console.log("Migrations applied successfully");
+await sql.end();


### PR DESCRIPTION
This pull request introduces a new server-side sharing feature for canvases, refactors how shared canvases are persisted and loaded, and lays the groundwork for multi-user features with new database tables and migrations. The most important changes are grouped below:

**1. Server-side Canvas Sharing Implementation**
- Added a new `shared_canvases` table and related type to the database schema to store shared canvases with unique IDs and creation timestamps (`lib/db/schema.ts`, `lib/db/migrations/0000_spooky_vivisector.sql`) [[1]](diffhunk://#diff-74fd593a5a80b2194712ee9d4571e67a7e254bc35c677fa90adc6218938ea6aaR112-R127) [[2]](diffhunk://#diff-bde1cafc1fb973d70fd3f77ad5b30ade8fa9ef777faa157b8f53fa596b254ab9R1-R70).
- Introduced API endpoints for sharing: a POST `/api/share` endpoint to create a shared canvas and return an ID, and a GET `/api/share/[id]` endpoint to retrieve a shared canvas by ID (`app/api/share/route.ts`, `app/api/share/[id]/route.ts`) ([app/api/share/route.tsR1-R36](diffhunk://#diff-744a343bf467cd7e4fbd30e0bce27f771329051fce674dcb7c271fac13a674a5R1-R36), [app/api/share/[id]/route.tsR1-R27](diffhunk://#diff-f604220ab25a57027bdb707c104b721e6672345444aaf9246779a55f000b13ecR1-R27)).

**2. Frontend Integration and Refactor**
- Refactored sharing logic: `buildShareUrl` now asynchronously POSTs the canvas to the server and generates a URL with a `?share=<id>` query parameter instead of encoding the canvas in the URL hash (`hooks/useCanvasPersistence.ts`).
- Updated the canvas loading logic to check for the `?share=<id>` parameter, fetch the shared canvas from the server, and clean up the URL after loading (`hooks/useCanvasPersistence.ts`).
- Improved the share button UX in the header: disables the button and shows a loading state while sharing is in progress, and handles clipboard errors gracefully (`components/layout/Header.tsx`) [[1]](diffhunk://#diff-fcb662a9307cafb03cb4a70f6d2ffead1ab24da3d4f0911dc2fae2da834b1ef1L50-R64) [[2]](diffhunk://#diff-fcb662a9307cafb03cb4a70f6d2ffead1ab24da3d4f0911dc2fae2da834b1ef1L98-R110).

**3. Database Migration and Operations**
- Added an initial migration that creates tables for shared canvases, users, friendships, challenges, and activity logs, including necessary indexes and constraints for future multi-user features (`lib/db/migrations/0000_spooky_vivisector.sql`, `lib/db/migrations/meta/_journal.json`) [[1]](diffhunk://#diff-bde1cafc1fb973d70fd3f77ad5b30ade8fa9ef777faa157b8f53fa596b254ab9R1-R70) [[2]](diffhunk://#diff-edfb4f9ca628b0dd2b98390acd26849769c5f6a2c919640f3a80425888931fe1R1-R13).
- Added a standalone migration runner script (`scripts/migrate.mjs`) and updated the Dockerfile to include migration scripts and migrations in the production image (`scripts/migrate.mjs`, `Dockerfile`) [[1]](diffhunk://#diff-700d4125fff702cac46affe14b7a0a2cf5a23684ef586c87c8993f5a09d3fc29R1-R22) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R49-R52).