### PR TITLE
Feat/semantic search fallback

### DIFF
--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -176,11 +176,27 @@ describe("GET /api/search", () => {
     expect(mockSearchByMeaning).not.toHaveBeenCalled();
   });
 
-  it("mode=meaning returns [] when semantic search throws", async () => {
+  it("mode=meaning falls back to keyword search when semantic search throws", async () => {
     mockSearchByMeaning.mockRejectedValueOnce(new Error("no embeddings"));
+    mockFetch.mockResolvedValueOnce(
+      quranComResponse([{ verse_key: "1:3", translations: [{ text: "the Lord of Mercy" }] }])
+    );
     const res = await GET(makeMeaningReq("mercy"));
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual([]);
+    expect(res.headers.get("x-search-fallback")).toBe("keyword");
+    const body = await res.json();
+    expect(body.map((r: { ref: string }) => r.ref)).toEqual(["1:3"]);
+  });
+
+  it("mode=meaning falls back to keyword when semantic search is empty (not seeded)", async () => {
+    mockSearchByMeaning.mockResolvedValueOnce([]);
+    mockFetch.mockResolvedValueOnce(
+      quranComResponse([{ verse_key: "1:1", translations: [{ text: "In the name of God" }] }])
+    );
+    const res = await GET(makeMeaningReq("mercy"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-search-fallback")).toBe("keyword");
+    expect((await res.json())[0].ref).toBe("1:1");
   });
 
   it("mode=meaning rate-limits under the client IP from x-forwarded-for", async () => {
@@ -195,11 +211,16 @@ describe("GET /api/search", () => {
     expect(mockConsume).toHaveBeenCalledWith("search:unknown");
   });
 
-  it("mode=meaning returns 429 when the rate limit is exceeded, without embedding", async () => {
+  it("mode=meaning falls back to keyword (not 429) when rate-limited, without embedding", async () => {
     mockConsume.mockResolvedValue(false);
+    mockFetch.mockResolvedValueOnce(
+      quranComResponse([{ verse_key: "2:1", translations: [{ text: "Alif Lam Mim" }] }])
+    );
     const res = await GET(makeMeaningReq("mercy"));
-    expect(res.status).toBe(429);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-search-fallback")).toBe("keyword");
     expect(mockSearchByMeaning).not.toHaveBeenCalled();
+    expect((await res.json())[0].ref).toBe("2:1");
   });
 
   it("does not rate-limit the keyword path", async () => {

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -6,6 +6,37 @@ import { consume } from "@/lib/rate-limit";
 import { clientKey } from "@/lib/http";
 import sanitizeHtml from "sanitize-html";
 
+/** Keyword search via the quran.com full-text API. Returns [] on any failure. */
+async function keywordSearch(q: string): Promise<SearchResult[]> {
+  try {
+    const url = `https://api.quran.com/api/v4/search?q=${encodeURIComponent(q)}&size=10&language=en&page=1`;
+    const res = await fetch(url, {
+      headers: { Accept: "application/json" },
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) {
+      console.error(`Search API error: ${res.status} ${res.statusText}`);
+      return [];
+    }
+    const data = await res.json();
+    return (data?.search?.results ?? [])
+      .filter((r: { verse_key?: string }) => r.verse_key && /^\d+:\d+$/.test(r.verse_key))
+      .map((r: { verse_key: string; translations?: Array<{ text?: string }> }) => {
+        const [surahStr] = r.verse_key.split(":");
+        const surahNum = parseInt(surahStr, 10);
+        const [surahName, surahNameArabic] = getSurahName(surahNum);
+        const snippet = sanitizeHtml(r.translations?.[0]?.text ?? "", {
+          allowedTags: [],
+          allowedAttributes: {},
+        }).slice(0, 140);
+        return { ref: r.verse_key as VerseRef, surahName, surahNameArabic, snippet } satisfies SearchResult;
+      });
+  } catch (err) {
+    console.error("Keyword search error:", err);
+    return [];
+  }
+}
+
 export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get("q")?.trim();
 
@@ -18,7 +49,6 @@ export async function GET(req: NextRequest) {
     const surahNum = parseInt(surahStr, 10);
     const ayahNum = parseInt(ayahStr, 10);
     const [surahName, surahNameArabic] = getSurahName(surahNum);
-
     const result: SearchResult = {
       ref: q as VerseRef,
       surahName,
@@ -28,81 +58,34 @@ export async function GET(req: NextRequest) {
     return NextResponse.json([result]);
   }
 
-  // Semantic ("by meaning") mode — ranks the local corpus by embedding
-  // similarity. Degrades gracefully to [] if embeddings aren't seeded or the
-  // embedding provider is unavailable, mirroring the keyword path's resilience.
+  // Semantic ("by meaning") mode — ranks the local corpus by embedding similarity.
+  // It can come up empty for benign reasons: embeddings not yet seeded, the embedding
+  // provider unavailable, the free-tier quota exhausted, or this caller hitting the
+  // per-IP limit. In all of those we fall back to free keyword search so "by meaning"
+  // is never blank, and it self-upgrades to true semantic results once embeddings exist.
   if (req.nextUrl.searchParams.get("mode") === "meaning") {
-    // This path calls a paid embedding provider on every request, so rate-limit
-    // it per client IP — otherwise a single caller can drive unbounded spend.
-    // The keyword and ref-format paths above are free and stay unlimited.
+    // The embedding call costs quota, so rate-limit it per client IP (keyword is free).
     const allowed = await consume(`search:${clientKey(req)}`);
-    if (!allowed) {
-      return NextResponse.json(
-        { error: "Too many requests — please slow down." },
-        { status: 429 }
-      );
-    }
-
-    try {
-      const matches = await searchByMeaning(q, 10);
-      const results: SearchResult[] = matches.map((m) => ({
-        ref: m.verse.ref,
-        surahName: m.verse.surahName,
-        surahNameArabic: m.verse.surahNameArabic,
-        snippet: m.verse.translation.slice(0, 140),
-      }));
-      return NextResponse.json(results);
-    } catch (err) {
-      console.error("Semantic search route error:", err);
-      return NextResponse.json([], { status: 200 });
-    }
-  }
-
-  try {
-    const url = `https://api.quran.com/api/v4/search?q=${encodeURIComponent(q)}&size=10&language=en&page=1`;
-    const res = await fetch(url, {
-      headers: { Accept: "application/json" },
-      next: { revalidate: 300 },
-    });
-
-    if (!res.ok) {
-      console.error(`Search API error: ${res.status} ${res.statusText}`);
-      return NextResponse.json([], { status: 200 });
-    }
-
-    const data = await res.json();
-    const results: SearchResult[] = (data?.search?.results ?? [])
-      .filter(
-        (r: { verse_key?: string }) =>
-          r.verse_key && /^\d+:\d+$/.test(r.verse_key)
-      )
-      .map(
-        (r: {
-          verse_key: string;
-          translations?: Array<{ text?: string }>;
-        }) => {
-          const [surahStr] = r.verse_key.split(":");
-          const surahNum = parseInt(surahStr, 10);
-          const [surahName, surahNameArabic] = getSurahName(surahNum);
-
-          const rawSnippet = r.translations?.[0]?.text ?? "";
-          const snippet = sanitizeHtml(rawSnippet, {
-            allowedTags: [],
-            allowedAttributes: {},
-          }).slice(0, 140);
-
-          return {
-            ref: r.verse_key as VerseRef,
-            surahName,
-            surahNameArabic,
-            snippet,
-          } satisfies SearchResult;
+    if (allowed) {
+      try {
+        const matches = await searchByMeaning(q, 10);
+        if (matches.length > 0) {
+          const results: SearchResult[] = matches.map((m) => ({
+            ref: m.verse.ref,
+            surahName: m.verse.surahName,
+            surahNameArabic: m.verse.surahNameArabic,
+            snippet: m.verse.translation.slice(0, 140),
+          }));
+          return NextResponse.json(results);
         }
-      );
-
-    return NextResponse.json(results);
-  } catch (err) {
-    console.error("Search route error:", err);
-    return NextResponse.json([], { status: 200 });
+      } catch (err) {
+        console.error("Semantic search route error:", err);
+      }
+    }
+    // No semantic results (empty / error / rate-limited) → keyword fallback.
+    const results = await keywordSearch(q);
+    return NextResponse.json(results, { headers: { "x-search-fallback": "keyword" } });
   }
+
+  return NextResponse.json(await keywordSearch(q));
 }

--- a/components/search/SearchDialog.tsx
+++ b/components/search/SearchDialog.tsx
@@ -36,7 +36,7 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
   const [isSearching, setIsSearching] = useState(false);
   const [previewError, setPreviewError] = useState(false);
   const [mode, setMode] = useState<SearchMode>("keyword");
-  const [rateLimited, setRateLimited] = useState(false);
+  const [fellBackToKeyword, setFellBackToKeyword] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -74,20 +74,19 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
     async (q: string, signal: AbortSignal, searchMode: SearchMode) => {
       setIsSearching(true);
       setSearchResults([]);
-      setRateLimited(false);
+      setFellBackToKeyword(false);
       try {
         const url = `/api/search?q=${encodeURIComponent(q)}${
           searchMode === "meaning" ? "&mode=meaning" : ""
         }`;
         const res = await fetch(url, { signal });
-        // The semantic path is rate-limited per IP (it calls a paid embedding
-        // provider); surface that distinctly rather than as "no results".
-        if (res.status === 429) {
-          setRateLimited(true);
-          return;
-        }
         if (!res.ok) throw new Error();
         const results: SearchResult[] = await res.json();
+        // In "by meaning" mode the server falls back to keyword search when
+        // semantic results aren't available; flag it so we can tell the user.
+        setFellBackToKeyword(
+          searchMode === "meaning" && res.headers.get("x-search-fallback") === "keyword"
+        );
         setSearchResults(results);
       } catch (err) {
         if ((err as Error).name !== "AbortError") {
@@ -199,7 +198,7 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
           setPreviewError(false);
           setLoading(false);
           setIsSearching(false);
-          setRateLimited(false);
+          setFellBackToKeyword(false);
           setMode("keyword");
           onClose();
         }
@@ -234,7 +233,7 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
                     setPreviewError(false);
                     setLoading(false);
                     setIsSearching(false);
-                    setRateLimited(false);
+                    setFellBackToKeyword(false);
                   }
                 }}
                 placeholder={
@@ -300,6 +299,11 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
 
               {showResults && (
                 <div className="p-3 space-y-0.5">
+                  {fellBackToKeyword && (
+                    <p className="px-2 pb-1.5 text-[10px] text-text-muted">
+                      Showing keyword matches — semantic search is warming up.
+                    </p>
+                  )}
                   {searchResults.map((result) => (
                     <SearchResultRow
                       key={result.ref}
@@ -323,15 +327,7 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
                 </div>
               )}
 
-              {rateLimited && !busy && (
-                <div className="px-4 py-6 text-center">
-                  <p className="text-sm text-text-muted">
-                    Too many searches — please wait a moment and try again.
-                  </p>
-                </div>
-              )}
-
-              {!showSeedVerses && !showPreview && !showResults && !busy && !previewError && !rateLimited && (
+              {!showSeedVerses && !showPreview && !showResults && !busy && !previewError && (
                 <div className="px-4 py-8 text-center">
                   <p className="text-sm text-text-muted">
                     {mode === "meaning"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest",
     "test:ci": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
-    "embed": "node scripts/embed-corpus.mjs",
+    "embed": "bun scripts/embed-corpus.mjs",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest",
     "test:ci": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
+    "embed": "node scripts/embed-corpus.mjs",
     "prepare": "husky"
   },
   "lint-staged": {


### PR DESCRIPTION
## Summary

<!-- 1–3 bullet points: what changed and why -->

-
-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

<!-- Complete this section if you modified any Claude prompts, divine name data, or verse connection logic. Leave blank otherwise. -->

- [ ] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below

**Details** (if applicable):
<!-- Describe any changes to prompts, expected output format, or theological framing. Note any deviations from or additions to the Maturidi/Hanafi tradition. -->

## Testing

- [ ] `npm run test:ci` passes locally
- [ ] `npx tsc --noEmit` passes locally
- [ ] `npm run lint` passes locally
- [ ] New tests added for new functionality
- [ ] Tested in browser (for UI changes)

## Checklist

- [ ] Branch is up to date with `main`
- [ ] No `Co-Authored-By` lines in commits
- [ ] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface
