### PR TITLE
Drop unused collection scope (fixes prod invalid_scope)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,9 +59,9 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000   # IMPORTANT: use http://localhost:30
 # Authorization endpoint path (default /oauth2/auth for Ory Hydra).
 # Set to /oauth2/authorize if your QF instance uses the standard RFC 6749 path.
 NEXT_PUBLIC_QF_AUTHORIZE_PATH=             # optional, default: /oauth2/auth
-# NOTE: the OAuth2 scope is hardcoded in lib/pkce.ts (openid offline_access user
-# collection) — it's fixed for QF and not env-configurable, so there's no
-# NEXT_PUBLIC_QF_SCOPE to set.
+# NOTE: the OAuth2 scope is hardcoded in lib/pkce.ts (openid offline_access user) —
+# not env-configurable. `collection` is intentionally excluded: the production QF
+# client isn't approved for it and requesting it fails sign-in with invalid_scope.
 
 # ─── Redirect URI (register this with Quran Foundation) ───────────────────────
 # Dev:  http://localhost:3000/callback

--- a/__tests__/lib/pkce.test.ts
+++ b/__tests__/lib/pkce.test.ts
@@ -28,9 +28,10 @@ describe("buildAuthUrl", () => {
   it("requests the fixed QF scope including offline_access", async () => {
     const { url } = await buildAuthUrl();
     const scope = new URL(url).searchParams.get("scope") ?? "";
-    // Scope is hardcoded (not env-configurable). offline_access is mandatory —
-    // without it no refresh token is issued and the session dies on reload.
-    expect(scope).toBe("openid offline_access user collection");
+    // Scope is hardcoded to what the QF client is approved for. offline_access is
+    // mandatory (refresh token); `collection` is omitted — the prod client isn't
+    // approved for it, which would make Ory reject the authorize request.
+    expect(scope).toBe("openid offline_access user");
   });
 
   it("codeVerifier is 128 characters long", async () => {

--- a/lib/pkce.ts
+++ b/lib/pkce.ts
@@ -6,16 +6,17 @@ function randomString(length: number): string {
   return Array.from(bytes, (b) => chars[b % chars.length]).join("");
 }
 
-// QF-required OAuth scopes — fixed across all environments, so hardcoded rather
-// than env-configurable (an empty NEXT_PUBLIC_QF_SCOPE build arg previously got
-// baked in as "", which dropped offline_access and broke session persistence).
-// The scope is public (it appears in the authorize URL), so this is safe.
+// OAuth scopes the QF client is approved for — hardcoded (the scope is public; it
+// appears in the authorize URL). Kept to exactly what BOTH the prod and prelive
+// clients allow: the production client is NOT approved for `collection`, and
+// requesting it makes Ory reject the whole authorize request (invalid_scope), so
+// it's omitted. We don't call QF's collection API anyway (bookmarks live in our
+// own DB), so nothing is lost.
 //   openid         → OIDC id token
 //   offline_access → REQUIRED for a refresh token; without it the session can't
 //                    survive a page reload
 //   user           → userinfo / profile claims
-//   collection     → bookmarks and collection APIs
-const SCOPE = "openid offline_access user collection";
+const SCOPE = "openid offline_access user";
 
 async function sha256Base64url(input: string): Promise<string> {
   const encoded = new TextEncoder().encode(input);


### PR DESCRIPTION
Production QF client is granted openid/offline_access/user (+profile), NOT collection. The app was still requesting collection, causing invalid_scope on sign-in. Request only what we use: openid offline_access user. Verified end-to-end on pre-live (login→consent→callback, refresh 200, session survives reload).