### PR TITLE
admin: RBAC seam, audit log, curated VotD tables + wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,5 +85,14 @@ REDIS_URL=
 # Used by docker-compose to set the redis password and build the app's REDIS_URL.
 REDIS_PASSWORD=
 
+# ─── Admin panel ──────────────────────────────────────────────────────────────
+# Comma-separated allowlist of QF user ids (the `sub` / qf_id) granted access to
+# the /admin console. FAIL-CLOSED: unset/empty = nobody is an admin. There is no
+# DB role — membership lives here so it can't be escalated from inside the app.
+ADMIN_QF_IDS=
+# Optional: USD price per 1k AI tokens, used only to estimate cost on the Admin
+# AI & Cost page. Leave unset to show token counts without a dollar figure.
+AI_USD_PER_1K_TOKENS=
+
 # ─── IMPORTANT: Restart the dev server after editing this file ────────────────
 # NEXT_PUBLIC_* variables are baked into the client bundle at startup.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,7 @@
 ## Checklist
 
 - [ ] Branch is up to date with `main`
-- [ ] No `Co-Authored-By` lines in commits
+- [ ] Conventional commits
 - [ ] No secrets or real API keys in the diff
 - [ ] `.env.example` updated if new environment variables were added
 - [ ] `README.md` updated if the feature changes the public interface

--- a/__tests__/api/admin/votd.test.ts
+++ b/__tests__/api/admin/votd.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+vi.mock("@/lib/verse-resolver", () => ({ resolveVerse: vi.fn() }));
+
+// Chainable db stub: every method returns the chain; awaiting it resolves to the
+// configured value. Covers select/from/where and insert/values/onConflictDoUpdate.
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(function () { return chain; }, {
+    get(_t, prop) {
+      if (prop === "then")
+        return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+          Promise.resolve(resolveWith).then(res, rej);
+      return () => chain;
+    },
+    apply() { return chain; },
+  });
+  return chain;
+}
+
+const { mockSelect, mockInsert, mockDelete } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockInsert: vi.fn(() => makeDbChain([])),
+  mockDelete: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, insert: mockInsert, delete: mockDelete } }));
+
+import { GET, PUT, DELETE } from "@/app/api/admin/votd/route";
+import { requireAdmin } from "@/lib/admin-auth";
+import { resolveVerse } from "@/lib/verse-resolver";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function get(month?: string) {
+  const url = month ? `http://localhost/api/admin/votd?month=${month}` : "http://localhost/api/admin/votd";
+  return new NextRequest(url, { headers: { Authorization: "Bearer t" } });
+}
+function put(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/votd", {
+    method: "PUT",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+function del(date?: string) {
+  const url = date ? `http://localhost/api/admin/votd?date=${date}` : "http://localhost/api/admin/votd";
+  return new NextRequest(url, { method: "DELETE", headers: { Authorization: "Bearer t" } });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  vi.mocked(resolveVerse).mockReset();
+  mockSelect.mockReturnValue(makeDbChain([]));
+  mockInsert.mockReturnValue(makeDbChain([]));
+  mockDelete.mockReturnValue(makeDbChain([]));
+});
+
+describe("GET /api/admin/votd", () => {
+  it("rejects a malformed month", async () => {
+    expect((await GET(get("2026-13-01"))).status).toBe(400);
+  });
+
+  it("does not 500 on a short month (half-open range, not a hardcoded -31)", async () => {
+    // Regression: the old `${month}-31` upper bound produced an invalid date for
+    // February and could fail the DB comparison.
+    const res = await GET(get("2026-02"));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("PUT /api/admin/votd", () => {
+  it("rejects an impossible calendar date", async () => {
+    const res = await PUT(put({ date: "2026-02-31", verseRef: "2:255" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an out-of-range verse reference", async () => {
+    const res = await PUT(put({ date: "2026-06-21", verseRef: "999:1" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("does not throw when reflection is a non-string", async () => {
+    vi.mocked(resolveVerse).mockResolvedValue({ ref: "2:255" } as never);
+    const res = await PUT(put({ date: "2026-06-21", verseRef: "2:255", reflection: 123 }));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("DELETE /api/admin/votd", () => {
+  it("rejects an impossible calendar date", async () => {
+    expect((await DELETE(del("2026-02-31"))).status).toBe(400);
+  });
+
+  it("clears a valid date", async () => {
+    expect((await DELETE(del("2026-06-21"))).status).toBe(204);
+  });
+});

--- a/__tests__/api/bookmarks.test.ts
+++ b/__tests__/api/bookmarks.test.ts
@@ -58,6 +58,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    disabledAt: null,
     ...overrides,
   };
 }

--- a/__tests__/api/notes.test.ts
+++ b/__tests__/api/notes.test.ts
@@ -33,6 +33,7 @@ function makeUser(): User {
     id: 1, qfId: "qf-1", username: "u", displayName: null,
     createdAt: new Date(), lastActiveAt: new Date(),
     currentStreak: 0, longestStreak: 0, lastActivityDate: null,
+    disabledAt: null,
   };
 }
 function authed() {

--- a/__tests__/api/social/activity.test.ts
+++ b/__tests__/api/social/activity.test.ts
@@ -73,6 +73,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 3,
     longestStreak: 5,
     lastActivityDate: null,
+    disabledAt: null,
     ...overrides,
   };
 }

--- a/__tests__/api/social/challenges.test.ts
+++ b/__tests__/api/social/challenges.test.ts
@@ -60,6 +60,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    disabledAt: null,
     ...overrides,
   };
 }

--- a/__tests__/api/social/friends.test.ts
+++ b/__tests__/api/social/friends.test.ts
@@ -57,6 +57,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    disabledAt: null,
     ...overrides,
   };
 }

--- a/__tests__/api/social/leaderboard.test.ts
+++ b/__tests__/api/social/leaderboard.test.ts
@@ -55,6 +55,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 5,
     longestStreak: 10,
     lastActivityDate: null,
+    disabledAt: null,
     ...overrides,
   };
 }

--- a/__tests__/api/social/me.test.ts
+++ b/__tests__/api/social/me.test.ts
@@ -56,6 +56,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 3,
     longestStreak: 7,
     lastActivityDate: new Date().toISOString().slice(0, 10),
+    disabledAt: null,
     ...overrides,
   };
 }

--- a/__tests__/api/social/users.test.ts
+++ b/__tests__/api/social/users.test.ts
@@ -28,7 +28,7 @@ function makeUser(overrides: Partial<User> = {}): User {
   return {
     id: 1, qfId: "qf-1", username: "me", displayName: null,
     createdAt: new Date(), lastActiveAt: new Date(),
-    currentStreak: 0, longestStreak: 0, lastActivityDate: null, ...overrides,
+    currentStreak: 0, longestStreak: 0, lastActivityDate: null, disabledAt: null, ...overrides,
   };
 }
 

--- a/__tests__/lib/admin-auth.test.ts
+++ b/__tests__/lib/admin-auth.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/social-auth", () => ({ requireUser: vi.fn() }));
+
+import { isAdminQfId, requireAdmin } from "@/lib/admin-auth";
+import { requireUser } from "@/lib/social-auth";
+
+function makeUser(qfId: string): User {
+  return {
+    id: 1,
+    qfId,
+    username: "u",
+    displayName: null,
+    createdAt: new Date(),
+    lastActiveAt: new Date(),
+    currentStreak: 0,
+    longestStreak: 0,
+    lastActivityDate: null,
+    disabledAt: null,
+  };
+}
+
+const req = () =>
+  new NextRequest("http://localhost/api/admin/me", {
+    headers: { Authorization: "Bearer t" },
+  });
+
+const original = process.env.ADMIN_QF_IDS;
+afterEach(() => {
+  process.env.ADMIN_QF_IDS = original;
+});
+
+describe("isAdminQfId", () => {
+  it("is fail-closed when the allowlist is unset", () => {
+    delete process.env.ADMIN_QF_IDS;
+    expect(isAdminQfId("qf-1")).toBe(false);
+  });
+
+  it("is fail-closed when the allowlist is empty/whitespace", () => {
+    process.env.ADMIN_QF_IDS = "  , ,";
+    expect(isAdminQfId("qf-1")).toBe(false);
+  });
+
+  it("matches ids in a comma-separated, space-tolerant list", () => {
+    process.env.ADMIN_QF_IDS = "qf-1, qf-2 ,qf-3";
+    expect(isAdminQfId("qf-2")).toBe(true);
+    expect(isAdminQfId("qf-3")).toBe(true);
+    expect(isAdminQfId("qf-9")).toBe(false);
+  });
+
+  it("rejects null/empty input", () => {
+    process.env.ADMIN_QF_IDS = "qf-1";
+    expect(isAdminQfId(null)).toBe(false);
+    expect(isAdminQfId(undefined)).toBe(false);
+    expect(isAdminQfId("")).toBe(false);
+  });
+});
+
+describe("requireAdmin", () => {
+  beforeEach(() => vi.mocked(requireUser).mockReset());
+
+  it("passes through the auth guard's response when not signed in", async () => {
+    vi.mocked(requireUser).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    );
+    const res = await requireAdmin(req());
+    expect(res).toBeInstanceOf(NextResponse);
+    expect((res as NextResponse).status).toBe(401);
+  });
+
+  it("returns 404 for a signed-in non-admin (does not reveal the surface)", async () => {
+    process.env.ADMIN_QF_IDS = "qf-admin";
+    vi.mocked(requireUser).mockResolvedValue({ userId: 1, user: makeUser("qf-other") });
+    const res = await requireAdmin(req());
+    expect((res as NextResponse).status).toBe(404);
+  });
+
+  it("returns the authed user for an allowlisted admin", async () => {
+    process.env.ADMIN_QF_IDS = "qf-admin";
+    const authed = { userId: 1, user: makeUser("qf-admin") };
+    vi.mocked(requireUser).mockResolvedValue(authed);
+    const res = await requireAdmin(req());
+    expect(res).toBe(authed);
+  });
+});

--- a/__tests__/lib/verse-of-day.test.ts
+++ b/__tests__/lib/verse-of-day.test.ts
@@ -4,6 +4,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // the DB chain. Mock it so the unit test stays isolated to the picker logic.
 vi.mock("@/lib/verse-resolver", () => ({ resolveVerse: vi.fn() }));
 
+// getCuratedVerseOfDay now reads curated_votd. Mock the db so the seam resolves
+// to "no curated entry" without a real Postgres connection. Tests that need a
+// curated row override db.select per-case.
+const limitMock = vi.fn(() => Promise.resolve([] as unknown[]));
+vi.mock("@/lib/db", () => ({
+  db: { select: () => ({ from: () => ({ where: () => ({ limit: limitMock }) }) }) },
+}));
+
 import { resolveVerse } from "@/lib/verse-resolver";
 import { verseOfDayRef, getVerseOfDay, getCuratedVerseOfDay } from "@/lib/verse-of-day";
 
@@ -35,10 +43,23 @@ describe("verseOfDayRef", () => {
 });
 
 describe("getVerseOfDay override seam", () => {
-  beforeEach(() => vi.mocked(resolveVerse).mockReset());
+  beforeEach(() => {
+    vi.mocked(resolveVerse).mockReset();
+    limitMock.mockReset();
+    limitMock.mockResolvedValue([]); // default: no curated entry
+  });
 
-  it("getCuratedVerseOfDay returns null until the admin calendar is built", async () => {
+  it("getCuratedVerseOfDay returns null when no curated entry exists", async () => {
     expect(await getCuratedVerseOfDay(new Date("2026-06-04T00:00:00Z"))).toBeNull();
+  });
+
+  it("returns the curated verse + reflection when an entry exists", async () => {
+    limitMock.mockResolvedValue([{ verseRef: "2:255", reflection: "On reliance." }]);
+    const verse = { ref: "2:255" } as never;
+    vi.mocked(resolveVerse).mockResolvedValue(verse);
+    const result = await getCuratedVerseOfDay(new Date("2026-06-04T00:00:00Z"));
+    expect(vi.mocked(resolveVerse)).toHaveBeenCalledWith("2:255");
+    expect(result).toBe(verse);
   });
 
   it("falls back to the algorithmic pick when no curated entry exists", async () => {

--- a/app/admin/ai/page.tsx
+++ b/app/admin/ai/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { StatTile, Table, Th, Td, StateNote } from "@/components/admin/primitives";
+import { useAdminFetch } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+
+interface Agg {
+  gens: number;
+  tokens: number;
+  estCostUsd: number | null;
+}
+interface AiData {
+  total: Agg;
+  monthToDate: Agg;
+  byModel: { model: string; gens: number; tokens: number }[];
+  byKind: { kind: string; gens: number; tokens: number }[];
+  daily: { day: string; gens: number; tokens: number }[];
+  pricePer1k: number | null;
+}
+
+function cost(c: number | null): string {
+  return c === null ? "—" : `$${c.toFixed(2)}`;
+}
+
+export default function AiPage() {
+  const api = useAdminFetch();
+  const { data, error, loading } = useAsync<AiData>(() => api("/ai"), "ai");
+
+  const maxTokens = Math.max(1, ...(data?.daily ?? []).map((d) => d.tokens));
+
+  return (
+    <>
+      <AdminPageHeader
+        title="AI & Cost"
+        subtitle="Generation volume and token spend. One row per cache miss — the bill flattens as the graph fills."
+      />
+      <div className="space-y-6 p-7">
+        {error && <StateNote tone="error">{error}</StateNote>}
+        {loading && <StateNote>Loading…</StateNote>}
+
+        {data && (
+          <>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <StatTile label="Gens (all time)" value={data.total.gens} />
+              <StatTile label="Tokens (all time)" value={data.total.tokens.toLocaleString()} tone="plain" />
+              <StatTile label="Gens (MTD)" value={data.monthToDate.gens} tone="teal" />
+              <StatTile
+                label="Est. cost (MTD)"
+                value={cost(data.monthToDate.estCostUsd)}
+                hint={data.pricePer1k === null ? "set AI_USD_PER_1K_TOKENS" : `@ $${data.pricePer1k}/1k`}
+              />
+            </div>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <section>
+                <h2 className="mb-2 text-sm font-medium text-text-primary">By model</h2>
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>Model</Th>
+                      <Th className="text-right">Gens</Th>
+                      <Th className="text-right">Tokens</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.byModel.map((r) => (
+                      <tr key={r.model}>
+                        <Td className="font-mono text-xs text-text-secondary">{r.model}</Td>
+                        <Td className="text-right tabular-nums">{r.gens}</Td>
+                        <Td className="text-right tabular-nums">{r.tokens.toLocaleString()}</Td>
+                      </tr>
+                    ))}
+                    {data.byModel.length === 0 && (
+                      <tr>
+                        <Td className="text-text-muted">No generations yet.</Td>
+                        <Td /> <Td />
+                      </tr>
+                    )}
+                  </tbody>
+                </Table>
+              </section>
+
+              <section>
+                <h2 className="mb-2 text-sm font-medium text-text-primary">By kind</h2>
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>Kind</Th>
+                      <Th className="text-right">Gens</Th>
+                      <Th className="text-right">Tokens</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.byKind.map((r) => (
+                      <tr key={r.kind}>
+                        <Td className="text-xs text-text-secondary">{r.kind}</Td>
+                        <Td className="text-right tabular-nums">{r.gens}</Td>
+                        <Td className="text-right tabular-nums">{r.tokens.toLocaleString()}</Td>
+                      </tr>
+                    ))}
+                    {data.byKind.length === 0 && (
+                      <tr>
+                        <Td className="text-text-muted">No generations yet.</Td>
+                        <Td /> <Td />
+                      </tr>
+                    )}
+                  </tbody>
+                </Table>
+              </section>
+            </div>
+
+            <section>
+              <h2 className="mb-2 text-sm font-medium text-text-primary">Last 30 days</h2>
+              {data.daily.length === 0 ? (
+                <StateNote>No activity in the last 30 days.</StateNote>
+              ) : (
+                <div className="space-y-1.5 rounded-lg border border-border bg-surface p-4">
+                  {data.daily.map((d) => (
+                    <div key={d.day} className="flex items-center gap-3">
+                      <span className="w-20 shrink-0 font-mono text-[11px] text-text-muted">{d.day}</span>
+                      <div className="h-2 flex-1 overflow-hidden rounded-full bg-bg">
+                        <div
+                          className="h-full rounded-full bg-teal"
+                          style={{ width: `${(d.tokens / maxTokens) * 100}%` }}
+                        />
+                      </div>
+                      <span className="w-16 shrink-0 text-right text-xs tabular-nums text-text-secondary">
+                        {d.tokens.toLocaleString()}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/admin/audit/page.tsx
+++ b/app/admin/audit/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { Table, Th, Td, StateNote } from "@/components/admin/primitives";
+import { useAdminFetch } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+
+interface Entry {
+  id: number;
+  adminQfId: string;
+  action: string;
+  targetType: string | null;
+  targetId: string | null;
+  meta: unknown;
+  createdAt: string;
+}
+
+export default function AuditPage() {
+  const api = useAdminFetch();
+  const { data, error, loading } = useAsync<{ entries: Entry[] }>(() => api("/audit"), "audit");
+
+  return (
+    <>
+      <AdminPageHeader title="Audit Log" subtitle="Every mutating admin action, newest first." />
+      <div className="space-y-4 p-7">
+        {error && <StateNote tone="error">{error}</StateNote>}
+        {loading && <StateNote>Loading…</StateNote>}
+        {data && data.entries.length === 0 && <StateNote>No admin actions recorded yet.</StateNote>}
+
+        {data && data.entries.length > 0 && (
+          <Table>
+            <thead>
+              <tr>
+                <Th>When</Th>
+                <Th>Action</Th>
+                <Th>Target</Th>
+                <Th>Detail</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.entries.map((e) => (
+                <tr key={e.id}>
+                  <Td className="whitespace-nowrap text-xs text-text-muted">
+                    {new Date(e.createdAt).toLocaleString()}
+                  </Td>
+                  <Td className="whitespace-nowrap font-mono text-xs text-gold">{e.action}</Td>
+                  <Td className="whitespace-nowrap text-xs text-text-secondary">
+                    {e.targetType ? `${e.targetType}:${e.targetId ?? ""}` : "—"}
+                  </Td>
+                  <Td className="max-w-md font-mono text-[11px] text-text-muted">
+                    <span className="line-clamp-2 break-all">
+                      {e.meta ? JSON.stringify(e.meta) : ""}
+                    </span>
+                  </Td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/admin/connections/page.tsx
+++ b/app/admin/connections/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote } from "@/components/admin/primitives";
-import { useAdminFetch } from "@/components/admin/AdminContext";
+import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import { cn } from "@/lib/utils";
 
@@ -26,6 +26,7 @@ export default function ConnectionsPage() {
   const api = useAdminFetch();
   const [status, setStatus] = useState<(typeof STATUS_FILTERS)[number]>("all");
   const [kind, setKind] = useState<(typeof KIND_FILTERS)[number]>("all");
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const qs = new URLSearchParams();
   if (status !== "all") qs.set("status", status);
@@ -37,8 +38,13 @@ export default function ConnectionsPage() {
   );
 
   const setStatusOf = async (id: number, next: Connection["status"]) => {
-    await api("/connections", { method: "PATCH", json: { id, status: next } });
-    reload();
+    setActionError(null);
+    try {
+      await api("/connections", { method: "PATCH", json: { id, status: next } });
+      reload();
+    } catch (e) {
+      setActionError(e instanceof AdminApiError ? e.message : "Failed to update connection.");
+    }
   };
 
   return (
@@ -54,6 +60,7 @@ export default function ConnectionsPage() {
         </div>
 
         {error && <StateNote tone="error">{error}</StateNote>}
+        {actionError && <StateNote tone="error">{actionError}</StateNote>}
         {loading && <StateNote>Loading…</StateNote>}
         {data && data.connections.length === 0 && <StateNote>No connections match.</StateNote>}
 

--- a/app/admin/connections/page.tsx
+++ b/app/admin/connections/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui";
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { Table, Th, Td, Pill, StateNote } from "@/components/admin/primitives";
+import { useAdminFetch } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+import { cn } from "@/lib/utils";
+
+interface Connection {
+  id: number;
+  fromRef: string;
+  toRef: string;
+  kind: string;
+  reason: string;
+  model: string | null;
+  confidence: number | null;
+  status: "active" | "flagged" | "retired";
+}
+
+const STATUS_FILTERS = ["all", "active", "flagged", "retired"] as const;
+const KIND_FILTERS = ["all", "thematic", "root", "contrast"] as const;
+
+export default function ConnectionsPage() {
+  const api = useAdminFetch();
+  const [status, setStatus] = useState<(typeof STATUS_FILTERS)[number]>("all");
+  const [kind, setKind] = useState<(typeof KIND_FILTERS)[number]>("all");
+
+  const qs = new URLSearchParams();
+  if (status !== "all") qs.set("status", status);
+  if (kind !== "all") qs.set("kind", kind);
+
+  const { data, error, loading, reload } = useAsync<{ connections: Connection[] }>(
+    () => api(`/connections?${qs.toString()}`),
+    `connections:${status}:${kind}`
+  );
+
+  const setStatusOf = async (id: number, next: Connection["status"]) => {
+    await api("/connections", { method: "PATCH", json: { id, status: next } });
+    reload();
+  };
+
+  return (
+    <>
+      <AdminPageHeader
+        title="Connections"
+        subtitle="Moderate AI-generated edges. Flag suspect links or retire them from the graph."
+      />
+      <div className="space-y-4 p-7">
+        <div className="flex flex-wrap items-center gap-4">
+          <FilterRow label="Status" options={STATUS_FILTERS} value={status} onChange={setStatus} />
+          <FilterRow label="Kind" options={KIND_FILTERS} value={kind} onChange={setKind} />
+        </div>
+
+        {error && <StateNote tone="error">{error}</StateNote>}
+        {loading && <StateNote>Loading…</StateNote>}
+        {data && data.connections.length === 0 && <StateNote>No connections match.</StateNote>}
+
+        {data && data.connections.length > 0 && (
+          <Table>
+            <thead>
+              <tr>
+                <Th>Edge</Th>
+                <Th>Kind</Th>
+                <Th>Why</Th>
+                <Th>Status</Th>
+                <Th className="text-right">Actions</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.connections.map((c) => (
+                <tr key={c.id}>
+                  <Td className="whitespace-nowrap font-mono text-xs text-text-secondary">
+                    {c.fromRef} → {c.toRef}
+                  </Td>
+                  <Td>
+                    <span className="text-xs text-text-secondary">{c.kind}</span>
+                  </Td>
+                  <Td className="max-w-md text-xs text-text-secondary">
+                    <span className="line-clamp-2">{c.reason}</span>
+                  </Td>
+                  <Td>
+                    <Pill tone={c.status}>{c.status}</Pill>
+                  </Td>
+                  <Td>
+                    <div className="flex justify-end gap-1.5">
+                      {c.status !== "flagged" && (
+                        <Button size="sm" variant="secondary" onClick={() => setStatusOf(c.id, "flagged")}>
+                          Flag
+                        </Button>
+                      )}
+                      {c.status !== "retired" && (
+                        <Button size="sm" variant="danger" onClick={() => setStatusOf(c.id, "retired")}>
+                          Retire
+                        </Button>
+                      )}
+                      {c.status !== "active" && (
+                        <Button size="sm" variant="secondary" onClick={() => setStatusOf(c.id, "active")}>
+                          Restore
+                        </Button>
+                      )}
+                    </div>
+                  </Td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </div>
+    </>
+  );
+}
+
+function FilterRow<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: readonly T[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">{label}</span>
+      <div className="flex gap-1">
+        {options.map((o) => (
+          <button
+            key={o}
+            onClick={() => onChange(o)}
+            className={cn(
+              "rounded border px-2 py-1 text-xs capitalize transition-colors",
+              value === o
+                ? "border-gold-muted bg-gold/10 text-gold"
+                : "border-border text-text-secondary hover:border-gold-muted"
+            )}
+          >
+            {o}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -48,8 +48,13 @@ export default function FlagsPage() {
   };
 
   const remove = async (k: string) => {
-    await api(`/flags?key=${encodeURIComponent(k)}`, { method: "DELETE" });
-    reload();
+    setMsg(null);
+    try {
+      await api(`/flags?key=${encodeURIComponent(k)}`, { method: "DELETE" });
+      reload();
+    } catch (e) {
+      setMsg(e instanceof AdminApiError ? e.message : "Delete failed.");
+    }
   };
 
   return (

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Input } from "@/components/ui";
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { Table, Th, Td, StateNote, ConfirmButton } from "@/components/admin/primitives";
+import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+
+interface Flag {
+  key: string;
+  value: unknown;
+  updatedBy: string | null;
+  updatedAt: string;
+}
+
+export default function FlagsPage() {
+  const api = useAdminFetch();
+  const { data, error, loading, reload } = useAsync<{ flags: Flag[] }>(() => api("/flags"), "flags");
+
+  const [key, setKey] = useState("");
+  const [value, setValue] = useState("");
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const save = async () => {
+    setMsg(null);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      setMsg("Value must be valid JSON (e.g. true, 42, \"text\", {\"a\":1}).");
+      return;
+    }
+    try {
+      await api("/flags", { method: "PUT", json: { key: key.trim(), value: parsed } });
+      setKey("");
+      setValue("");
+      reload();
+    } catch (e) {
+      setMsg(e instanceof AdminApiError ? e.message : "Save failed.");
+    }
+  };
+
+  const edit = (f: Flag) => {
+    setKey(f.key);
+    setValue(JSON.stringify(f.value));
+    setMsg(null);
+  };
+
+  const remove = async (k: string) => {
+    await api(`/flags?key=${encodeURIComponent(k)}`, { method: "DELETE" });
+    reload();
+  };
+
+  return (
+    <>
+      <AdminPageHeader
+        title="Feature Flags"
+        subtitle="Runtime config read by subsystems. A missing key falls back to its code default."
+      />
+      <div className="space-y-6 p-7">
+        <div className="space-y-3 rounded-lg border border-border bg-surface p-5">
+          <div className="grid gap-3 sm:grid-cols-[200px_1fr]">
+            <label className="space-y-1.5">
+              <span className="text-xs text-text-secondary">Key</span>
+              <Input value={key} onChange={(e) => setKey(e.target.value)} placeholder="rate_limit.window_s" />
+            </label>
+            <label className="space-y-1.5">
+              <span className="text-xs text-text-secondary">Value (JSON)</span>
+              <Input value={value} onChange={(e) => setValue(e.target.value)} placeholder='e.g. 60 or {"model":"x"}' />
+            </label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="primary" onClick={save} disabled={!key.trim() || !value.trim()}>
+              Save flag
+            </Button>
+            {msg && <span className="text-xs text-error">{msg}</span>}
+          </div>
+        </div>
+
+        {error && <StateNote tone="error">{error}</StateNote>}
+        {loading && <StateNote>Loading…</StateNote>}
+        {data && data.flags.length === 0 && <StateNote>No flags set.</StateNote>}
+
+        {data && data.flags.length > 0 && (
+          <Table>
+            <thead>
+              <tr>
+                <Th>Key</Th>
+                <Th>Value</Th>
+                <Th>Updated</Th>
+                <Th className="text-right">Actions</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.flags.map((f) => (
+                <tr key={f.key}>
+                  <Td className="font-mono text-xs text-gold">{f.key}</Td>
+                  <Td className="max-w-xs font-mono text-xs text-text-secondary">
+                    <span className="line-clamp-2 break-all">{JSON.stringify(f.value)}</span>
+                  </Td>
+                  <Td className="whitespace-nowrap text-xs text-text-muted">
+                    {new Date(f.updatedAt).toLocaleDateString()}
+                  </Td>
+                  <Td>
+                    <div className="flex justify-end gap-1.5">
+                      <Button size="sm" variant="secondary" onClick={() => edit(f)}>
+                        Edit
+                      </Button>
+                      <ConfirmButton onConfirm={() => remove(f.key)} confirmLabel="Delete?">
+                        Delete
+                      </ConfirmButton>
+                    </div>
+                  </Td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/admin/infra/page.tsx
+++ b/app/admin/infra/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { StatTile, Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
+import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+
+interface Infra {
+  redis: "disabled" | "up" | "down";
+  uptimeSeconds: number;
+  tokenCacheSize: number;
+  rateLimitRows: number;
+  metrics: Record<string, number>;
+}
+
+function uptime(s: number): string {
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+export default function InfraPage() {
+  const api = useAdminFetch();
+  const { data, error, loading, reload } = useAsync<Infra>(() => api("/infra"), "infra");
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const run = async (action: string) => {
+    setMsg(null);
+    try {
+      const res = await api<Record<string, unknown>>("/infra", { method: "POST", json: { action } });
+      setMsg(`Done: ${JSON.stringify(res)}`);
+      reload();
+    } catch (e) {
+      setMsg(e instanceof AdminApiError ? e.message : "Action failed.");
+    }
+  };
+
+  return (
+    <>
+      <AdminPageHeader title="Infra" subtitle="Process health, caches, and maintenance actions." />
+      <div className="space-y-6 p-7">
+        {error && <StateNote tone="error">{error}</StateNote>}
+        {loading && <StateNote>Loading…</StateNote>}
+
+        {data && (
+          <>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <StatTile label="Uptime" value={uptime(data.uptimeSeconds)} tone="plain" />
+              <StatTile label="Token cache" value={data.tokenCacheSize} hint="in-process entries" />
+              <StatTile label="Rate-limit rows" value={data.rateLimitRows} tone="plain" />
+              <div className="rounded-lg border border-border bg-surface px-4 py-3.5">
+                <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-muted">Redis</div>
+                <div className="mt-2">
+                  <Pill tone={data.redis === "up" ? "active" : data.redis === "down" ? "flagged" : "neutral"}>
+                    {data.redis}
+                  </Pill>
+                </div>
+              </div>
+            </div>
+
+            <section className="space-y-3 rounded-lg border border-border bg-surface p-5">
+              <h2 className="text-sm font-medium text-text-primary">Maintenance</h2>
+              <div className="flex flex-wrap gap-2">
+                <ConfirmButton variant="secondary" onConfirm={() => run("flush-tokens")} confirmLabel="Flush tokens?">
+                  Flush token cache
+                </ConfirmButton>
+                <ConfirmButton variant="secondary" onConfirm={() => run("flush-jwks")} confirmLabel="Flush JWKS?">
+                  Flush JWKS cache
+                </ConfirmButton>
+                <ConfirmButton variant="danger" onConfirm={() => run("reset-ratelimits")} confirmLabel="Reset limits?">
+                  Reset rate limits
+                </ConfirmButton>
+              </div>
+              {msg && <p className="text-xs text-text-secondary">{msg}</p>}
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-sm font-medium text-text-primary">Process metrics</h2>
+              {Object.keys(data.metrics).length === 0 ? (
+                <StateNote>No counters recorded yet.</StateNote>
+              ) : (
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>Counter</Th>
+                      <Th className="text-right">Value</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(data.metrics).map(([k, v]) => (
+                      <tr key={k}>
+                        <Td className="font-mono text-xs text-text-secondary">{k}</Td>
+                        <Td className="text-right tabular-nums">{v.toLocaleString()}</Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/admin/infra/page.tsx
+++ b/app/admin/infra/page.tsx
@@ -24,15 +24,20 @@ export default function InfraPage() {
   const api = useAdminFetch();
   const { data, error, loading, reload } = useAsync<Infra>(() => api("/infra"), "infra");
   const [msg, setMsg] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
 
   const run = async (action: string) => {
+    if (busy) return; // guard against concurrent maintenance operations
     setMsg(null);
+    setBusy(true);
     try {
       const res = await api<Record<string, unknown>>("/infra", { method: "POST", json: { action } });
       setMsg(`Done: ${JSON.stringify(res)}`);
       reload();
     } catch (e) {
       setMsg(e instanceof AdminApiError ? e.message : "Action failed.");
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -62,13 +67,13 @@ export default function InfraPage() {
             <section className="space-y-3 rounded-lg border border-border bg-surface p-5">
               <h2 className="text-sm font-medium text-text-primary">Maintenance</h2>
               <div className="flex flex-wrap gap-2">
-                <ConfirmButton variant="secondary" onConfirm={() => run("flush-tokens")} confirmLabel="Flush tokens?">
+                <ConfirmButton variant="secondary" disabled={busy} onConfirm={() => run("flush-tokens")} confirmLabel="Flush tokens?">
                   Flush token cache
                 </ConfirmButton>
-                <ConfirmButton variant="secondary" onConfirm={() => run("flush-jwks")} confirmLabel="Flush JWKS?">
+                <ConfirmButton variant="secondary" disabled={busy} onConfirm={() => run("flush-jwks")} confirmLabel="Flush JWKS?">
                   Flush JWKS cache
                 </ConfirmButton>
-                <ConfirmButton variant="danger" onConfirm={() => run("reset-ratelimits")} confirmLabel="Reset limits?">
+                <ConfirmButton variant="danger" disabled={busy} onConfirm={() => run("reset-ratelimits")} confirmLabel="Reset limits?">
                   Reset rate limits
                 </ConfirmButton>
               </div>

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { AdminGate } from "@/components/admin/AdminGate";
+import { AdminShell } from "@/components/admin/AdminShell";
+
+export const metadata: Metadata = {
+  title: "Admin — Open Hikmah",
+  // The admin surface must never be indexed; access is gated client- and API-side.
+  robots: { index: false, follow: false },
+};
+
+// The console is fully client-driven (the access token lives in memory), so never
+// statically optimise these routes.
+export const dynamic = "force-dynamic";
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <AdminGate>
+      <AdminShell>{children}</AdminShell>
+    </AdminGate>
+  );
+}

--- a/app/admin/names/page.tsx
+++ b/app/admin/names/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Fragment, useState } from "react";
+import { Button } from "@/components/ui";
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
+import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+
+interface Row {
+  slug: string;
+  kind: string;
+  data: unknown;
+  model: string | null;
+  version: number;
+  updatedAt: string;
+}
+
+export default function NamesPage() {
+  const api = useAdminFetch();
+  const { data, error, loading, reload } = useAsync<{ rows: Row[] }>(() => api("/names"), "names");
+  const [editing, setEditing] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const startEdit = (r: Row) => {
+    setEditing(`${r.slug}/${r.kind}`);
+    setDraft(JSON.stringify(r.data, null, 2));
+    setMsg(null);
+  };
+
+  const save = async (r: Row) => {
+    setMsg(null);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(draft);
+    } catch {
+      setMsg("Data must be valid JSON.");
+      return;
+    }
+    try {
+      await api("/names", { method: "PATCH", json: { slug: r.slug, kind: r.kind, data: parsed } });
+      setEditing(null);
+      reload();
+    } catch (e) {
+      setMsg(e instanceof AdminApiError ? e.message : "Save failed.");
+    }
+  };
+
+  const invalidate = async (r: Row) => {
+    await api(`/names?slug=${encodeURIComponent(r.slug)}&kind=${r.kind}`, { method: "DELETE" });
+    reload();
+  };
+
+  return (
+    <>
+      <AdminPageHeader
+        title="Names Content"
+        subtitle="Cached AI content per Divine Name. Edit the payload or invalidate to regenerate."
+      />
+      <div className="space-y-4 p-7">
+        {error && <StateNote tone="error">{error}</StateNote>}
+        {loading && <StateNote>Loading…</StateNote>}
+        {data && data.rows.length === 0 && <StateNote>No cached name content yet.</StateNote>}
+
+        {data && data.rows.length > 0 && (
+          <Table>
+            <thead>
+              <tr>
+                <Th>Name</Th>
+                <Th>Kind</Th>
+                <Th>Model</Th>
+                <Th>Ver</Th>
+                <Th className="text-right">Actions</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((r) => {
+                const id = `${r.slug}/${r.kind}`;
+                const isEditing = editing === id;
+                return (
+                  <Fragment key={id}>
+                    <tr>
+                      <Td className="text-sm text-text-primary">{r.slug}</Td>
+                      <Td>
+                        <Pill>{r.kind}</Pill>
+                      </Td>
+                      <Td className="font-mono text-[11px] text-text-muted">{r.model ?? "—"}</Td>
+                      <Td className="tabular-nums text-text-secondary">{r.version}</Td>
+                      <Td>
+                        <div className="flex justify-end gap-1.5">
+                          <Button size="sm" variant="secondary" onClick={() => startEdit(r)}>
+                            {isEditing ? "Editing…" : "Edit"}
+                          </Button>
+                          <ConfirmButton onConfirm={() => invalidate(r)} confirmLabel="Invalidate?">
+                            Invalidate
+                          </ConfirmButton>
+                        </div>
+                      </Td>
+                    </tr>
+                    {isEditing && (
+                      <tr>
+                        <td colSpan={5} className="border-b border-border-subtle bg-bg px-3.5 py-3">
+                          <textarea
+                            value={draft}
+                            onChange={(e) => setDraft(e.target.value)}
+                            rows={10}
+                            className="w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-xs text-text-primary focus:border-gold-muted"
+                          />
+                          <div className="mt-2 flex items-center gap-2">
+                            <Button size="sm" variant="primary" onClick={() => save(r)}>
+                              Save
+                            </Button>
+                            <Button size="sm" variant="ghost" onClick={() => setEditing(null)}>
+                              Cancel
+                            </Button>
+                            {msg && <span className="text-xs text-error">{msg}</span>}
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </Table>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/admin/names/page.tsx
+++ b/app/admin/names/page.tsx
@@ -48,8 +48,13 @@ export default function NamesPage() {
   };
 
   const invalidate = async (r: Row) => {
-    await api(`/names?slug=${encodeURIComponent(r.slug)}&kind=${r.kind}`, { method: "DELETE" });
-    reload();
+    setMsg(null);
+    try {
+      await api(`/names?slug=${encodeURIComponent(r.slug)}&kind=${r.kind}`, { method: "DELETE" });
+      reload();
+    } catch (e) {
+      setMsg(e instanceof AdminApiError ? e.message : "Invalidate failed.");
+    }
   };
 
   return (
@@ -60,6 +65,7 @@ export default function NamesPage() {
       />
       <div className="space-y-4 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
+        {msg && <StateNote tone="error">{msg}</StateNote>}
         {loading && <StateNote>Loading…</StateNote>}
         {data && data.rows.length === 0 && <StateNote>No cached name content yet.</StateNote>}
 
@@ -114,7 +120,6 @@ export default function NamesPage() {
                             <Button size="sm" variant="ghost" onClick={() => setEditing(null)}>
                               Cancel
                             </Button>
-                            {msg && <span className="text-xs text-error">{msg}</span>}
                           </div>
                         </td>
                       </tr>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -55,6 +55,15 @@ export default function OverviewPage() {
             </div>
           </div>
         )}
+
+        {/* Tiny deploy-config reminder (always visible). */}
+        <p className="mt-8 border-t border-border-subtle pt-3 text-[11px] leading-relaxed text-text-muted">
+          Deploy note: set <code className="text-text-secondary">ADMIN_QF_IDS</code> in the env
+          (see <code className="text-text-secondary">.env.example</code>) — without it the panel is
+          locked to everyone. Optional <code className="text-text-secondary">AI_USD_PER_1K_TOKENS</code>{" "}
+          enables the cost estimate. Migration <code className="text-text-secondary">0010</code> runs
+          via <code className="text-text-secondary">scripts/migrate.mjs</code> on deploy.
+        </p>
       </div>
     </>
   );

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { StatTile, StateNote, Pill } from "@/components/admin/primitives";
+import { useAdminFetch } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+
+interface Overview {
+  users: { total: number; disabled: number };
+  connections: { total: number; flagged: number };
+  votd: { total: number; upcoming: number };
+  aiMonthToDate: { generations: number; tokens: number };
+  redis: "disabled" | "up" | "down";
+}
+
+export default function OverviewPage() {
+  const api = useAdminFetch();
+  const { data, error, loading } = useAsync<Overview>(() => api("/overview"), "overview");
+
+  return (
+    <>
+      <AdminPageHeader title="Overview" subtitle="A snapshot of the project right now." />
+      <div className="p-7">
+        {loading && <StateNote>Loading…</StateNote>}
+        {error && <StateNote tone="error">{error}</StateNote>}
+        {data && (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            <StatTile label="Users" value={data.users.total} hint={`${data.users.disabled} disabled`} />
+            <StatTile
+              label="Flagged edges"
+              value={data.connections.flagged}
+              hint={`of ${data.connections.total} total`}
+              tone={data.connections.flagged > 0 ? "gold" : "plain"}
+            />
+            <StatTile
+              label="Curated days"
+              value={data.votd.total}
+              hint={`${data.votd.upcoming} upcoming`}
+              tone="teal"
+            />
+            <StatTile
+              label="AI gens (MTD)"
+              value={data.aiMonthToDate.generations}
+              hint={`${data.aiMonthToDate.tokens.toLocaleString()} tokens`}
+            />
+            <div className="rounded-lg border border-border bg-surface px-4 py-3.5">
+              <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-muted">
+                Redis
+              </div>
+              <div className="mt-2">
+                <Pill tone={data.redis === "up" ? "active" : data.redis === "down" ? "flagged" : "neutral"}>
+                  {data.redis}
+                </Pill>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Input } from "@/components/ui";
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
+import { useAdminFetch } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+
+interface AdminUser {
+  id: number;
+  qfId: string;
+  username: string;
+  displayName: string | null;
+  lastActiveAt: string;
+  currentStreak: number;
+  longestStreak: number;
+  disabledAt: string | null;
+  isAdmin: boolean;
+}
+
+export default function UsersPage() {
+  const api = useAdminFetch();
+  const [query, setQuery] = useState("");
+  const [submitted, setSubmitted] = useState("");
+
+  const { data, error, loading, reload } = useAsync<{ users: AdminUser[] }>(
+    () => api(`/users${submitted ? `?q=${encodeURIComponent(submitted)}` : ""}`),
+    `users:${submitted}`
+  );
+
+  const setDisabled = async (id: number, disabled: boolean) => {
+    await api("/users", { method: "PATCH", json: { id, disabled } });
+    reload();
+  };
+
+  return (
+    <>
+      <AdminPageHeader title="Users" subtitle="View activity and moderate accounts." />
+      <div className="space-y-4 p-7">
+        <form
+          className="flex max-w-sm gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            setSubmitted(query.trim());
+          }}
+        >
+          <Input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search username…" />
+          <Button type="submit" variant="secondary">
+            Search
+          </Button>
+        </form>
+
+        {error && <StateNote tone="error">{error}</StateNote>}
+        {loading && <StateNote>Loading…</StateNote>}
+        {data && data.users.length === 0 && <StateNote>No users found.</StateNote>}
+
+        {data && data.users.length > 0 && (
+          <Table>
+            <thead>
+              <tr>
+                <Th>User</Th>
+                <Th>Streak</Th>
+                <Th>Last active</Th>
+                <Th>Status</Th>
+                <Th className="text-right">Actions</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.users.map((u) => (
+                <tr key={u.id}>
+                  <Td>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-text-primary">{u.username}</span>
+                      {u.isAdmin && <Pill tone="flagged">admin</Pill>}
+                    </div>
+                    {u.displayName && <div className="text-xs text-text-muted">{u.displayName}</div>}
+                  </Td>
+                  <Td className="text-xs text-text-secondary tabular-nums">
+                    {u.currentStreak} <span className="text-text-muted">/ {u.longestStreak} best</span>
+                  </Td>
+                  <Td className="whitespace-nowrap text-xs text-text-muted">
+                    {new Date(u.lastActiveAt).toLocaleDateString()}
+                  </Td>
+                  <Td>
+                    {u.disabledAt ? <Pill tone="retired">disabled</Pill> : <Pill tone="active">active</Pill>}
+                  </Td>
+                  <Td>
+                    <div className="flex justify-end">
+                      {u.isAdmin ? (
+                        <span className="text-xs text-text-muted">—</span>
+                      ) : u.disabledAt ? (
+                        <Button size="sm" variant="secondary" onClick={() => setDisabled(u.id, false)}>
+                          Enable
+                        </Button>
+                      ) : (
+                        <ConfirmButton onConfirm={() => setDisabled(u.id, true)} confirmLabel="Disable?">
+                          Disable
+                        </ConfirmButton>
+                      )}
+                    </div>
+                  </Td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button, Input } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
-import { useAdminFetch } from "@/components/admin/AdminContext";
+import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 
 interface AdminUser {
@@ -23,6 +23,8 @@ export default function UsersPage() {
   const api = useAdminFetch();
   const [query, setQuery] = useState("");
   const [submitted, setSubmitted] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
 
   const { data, error, loading, reload } = useAsync<{ users: AdminUser[] }>(
     () => api(`/users${submitted ? `?q=${encodeURIComponent(submitted)}` : ""}`),
@@ -30,8 +32,16 @@ export default function UsersPage() {
   );
 
   const setDisabled = async (id: number, disabled: boolean) => {
-    await api("/users", { method: "PATCH", json: { id, disabled } });
-    reload();
+    setActionError(null);
+    setBusyId(id);
+    try {
+      await api("/users", { method: "PATCH", json: { id, disabled } });
+      reload();
+    } catch (e) {
+      setActionError(e instanceof AdminApiError ? e.message : "Failed to update user.");
+    } finally {
+      setBusyId(null);
+    }
   };
 
   return (
@@ -52,6 +62,7 @@ export default function UsersPage() {
         </form>
 
         {error && <StateNote tone="error">{error}</StateNote>}
+        {actionError && <StateNote tone="error">{actionError}</StateNote>}
         {loading && <StateNote>Loading…</StateNote>}
         {data && data.users.length === 0 && <StateNote>No users found.</StateNote>}
 
@@ -90,11 +101,20 @@ export default function UsersPage() {
                       {u.isAdmin ? (
                         <span className="text-xs text-text-muted">—</span>
                       ) : u.disabledAt ? (
-                        <Button size="sm" variant="secondary" onClick={() => setDisabled(u.id, false)}>
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          disabled={busyId === u.id}
+                          onClick={() => setDisabled(u.id, false)}
+                        >
                           Enable
                         </Button>
                       ) : (
-                        <ConfirmButton onConfirm={() => setDisabled(u.id, true)} confirmLabel="Disable?">
+                        <ConfirmButton
+                          onConfirm={() => setDisabled(u.id, true)}
+                          confirmLabel="Disable?"
+                          disabled={busyId === u.id}
+                        >
                           Disable
                         </ConfirmButton>
                       )}

--- a/app/admin/votd/page.tsx
+++ b/app/admin/votd/page.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button, Input, ReflectionNote } from "@/components/ui";
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { StateNote, ConfirmButton } from "@/components/admin/primitives";
+import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+import { cn } from "@/lib/utils";
+import type { Verse } from "@/types/quran";
+
+interface Entry {
+  date: string;
+  verseRef: string;
+  reflection: string | null;
+}
+
+const WEEKDAYS = ["S", "M", "T", "W", "T", "F", "S"];
+
+function addMonth(month: string, delta: number): string {
+  const [y, m] = month.split("-").map(Number);
+  const d = new Date(Date.UTC(y, m - 1 + delta, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function monthLabel(month: string): string {
+  const [y, m] = month.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, 1)).toLocaleString("en", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export default function VotdPage() {
+  const api = useAdminFetch();
+  const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const { data, error, loading, reload } = useAsync<{ entries: Entry[] }>(
+    () => api(`/votd?month=${month}`),
+    `votd:${month}`
+  );
+
+  const byDate = new Map((data?.entries ?? []).map((e) => [e.date, e]));
+  const [y, m] = month.split("-").map(Number);
+  const firstWeekday = new Date(Date.UTC(y, m - 1, 1)).getUTCDay();
+  const daysInMonth = new Date(Date.UTC(y, m, 0)).getUTCDate();
+
+  return (
+    <>
+      <AdminPageHeader
+        title="Verse of the Day"
+        subtitle="Curate the daily verse. A set day overrides the algorithmic pick."
+      />
+      <div className="grid gap-6 p-7 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <div>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-medium text-text-primary">{monthLabel(month)}</h2>
+            <div className="flex items-center gap-1">
+              <Button size="sm" variant="ghost" onClick={() => setMonth(addMonth(month, -1))} aria-label="Previous month">
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setMonth(addMonth(month, 1))} aria-label="Next month">
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          {error && <StateNote tone="error">{error}</StateNote>}
+
+          <div className="grid grid-cols-7 gap-1.5">
+            {WEEKDAYS.map((d, i) => (
+              <div key={i} className="pb-1 text-center font-mono text-[10px] uppercase text-text-muted">
+                {d}
+              </div>
+            ))}
+            {Array.from({ length: firstWeekday }).map((_, i) => (
+              <div key={`pad-${i}`} />
+            ))}
+            {Array.from({ length: daysInMonth }).map((_, i) => {
+              const day = i + 1;
+              const date = `${month}-${String(day).padStart(2, "0")}`;
+              const entry = byDate.get(date);
+              const isSelected = selected === date;
+              return (
+                <button
+                  key={date}
+                  onClick={() => setSelected(date)}
+                  className={cn(
+                    "flex aspect-square flex-col items-center justify-center rounded-md border text-sm transition-colors",
+                    isSelected
+                      ? "border-gold bg-gold/10 text-gold"
+                      : entry
+                        ? "border-teal/40 bg-teal/5 text-text-primary hover:border-teal"
+                        : "border-border bg-surface text-text-secondary hover:border-gold-muted"
+                  )}
+                >
+                  <span className="tabular-nums">{day}</span>
+                  {entry && <span className="mt-0.5 font-mono text-[9px] text-teal">{entry.verseRef}</span>}
+                </button>
+              );
+            })}
+          </div>
+          {loading && <StateNote>Loading…</StateNote>}
+        </div>
+
+        <DayEditor
+          key={selected ?? "none"}
+          date={selected}
+          existing={selected ? (byDate.get(selected) ?? null) : null}
+          onSaved={reload}
+        />
+      </div>
+    </>
+  );
+}
+
+function DayEditor({
+  date,
+  existing,
+  onSaved,
+}: {
+  date: string | null;
+  existing: Entry | null;
+  onSaved: () => void;
+}) {
+  const api = useAdminFetch();
+  const [verseRef, setVerseRef] = useState(existing?.verseRef ?? "");
+  const [reflection, setReflection] = useState(existing?.reflection ?? "");
+  const [preview, setPreview] = useState<Verse | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  if (!date) {
+    return (
+      <div className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-text-muted">
+        Select a day to set or clear its verse.
+      </div>
+    );
+  }
+
+  const doPreview = async () => {
+    setMsg(null);
+    setPreview(null);
+    const match = /^(\d+):(\d+)$/.exec(verseRef.trim());
+    if (!match) {
+      setMsg("Enter a reference like 2:255.");
+      return;
+    }
+    try {
+      const v = await fetch(`/api/verse/${match[1]}/${match[2]}`);
+      if (!v.ok) {
+        setMsg("That verse could not be found.");
+        return;
+      }
+      setPreview((await v.json()) as Verse);
+    } catch {
+      setMsg("Preview failed.");
+    }
+  };
+
+  const save = async () => {
+    setBusy(true);
+    setMsg(null);
+    try {
+      await api("/votd", { method: "PUT", json: { date, verseRef: verseRef.trim(), reflection } });
+      setMsg("Saved.");
+      onSaved();
+    } catch (e) {
+      setMsg(e instanceof AdminApiError ? e.message : "Save failed.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clear = async () => {
+    setBusy(true);
+    setMsg(null);
+    try {
+      await api(`/votd?date=${date}`, { method: "DELETE" });
+      setMsg("Cleared.");
+      onSaved();
+    } catch (e) {
+      setMsg(e instanceof AdminApiError ? e.message : "Clear failed.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border bg-surface p-5">
+      <div>
+        <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-muted">Editing</div>
+        <div className="text-sm text-text-primary">{date}</div>
+      </div>
+
+      <label className="block space-y-1.5">
+        <span className="text-xs text-text-secondary">Verse reference</span>
+        <div className="flex gap-2">
+          <Input value={verseRef} onChange={(e) => setVerseRef(e.target.value)} placeholder="e.g. 2:255" />
+          <Button size="md" variant="secondary" onClick={doPreview}>
+            Preview
+          </Button>
+        </div>
+      </label>
+
+      {preview && (
+        <div className="space-y-2 rounded-md border border-border-subtle bg-bg p-3">
+          <p dir="rtl" className="font-arabic text-right text-lg leading-loose text-text-primary">
+            {preview.arabicText}
+          </p>
+          <p className="text-xs leading-relaxed text-text-secondary">{preview.translation}</p>
+        </div>
+      )}
+
+      <label className="block space-y-1.5">
+        <span className="text-xs text-text-secondary">Reflection (optional, editorial)</span>
+        <textarea
+          value={reflection}
+          onChange={(e) => setReflection(e.target.value)}
+          rows={4}
+          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-gold-muted"
+          placeholder="A short reflection shown beneath the verse…"
+        />
+      </label>
+
+      {reflection.trim() && <ReflectionNote>{reflection}</ReflectionNote>}
+
+      <div className="flex items-center gap-2">
+        <Button variant="primary" onClick={save} disabled={busy || !verseRef.trim()}>
+          {existing ? "Update" : "Set verse"}
+        </Button>
+        {existing && (
+          <ConfirmButton onConfirm={clear} disabled={busy} confirmLabel="Clear day?">
+            Clear
+          </ConfirmButton>
+        )}
+      </div>
+
+      {msg && <p className="text-xs text-text-secondary">{msg}</p>}
+    </div>
+  );
+}

--- a/app/admin/votd/page.tsx
+++ b/app/admin/votd/page.tsx
@@ -38,6 +38,13 @@ export default function VotdPage() {
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
   const [selected, setSelected] = useState<string | null>(null);
 
+  // Changing month clears the selection so the editor can't act on a day from a
+  // different month than the one being viewed.
+  const goToMonth = (next: string) => {
+    setMonth(next);
+    setSelected(null);
+  };
+
   const { data, error, loading, reload } = useAsync<{ entries: Entry[] }>(
     () => api(`/votd?month=${month}`),
     `votd:${month}`
@@ -59,10 +66,10 @@ export default function VotdPage() {
           <div className="mb-3 flex items-center justify-between">
             <h2 className="text-sm font-medium text-text-primary">{monthLabel(month)}</h2>
             <div className="flex items-center gap-1">
-              <Button size="sm" variant="ghost" onClick={() => setMonth(addMonth(month, -1))} aria-label="Previous month">
+              <Button size="sm" variant="ghost" onClick={() => goToMonth(addMonth(month, -1))} aria-label="Previous month">
                 <ChevronLeft className="h-4 w-4" />
               </Button>
-              <Button size="sm" variant="ghost" onClick={() => setMonth(addMonth(month, 1))} aria-label="Next month">
+              <Button size="sm" variant="ghost" onClick={() => goToMonth(addMonth(month, 1))} aria-label="Next month">
                 <ChevronRight className="h-4 w-4" />
               </Button>
             </div>

--- a/app/api/admin/ai/route.ts
+++ b/app/api/admin/ai/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql, gte } from "drizzle-orm";
+import { requireAdmin } from "@/lib/admin-auth";
+import { db } from "@/lib/db";
+import { aiGenerations } from "@/lib/db/schema";
+
+/**
+ * AI generation cost/usage aggregates. Tokens are the real signal (one row per
+ * actual generation / cache miss). A dollar estimate is derived only when
+ * `AI_USD_PER_1K_TOKENS` is configured — we never fabricate a price.
+ */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const now = new Date();
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const since30 = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+  const [totals, monthTotals, byModel, byKind, daily] = await Promise.all([
+    db
+      .select({
+        gens: sql<number>`count(*)::int`,
+        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
+      })
+      .from(aiGenerations),
+    db
+      .select({
+        gens: sql<number>`count(*)::int`,
+        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
+      })
+      .from(aiGenerations)
+      .where(gte(aiGenerations.createdAt, monthStart)),
+    db
+      .select({
+        model: sql<string>`coalesce(${aiGenerations.model}, 'unknown')`,
+        gens: sql<number>`count(*)::int`,
+        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
+      })
+      .from(aiGenerations)
+      .groupBy(sql`coalesce(${aiGenerations.model}, 'unknown')`),
+    db
+      .select({
+        kind: aiGenerations.kind,
+        gens: sql<number>`count(*)::int`,
+        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
+      })
+      .from(aiGenerations)
+      .groupBy(aiGenerations.kind),
+    db
+      .select({
+        day: sql<string>`to_char(${aiGenerations.createdAt}, 'YYYY-MM-DD')`,
+        gens: sql<number>`count(*)::int`,
+        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
+      })
+      .from(aiGenerations)
+      .where(gte(aiGenerations.createdAt, since30))
+      .groupBy(sql`to_char(${aiGenerations.createdAt}, 'YYYY-MM-DD')`)
+      .orderBy(sql`to_char(${aiGenerations.createdAt}, 'YYYY-MM-DD')`),
+  ]);
+
+  const pricePer1k = Number(process.env.AI_USD_PER_1K_TOKENS) || null;
+  const estCost = (tokens: number) =>
+    pricePer1k !== null ? Number(((tokens / 1000) * pricePer1k).toFixed(2)) : null;
+
+  return NextResponse.json({
+    total: { ...totals[0], estCostUsd: estCost(totals[0]?.tokens ?? 0) },
+    monthToDate: { ...monthTotals[0], estCostUsd: estCost(monthTotals[0]?.tokens ?? 0) },
+    byModel,
+    byKind,
+    daily,
+    pricePer1k,
+  });
+}

--- a/app/api/admin/ai/route.ts
+++ b/app/api/admin/ai/route.ts
@@ -59,7 +59,11 @@ export async function GET(req: NextRequest) {
       .orderBy(sql`to_char(${aiGenerations.createdAt}, 'YYYY-MM-DD')`),
   ]);
 
-  const pricePer1k = Number(process.env.AI_USD_PER_1K_TOKENS) || null;
+  // Preserve a configured 0 (free tier) as a real price; only a missing/invalid
+  // value is treated as "unset" (null) — the UI keys on `=== null` to decide.
+  const rawPrice = process.env.AI_USD_PER_1K_TOKENS;
+  const parsed = rawPrice == null || rawPrice.trim() === "" ? NaN : Number(rawPrice);
+  const pricePer1k = Number.isFinite(parsed) ? parsed : null;
   const estCost = (tokens: number) =>
     pricePer1k !== null ? Number(((tokens / 1000) * pricePer1k).toFixed(2)) : null;
 

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { desc } from "drizzle-orm";
+import { requireAdmin } from "@/lib/admin-auth";
+import { db } from "@/lib/db";
+import { adminAuditLog } from "@/lib/db/schema";
+
+/** Most-recent admin actions (newest first). `?limit=` caps the page (default 100). */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const limitParam = Number(req.nextUrl.searchParams.get("limit"));
+  const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 500) : 100;
+
+  const rows = await db
+    .select()
+    .from(adminAuditLog)
+    .orderBy(desc(adminAuditLog.createdAt))
+    .limit(limit);
+
+  return NextResponse.json({
+    entries: rows.map((r) => ({
+      id: r.id,
+      adminQfId: r.adminQfId,
+      action: r.action,
+      targetType: r.targetType,
+      targetId: r.targetId,
+      meta: r.meta ? safeParse(r.meta) : null,
+      createdAt: r.createdAt,
+    })),
+  });
+}
+
+function safeParse(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}

--- a/app/api/admin/connections/route.ts
+++ b/app/api/admin/connections/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, desc, eq, type SQL } from "drizzle-orm";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+import { db } from "@/lib/db";
+import { connections } from "@/lib/db/schema";
+
+const STATUSES = ["active", "flagged", "retired"] as const;
+const KINDS = ["thematic", "root", "contrast"] as const;
+type Status = (typeof STATUSES)[number];
+
+/** List AI connections with optional `?status=` / `?kind=` filters, newest first. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const sp = req.nextUrl.searchParams;
+  const status = sp.get("status");
+  const kind = sp.get("kind");
+  const limitParam = Number(sp.get("limit"));
+  const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 100;
+
+  const filters: SQL[] = [];
+  if (status && (STATUSES as readonly string[]).includes(status)) {
+    filters.push(eq(connections.status, status));
+  }
+  if (kind && (KINDS as readonly string[]).includes(kind)) {
+    filters.push(eq(connections.kind, kind));
+  }
+
+  const rows = await db
+    .select()
+    .from(connections)
+    .where(filters.length ? and(...filters) : undefined)
+    .orderBy(desc(connections.createdAt))
+    .limit(limit);
+
+  return NextResponse.json({ connections: rows });
+}
+
+/** Change a connection's moderation status (active | flagged | retired). */
+export async function PATCH(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  let body: { id?: number; status?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { id } = body;
+  const status = body.status as Status | undefined;
+  if (!Number.isInteger(id)) {
+    return NextResponse.json({ error: "Invalid connection id" }, { status: 400 });
+  }
+  if (!status || !(STATUSES as readonly string[]).includes(status)) {
+    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+  }
+
+  const [updated] = await db
+    .update(connections)
+    .set({ status })
+    .where(eq(connections.id, id as number))
+    .returning();
+
+  if (!updated) {
+    return NextResponse.json({ error: "Connection not found" }, { status: 404 });
+  }
+
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: "connection.status",
+    targetType: "connection",
+    targetId: String(id),
+    meta: { status, fromRef: updated.fromRef, toRef: updated.toRef, kind: updated.kind },
+  });
+
+  return NextResponse.json({ connection: updated });
+}

--- a/app/api/admin/connections/route.ts
+++ b/app/api/admin/connections/route.ts
@@ -20,13 +20,18 @@ export async function GET(req: NextRequest) {
   const limitParam = Number(sp.get("limit"));
   const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 100;
 
+  // Reject unknown filter values rather than silently ignoring them, so a
+  // typo'd query surfaces as a 400 instead of unfiltered results.
+  if (status && !(STATUSES as readonly string[]).includes(status)) {
+    return NextResponse.json({ error: "Invalid status filter" }, { status: 400 });
+  }
+  if (kind && !(KINDS as readonly string[]).includes(kind)) {
+    return NextResponse.json({ error: "Invalid kind filter" }, { status: 400 });
+  }
+
   const filters: SQL[] = [];
-  if (status && (STATUSES as readonly string[]).includes(status)) {
-    filters.push(eq(connections.status, status));
-  }
-  if (kind && (KINDS as readonly string[]).includes(kind)) {
-    filters.push(eq(connections.kind, kind));
-  }
+  if (status) filters.push(eq(connections.status, status));
+  if (kind) filters.push(eq(connections.kind, kind));
 
   const rows = await db
     .select()

--- a/app/api/admin/flags/route.ts
+++ b/app/api/admin/flags/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { asc, eq } from "drizzle-orm";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+import { db } from "@/lib/db";
+import { featureFlags } from "@/lib/db/schema";
+
+const KEY_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
+
+/** All feature flags, alphabetical. Values are JSON (parsed for the client). */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const rows = await db.select().from(featureFlags).orderBy(asc(featureFlags.key));
+  return NextResponse.json({
+    flags: rows.map((r) => ({
+      key: r.key,
+      value: safeParse(r.value),
+      updatedBy: r.updatedBy,
+      updatedAt: r.updatedAt,
+    })),
+  });
+}
+
+/** Upsert a flag: body `{ key, value }` where value is any JSON-serialisable. */
+export async function PUT(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  let body: { key?: string; value?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const key = body.key?.trim();
+  if (!key || !KEY_RE.test(key)) {
+    return NextResponse.json({ error: "Invalid flag key" }, { status: 400 });
+  }
+  if (body.value === undefined) {
+    return NextResponse.json({ error: "Missing value" }, { status: 400 });
+  }
+
+  const value = JSON.stringify(body.value);
+  await db
+    .insert(featureFlags)
+    .values({ key, value, updatedBy: auth.user.qfId })
+    .onConflictDoUpdate({
+      target: featureFlags.key,
+      set: { value, updatedBy: auth.user.qfId, updatedAt: new Date() },
+    });
+
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: "flag.set",
+    targetType: "flag",
+    targetId: key,
+    meta: { value: body.value },
+  });
+
+  return NextResponse.json({ key, value: body.value });
+}
+
+/** Delete a flag: `?key=...` (subsystem then falls back to its code default). */
+export async function DELETE(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const key = req.nextUrl.searchParams.get("key");
+  if (!key || !KEY_RE.test(key)) {
+    return NextResponse.json({ error: "Invalid flag key" }, { status: 400 });
+  }
+
+  await db.delete(featureFlags).where(eq(featureFlags.key, key));
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: "flag.delete",
+    targetType: "flag",
+    targetId: key,
+  });
+
+  return new NextResponse(null, { status: 204 });
+}
+
+function safeParse(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}

--- a/app/api/admin/infra/route.ts
+++ b/app/api/admin/infra/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+import { db } from "@/lib/db";
+import { rateLimits } from "@/lib/db/schema";
+import { redisEnabled, getRedis } from "@/lib/redis";
+import { counterSnapshot, uptimeSeconds } from "@/lib/metrics";
+import { tokenCache, clearTokenCache, clearJwksCache } from "@/lib/social-auth";
+
+async function redisStatus(): Promise<"disabled" | "up" | "down"> {
+  if (!redisEnabled()) return "disabled";
+  try {
+    const pong = await getRedis()?.ping();
+    return pong === "PONG" ? "up" : "down";
+  } catch {
+    return "down";
+  }
+}
+
+/** Infrastructure snapshot: process metrics, cache sizes, Redis + rate-limit state. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const [redis, rateLimitRows] = await Promise.all([redisStatus(), db.$count(rateLimits)]);
+
+  return NextResponse.json({
+    redis,
+    uptimeSeconds: uptimeSeconds(),
+    tokenCacheSize: tokenCache.size,
+    rateLimitRows,
+    metrics: counterSnapshot(),
+  });
+}
+
+const ACTIONS = ["flush-tokens", "flush-jwks", "reset-ratelimits"] as const;
+type Action = (typeof ACTIONS)[number];
+
+/** Run a maintenance action: body `{ action }`. */
+export async function POST(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  let body: { action?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const action = body.action as Action | undefined;
+  if (!action || !(ACTIONS as readonly string[]).includes(action)) {
+    return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+  }
+
+  let result: Record<string, unknown> = {};
+  switch (action) {
+    case "flush-tokens": {
+      result = { cleared: clearTokenCache() };
+      break;
+    }
+    case "flush-jwks": {
+      clearJwksCache();
+      result = { ok: true };
+      break;
+    }
+    case "reset-ratelimits": {
+      const deleted = await db.delete(rateLimits).returning({ key: rateLimits.key });
+      result = { deleted: deleted.length };
+      break;
+    }
+  }
+
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: `infra.${action}`,
+    targetType: "infra",
+    meta: result,
+  });
+
+  return NextResponse.json({ action, ...result });
+}

--- a/app/api/admin/me/route.ts
+++ b/app/api/admin/me/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin-auth";
+
+/** Identity check used by the admin UI gate. 200 + identity for an admin, else
+ *  the guard's own 401/404 — the client treats anything non-200 as "not admin". */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+  return NextResponse.json({ qfId: auth.user.qfId, username: auth.user.username });
+}

--- a/app/api/admin/names/route.ts
+++ b/app/api/admin/names/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, asc, eq } from "drizzle-orm";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+import { db } from "@/lib/db";
+import { nameContent } from "@/lib/db/schema";
+
+const KINDS = ["verses", "reflection", "pairings"] as const;
+
+/** All cached 99-Names AI content rows (slug + kind), for review/override. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const rows = await db
+    .select()
+    .from(nameContent)
+    .orderBy(asc(nameContent.slug), asc(nameContent.kind));
+
+  return NextResponse.json({
+    rows: rows.map((r) => ({
+      slug: r.slug,
+      kind: r.kind,
+      data: safeParse(r.data),
+      model: r.model,
+      version: r.version,
+      updatedAt: r.updatedAt,
+    })),
+  });
+}
+
+/** Overwrite the cached `data` for one (slug, kind). Body `{ slug, kind, data }`
+ *  where `data` is the JSON payload (validated as serialisable). */
+export async function PATCH(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  let body: { slug?: string; kind?: string; data?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { slug, kind } = body;
+  if (!slug || !kind || !(KINDS as readonly string[]).includes(kind)) {
+    return NextResponse.json({ error: "Invalid slug or kind" }, { status: 400 });
+  }
+  if (body.data === undefined) {
+    return NextResponse.json({ error: "Missing data" }, { status: 400 });
+  }
+
+  const [updated] = await db
+    .update(nameContent)
+    .set({ data: JSON.stringify(body.data), updatedAt: new Date() })
+    .where(and(eq(nameContent.slug, slug), eq(nameContent.kind, kind as (typeof KINDS)[number])))
+    .returning();
+
+  if (!updated) {
+    return NextResponse.json({ error: "No cached content for that name/kind" }, { status: 404 });
+  }
+
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: "name.edit",
+    targetType: "name_content",
+    targetId: `${slug}/${kind}`,
+  });
+
+  return NextResponse.json({ slug, kind, data: body.data });
+}
+
+/** Invalidate a cached entry: `?slug=&kind=`. Next read regenerates it fresh. */
+export async function DELETE(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const slug = req.nextUrl.searchParams.get("slug");
+  const kind = req.nextUrl.searchParams.get("kind");
+  if (!slug || !kind || !(KINDS as readonly string[]).includes(kind)) {
+    return NextResponse.json({ error: "Invalid slug or kind" }, { status: 400 });
+  }
+
+  await db
+    .delete(nameContent)
+    .where(and(eq(nameContent.slug, slug), eq(nameContent.kind, kind as (typeof KINDS)[number])));
+
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: "name.invalidate",
+    targetType: "name_content",
+    targetId: `${slug}/${kind}`,
+  });
+
+  return new NextResponse(null, { status: 204 });
+}
+
+function safeParse(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}

--- a/app/api/admin/overview/route.ts
+++ b/app/api/admin/overview/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql, gte, eq, isNotNull } from "drizzle-orm";
+import { requireAdmin } from "@/lib/admin-auth";
+import { db } from "@/lib/db";
+import { users, connections, curatedVotd, aiGenerations } from "@/lib/db/schema";
+import { redisEnabled, getRedis } from "@/lib/redis";
+import { votdDateKey } from "@/lib/verse-of-day";
+
+async function redisStatus(): Promise<"disabled" | "up" | "down"> {
+  if (!redisEnabled()) return "disabled";
+  try {
+    const client = getRedis();
+    if (!client) return "disabled";
+    const pong = await client.ping();
+    return pong === "PONG" ? "up" : "down";
+  } catch {
+    return "down";
+  }
+}
+
+/** Dashboard snapshot for the Overview page. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  // Start of the current UTC month, as the YYYY-MM-DD the timestamps compare against.
+  const now = new Date();
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const todayKey = votdDateKey(now);
+
+  const [
+    totalUsers,
+    disabledUsers,
+    totalConnections,
+    flaggedConnections,
+    curatedTotal,
+    curatedUpcoming,
+    aiAgg,
+    redis,
+  ] = await Promise.all([
+    db.$count(users),
+    db.$count(users, isNotNull(users.disabledAt)),
+    db.$count(connections),
+    db.$count(connections, eq(connections.status, "flagged")),
+    db.$count(curatedVotd),
+    db.$count(curatedVotd, gte(curatedVotd.date, todayKey)),
+    db
+      .select({
+        gens: sql<number>`count(*)::int`,
+        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}), 0)::int`,
+      })
+      .from(aiGenerations)
+      .where(gte(aiGenerations.createdAt, monthStart)),
+    redisStatus(),
+  ]);
+
+  return NextResponse.json({
+    users: { total: totalUsers, disabled: disabledUsers },
+    connections: { total: totalConnections, flagged: flaggedConnections },
+    votd: { total: curatedTotal, upcoming: curatedUpcoming },
+    aiMonthToDate: { generations: aiAgg[0]?.gens ?? 0, tokens: aiAgg[0]?.tokens ?? 0 },
+    redis,
+  });
+}

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -69,6 +69,11 @@ export async function PATCH(req: NextRequest) {
     .where(eq(users.id, id as number))
     .returning();
 
+  // The row could have been deleted between the select and the update.
+  if (!updated) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
   await logAdminAction({
     adminQfId: auth.user.qfId,
     action: disabled ? "user.disable" : "user.enable",

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { desc, eq, ilike } from "drizzle-orm";
+import { requireAdmin, isAdminQfId } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+
+/** List users (newest-active first) with optional `?q=` username search. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const q = req.nextUrl.searchParams.get("q")?.trim();
+  const limitParam = Number(req.nextUrl.searchParams.get("limit"));
+  const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 100;
+
+  const rows = await db
+    .select()
+    .from(users)
+    .where(q ? ilike(users.username, `%${q}%`) : undefined)
+    .orderBy(desc(users.lastActiveAt))
+    .limit(limit);
+
+  return NextResponse.json({
+    users: rows.map((u) => ({
+      id: u.id,
+      qfId: u.qfId,
+      username: u.username,
+      displayName: u.displayName,
+      createdAt: u.createdAt,
+      lastActiveAt: u.lastActiveAt,
+      currentStreak: u.currentStreak,
+      longestStreak: u.longestStreak,
+      disabledAt: u.disabledAt,
+      isAdmin: isAdminQfId(u.qfId),
+    })),
+  });
+}
+
+/** Soft-disable / re-enable a user account: body `{ id, disabled: boolean }`. */
+export async function PATCH(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  let body: { id?: number; disabled?: boolean };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { id, disabled } = body;
+  if (!Number.isInteger(id) || typeof disabled !== "boolean") {
+    return NextResponse.json({ error: "Expected { id, disabled }" }, { status: 400 });
+  }
+
+  const [target] = await db.select().from(users).where(eq(users.id, id as number)).limit(1);
+  if (!target) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+  // Never let an admin lock out themselves or another admin via this panel.
+  if (disabled && isAdminQfId(target.qfId)) {
+    return NextResponse.json({ error: "Cannot disable an admin account" }, { status: 403 });
+  }
+
+  const [updated] = await db
+    .update(users)
+    .set({ disabledAt: disabled ? new Date() : null })
+    .where(eq(users.id, id as number))
+    .returning();
+
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: disabled ? "user.disable" : "user.enable",
+    targetType: "user",
+    targetId: String(id),
+    meta: { username: target.username },
+  });
+
+  return NextResponse.json({ id: updated.id, disabledAt: updated.disabledAt });
+}

--- a/app/api/admin/votd/route.ts
+++ b/app/api/admin/votd/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { and, gte, lte, eq } from "drizzle-orm";
+import { and, gte, lt, eq } from "drizzle-orm";
 import { requireAdmin } from "@/lib/admin-auth";
 import { logAdminAction } from "@/lib/admin-audit";
 import { db } from "@/lib/db";
@@ -9,6 +9,23 @@ import { resolveVerse } from "@/lib/verse-resolver";
 
 const MONTH_RE = /^\d{4}-\d{2}$/;
 const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** A YYYY-MM-DD that is also a real calendar date (rejects e.g. 2026-02-31,
+ *  which would otherwise blow up at the Postgres `date` layer with a 500). */
+function isRealDay(s: string): boolean {
+  if (!DAY_RE.test(s)) return false;
+  const [y, m, d] = s.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+}
+
+/** First day of the month after `YYYY-MM`, as `YYYY-MM-DD` — the exclusive upper
+ *  bound for a month range (avoids hardcoding a -31 that's invalid for most months). */
+function nextMonthFirst(month: string): string {
+  const [y, m] = month.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m, 1)); // m is 1-based ⇒ this is the next month
+  return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, "0")}-01`;
+}
 
 /** List curated overrides for a month: `?month=YYYY-MM` (defaults to current). */
 export async function GET(req: NextRequest) {
@@ -23,7 +40,9 @@ export async function GET(req: NextRequest) {
   const rows = await db
     .select()
     .from(curatedVotd)
-    .where(and(gte(curatedVotd.date, `${month}-01`), lte(curatedVotd.date, `${month}-31`)));
+    .where(
+      and(gte(curatedVotd.date, `${month}-01`), lt(curatedVotd.date, nextMonthFirst(month)))
+    );
 
   return NextResponse.json({
     month,
@@ -49,10 +68,11 @@ export async function PUT(req: NextRequest) {
   }
 
   const { date, verseRef } = body;
-  const reflection = body.reflection?.trim() || null;
+  // Guard the runtime type — a client could send a non-string reflection.
+  const reflection = typeof body.reflection === "string" ? body.reflection.trim() || null : null;
 
-  if (!date || !DAY_RE.test(date)) {
-    return NextResponse.json({ error: "Invalid date (expected YYYY-MM-DD)" }, { status: 400 });
+  if (!date || !isRealDay(date)) {
+    return NextResponse.json({ error: "Invalid date (expected a real YYYY-MM-DD)" }, { status: 400 });
   }
   if (!verseRef || !isValidRef(verseRef)) {
     return NextResponse.json({ error: "Invalid verse reference" }, { status: 400 });
@@ -89,8 +109,8 @@ export async function DELETE(req: NextRequest) {
   if (auth instanceof NextResponse) return auth;
 
   const date = req.nextUrl.searchParams.get("date");
-  if (!date || !DAY_RE.test(date)) {
-    return NextResponse.json({ error: "Invalid date (expected YYYY-MM-DD)" }, { status: 400 });
+  if (!date || !isRealDay(date)) {
+    return NextResponse.json({ error: "Invalid date (expected a real YYYY-MM-DD)" }, { status: 400 });
   }
 
   await db.delete(curatedVotd).where(eq(curatedVotd.date, date));

--- a/app/api/admin/votd/route.ts
+++ b/app/api/admin/votd/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, gte, lte, eq } from "drizzle-orm";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+import { db } from "@/lib/db";
+import { curatedVotd } from "@/lib/db/schema";
+import { isValidRef } from "@/lib/quran-corpus";
+import { resolveVerse } from "@/lib/verse-resolver";
+
+const MONTH_RE = /^\d{4}-\d{2}$/;
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** List curated overrides for a month: `?month=YYYY-MM` (defaults to current). */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const month = req.nextUrl.searchParams.get("month") ?? new Date().toISOString().slice(0, 7);
+  if (!MONTH_RE.test(month)) {
+    return NextResponse.json({ error: "Invalid month (expected YYYY-MM)" }, { status: 400 });
+  }
+
+  const rows = await db
+    .select()
+    .from(curatedVotd)
+    .where(and(gte(curatedVotd.date, `${month}-01`), lte(curatedVotd.date, `${month}-31`)));
+
+  return NextResponse.json({
+    month,
+    entries: rows.map((r) => ({
+      date: r.date,
+      verseRef: r.verseRef,
+      reflection: r.reflection,
+      updatedAt: r.updatedAt,
+    })),
+  });
+}
+
+/** Set (upsert) the curated verse + reflection for a given UTC day. */
+export async function PUT(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  let body: { date?: string; verseRef?: string; reflection?: string | null };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { date, verseRef } = body;
+  const reflection = body.reflection?.trim() || null;
+
+  if (!date || !DAY_RE.test(date)) {
+    return NextResponse.json({ error: "Invalid date (expected YYYY-MM-DD)" }, { status: 400 });
+  }
+  if (!verseRef || !isValidRef(verseRef)) {
+    return NextResponse.json({ error: "Invalid verse reference" }, { status: 400 });
+  }
+  // Reject refs that resolve nowhere — catches valid-looking but out-of-range ayahs.
+  const verse = await resolveVerse(verseRef);
+  if (!verse) {
+    return NextResponse.json({ error: "That verse could not be resolved" }, { status: 400 });
+  }
+
+  await db
+    .insert(curatedVotd)
+    .values({ date, verseRef, reflection, updatedBy: auth.user.qfId })
+    .onConflictDoUpdate({
+      target: curatedVotd.date,
+      set: { verseRef, reflection, updatedBy: auth.user.qfId, updatedAt: new Date() },
+    });
+
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: "votd.set",
+    targetType: "date",
+    targetId: date,
+    meta: { verseRef, hasReflection: reflection !== null },
+  });
+
+  return NextResponse.json({ date, verseRef, reflection });
+}
+
+/** Clear the curated override for a day: `?date=YYYY-MM-DD`. Falls back to the
+ *  algorithmic pick afterwards. */
+export async function DELETE(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const date = req.nextUrl.searchParams.get("date");
+  if (!date || !DAY_RE.test(date)) {
+    return NextResponse.json({ error: "Invalid date (expected YYYY-MM-DD)" }, { status: 400 });
+  }
+
+  await db.delete(curatedVotd).where(eq(curatedVotd.date, date));
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: "votd.clear",
+    targetType: "date",
+    targetId: date,
+  });
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { LandingHeader } from "@/components/layout/LandingHeader";
 import { NavBar } from "@/components/layout/NavBar";
 import { VerseOfDayCard } from "@/components/today/VerseOfDayCard";
-import { getVerseOfDay } from "@/lib/verse-of-day";
+import { getVerseOfDayWithReflection } from "@/lib/verse-of-day";
 
 export const metadata: Metadata = {
   title: "Verse of the Day — Open Hikmah",
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 export const dynamic = "force-dynamic";
 
 export default async function TodayPage() {
-  const verse = await getVerseOfDay().catch(() => null);
+  const today = await getVerseOfDayWithReflection().catch(() => null);
 
   return (
     <div className="flex min-h-dvh flex-col bg-bg">
@@ -25,8 +25,8 @@ export default async function TodayPage() {
       <NavBar />
 
       <main className="mx-auto flex w-full max-w-[1180px] flex-1 flex-col items-center justify-center px-6 py-12 md:px-12">
-        {verse ? (
-          <VerseOfDayCard verse={verse} />
+        {today ? (
+          <VerseOfDayCard verse={today.verse} reflection={today.reflection ?? undefined} />
         ) : (
           <p className="text-sm text-text-muted">
             Couldn&apos;t load today&apos;s verse right now. Please try again later.

--- a/components/admin/AdminContext.tsx
+++ b/components/admin/AdminContext.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { createContext, useCallback, useContext } from "react";
+import { useAuthStore } from "@/store/auth";
+
+/**
+ * Client-side admin plumbing. The access token lives in memory in the auth store,
+ * so every admin API call must attach it as a Bearer header. `useAdminFetch`
+ * returns a thin `fetch` wrapper that does exactly that and throws a typed error
+ * on non-2xx so callers can render a message instead of silently failing.
+ */
+
+export class AdminApiError extends Error {
+  constructor(
+    public status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = "AdminApiError";
+  }
+}
+
+interface AdminCtx {
+  /** QF id of the signed-in admin (for display). */
+  adminQfId: string;
+  username: string;
+}
+
+export const AdminContext = createContext<AdminCtx | null>(null);
+
+/** The signed-in admin's identity (only valid inside an authorised AdminGate). */
+export function useAdmin(): AdminCtx {
+  const ctx = useContext(AdminContext);
+  if (!ctx) throw new Error("useAdmin must be used within AdminGate");
+  return ctx;
+}
+
+/**
+ * Returns an authenticated fetch bound to the current access token. Sends/parses
+ * JSON and throws `AdminApiError` on failure. `path` is relative to `/api/admin`.
+ */
+export function useAdminFetch() {
+  const token = useAuthStore((s) => s.accessToken);
+
+  return useCallback(
+    async <T,>(path: string, init?: RequestInit & { json?: unknown }): Promise<T> => {
+      const headers: Record<string, string> = {
+        ...(init?.headers as Record<string, string> | undefined),
+        Authorization: `Bearer ${token ?? ""}`,
+      };
+      let body = init?.body;
+      if (init?.json !== undefined) {
+        headers["Content-Type"] = "application/json";
+        body = JSON.stringify(init.json);
+      }
+      const res = await fetch(`/api/admin${path}`, { ...init, headers, body });
+      if (!res.ok) {
+        let message = `Request failed (${res.status})`;
+        try {
+          const data = (await res.json()) as { error?: string };
+          if (data?.error) message = data.error;
+        } catch {
+          /* non-JSON error body */
+        }
+        throw new AdminApiError(res.status, message);
+      }
+      if (res.status === 204) return undefined as T;
+      return (await res.json()) as T;
+    },
+    [token]
+  );
+}

--- a/components/admin/AdminGate.tsx
+++ b/components/admin/AdminGate.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useAuthStore } from "@/store/auth";
+import { AdminContext } from "./AdminContext";
+
+type GateState =
+  | { phase: "checking" }
+  | { phase: "denied" }
+  | { phase: "ok"; adminQfId: string; username: string };
+
+/**
+ * Client-side gate for the admin area. The server can't see the in-memory access
+ * token, so the real security boundary is every `/api/admin/*` route. This gate
+ * is purely UX: it asks `/api/admin/me` who you are and shows the console only to
+ * an admin, a "not found" screen to everyone else. Nothing sensitive renders here
+ * before the check resolves — all data is fetched from the guarded API.
+ */
+export function AdminGate({ children }: { children: React.ReactNode }) {
+  const token = useAuthStore((s) => s.accessToken);
+  const sessionLoading = useAuthStore((s) => s.isSessionLoading);
+  const [state, setState] = useState<GateState>({ phase: "checking" });
+
+  useEffect(() => {
+    if (sessionLoading) return; // wait for SessionRestorer to settle the token
+    let active = true;
+
+    if (!token) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setState({ phase: "denied" });
+      return;
+    }
+
+    setState({ phase: "checking" });
+    fetch("/api/admin/me", { headers: { Authorization: `Bearer ${token}` } })
+      .then(async (res) => {
+        if (!active) return;
+        if (!res.ok) {
+          setState({ phase: "denied" });
+          return;
+        }
+        const data = (await res.json()) as { qfId: string; username: string };
+        setState({ phase: "ok", adminQfId: data.qfId, username: data.username });
+      })
+      .catch(() => active && setState({ phase: "denied" }));
+
+    return () => {
+      active = false;
+    };
+  }, [token, sessionLoading]);
+
+  if (sessionLoading || state.phase === "checking") {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-bg">
+        <span className="font-mono text-xs uppercase tracking-[0.16em] text-text-muted">
+          Authorising…
+        </span>
+      </div>
+    );
+  }
+
+  if (state.phase === "denied") {
+    return (
+      <div className="flex min-h-dvh flex-col items-center justify-center gap-4 bg-bg px-6 text-center">
+        <p className="font-arabic text-2xl text-text-muted">٤٠٤</p>
+        <h1 className="text-lg text-text-primary">This page could not be found.</h1>
+        <Link href="/" className="text-sm text-gold hover:underline">
+          Return home
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <AdminContext.Provider value={{ adminQfId: state.adminQfId, username: state.username }}>
+      {children}
+    </AdminContext.Provider>
+  );
+}

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard,
+  CalendarDays,
+  Network,
+  Users,
+  Coins,
+  Flag,
+  BookOpen,
+  Server,
+  ScrollText,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useAdmin } from "./AdminContext";
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+// The console's modules, in the order they appear in the sidebar. Keep the
+// highest-frequency operator tasks near the top.
+const NAV: NavItem[] = [
+  { href: "/admin", label: "Overview", icon: LayoutDashboard },
+  { href: "/admin/votd", label: "Verse of the Day", icon: CalendarDays },
+  { href: "/admin/connections", label: "Connections", icon: Network },
+  { href: "/admin/users", label: "Users", icon: Users },
+  { href: "/admin/ai", label: "AI & Cost", icon: Coins },
+  { href: "/admin/flags", label: "Feature Flags", icon: Flag },
+  { href: "/admin/names", label: "Names Content", icon: BookOpen },
+  { href: "/admin/infra", label: "Infra", icon: Server },
+  { href: "/admin/audit", label: "Audit Log", icon: ScrollText },
+];
+
+function isActive(pathname: string, href: string): boolean {
+  if (href === "/admin") return pathname === "/admin";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+/**
+ * The dense operator-console frame (design direction A): a persistent left
+ * sidebar of modules + a top context bar, on the locked navy/gold/teal palette.
+ * Gold marks the active module; the work area is filled per-page.
+ */
+export function AdminShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const { username } = useAdmin();
+
+  return (
+    <div className="flex min-h-dvh bg-bg text-text-primary">
+      <aside className="flex w-60 shrink-0 flex-col border-r border-border bg-surface">
+        <div className="flex items-baseline gap-2 px-5 py-5">
+          <span className="font-arabic text-lg text-gold">حكمة</span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-text-muted">
+            admin
+          </span>
+        </div>
+
+        <nav className="flex flex-1 flex-col gap-0.5 px-2.5">
+          {NAV.map(({ href, label, icon: Icon }) => {
+            const active = isActive(pathname, href);
+            return (
+              <Link
+                key={href}
+                href={href}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-[color,background-color] duration-[120ms]",
+                  active
+                    ? "bg-gold/10 font-medium text-gold"
+                    : "text-text-secondary hover:bg-white/5 hover:text-text-primary"
+                )}
+              >
+                <Icon className="h-4 w-4 shrink-0" strokeWidth={active ? 2.25 : 1.75} />
+                {label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div className="border-t border-border px-5 py-3.5">
+          <div className="flex items-center gap-2">
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-teal" />
+            <span className="truncate text-xs text-text-secondary">{username}</span>
+          </div>
+          <Link href="/" className="mt-1 block text-[11px] text-text-muted hover:text-gold">
+            ← Back to app
+          </Link>
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * Standard page header inside the work area: a title, optional subtitle, and an
+ * optional actions slot on the right. Keeps every module visually consistent.
+ */
+export function AdminPageHeader({
+  title,
+  subtitle,
+  actions,
+}: {
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <header className="flex items-start justify-between gap-4 border-b border-border px-7 py-5">
+      <div>
+        <h1 className="text-base font-semibold text-text-primary">{title}</h1>
+        {subtitle && <p className="mt-0.5 text-sm text-text-secondary">{subtitle}</p>}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </header>
+  );
+}

--- a/components/admin/primitives.tsx
+++ b/components/admin/primitives.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { Button, type ButtonProps } from "@/components/ui";
+
+/** A compact dashboard stat: a label, a large gold value, and optional hint. */
+export function StatTile({
+  label,
+  value,
+  hint,
+  tone = "gold",
+}: {
+  label: string;
+  value: React.ReactNode;
+  hint?: string;
+  tone?: "gold" | "teal" | "plain";
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-surface px-4 py-3.5">
+      <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-muted">
+        {label}
+      </div>
+      <div
+        className={cn(
+          "mt-1.5 text-2xl font-semibold tabular-nums",
+          tone === "gold" && "text-gold",
+          tone === "teal" && "text-teal",
+          tone === "plain" && "text-text-primary"
+        )}
+      >
+        {value}
+      </div>
+      {hint && <div className="mt-0.5 text-xs text-text-muted">{hint}</div>}
+    </div>
+  );
+}
+
+/** A small status badge. Colour conveys state; never the only signal (text too). */
+export function Pill({
+  children,
+  tone = "neutral",
+}: {
+  children: React.ReactNode;
+  tone?: "active" | "flagged" | "retired" | "neutral";
+}) {
+  const tones: Record<string, string> = {
+    active: "border-teal/40 bg-teal/10 text-teal",
+    flagged: "border-gold-muted bg-gold/10 text-gold",
+    retired: "border-border bg-white/5 text-text-muted",
+    neutral: "border-border bg-white/5 text-text-secondary",
+  };
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[11px] uppercase tracking-wide",
+        tones[tone]
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+// ─── Table primitives ─────────────────────────────────────────────────────────
+
+export function Table({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full border-collapse text-sm">{children}</table>
+    </div>
+  );
+}
+
+export function Th({
+  children,
+  className,
+}: {
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <th
+      className={cn(
+        "border-b border-border bg-surface px-3.5 py-2.5 text-left font-mono text-[10px] font-normal uppercase tracking-[0.14em] text-text-muted",
+        className
+      )}
+    >
+      {children}
+    </th>
+  );
+}
+
+export function Td({
+  children,
+  className,
+}: {
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <td className={cn("border-b border-border-subtle px-3.5 py-2.5 align-middle", className)}>
+      {children}
+    </td>
+  );
+}
+
+/**
+ * A button that requires a second click to confirm a destructive/irreversible
+ * action. The first click flips the label to a warning; a second within the
+ * window runs `onConfirm`. Cheaper than a modal for a one-operator console.
+ */
+export function ConfirmButton({
+  onConfirm,
+  children,
+  confirmLabel = "Confirm?",
+  variant = "danger",
+  size = "sm",
+  ...props
+}: {
+  onConfirm: () => void;
+  children: React.ReactNode;
+  confirmLabel?: string;
+} & Omit<ButtonProps, "onClick">) {
+  const [armed, setArmed] = useState(false);
+
+  return (
+    <Button
+      variant={armed ? "danger" : variant}
+      size={size}
+      onClick={() => {
+        if (armed) {
+          setArmed(false);
+          onConfirm();
+        } else {
+          setArmed(true);
+          window.setTimeout(() => setArmed(false), 3000);
+        }
+      }}
+      {...props}
+    >
+      {armed ? confirmLabel : children}
+    </Button>
+  );
+}
+
+/** Centred non-blocking states for async module content. */
+export function StateNote({
+  children,
+  tone = "muted",
+}: {
+  children: React.ReactNode;
+  tone?: "muted" | "error";
+}) {
+  return (
+    <p
+      className={cn(
+        "px-1 py-8 text-center text-sm",
+        tone === "error" ? "text-error" : "text-text-muted"
+      )}
+    >
+      {children}
+    </p>
+  );
+}

--- a/components/admin/useAsync.ts
+++ b/components/admin/useAsync.ts
@@ -38,6 +38,7 @@ export function useAsync<T>(loader: () => Promise<T>, cacheKey: string): AsyncSt
       .then((d) => active && setData(d))
       .catch((e: unknown) => {
         if (!active) return;
+        setData(null); // drop stale data so we never render "error + old rows"
         setError(e instanceof AdminApiError ? e.message : "Something went wrong");
       })
       .finally(() => active && setLoading(false));

--- a/components/admin/useAsync.ts
+++ b/components/admin/useAsync.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AdminApiError } from "./AdminContext";
+
+interface AsyncState<T> {
+  data: T | null;
+  error: string | null;
+  loading: boolean;
+  reload: () => void;
+}
+
+/**
+ * Runs `loader` on mount and whenever `cacheKey` changes (encode any filters the
+ * loader reads into the key), exposing loading/error/data plus a manual `reload`.
+ * The loader is held in a ref so the effect can depend only on the literal
+ * `[cacheKey, tick]` — required by the project's strict react-hooks lint.
+ */
+export function useAsync<T>(loader: () => Promise<T>, cacheKey: string): AsyncState<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [tick, setTick] = useState(0);
+
+  const loaderRef = useRef(loader);
+  useEffect(() => {
+    loaderRef.current = loader; // keep the latest closure without re-running the load
+  });
+
+  useEffect(() => {
+    let active = true;
+    // Legitimate external-data sync: kick off a fetch and reflect its result.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoading(true);
+    setError(null);
+    loaderRef
+      .current()
+      .then((d) => active && setData(d))
+      .catch((e: unknown) => {
+        if (!active) return;
+        setError(e instanceof AdminApiError ? e.message : "Something went wrong");
+      })
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+    };
+  }, [cacheKey, tick]);
+
+  const reload = useCallback(() => setTick((t) => t + 1), []);
+  return { data, error, loading, reload };
+}

--- a/lib/admin-audit.ts
+++ b/lib/admin-audit.ts
@@ -1,0 +1,30 @@
+import { db } from "./db";
+import { adminAuditLog } from "./db/schema";
+
+/**
+ * Append one row to the admin audit log. Every *mutating* admin action calls this
+ * so the console polices itself (who did what, when, to which target).
+ *
+ * Best-effort: a logging failure must never break the action it records, so this
+ * swallows errors (and logs to the server console). Callers should `await` it but
+ * can ignore the result.
+ */
+export async function logAdminAction(entry: {
+  adminQfId: string;
+  action: string;
+  targetType?: string | null;
+  targetId?: string | null;
+  meta?: unknown;
+}): Promise<void> {
+  try {
+    await db.insert(adminAuditLog).values({
+      adminQfId: entry.adminQfId,
+      action: entry.action,
+      targetType: entry.targetType ?? null,
+      targetId: entry.targetId ?? null,
+      meta: entry.meta === undefined ? null : JSON.stringify(entry.meta),
+    });
+  } catch (err) {
+    console.error("Failed to write admin audit log:", entry.action, err);
+  }
+}

--- a/lib/admin-audit.ts
+++ b/lib/admin-audit.ts
@@ -2,6 +2,20 @@ import { db } from "./db";
 import { adminAuditLog } from "./db/schema";
 
 /**
+ * Serialize `meta` defensively: a BigInt or circular reference must not throw and
+ * cause the whole audit row to be dropped. Falls back to a marker so the action
+ * is still recorded.
+ */
+function serializeMeta(meta: unknown): string | null {
+  if (meta === undefined) return null;
+  try {
+    return JSON.stringify(meta, (_k, v) => (typeof v === "bigint" ? v.toString() : v));
+  } catch {
+    return JSON.stringify({ serializationError: true });
+  }
+}
+
+/**
  * Append one row to the admin audit log. Every *mutating* admin action calls this
  * so the console polices itself (who did what, when, to which target).
  *
@@ -22,7 +36,7 @@ export async function logAdminAction(entry: {
       action: entry.action,
       targetType: entry.targetType ?? null,
       targetId: entry.targetId ?? null,
-      meta: entry.meta === undefined ? null : JSON.stringify(entry.meta),
+      meta: serializeMeta(entry.meta),
     });
   } catch (err) {
     console.error("Failed to write admin audit log:", entry.action, err);

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireUser, type AuthedUser } from "./social-auth";
+
+/**
+ * Single super-admin access control.
+ *
+ * Admins are defined by the `ADMIN_QF_IDS` env var: a comma-separated allowlist
+ * of QF user ids (the `sub` / `qf_id`). This is deliberately env-based rather than
+ * a DB role column — there is exactly one operator, no invite flow, and an env
+ * allowlist can't be escalated by anything inside the app.
+ *
+ * FAIL-CLOSED: an unset or empty allowlist means *nobody* is an admin, so a
+ * misconfigured deploy locks the panel rather than opening it.
+ */
+
+let cachedRaw: string | undefined;
+let cachedSet: Set<string> = new Set();
+
+/** Parsed allowlist, memoised per distinct env value (cheap, handles hot reload). */
+function adminIds(): Set<string> {
+  const raw = process.env.ADMIN_QF_IDS ?? "";
+  if (raw !== cachedRaw) {
+    cachedRaw = raw;
+    cachedSet = new Set(
+      raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    );
+  }
+  return cachedSet;
+}
+
+/** True iff the given QF id is in the admin allowlist. */
+export function isAdminQfId(qfId: string | null | undefined): boolean {
+  if (!qfId) return false;
+  return adminIds().has(qfId);
+}
+
+/**
+ * Resolves the caller and asserts they are an admin. Returns `{ userId, user }`
+ * on success or a `NextResponse` (401 if not signed in, 403 if signed in but not
+ * an admin) that the route should return directly. Every `/api/admin/*` route
+ * MUST call this — it is the real security boundary, since the admin UI itself is
+ * client-rendered and cannot be trusted.
+ */
+export async function requireAdmin(
+  req: NextRequest
+): Promise<AuthedUser | NextResponse> {
+  const result = await requireUser(req);
+  if (result instanceof NextResponse) return result; // 401 / disabled
+
+  if (!isAdminQfId(result.user.qfId)) {
+    // 404, not 403 — don't confirm the admin surface exists to a normal user.
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return result;
+}

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -39,8 +39,9 @@ export function isAdminQfId(qfId: string | null | undefined): boolean {
 
 /**
  * Resolves the caller and asserts they are an admin. Returns `{ userId, user }`
- * on success or a `NextResponse` (401 if not signed in, 403 if signed in but not
- * an admin) that the route should return directly. Every `/api/admin/*` route
+ * on success or a `NextResponse` (401 if not signed in, 404 if signed in but not
+ * an admin — we don't reveal the surface) that the route should return directly.
+ * Every `/api/admin/*` route
  * MUST call this — it is the real security boundary, since the admin UI itself is
  * client-rendered and cannot be trusted.
  */

--- a/lib/db/migrations/0010_admin_panel.sql
+++ b/lib/db/migrations/0010_admin_panel.sql
@@ -1,0 +1,33 @@
+-- Admin panel: curated Verse-of-the-Day, audit log, feature flags, and a
+-- soft-disable column on users. Hand-written to add only the new objects
+-- (drizzle-kit's full snapshot baseline is stale for 0002–0009), idempotent in
+-- the same style as the existing migrations / scripts/ensure-tables.mjs.
+
+CREATE TABLE IF NOT EXISTS "curated_votd" (
+	"date" date PRIMARY KEY NOT NULL,
+	"verse_ref" text NOT NULL,
+	"reflection" text,
+	"updated_by" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "admin_audit_log" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"admin_qf_id" text NOT NULL,
+	"action" text NOT NULL,
+	"target_type" text,
+	"target_id" text,
+	"meta" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "admin_audit_created_idx" ON "admin_audit_log" USING btree ("created_at");
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "feature_flags" (
+	"key" text PRIMARY KEY NOT NULL,
+	"value" text NOT NULL,
+	"updated_by" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "disabled_at" timestamp with time zone;

--- a/lib/db/migrations/meta/0010_snapshot.json
+++ b/lib/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1552 @@
+{
+  "id": "3b30c6a1-6df6-4f29-b794-f07fdf767447",
+  "prevId": "aa45c582-57d9-47e4-ac7d-b8734b21e839",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_date": {
+          "name": "activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_date_idx": {
+          "name": "activity_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_type_date_idx": {
+          "name": "activity_user_type_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_user_id_users_id_fk": {
+          "name": "activity_log_user_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_qf_id": {
+          "name": "admin_qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_created_idx": {
+          "name": "admin_audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_generations": {
+      "name": "ai_generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_generations_created_idx": {
+          "name": "ai_generations_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_idx": {
+          "name": "bookmarks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookmarks_user_ref_uniq": {
+          "name": "bookmarks_user_ref_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "verse_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenger_id": {
+          "name": "challenger_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenged_id": {
+          "name": "challenged_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_challenger_status_idx": {
+          "name": "challenges_challenger_status_idx",
+          "columns": [
+            {
+              "expression": "challenger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_challenged_status_idx": {
+          "name": "challenges_challenged_status_idx",
+          "columns": [
+            {
+              "expression": "challenged_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_ends_at_idx": {
+          "name": "challenges_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_challenger_id_users_id_fk": {
+          "name": "challenges_challenger_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_challenged_id_users_id_fk": {
+          "name": "challenges_challenged_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenged_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_winner_id_users_id_fk": {
+          "name": "challenges_winner_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_challenge": {
+          "name": "no_self_challenge",
+          "value": "\"challenges\".\"challenger_id\" != \"challenges\".\"challenged_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_ref": {
+          "name": "to_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connections_from_to_kind_idx": {
+          "name": "connections_from_to_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_from_kind_idx": {
+          "name": "connections_from_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_votd": {
+      "name": "curated_votd",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "friendships_pair_idx": {
+          "name": "friendships_pair_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_addressee_status_idx": {
+          "name": "friendships_addressee_status_idx",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_requester_status_idx": {
+          "name": "friendships_requester_status_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_requester_id_users_id_fk": {
+          "name": "friendships_requester_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_addressee_id_users_id_fk": {
+          "name": "friendships_addressee_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_friendship": {
+          "name": "no_self_friendship",
+          "value": "\"friendships\".\"requester_id\" != \"friendships\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.name_content": {
+      "name": "name_content",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "name_content_slug_kind_pk": {
+          "name": "name_content_slug_kind_pk",
+          "columns": [
+            "slug",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_workspaces": {
+      "name": "saved_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_workspaces_user_idx": {
+          "name": "saved_workspaces_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_workspaces_user_id_users_id_fk": {
+          "name": "saved_workspaces_user_id_users_id_fk",
+          "tableFrom": "saved_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_canvases": {
+      "name": "shared_canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qf_id": {
+          "name": "qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_qf_id_idx": {
+          "name": "users_qf_id_idx",
+          "columns": [
+            {
+              "expression": "qf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_active_idx": {
+          "name": "users_last_active_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_qf_id_unique": {
+          "name": "users_qf_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qf_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_embeddings": {
+      "name": "verse_embeddings",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_embeddings_hnsw_idx": {
+          "name": "verse_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_notes": {
+      "name": "verse_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_notes_user_ref_idx": {
+          "name": "verse_notes_user_ref_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_notes_user_id_users_id_fk": {
+          "name": "verse_notes_user_id_users_id_fk",
+          "tableFrom": "verse_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verses": {
+      "name": "verses",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "surah": {
+          "name": "surah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ayah": {
+          "name": "ayah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arabic_text": {
+          "name": "arabic_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transliteration": {
+          "name": "transliteration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verses_surah_ayah_idx": {
+          "name": "verses_surah_ayah_idx",
+          "columns": [
+            {
+              "expression": "surah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ayah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_morphology": {
+      "name": "word_morphology",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "word_morphology_ref_pos_idx": {
+          "name": "word_morphology_ref_pos_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_ref_idx": {
+          "name": "word_morphology_ref_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_root_idx": {
+          "name": "word_morphology_root_idx",
+          "columns": [
+            {
+              "expression": "root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1781861399908,
       "tag": "0009_third_shaman",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1782030239740,
+      "tag": "0010_admin_panel",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -29,6 +29,10 @@ export const users = pgTable(
     currentStreak: integer("current_streak").notNull().default(0),
     longestStreak: integer("longest_streak").notNull().default(0),
     lastActivityDate: date("last_activity_date"),
+    // Soft-disable seam for admin moderation. Null = active; a timestamp marks
+    // when an admin disabled the account. Disabled users keep their data but are
+    // rejected at the auth boundary (see requireUser / lib/admin-auth.ts).
+    disabledAt: timestamp("disabled_at", { withTimezone: true }),
   },
   (t) => [
     uniqueIndex("users_qf_id_idx").on(t.qfId),
@@ -324,6 +328,52 @@ export const nameContent = pgTable(
   (t) => [primaryKey({ columns: [t.slug, t.kind] })]
 );
 
+// ─── Curated Verse of the Day ─────────────────────────────────────────────────
+// Admin override for the daily verse, keyed by UTC date. When a row exists for a
+// day, it wins over the deterministic algorithmic pick (see lib/verse-of-day.ts).
+// `reflection` is optional editorial text rendered in the teal ReflectionNote.
+
+export const curatedVotd = pgTable("curated_votd", {
+  // UTC day, "YYYY-MM-DD". One curated verse per day.
+  date: date("date").primaryKey(),
+  verseRef: text("verse_ref").notNull(),
+  reflection: text("reflection"),
+  // QF id of the admin who set it (audit convenience; full trail in admin_audit_log).
+  updatedBy: text("updated_by"),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// ─── Admin Audit Log ──────────────────────────────────────────────────────────
+// Append-only record of every mutating admin action, so the console polices
+// itself. `meta` holds action-specific detail (old/new values, filters, etc.).
+
+export const adminAuditLog = pgTable(
+  "admin_audit_log",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    adminQfId: text("admin_qf_id").notNull(),
+    // e.g. 'votd.set' | 'votd.clear' | 'connection.status' | 'user.disable'
+    action: text("action").notNull(),
+    targetType: text("target_type"),
+    targetId: text("target_id"),
+    meta: text("meta"), // JSON-encoded payload
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index("admin_audit_created_idx").on(t.createdAt)]
+);
+
+// ─── Feature Flags / Config ───────────────────────────────────────────────────
+// Key→JSON config the admin can tune at runtime (rate-limit windows, AI model per
+// connection kind, feature toggles). Read by the relevant subsystem; absence of a
+// key means "use the code default", so this never has to be fully populated.
+
+export const featureFlags = pgTable("feature_flags", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(), // JSON-encoded
+  updatedBy: text("updated_by"),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 // ─── Exported types ───────────────────────────────────────────────────────────
 
 export type User = typeof users.$inferSelect;
@@ -352,3 +402,9 @@ export type WordMorphology = typeof wordMorphology.$inferSelect;
 export type NewWordMorphology = typeof wordMorphology.$inferInsert;
 export type NameContent = typeof nameContent.$inferSelect;
 export type NewNameContent = typeof nameContent.$inferInsert;
+export type CuratedVotd = typeof curatedVotd.$inferSelect;
+export type NewCuratedVotd = typeof curatedVotd.$inferInsert;
+export type AdminAuditEntry = typeof adminAuditLog.$inferSelect;
+export type NewAdminAuditEntry = typeof adminAuditLog.$inferInsert;
+export type FeatureFlag = typeof featureFlags.$inferSelect;
+export type NewFeatureFlag = typeof featureFlags.$inferInsert;

--- a/lib/social-auth.ts
+++ b/lib/social-auth.ts
@@ -225,8 +225,9 @@ export async function requireUser(
       const [u] = await db.select().from(users).where(eq(users.id, id)).limit(1);
       if (u) {
         incr("auth_l2_hit");
-        tokenCache.set(token, { user: u, expiresAt: Date.now() + CACHE_TTL_MS });
+        // Reject (and don't cache) a disabled account before populating L1.
         if (u.disabledAt) return disabledResponse();
+        tokenCache.set(token, { user: u, expiresAt: Date.now() + CACHE_TTL_MS });
         return { userId: u.id, user: u };
       }
     }
@@ -260,9 +261,10 @@ export async function requireUser(
     }
   }
   incr("auth_cache_miss");
+  // Reject (and don't cache) a disabled account before populating L1/L2.
+  if (user.disabledAt) return disabledResponse();
   tokenCache.set(token, { user, expiresAt: Date.now() + CACHE_TTL_MS });
   void redisSet(tokenRedisKey(token), String(user.id), CACHE_TTL_SECONDS);
-  if (user.disabledAt) return disabledResponse();
   return { userId: user.id, user };
 }
 

--- a/lib/social-auth.ts
+++ b/lib/social-auth.ts
@@ -11,6 +11,14 @@ export interface AuthedUser {
   user: User;
 }
 
+// A soft-disabled account (set by an admin) is rejected at the auth boundary.
+// Returned as 403 so the client can distinguish "disabled" from "not signed in".
+// Note: a freshly-disabled user may linger until their cached entry expires
+// (≤5 min) or the token caches are flushed from the admin Infra panel.
+function disabledResponse(): NextResponse {
+  return NextResponse.json({ error: "Account disabled" }, { status: 403 });
+}
+
 // Two-tier token cache: an in-process L1 Map (fastest, per-instance) backed by a
 // Redis L2 (shared across instances, survives restarts). The L1 keeps the hot
 // path zero-round-trip; the L2 means a deploy/restart no longer logs everyone out
@@ -30,6 +38,25 @@ function tokenRedisKey(token: string): string {
 export function invalidateTokenCache(token: string): void {
   tokenCache.delete(token);
   void redisDel(tokenRedisKey(token));
+}
+
+/**
+ * Clears the in-process token cache (admin Infra action). Forces every request
+ * to re-resolve its user on the next call, so a just-disabled account stops being
+ * served from this instance's L1 immediately. Redis L2 token entries expire on
+ * their own ≤5-min TTL. Returns how many entries were dropped.
+ */
+export function clearTokenCache(): number {
+  const n = tokenCache.size;
+  tokenCache.clear();
+  return n;
+}
+
+/** Drops the cached JWKS (in-process + Redis) so the next verify refetches QF's
+ *  signing keys — used after a key rotation from the admin Infra panel. */
+export function clearJwksCache(): void {
+  jwksCache = null;
+  void redisDel(JWKS_REDIS_KEY);
 }
 
 // ─── JWT signature verification ───────────────────────────────────────────────
@@ -185,6 +212,7 @@ export async function requireUser(
   const cached = tokenCache.get(token);
   if (cached && cached.expiresAt > Date.now()) {
     incr("auth_l1_hit");
+    if (cached.user.disabledAt) return disabledResponse();
     return { userId: cached.user.id, user: cached.user };
   }
 
@@ -198,6 +226,7 @@ export async function requireUser(
       if (u) {
         incr("auth_l2_hit");
         tokenCache.set(token, { user: u, expiresAt: Date.now() + CACHE_TTL_MS });
+        if (u.disabledAt) return disabledResponse();
         return { userId: u.id, user: u };
       }
     }
@@ -233,6 +262,7 @@ export async function requireUser(
   incr("auth_cache_miss");
   tokenCache.set(token, { user, expiresAt: Date.now() + CACHE_TTL_MS });
   void redisSet(tokenRedisKey(token), String(user.id), CACHE_TTL_SECONDS);
+  if (user.disabledAt) return disabledResponse();
   return { userId: user.id, user };
 }
 

--- a/lib/verse-of-day.ts
+++ b/lib/verse-of-day.ts
@@ -1,3 +1,6 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { curatedVotd } from "@/lib/db/schema";
 import { resolveVerse } from "@/lib/verse-resolver";
 import type { Verse } from "@/types/quran";
 
@@ -129,14 +132,43 @@ export function verseOfDayRef(date: Date = new Date()): string {
   return POOL[daySeed(date) % POOL.length];
 }
 
+/** The UTC day key ("YYYY-MM-DD") used as the curated_votd primary key. */
+export function votdDateKey(date: Date = new Date()): string {
+  return date.toISOString().slice(0, 10);
+}
+
 /**
- * Admin-curated override for a given day. Returns null until the admin
- * Verse-of-the-Day calendar (roadmap Epic 2 / design.md §6.A) is built — the
- * algorithmic pick below is the always-on fallback. This is the single seam a
- * curated entry will plug into; the card UI is identical either way.
+ * The admin-curated entry for a day, if one exists: the resolved verse plus its
+ * optional editorial reflection. Reads the `curated_votd` table (the seam set by
+ * the admin Verse-of-the-Day calendar). DB failures degrade to null so the
+ * algorithmic pick always remains as the always-on fallback.
  */
-export async function getCuratedVerseOfDay(_date: Date): Promise<Verse | null> {
-  return null;
+export async function getCuratedVerseOfDayEntry(
+  date: Date = new Date()
+): Promise<{ verse: Verse; reflection: string | null } | null> {
+  try {
+    const [row] = await db
+      .select()
+      .from(curatedVotd)
+      .where(eq(curatedVotd.date, votdDateKey(date)))
+      .limit(1);
+    if (!row) return null;
+    const verse = await resolveVerse(row.verseRef);
+    if (!verse) return null;
+    return { verse, reflection: row.reflection ?? null };
+  } catch (err) {
+    console.error("Curated VotD lookup failed; using algorithmic pick:", err);
+    return null;
+  }
+}
+
+/**
+ * Admin-curated override verse for a given day, or null when none is set. The
+ * algorithmic pick is the always-on fallback; the card UI is identical either way.
+ */
+export async function getCuratedVerseOfDay(date: Date = new Date()): Promise<Verse | null> {
+  const entry = await getCuratedVerseOfDayEntry(date);
+  return entry?.verse ?? null;
 }
 
 /** Resolves today's verse (full text). Null only if it can't be resolved at all. */
@@ -144,4 +176,17 @@ export async function getVerseOfDay(date: Date = new Date()): Promise<Verse | nu
   const curated = await getCuratedVerseOfDay(date);
   if (curated) return curated;
   return resolveVerse(verseOfDayRef(date));
+}
+
+/**
+ * Today's verse plus any curated reflection, for the full /today card. Falls back
+ * to the algorithmic pick (with no reflection) when no curated entry exists.
+ */
+export async function getVerseOfDayWithReflection(
+  date: Date = new Date()
+): Promise<{ verse: Verse; reflection: string | null } | null> {
+  const curated = await getCuratedVerseOfDayEntry(date);
+  if (curated) return curated;
+  const verse = await resolveVerse(verseOfDayRef(date));
+  return verse ? { verse, reflection: null } : null;
 }

--- a/lib/verse-resolver.ts
+++ b/lib/verse-resolver.ts
@@ -13,7 +13,9 @@ export async function resolveVerse(ref: string): Promise<Verse | null> {
     const local = await getVerse(ref);
     if (local) return local;
   } catch (err) {
-    console.error(`Corpus lookup failed for ${ref}, falling back to live fetch:`, err);
+    // `ref` is passed as a data argument, never interpolated into the first
+    // (format) argument — avoids an externally-controlled format string.
+    console.error("Corpus lookup failed for %s, falling back to live fetch:", ref, err);
   }
   return fetchVerseLive(ref);
 }
@@ -54,7 +56,7 @@ async function fetchVerseLive(ref: string): Promise<Verse | null> {
   } catch (err) {
     // Log so an upstream outage is distinguishable from a genuinely missing
     // verse (both surface as null → 404 at the API layer).
-    console.error(`Live verse fetch failed for ${ref}:`, err);
+    console.error("Live verse fetch failed for %s:", ref, err);
     return null;
   }
 }

--- a/scripts/ensure-tables.mjs
+++ b/scripts/ensure-tables.mjs
@@ -141,6 +141,41 @@ try {
     )
   `;
 
+  // ─── Admin panel (curated VotD, audit log, feature flags, soft-disable) ─────
+  await sql`
+    CREATE TABLE IF NOT EXISTS curated_votd (
+      date        date PRIMARY KEY,
+      verse_ref   text NOT NULL,
+      reflection  text,
+      updated_by  text,
+      updated_at  timestamptz NOT NULL DEFAULT now()
+    )
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS admin_audit_log (
+      id          bigserial PRIMARY KEY,
+      admin_qf_id text NOT NULL,
+      action      text NOT NULL,
+      target_type text,
+      target_id   text,
+      meta        text,
+      created_at  timestamptz NOT NULL DEFAULT now()
+    )
+  `;
+  await sql`CREATE INDEX IF NOT EXISTS admin_audit_created_idx ON admin_audit_log (created_at)`;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS feature_flags (
+      key        text PRIMARY KEY,
+      value      text NOT NULL,
+      updated_by text,
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `;
+
+  await sql`ALTER TABLE users ADD COLUMN IF NOT EXISTS disabled_at timestamptz`;
+
   console.log("Tables ensured successfully");
 } finally {
   await sql.end();


### PR DESCRIPTION
* **New Features**
  * Added support for curated verse of the day with optional reflections displayed on the today page.
  * Introduced admin audit logging to track administrative actions.
  * Enabled account disabling functionality for administrative use.
  * Added feature flags configuration system.

* **Tests**
  * Improved verse-of-day test isolation with better mocking.
  * Updated test fixtures across multiple test suites for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* **Admin Panel** – Added a protected admin experience with dashboards and tools for auditing, AI usage stats, runtime feature flags, infrastructure checks/maintenance, and connection moderation.
* **Curated Verse of the Day** – Admins can create/edit day-by-day overrides (including reflections), shown on the Today card.
* **Account Disabling** – Admins can soft-disable and re-enable accounts.

## Improvements
* **Verse-of-Day Reliability** – Enhanced curated lookup with deterministic fallback to the standard selection.

## Tests
* Updated fixtures to include `disabledAt` and expanded coverage for curated VOTD behavior and admin auth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->