### PR TITLE
fix: audit hardening pass — security, race conditions, error handling, a11y

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ hosting.md
 
 # Playwright scratch dir (console logs, page snapshots, review screenshots) — local only
 /.playwright-mcp/
+/graphify-out
 .mcp.json
 
 # Claude Code personal/local settings (machine-specific; shared config lives in .claude/settings.json)

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ hosting.md
 
 # Claude Code managed skills (tooling-synced duplicate; tracked under .agents/skills)
 /.claude/skills/
+
+# Ad hoc local screenshots/reference images (not app assets)
+/pics/

--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,4 @@ hosting.md
 # Claude Code managed skills (tooling-synced duplicate; tracked under .agents/skills)
 /.claude/skills/
 
-# Ad hoc local screenshots/reference images (not app assets)
-/pics/
+/local/

--- a/__tests__/api/admin/challenges.test.ts
+++ b/__tests__/api/admin/challenges.test.ts
@@ -84,9 +84,9 @@ describe("admin challenges [id]", () => {
     expect((await PATCH(req("PATCH", { action: "nope" }), params)).status).toBe(400);
   });
 
-  it("404s when the row is deleted before the end-update lands", async () => {
-    mockUpdate.mockReturnValue(makeDbChain([])); // update matched nothing
-    expect((await PATCH(req("PATCH", { action: "end" }), params)).status).toBe(404);
+  it("409s when a concurrent request already ended the challenge before this update lands", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([])); // scoped update matched nothing (status changed underneath us)
+    expect((await PATCH(req("PATCH", { action: "end" }), params)).status).toBe(409);
   });
 
   it("voids a challenge (204)", async () => {

--- a/__tests__/api/admin/challenges.test.ts
+++ b/__tests__/api/admin/challenges.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/lib/challenges", () => ({
   scoreChallenge: vi.fn(async () => 0),
   pickWinner: vi.fn(() => 1),
   resolveEndedChallenges: vi.fn(async () => new Map([[1, { challengerScore: 1, challengedScore: 0 }]])),
+  resolveExpiredPending: vi.fn(async () => 0),
 }));
 
 function makeDbChain(resolveWith: unknown = []) {

--- a/__tests__/api/connections.test.ts
+++ b/__tests__/api/connections.test.ts
@@ -188,7 +188,7 @@ describe("POST /api/connections", () => {
     }
   });
 
-  it("rate-limits under the client IP from x-forwarded-for", async () => {
+  it("rate-limits under the last (proxy-appended) hop of x-forwarded-for", async () => {
     mockFetch.mockImplementation(async (url: string) => {
       if (typeof url !== "string") return { ok: false };
       if (url.includes("ar.alafasy")) return arabicResp();
@@ -200,7 +200,7 @@ describe("POST /api/connections", () => {
       { "x-forwarded-for": "203.0.113.7, 70.41.3.18" }
     );
     await POST(req);
-    expect(mockConsume).toHaveBeenCalledWith("gen:203.0.113.7");
+    expect(mockConsume).toHaveBeenCalledWith("gen:70.41.3.18");
   });
 
   it("buckets requests with a malformed/oversized x-forwarded-for under 'unknown'", async () => {

--- a/__tests__/api/notes.test.ts
+++ b/__tests__/api/notes.test.ts
@@ -18,12 +18,18 @@ function makeDbChain(resolveWith: unknown = []) {
   return chain;
 }
 
-const { mockSelect, mockInsert } = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockConsume } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])),
   mockInsert: vi.fn(() => makeDbChain([])),
+  mockConsume: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/db", () => ({ db: { select: mockSelect, insert: mockInsert } }));
+vi.mock("@/lib/rate-limit", () => ({
+  consume: mockConsume,
+  MUTATION_LIMIT: 60,
+  MUTATION_WINDOW_SECONDS: 600,
+}));
 
 import { GET, POST } from "@/app/api/notes/route";
 import { requireUser } from "@/lib/social-auth";
@@ -86,11 +92,19 @@ describe("POST /api/notes", () => {
   beforeEach(() => {
     mockInsert.mockReset();
     mockInsert.mockReturnValue(makeDbChain([{ id: 1, verseRef: "2:255", note: "hi" }]));
+    mockConsume.mockReset();
+    mockConsume.mockResolvedValue(true);
   });
 
   it("401 when unauthenticated", async () => {
     unauthed();
     expect((await POST(req("POST", { ref: "2:255", note: "x" }))).status).toBe(401);
+  });
+
+  it("429 when the per-user notes rate limit is exceeded", async () => {
+    authed();
+    mockConsume.mockResolvedValue(false);
+    expect((await POST(req("POST", { ref: "2:255", note: "x" }))).status).toBe(429);
   });
 
   it("400 for malformed JSON body", async () => {

--- a/__tests__/api/notes.test.ts
+++ b/__tests__/api/notes.test.ts
@@ -18,17 +18,15 @@ function makeDbChain(resolveWith: unknown = []) {
   return chain;
 }
 
-const { mockSelect, mockInsert, mockConsume } = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockRateLimitOrNull } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])),
   mockInsert: vi.fn(() => makeDbChain([])),
-  mockConsume: vi.fn(async () => true),
+  mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
 }));
 
 vi.mock("@/lib/db", () => ({ db: { select: mockSelect, insert: mockInsert } }));
 vi.mock("@/lib/rate-limit", () => ({
-  consume: mockConsume,
-  MUTATION_LIMIT: 60,
-  MUTATION_WINDOW_SECONDS: 600,
+  rateLimitOrNull: mockRateLimitOrNull,
 }));
 
 import { GET, POST } from "@/app/api/notes/route";
@@ -92,8 +90,8 @@ describe("POST /api/notes", () => {
   beforeEach(() => {
     mockInsert.mockReset();
     mockInsert.mockReturnValue(makeDbChain([{ id: 1, verseRef: "2:255", note: "hi" }]));
-    mockConsume.mockReset();
-    mockConsume.mockResolvedValue(true);
+    mockRateLimitOrNull.mockReset();
+    mockRateLimitOrNull.mockResolvedValue(null);
   });
 
   it("401 when unauthenticated", async () => {
@@ -103,7 +101,7 @@ describe("POST /api/notes", () => {
 
   it("429 when the per-user notes rate limit is exceeded", async () => {
     authed();
-    mockConsume.mockResolvedValue(false);
+    mockRateLimitOrNull.mockResolvedValue(NextResponse.json({ error: "Too many" }, { status: 429 }));
     expect((await POST(req("POST", { ref: "2:255", note: "x" }))).status).toBe(429);
   });
 

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -199,10 +199,10 @@ describe("GET /api/search", () => {
     expect((await res.json())[0].ref).toBe("1:1");
   });
 
-  it("mode=meaning rate-limits under the client IP from x-forwarded-for", async () => {
+  it("mode=meaning rate-limits under the last (proxy-appended) hop of x-forwarded-for", async () => {
     mockSearchByMeaning.mockResolvedValueOnce([]);
     await GET(makeMeaningReq("mercy", { "x-forwarded-for": "203.0.113.7, 70.41.3.18" }));
-    expect(mockConsume).toHaveBeenCalledWith("search:203.0.113.7");
+    expect(mockConsume).toHaveBeenCalledWith("search:70.41.3.18");
   });
 
   it("mode=meaning buckets a malformed x-forwarded-for under 'unknown'", async () => {

--- a/__tests__/api/social/activity.test.ts
+++ b/__tests__/api/social/activity.test.ts
@@ -30,17 +30,32 @@ function makeDbChain(resolveWith: unknown = undefined) {
 }
 
 // Use vi.hoisted so mock fns are defined before vi.mock factories run
-const { mockInsert, mockUpdate, mockConsume } = vi.hoisted(() => ({
-  mockInsert: vi.fn(() => makeDbChain()),
-  mockUpdate: vi.fn(() => makeDbChain()),
-  mockConsume: vi.fn(async () => true),
-}));
+const { mockInsert, mockUpdate, mockTxSelect, mockTransaction, mockConsume } = vi.hoisted(() => {
+  const insert = vi.fn(() => makeDbChain());
+  const update = vi.fn(() => makeDbChain());
+  const txSelect = vi.fn(() => makeDbChain([]));
+  // The route does insert + streak read/compute/write inside a
+  // db.transaction(async (tx) => ...) — the tx object exposes the same
+  // insert/update/select surface, reusing the same mocks so existing test
+  // expectations (mockInsert/mockUpdate called, etc.) still hold.
+  const transaction = vi.fn(async (cb: (tx: unknown) => unknown) =>
+    cb({ insert, update, select: txSelect })
+  );
+  return {
+    mockInsert: insert,
+    mockUpdate: update,
+    mockTxSelect: txSelect,
+    mockTransaction: transaction,
+    mockConsume: vi.fn(async () => true),
+  };
+});
 
 vi.mock("@/lib/db", () => ({
   db: {
     insert: mockInsert,
     update: mockUpdate,
     select: vi.fn(() => makeDbChain([])),
+    transaction: mockTransaction,
   },
 }));
 vi.mock("@/lib/rate-limit", () => ({
@@ -86,6 +101,10 @@ function makeUser(overrides: Partial<User> = {}): User {
 
 function authedAs(user: User) {
   vi.mocked(requireUser).mockResolvedValue({ userId: user.id, user });
+  // The route re-reads the user row inside the transaction (row lock) instead
+  // of trusting the cached `authed.user` snapshot — keep the two in sync for
+  // tests that don't care about the staleness race itself.
+  mockTxSelect.mockReturnValue(makeDbChain([user]));
 }
 
 function makeReq(body: object, token = "valid-token") {
@@ -113,6 +132,8 @@ describe("POST /api/social/activity", () => {
     vi.mocked(requireUser).mockReset();
     mockInsert.mockReturnValue(makeDbChain());
     mockUpdate.mockReturnValue(makeDbChain());
+    mockTxSelect.mockReturnValue(makeDbChain([]));
+    mockTransaction.mockClear();
     mockConsume.mockReset();
     mockConsume.mockResolvedValue(true);
   });
@@ -209,6 +230,26 @@ describe("POST /api/social/activity", () => {
       const res = await POST(makeReq({ type }));
       expect(res.status).toBe(200);
     }
+  });
+
+  it("computes the streak from the freshly re-read (locked) user row, not the cached snapshot", async () => {
+    // authed.user (from requireUser, possibly a stale cache) says streak=3,
+    // but a concurrent request already bumped it to 9 in the DB — the fix
+    // must use the fresh row, not the stale cached one.
+    authedAs(makeUser({ currentStreak: 3, longestStreak: 3, lastActivityDate: yesterdayStr() }));
+    mockTxSelect.mockReturnValue(
+      makeDbChain([makeUser({ currentStreak: 9, longestStreak: 9, lastActivityDate: yesterdayStr() })])
+    );
+    const res = await POST(makeReq({ type: "verse_added" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.streak).toBe(10);
+  });
+
+  it("runs the insert and streak update inside a single transaction", async () => {
+    authedAs(makeUser({ currentStreak: 1, lastActivityDate: yesterdayStr() }));
+    await POST(makeReq({ type: "verse_added" }));
+    expect(mockTransaction).toHaveBeenCalledOnce();
   });
 });
 

--- a/__tests__/api/social/activity.test.ts
+++ b/__tests__/api/social/activity.test.ts
@@ -30,9 +30,10 @@ function makeDbChain(resolveWith: unknown = undefined) {
 }
 
 // Use vi.hoisted so mock fns are defined before vi.mock factories run
-const { mockInsert, mockUpdate } = vi.hoisted(() => ({
+const { mockInsert, mockUpdate, mockConsume } = vi.hoisted(() => ({
   mockInsert: vi.fn(() => makeDbChain()),
   mockUpdate: vi.fn(() => makeDbChain()),
+  mockConsume: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -41,6 +42,11 @@ vi.mock("@/lib/db", () => ({
     update: mockUpdate,
     select: vi.fn(() => makeDbChain([])),
   },
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  consume: mockConsume,
+  MUTATION_LIMIT: 60,
+  MUTATION_WINDOW_SECONDS: 600,
 }));
 
 import { POST, GET } from "@/app/api/social/activity/route";
@@ -107,6 +113,8 @@ describe("POST /api/social/activity", () => {
     vi.mocked(requireUser).mockReset();
     mockInsert.mockReturnValue(makeDbChain());
     mockUpdate.mockReturnValue(makeDbChain());
+    mockConsume.mockReset();
+    mockConsume.mockResolvedValue(true);
   });
 
   it("returns 401 when requireUser returns 401 response", async () => {
@@ -115,6 +123,13 @@ describe("POST /api/social/activity", () => {
     );
     const res = await POST(makeReq({ type: "verse_added" }));
     expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when the per-user activity rate limit is exceeded", async () => {
+    authedAs(makeUser());
+    mockConsume.mockResolvedValue(false);
+    const res = await POST(makeReq({ type: "verse_added" }));
+    expect(res.status).toBe(429);
   });
 
   it("returns 400 for missing activity type", async () => {

--- a/__tests__/api/social/activity.test.ts
+++ b/__tests__/api/social/activity.test.ts
@@ -30,7 +30,7 @@ function makeDbChain(resolveWith: unknown = undefined) {
 }
 
 // Use vi.hoisted so mock fns are defined before vi.mock factories run
-const { mockInsert, mockUpdate, mockTxSelect, mockTransaction, mockConsume } = vi.hoisted(() => {
+const { mockInsert, mockUpdate, mockTxSelect, mockTransaction, mockRateLimitOrNull } = vi.hoisted(() => {
   const insert = vi.fn(() => makeDbChain());
   const update = vi.fn(() => makeDbChain());
   const txSelect = vi.fn(() => makeDbChain([]));
@@ -46,7 +46,7 @@ const { mockInsert, mockUpdate, mockTxSelect, mockTransaction, mockConsume } = v
     mockUpdate: update,
     mockTxSelect: txSelect,
     mockTransaction: transaction,
-    mockConsume: vi.fn(async () => true),
+    mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
   };
 });
 
@@ -59,8 +59,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 vi.mock("@/lib/rate-limit", () => ({
-  consume: mockConsume,
-  MUTATION_LIMIT: 60,
+  rateLimitOrNull: mockRateLimitOrNull,
   MUTATION_WINDOW_SECONDS: 600,
 }));
 
@@ -134,8 +133,8 @@ describe("POST /api/social/activity", () => {
     mockUpdate.mockReturnValue(makeDbChain());
     mockTxSelect.mockReturnValue(makeDbChain([]));
     mockTransaction.mockClear();
-    mockConsume.mockReset();
-    mockConsume.mockResolvedValue(true);
+    mockRateLimitOrNull.mockReset();
+    mockRateLimitOrNull.mockResolvedValue(null);
   });
 
   it("returns 401 when requireUser returns 401 response", async () => {
@@ -148,7 +147,7 @@ describe("POST /api/social/activity", () => {
 
   it("returns 429 when the per-user activity rate limit is exceeded", async () => {
     authedAs(makeUser());
-    mockConsume.mockResolvedValue(false);
+    mockRateLimitOrNull.mockResolvedValue(NextResponse.json({ error: "Too many" }, { status: 429 }));
     const res = await POST(makeReq({ type: "verse_added" }));
     expect(res.status).toBe(429);
   });

--- a/__tests__/api/social/challenges.test.ts
+++ b/__tests__/api/social/challenges.test.ts
@@ -321,8 +321,10 @@ describe("GET /api/social/challenges", () => {
         { id: 1, username: "alice" },
         { id: 2, username: "bob" },
       ]));
-    // No further score queries expected — cached scores are reused in enrichment
-    mockUpdate.mockReturnValue(makeDbChain([]));
+    // No further score queries expected — cached scores are reused in enrichment.
+    // The guarded update must return the row (simulating no concurrent writer)
+    // for resolveEndedChallenges to populate its resolved-scores cache.
+    mockUpdate.mockReturnValue(makeDbChain([{ id: expired.id }]));
     const res = await GET(makeGetReq());
     expect(res.status).toBe(200);
     expect(mockUpdate).toHaveBeenCalled();

--- a/__tests__/api/social/challenges.test.ts
+++ b/__tests__/api/social/challenges.test.ts
@@ -217,6 +217,35 @@ describe("POST /api/social/challenges", () => {
     expect(body.error).toMatch(/already exists/i);
   });
 
+  it("returns 409 when a still-live pending challenge already exists", async () => {
+    authedAs(makeUser({ id: 1 }));
+    mockSelect
+      .mockReturnValueOnce(makeDbChain([{ id: 2, username: "bob" }]))
+      .mockReturnValueOnce(makeDbChain([{ id: 5, status: "accepted" }])) // friendship
+      // existing-challenge query: a pending invite whose endsAt is still in the
+      // future satisfies the route's `gte(challenges.endsAt, now)` guard, so the
+      // block query matches it (mirrors what the real WHERE clause would return).
+      .mockReturnValueOnce(makeDbChain([makeChallenge({ status: "pending" })]));
+    const res = await POST(makePostReq({ challengedUsername: "bob", duration: "24h" }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/already exists/i);
+  });
+
+  it("allows creating a new challenge when the only existing one is an expired pending invite", async () => {
+    authedAs(makeUser({ id: 1 }));
+    mockSelect
+      .mockReturnValueOnce(makeDbChain([{ id: 2, username: "bob" }]))
+      .mockReturnValueOnce(makeDbChain([{ id: 5, status: "accepted" }])) // friendship
+      // existing-challenge query: an expired pending invite fails the route's
+      // `gte(challenges.endsAt, now)` guard, so the real WHERE clause excludes
+      // it — represented here by the block query finding no match.
+      .mockReturnValueOnce(makeDbChain([]));
+    mockInsert.mockReturnValue(makeDbChain([makeChallenge({ status: "pending" })]));
+    const res = await POST(makePostReq({ challengedUsername: "bob", duration: "24h" }));
+    expect(res.status).toBe(201);
+  });
+
   it("returns 201 on success", async () => {
     authedAs(makeUser({ id: 1 }));
     mockSelect

--- a/__tests__/api/social/challenges.test.ts
+++ b/__tests__/api/social/challenges.test.ts
@@ -245,13 +245,15 @@ describe("GET /api/social/challenges", () => {
   });
 
   it("bounds the challenges query with orderBy + limit(200)", async () => {
-    // NOTE: the route issues the unbounded resolution select FIRST, then the capped
-    // display select. The recording chain is wired to that second select. If the
-    // route is reordered, update which Once() carries the recording chain.
+    // NOTE: the route issues the unbounded active-resolution select, then the
+    // unbounded pending-expiry select, then the capped display select. The
+    // recording chain is wired to that third select. If the route is
+    // reordered, update which Once() carries the recording chain.
     authedAs(makeUser({ id: 1 }));
     const calls: Record<string, unknown[][]> = {};
     mockSelect
       .mockReturnValueOnce(makeDbChain([]))                // resolution query (no ended-active)
+      .mockReturnValueOnce(makeDbChain([]))                // pending-expiry query (none expired)
       .mockReturnValueOnce(makeRecordingChain([], calls)); // capped display query
     const res = await GET(makeGetReq());
     expect(res.status).toBe(200);
@@ -271,6 +273,7 @@ describe("GET /api/social/challenges", () => {
     const challenge = makeChallenge({ status: "pending" });
     mockSelect
       .mockReturnValueOnce(makeDbChain([]))                     // resolution query (none ended-active)
+      .mockReturnValueOnce(makeDbChain([]))                     // pending-expiry query (none expired)
       .mockReturnValueOnce(makeDbChain([challenge]))            // capped display query
       .mockReturnValueOnce(makeDbChain([                        // users query
         { id: 1, username: "alice" },
@@ -295,6 +298,7 @@ describe("GET /api/social/challenges", () => {
       .mockReturnValueOnce(makeDbChain([expired]))             // resolution query (the ended-active row)
       .mockReturnValueOnce(makeDbChain([{ score: 3 }]))        // challengerScore (resolution)
       .mockReturnValueOnce(makeDbChain([{ score: 1 }]))        // challengedScore (resolution)
+      .mockReturnValueOnce(makeDbChain([]))                     // pending-expiry query (none expired)
       .mockReturnValueOnce(makeDbChain([                        // capped display query — re-reads the
         makeChallenge({ status: "completed", winnerId: 1 }),    // now-finalized row
       ]))
@@ -322,6 +326,7 @@ describe("GET /api/social/challenges", () => {
     });
     mockSelect
       .mockReturnValueOnce(makeDbChain([]))                     // resolution query (not ended → none)
+      .mockReturnValueOnce(makeDbChain([]))                     // pending-expiry query (none expired)
       .mockReturnValueOnce(makeDbChain([active]))               // capped display query
       .mockReturnValueOnce(makeDbChain([                        // users
         { id: 1, username: "alice" },
@@ -342,6 +347,7 @@ describe("GET /api/social/challenges", () => {
     const pending = makeChallenge({ status: "pending" });
     mockSelect
       .mockReturnValueOnce(makeDbChain([]))                     // resolution query (none ended-active)
+      .mockReturnValueOnce(makeDbChain([]))                     // pending-expiry query (none expired)
       .mockReturnValueOnce(makeDbChain([pending]))              // capped display query
       .mockReturnValueOnce(makeDbChain([                        // users
         { id: 1, username: "alice" },

--- a/__tests__/api/social/challenges.test.ts
+++ b/__tests__/api/social/challenges.test.ts
@@ -51,12 +51,12 @@ function makeRecordingChain(resolveWith: unknown, calls: Record<string, unknown[
   return chain;
 }
 
-const { mockSelect, mockInsert, mockUpdate, mockDelete, mockConsume } = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockUpdate, mockDelete, mockRateLimitOrNull } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])),
   mockInsert: vi.fn(() => makeDbChain([])),
   mockUpdate: vi.fn(() => makeDbChain([])),
   mockDelete: vi.fn(() => makeDbChain([])),
-  mockConsume: vi.fn(async () => true),
+  mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -68,9 +68,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 vi.mock("@/lib/rate-limit", () => ({
-  consume: mockConsume,
-  MUTATION_LIMIT: 60,
-  MUTATION_WINDOW_SECONDS: 600,
+  rateLimitOrNull: mockRateLimitOrNull,
 }));
 
 import { GET, POST } from "@/app/api/social/challenges/route";
@@ -145,8 +143,8 @@ describe("POST /api/social/challenges", () => {
     mockSelect.mockReturnValue(makeDbChain([]));
     mockInsert.mockReturnValue(makeDbChain([makeChallenge()]));
     mockDelete.mockReturnValue(makeDbChain([]));
-    mockConsume.mockReset();
-    mockConsume.mockResolvedValue(true);
+    mockRateLimitOrNull.mockReset();
+    mockRateLimitOrNull.mockResolvedValue(null);
   });
 
   it("returns 401 when unauthorized", async () => {
@@ -159,7 +157,7 @@ describe("POST /api/social/challenges", () => {
 
   it("returns 429 when the per-user challenge rate limit is exceeded", async () => {
     authedAs(makeUser());
-    mockConsume.mockResolvedValue(false);
+    mockRateLimitOrNull.mockResolvedValue(NextResponse.json({ error: "Too many" }, { status: 429 }));
     const res = await POST(makePostReq({ challengedUsername: "bob", duration: "24h" }));
     expect(res.status).toBe(429);
   });

--- a/__tests__/api/social/challenges.test.ts
+++ b/__tests__/api/social/challenges.test.ts
@@ -51,11 +51,12 @@ function makeRecordingChain(resolveWith: unknown, calls: Record<string, unknown[
   return chain;
 }
 
-const { mockSelect, mockInsert, mockUpdate, mockDelete } = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockUpdate, mockDelete, mockConsume } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])),
   mockInsert: vi.fn(() => makeDbChain([])),
   mockUpdate: vi.fn(() => makeDbChain([])),
   mockDelete: vi.fn(() => makeDbChain([])),
+  mockConsume: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -65,6 +66,11 @@ vi.mock("@/lib/db", () => ({
     update: mockUpdate,
     delete: mockDelete,
   },
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  consume: mockConsume,
+  MUTATION_LIMIT: 60,
+  MUTATION_WINDOW_SECONDS: 600,
 }));
 
 import { GET, POST } from "@/app/api/social/challenges/route";
@@ -139,6 +145,8 @@ describe("POST /api/social/challenges", () => {
     mockSelect.mockReturnValue(makeDbChain([]));
     mockInsert.mockReturnValue(makeDbChain([makeChallenge()]));
     mockDelete.mockReturnValue(makeDbChain([]));
+    mockConsume.mockReset();
+    mockConsume.mockResolvedValue(true);
   });
 
   it("returns 401 when unauthorized", async () => {
@@ -147,6 +155,13 @@ describe("POST /api/social/challenges", () => {
     );
     const res = await POST(makePostReq({ challengedUsername: "bob", duration: "24h" }));
     expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when the per-user challenge rate limit is exceeded", async () => {
+    authedAs(makeUser());
+    mockConsume.mockResolvedValue(false);
+    const res = await POST(makePostReq({ challengedUsername: "bob", duration: "24h" }));
+    expect(res.status).toBe(429);
   });
 
   it("returns 400 when challengedUsername is missing", async () => {

--- a/__tests__/api/social/friends.test.ts
+++ b/__tests__/api/social/friends.test.ts
@@ -27,10 +27,11 @@ function makeDbChain(resolveWith: unknown = []) {
   return chain;
 }
 
-const { mockSelect, mockInsert, mockUpdate } = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockUpdate, mockConsume } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])),
   mockInsert: vi.fn(() => makeDbChain([])),
   mockUpdate: vi.fn(() => makeDbChain([])),
+  mockConsume: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -39,6 +40,11 @@ vi.mock("@/lib/db", () => ({
     insert: mockInsert,
     update: mockUpdate,
   },
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  consume: mockConsume,
+  MUTATION_LIMIT: 60,
+  MUTATION_WINDOW_SECONDS: 600,
 }));
 
 import { GET, POST } from "@/app/api/social/friends/route";
@@ -118,6 +124,8 @@ describe("POST /api/social/friends", () => {
       makeDbChain([{ id: 10, status: "pending", requesterId: 1, addresseeId: 2 }])
     );
     mockUpdate.mockReturnValue(makeDbChain([]));
+    mockConsume.mockReset();
+    mockConsume.mockResolvedValue(true);
   });
 
   it("returns 401 when unauthorized", async () => {
@@ -126,6 +134,13 @@ describe("POST /api/social/friends", () => {
     );
     const res = await POST(makePostReq({ username: "friend99" }));
     expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when the per-user friend-request rate limit is exceeded", async () => {
+    authedAs(makeUser());
+    mockConsume.mockResolvedValue(false);
+    const res = await POST(makePostReq({ username: "friend99" }));
+    expect(res.status).toBe(429);
   });
 
   it("returns 400 when username is missing", async () => {

--- a/__tests__/api/social/friends.test.ts
+++ b/__tests__/api/social/friends.test.ts
@@ -27,11 +27,11 @@ function makeDbChain(resolveWith: unknown = []) {
   return chain;
 }
 
-const { mockSelect, mockInsert, mockUpdate, mockConsume } = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockUpdate, mockRateLimitOrNull } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])),
   mockInsert: vi.fn(() => makeDbChain([])),
   mockUpdate: vi.fn(() => makeDbChain([])),
-  mockConsume: vi.fn(async () => true),
+  mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -42,9 +42,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 vi.mock("@/lib/rate-limit", () => ({
-  consume: mockConsume,
-  MUTATION_LIMIT: 60,
-  MUTATION_WINDOW_SECONDS: 600,
+  rateLimitOrNull: mockRateLimitOrNull,
 }));
 
 import { GET, POST } from "@/app/api/social/friends/route";
@@ -124,8 +122,8 @@ describe("POST /api/social/friends", () => {
       makeDbChain([{ id: 10, status: "pending", requesterId: 1, addresseeId: 2 }])
     );
     mockUpdate.mockReturnValue(makeDbChain([]));
-    mockConsume.mockReset();
-    mockConsume.mockResolvedValue(true);
+    mockRateLimitOrNull.mockReset();
+    mockRateLimitOrNull.mockResolvedValue(null);
   });
 
   it("returns 401 when unauthorized", async () => {
@@ -138,7 +136,7 @@ describe("POST /api/social/friends", () => {
 
   it("returns 429 when the per-user friend-request rate limit is exceeded", async () => {
     authedAs(makeUser());
-    mockConsume.mockResolvedValue(false);
+    mockRateLimitOrNull.mockResolvedValue(NextResponse.json({ error: "Too many" }, { status: 429 }));
     const res = await POST(makePostReq({ username: "friend99" }));
     expect(res.status).toBe(429);
   });

--- a/__tests__/api/social/me.test.ts
+++ b/__tests__/api/social/me.test.ts
@@ -215,4 +215,27 @@ describe("PATCH /api/social/me", () => {
       expect(res.status).toBe(200);
     }
   });
+
+  it("returns 409 (not 500) when a concurrent PATCH wins the username race", async () => {
+    authedAs(makeUser({ id: 1 }));
+    // The collision pre-check passes (no row found yet)...
+    mockSelect.mockReturnValue(makeDbChain([]));
+    // ...but the UPDATE itself hits the DB's unique constraint because another
+    // request grabbed the same username in between.
+    mockUpdate.mockReturnValue(
+      makeDbChain(Promise.reject(Object.assign(new Error("duplicate key"), { code: "23505" })))
+    );
+    const res = await PATCH(makePatchReq({ username: "racedname" }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/already taken/i);
+  });
+
+  it("returns 500 on an unrelated db error during update", async () => {
+    authedAs(makeUser({ id: 1 }));
+    mockSelect.mockReturnValue(makeDbChain([]));
+    mockUpdate.mockReturnValue(makeDbChain(Promise.reject(new Error("connection lost"))));
+    const res = await PATCH(makePatchReq({ username: "anyname" }));
+    expect(res.status).toBe(500);
+  });
 });

--- a/__tests__/api/social/me.test.ts
+++ b/__tests__/api/social/me.test.ts
@@ -238,4 +238,16 @@ describe("PATCH /api/social/me", () => {
     const res = await PATCH(makePatchReq({ username: "anyname" }));
     expect(res.status).toBe(500);
   });
+
+  it("returns 409 when the unique-violation code is nested under err.cause (driver-wrapped)", async () => {
+    authedAs(makeUser({ id: 1 }));
+    mockSelect.mockReturnValue(makeDbChain([]));
+    const wrapped = new Error("duplicate key");
+    (wrapped as Error & { cause?: unknown }).cause = { code: "23505" };
+    mockUpdate.mockReturnValue(makeDbChain(Promise.reject(wrapped)));
+    const res = await PATCH(makePatchReq({ username: "racedname2" }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/already taken/i);
+  });
 });

--- a/__tests__/api/workspace.test.ts
+++ b/__tests__/api/workspace.test.ts
@@ -50,11 +50,11 @@ function makeRecordingChain(resolveWith: unknown, calls: Record<string, unknown[
   return chain;
 }
 
-const { mockSelect, mockInsert, mockDelete, mockConsume } = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockDelete, mockRateLimitOrNull } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])),
   mockInsert: vi.fn(() => makeDbChain([])),
   mockDelete: vi.fn(() => makeDbChain([])),
-  mockConsume: vi.fn(async () => true),
+  mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -65,9 +65,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 vi.mock("@/lib/rate-limit", () => ({
-  consume: mockConsume,
-  MUTATION_LIMIT: 60,
-  MUTATION_WINDOW_SECONDS: 600,
+  rateLimitOrNull: mockRateLimitOrNull,
 }));
 
 import { GET, POST } from "@/app/api/workspace/route";
@@ -162,8 +160,8 @@ describe("POST /api/workspace", () => {
     vi.mocked(requireUser).mockReset();
     mockInsert.mockReset();
     mockInsert.mockReturnValue(makeDbChain([{ id: 1, name: "Untitled canvas", createdAt: new Date() }]));
-    mockConsume.mockReset();
-    mockConsume.mockResolvedValue(true);
+    mockRateLimitOrNull.mockReset();
+    mockRateLimitOrNull.mockResolvedValue(null);
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -174,7 +172,7 @@ describe("POST /api/workspace", () => {
 
   it("returns 429 when the per-user canvas-save rate limit is exceeded", async () => {
     authed();
-    mockConsume.mockResolvedValue(false);
+    mockRateLimitOrNull.mockResolvedValue(NextResponse.json({ error: "Too many" }, { status: 429 }));
     const res = await POST(req("POST", { data: { nodes: [] } }));
     expect(res.status).toBe(429);
   });

--- a/__tests__/api/workspace.test.ts
+++ b/__tests__/api/workspace.test.ts
@@ -50,10 +50,11 @@ function makeRecordingChain(resolveWith: unknown, calls: Record<string, unknown[
   return chain;
 }
 
-const { mockSelect, mockInsert, mockDelete } = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockDelete, mockConsume } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])),
   mockInsert: vi.fn(() => makeDbChain([])),
   mockDelete: vi.fn(() => makeDbChain([])),
+  mockConsume: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -62,6 +63,11 @@ vi.mock("@/lib/db", () => ({
     insert: mockInsert,
     delete: mockDelete,
   },
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  consume: mockConsume,
+  MUTATION_LIMIT: 60,
+  MUTATION_WINDOW_SECONDS: 600,
 }));
 
 import { GET, POST } from "@/app/api/workspace/route";
@@ -156,12 +162,21 @@ describe("POST /api/workspace", () => {
     vi.mocked(requireUser).mockReset();
     mockInsert.mockReset();
     mockInsert.mockReturnValue(makeDbChain([{ id: 1, name: "Untitled canvas", createdAt: new Date() }]));
+    mockConsume.mockReset();
+    mockConsume.mockResolvedValue(true);
   });
 
   it("returns 401 when not authenticated", async () => {
     unauthed();
     const res = await POST(req("POST", { data: { nodes: [] } }));
     expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when the per-user canvas-save rate limit is exceeded", async () => {
+    authed();
+    mockConsume.mockResolvedValue(false);
+    const res = await POST(req("POST", { data: { nodes: [] } }));
+    expect(res.status).toBe(429);
   });
 
   it("returns 400 for malformed JSON body", async () => {

--- a/__tests__/lib/challenges.test.ts
+++ b/__tests__/lib/challenges.test.ts
@@ -69,7 +69,8 @@ describe("resolveEndedChallenges", () => {
     mockSelect.mockReset();
     mockUpdate.mockReset();
     mockSelect.mockReturnValue(makeDbChain([{ score: 0 }]));
-    mockUpdate.mockReturnValue(makeDbChain([]));
+    // Default: the guarded update matches (simulates no concurrent writer).
+    mockUpdate.mockReturnValue(makeDbChain([{ id: 0 }]));
   });
 
   it("finalizes an ended active challenge, sets winner, and mutates the row", async () => {
@@ -98,12 +99,24 @@ describe("resolveEndedChallenges", () => {
     expect(mockUpdate).not.toHaveBeenCalled();
     expect(resolved.size).toBe(0);
   });
+
+  it("does not mutate the row or count it when a concurrent writer already changed its status (lost race)", async () => {
+    // The guarded UPDATE (WHERE id AND status='active') matches nothing
+    // because another writer (admin "end", or a second resolver call) already
+    // transitioned this row first.
+    mockUpdate.mockReturnValue(makeDbChain([]));
+    const rows = [makeChallenge({ id: 13 })];
+    const resolved = await resolveEndedChallenges(rows, new Date());
+    expect(rows[0].status).toBe("active"); // left untouched, not clobbered
+    expect(resolved.size).toBe(0);
+  });
 });
 
 describe("resolveExpiredPending", () => {
   beforeEach(() => {
     mockUpdate.mockReset();
-    mockUpdate.mockReturnValue(makeDbChain([]));
+    // Default: the guarded update matches (simulates no concurrent writer).
+    mockUpdate.mockReturnValue(makeDbChain([{ id: 0 }]));
   });
 
   it("declines a pending invite past its endsAt", async () => {
@@ -126,6 +139,17 @@ describe("resolveExpiredPending", () => {
     const rows = [makeChallenge({ id: 12, status: "active", endsAt: new Date(Date.now() - 1000) })];
     const count = await resolveExpiredPending(rows, new Date());
     expect(mockUpdate).not.toHaveBeenCalled();
+    expect(count).toBe(0);
+  });
+
+  it("does not mutate the row or count it when the pair already accepted/declined/cancelled it (lost race)", async () => {
+    // The guarded UPDATE (WHERE id AND status='pending') matches nothing
+    // because the pair actioned this invite via the (already-guarded) PATCH
+    // route in the window between the caller's SELECT and this UPDATE.
+    mockUpdate.mockReturnValue(makeDbChain([]));
+    const rows = [makeChallenge({ id: 14, status: "pending", endsAt: new Date(Date.now() - 1000) })];
+    const count = await resolveExpiredPending(rows, new Date());
+    expect(rows[0].status).toBe("pending"); // left untouched, not clobbered
     expect(count).toBe(0);
   });
 });

--- a/__tests__/lib/challenges.test.ts
+++ b/__tests__/lib/challenges.test.ts
@@ -21,7 +21,7 @@ const { mockSelect, mockUpdate } = vi.hoisted(() => ({
 }));
 vi.mock("@/lib/db", () => ({ db: { select: mockSelect, update: mockUpdate } }));
 
-import { pickWinner, resolveEndedChallenges, isDuration, DURATIONS } from "@/lib/challenges";
+import { pickWinner, resolveEndedChallenges, resolveExpiredPending, isDuration, DURATIONS } from "@/lib/challenges";
 
 function makeChallenge(overrides: Partial<Challenge> = {}): Challenge {
   return {
@@ -97,5 +97,35 @@ describe("resolveEndedChallenges", () => {
     const resolved = await resolveEndedChallenges(rows, new Date());
     expect(mockUpdate).not.toHaveBeenCalled();
     expect(resolved.size).toBe(0);
+  });
+});
+
+describe("resolveExpiredPending", () => {
+  beforeEach(() => {
+    mockUpdate.mockReset();
+    mockUpdate.mockReturnValue(makeDbChain([]));
+  });
+
+  it("declines a pending invite past its endsAt", async () => {
+    const rows = [makeChallenge({ id: 10, status: "pending", endsAt: new Date(Date.now() - 1000) })];
+    const count = await resolveExpiredPending(rows, new Date());
+    expect(mockUpdate).toHaveBeenCalledOnce();
+    expect(rows[0].status).toBe("declined");
+    expect(count).toBe(1);
+  });
+
+  it("ignores pending invites that have not expired", async () => {
+    const rows = [makeChallenge({ id: 11, status: "pending", endsAt: new Date(Date.now() + 3_600_000) })];
+    const count = await resolveExpiredPending(rows, new Date());
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(rows[0].status).toBe("pending");
+    expect(count).toBe(0);
+  });
+
+  it("ignores non-pending challenges even past their endsAt", async () => {
+    const rows = [makeChallenge({ id: 12, status: "active", endsAt: new Date(Date.now() - 1000) })];
+    const count = await resolveExpiredPending(rows, new Date());
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(count).toBe(0);
   });
 });

--- a/__tests__/lib/http.test.ts
+++ b/__tests__/lib/http.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { clientKey } from "@/lib/http";
+
+function reqWithHeaders(headers: Record<string, string>): Request {
+  return new Request("https://example.com", { headers });
+}
+
+describe("clientKey", () => {
+  it("trusts x-real-ip over x-forwarded-for, since nginx always overwrites x-real-ip", () => {
+    const req = reqWithHeaders({
+      "x-real-ip": "203.0.113.9",
+      "x-forwarded-for": "1.2.3.4",
+    });
+    expect(clientKey(req)).toBe("203.0.113.9");
+  });
+
+  it("uses the last x-forwarded-for entry, not the client-controlled first one", () => {
+    // A spoofing client can prepend arbitrary values; nginx appends the real
+    // peer address last via $proxy_add_x_forwarded_for.
+    const req = reqWithHeaders({
+      "x-forwarded-for": "1.2.3.4, 203.0.113.9",
+    });
+    expect(clientKey(req)).toBe("203.0.113.9");
+  });
+
+  it("falls back to unknown when no valid IP is present", () => {
+    const req = reqWithHeaders({});
+    expect(clientKey(req)).toBe("unknown");
+  });
+
+  it("rejects malformed IP values", () => {
+    const req = reqWithHeaders({ "x-real-ip": "'; DROP TABLE users;--" });
+    expect(clientKey(req)).toBe("unknown");
+  });
+
+  it("does not let a client mint a fresh bucket per request via a spoofed x-forwarded-for prefix", () => {
+    const req1 = reqWithHeaders({ "x-forwarded-for": "9.9.9.1, 203.0.113.9" });
+    const req2 = reqWithHeaders({ "x-forwarded-for": "9.9.9.2, 203.0.113.9" });
+    expect(clientKey(req1)).toBe(clientKey(req2));
+  });
+});

--- a/__tests__/lib/quran-corpus.test.ts
+++ b/__tests__/lib/quran-corpus.test.ts
@@ -50,6 +50,13 @@ describe("quran-corpus", () => {
       expect(isValidRef("abc")).toBe(false);
       expect(isValidRef("2:255:3")).toBe(false);
     });
+    it("accepts the longest surah's last ayah but rejects past it", () => {
+      expect(isValidRef("2:286")).toBe(true); // Al-Baqarah, longest surah
+      expect(isValidRef("2:287")).toBe(false);
+    });
+    it("rejects an absurdly large ayah number regardless of surah", () => {
+      expect(isValidRef("114:99999")).toBe(false); // An-Nas has only 6 ayahs
+    });
   });
 
   describe("getVerse", () => {

--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/db", () => ({ db: { insert: mockInsert, delete: mockDelete } }));
 vi.mock("@/lib/redis", () => ({ redisIncrWithTtl: mockRedisIncr }));
 vi.mock("@/lib/metrics", () => ({ incr: mockIncr }));
 
-import { consume, sweepRateLimits, RateLimitError, positiveIntEnv } from "@/lib/rate-limit";
+import { consume, rateLimitOrNull, sweepRateLimits, RateLimitError, positiveIntEnv } from "@/lib/rate-limit";
 
 describe("rate-limit consume", () => {
   beforeEach(() => {
@@ -93,6 +93,27 @@ describe("rate-limit consume", () => {
     await consume("ip:1", 20, 60);
     expect(mockIncr).toHaveBeenCalledWith("ratelimit_redis_fallback");
     expect(mockIncr).toHaveBeenCalledWith("ratelimit_allow");
+  });
+});
+
+describe("rateLimitOrNull", () => {
+  beforeEach(() => {
+    mockReturning.mockReset();
+    mockRedisIncr.mockReset();
+  });
+
+  it("returns null (allowed) when under the limit", async () => {
+    mockRedisIncr.mockResolvedValue(5);
+    expect(await rateLimitOrNull("ip:1", "Too many", 20, 60)).toBeNull();
+  });
+
+  it("returns a 429 NextResponse with the given message when over the limit", async () => {
+    mockRedisIncr.mockResolvedValue(21);
+    const res = await rateLimitOrNull("ip:1", "Too many widgets", 20, 60);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(429);
+    const body = await res!.json();
+    expect(body.error).toBe("Too many widgets");
   });
 });
 

--- a/app/admin/error.tsx
+++ b/app/admin/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+// Scoped to the admin segment: AdminShell chrome (from layout.tsx) stays
+// mounted, only this page's content area is replaced. Next 16 passes
+// `unstable_retry`, not `reset`.
+export default function AdminError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} homeHref="/admin" homeLabel="Admin home" />;
+}

--- a/app/admin/loading.tsx
+++ b/app/admin/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/api/admin/ai/route.ts
+++ b/app/api/admin/ai/route.ts
@@ -13,66 +13,71 @@ export async function GET(req: NextRequest) {
   const auth = await requireAdmin(req);
   if (auth instanceof NextResponse) return auth;
 
-  const now = new Date();
-  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
-  const since30 = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  try {
+    const now = new Date();
+    const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+    const since30 = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
-  const [totals, monthTotals, byModel, byKind, daily] = await Promise.all([
-    db
-      .select({
-        gens: sql<number>`count(*)::int`,
-        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
-      })
-      .from(aiGenerations),
-    db
-      .select({
-        gens: sql<number>`count(*)::int`,
-        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
-      })
-      .from(aiGenerations)
-      .where(gte(aiGenerations.createdAt, monthStart)),
-    db
-      .select({
-        model: sql<string>`coalesce(${aiGenerations.model}, 'unknown')`,
-        gens: sql<number>`count(*)::int`,
-        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
-      })
-      .from(aiGenerations)
-      .groupBy(sql`coalesce(${aiGenerations.model}, 'unknown')`),
-    db
-      .select({
-        kind: aiGenerations.kind,
-        gens: sql<number>`count(*)::int`,
-        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
-      })
-      .from(aiGenerations)
-      .groupBy(aiGenerations.kind),
-    db
-      .select({
-        day: sql<string>`to_char(${aiGenerations.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`,
-        gens: sql<number>`count(*)::int`,
-        tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
-      })
-      .from(aiGenerations)
-      .where(gte(aiGenerations.createdAt, since30))
-      .groupBy(sql`to_char(${aiGenerations.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`)
-      .orderBy(sql`to_char(${aiGenerations.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`),
-  ]);
+    const [totals, monthTotals, byModel, byKind, daily] = await Promise.all([
+      db
+        .select({
+          gens: sql<number>`count(*)::int`,
+          tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
+        })
+        .from(aiGenerations),
+      db
+        .select({
+          gens: sql<number>`count(*)::int`,
+          tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
+        })
+        .from(aiGenerations)
+        .where(gte(aiGenerations.createdAt, monthStart)),
+      db
+        .select({
+          model: sql<string>`coalesce(${aiGenerations.model}, 'unknown')`,
+          gens: sql<number>`count(*)::int`,
+          tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
+        })
+        .from(aiGenerations)
+        .groupBy(sql`coalesce(${aiGenerations.model}, 'unknown')`),
+      db
+        .select({
+          kind: aiGenerations.kind,
+          gens: sql<number>`count(*)::int`,
+          tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
+        })
+        .from(aiGenerations)
+        .groupBy(aiGenerations.kind),
+      db
+        .select({
+          day: sql<string>`to_char(${aiGenerations.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`,
+          gens: sql<number>`count(*)::int`,
+          tokens: sql<number>`coalesce(sum(${aiGenerations.tokens}),0)::int`,
+        })
+        .from(aiGenerations)
+        .where(gte(aiGenerations.createdAt, since30))
+        .groupBy(sql`to_char(${aiGenerations.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`)
+        .orderBy(sql`to_char(${aiGenerations.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`),
+    ]);
 
-  // Preserve a configured 0 (free tier) as a real price; only a missing/invalid
-  // value is treated as "unset" (null) — the UI keys on `=== null` to decide.
-  const rawPrice = process.env.AI_USD_PER_1K_TOKENS;
-  const parsed = rawPrice == null || rawPrice.trim() === "" ? NaN : Number(rawPrice);
-  const pricePer1k = Number.isFinite(parsed) ? parsed : null;
-  const estCost = (tokens: number) =>
-    pricePer1k !== null ? Number(((tokens / 1000) * pricePer1k).toFixed(2)) : null;
+    // Preserve a configured 0 (free tier) as a real price; only a missing/invalid
+    // value is treated as "unset" (null) — the UI keys on `=== null` to decide.
+    const rawPrice = process.env.AI_USD_PER_1K_TOKENS;
+    const parsed = rawPrice == null || rawPrice.trim() === "" ? NaN : Number(rawPrice);
+    const pricePer1k = Number.isFinite(parsed) ? parsed : null;
+    const estCost = (tokens: number) =>
+      pricePer1k !== null ? Number(((tokens / 1000) * pricePer1k).toFixed(2)) : null;
 
-  return NextResponse.json({
-    total: { ...totals[0], estCostUsd: estCost(totals[0]?.tokens ?? 0) },
-    monthToDate: { ...monthTotals[0], estCostUsd: estCost(monthTotals[0]?.tokens ?? 0) },
-    byModel,
-    byKind,
-    daily,
-    pricePer1k,
-  });
+    return NextResponse.json({
+      total: { ...totals[0], estCostUsd: estCost(totals[0]?.tokens ?? 0) },
+      monthToDate: { ...monthTotals[0], estCostUsd: estCost(monthTotals[0]?.tokens ?? 0) },
+      byModel,
+      byKind,
+      daily,
+      pricePer1k,
+    });
+  } catch (err) {
+    console.error("admin ai GET db error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
 }

--- a/app/api/admin/challenges/[id]/route.ts
+++ b/app/api/admin/challenges/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { requireAdmin } from "@/lib/admin-auth";
 import { logAdminAction } from "@/lib/admin-audit";
 import { db } from "@/lib/db";
@@ -47,13 +47,16 @@ export async function PATCH(
       scoreChallenge(challenge.challengedId, ended),
     ]);
     const winnerId = pickWinner(challenge, challengerScore, challengedScore);
+    // Scope the WHERE to the state we just checked, so a concurrent "end" (or
+    // the lazy expiry resolver) that already completed this challenge loses
+    // the race cleanly instead of silently clobbering the other write.
     const [updated] = await db
       .update(challenges)
       .set({ status: "completed", winnerId, endsAt: now })
-      .where(eq(challenges.id, challengeId))
+      .where(and(eq(challenges.id, challengeId), eq(challenges.status, "active")))
       .returning();
     if (!updated) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
+      return NextResponse.json({ error: "Challenge was already ended by a concurrent request" }, { status: 409 });
     }
     await logAdminAction({
       adminQfId: auth.user.qfId,

--- a/app/api/admin/challenges/finalize/route.ts
+++ b/app/api/admin/challenges/finalize/route.ts
@@ -15,23 +15,28 @@ export async function POST(req: NextRequest) {
   const auth = await requireAdmin(req);
   if (auth instanceof NextResponse) return auth;
 
-  const now = new Date();
-  const ended = await db
-    .select()
-    .from(challenges)
-    .where(and(eq(challenges.status, "active"), lt(challenges.endsAt, now)));
+  try {
+    const now = new Date();
+    const ended = await db
+      .select()
+      .from(challenges)
+      .where(and(eq(challenges.status, "active"), lt(challenges.endsAt, now)));
 
-  const resolved = await resolveEndedChallenges(ended, now);
-  const count = resolved.size;
+    const resolved = await resolveEndedChallenges(ended, now);
+    const count = resolved.size;
 
-  if (count > 0) {
-    await logAdminAction({
-      adminQfId: auth.user.qfId,
-      action: "challenge.finalize",
-      targetType: "challenge",
-      meta: { resolved: count },
-    });
+    if (count > 0) {
+      await logAdminAction({
+        adminQfId: auth.user.qfId,
+        action: "challenge.finalize",
+        targetType: "challenge",
+        meta: { resolved: count },
+      });
+    }
+
+    return NextResponse.json({ resolved: count });
+  } catch (err) {
+    console.error("admin challenges finalize POST db error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-
-  return NextResponse.json({ resolved: count });
 }

--- a/app/api/admin/challenges/finalize/route.ts
+++ b/app/api/admin/challenges/finalize/route.ts
@@ -4,12 +4,13 @@ import { requireAdmin } from "@/lib/admin-auth";
 import { logAdminAction } from "@/lib/admin-audit";
 import { db } from "@/lib/db";
 import { challenges } from "@/lib/db/schema";
-import { resolveEndedChallenges } from "@/lib/challenges";
+import { resolveEndedChallenges, resolveExpiredPending } from "@/lib/challenges";
 
 /**
  * Finalize every `active` challenge whose window has ended (compute scores, set
- * winners, mark completed). This is the manual fix for the lazy-only expiry gap —
- * without it, an ended challenge nobody loads stays `active` indefinitely.
+ * winners, mark completed), and every `pending` invite nobody acted on. This is
+ * the manual fix for the lazy-only expiry gap — without it, an ended/ignored
+ * challenge nobody loads stays `active`/`pending` indefinitely.
  */
 export async function POST(req: NextRequest) {
   const auth = await requireAdmin(req);
@@ -21,16 +22,22 @@ export async function POST(req: NextRequest) {
       .select()
       .from(challenges)
       .where(and(eq(challenges.status, "active"), lt(challenges.endsAt, now)));
-
     const resolved = await resolveEndedChallenges(ended, now);
-    const count = resolved.size;
+
+    const expiredPending = await db
+      .select()
+      .from(challenges)
+      .where(and(eq(challenges.status, "pending"), lt(challenges.endsAt, now)));
+    const expiredPendingCount = await resolveExpiredPending(expiredPending, now);
+
+    const count = resolved.size + expiredPendingCount;
 
     if (count > 0) {
       await logAdminAction({
         adminQfId: auth.user.qfId,
         action: "challenge.finalize",
         targetType: "challenge",
-        meta: { resolved: count },
+        meta: { resolvedActive: resolved.size, expiredPending: expiredPendingCount },
       });
     }
 

--- a/app/api/admin/challenges/route.ts
+++ b/app/api/admin/challenges/route.ts
@@ -24,69 +24,74 @@ export async function GET(req: NextRequest) {
   const limitParam = Number(sp.get("limit"));
   const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 50;
 
-  // Finalize any ended active challenges FIRST, so both the stats aggregation and
-  // the returned list reflect the same (post-finalization) state.
-  const now = new Date();
-  const ended = await db
-    .select()
-    .from(challenges)
-    .where(and(eq(challenges.status, "active"), lt(challenges.endsAt, now)));
-  await resolveEndedChallenges(ended, now);
+  try {
+    // Finalize any ended active challenges FIRST, so both the stats aggregation and
+    // the returned list reflect the same (post-finalization) state.
+    const now = new Date();
+    const ended = await db
+      .select()
+      .from(challenges)
+      .where(and(eq(challenges.status, "active"), lt(challenges.endsAt, now)));
+    await resolveEndedChallenges(ended, now);
 
-  // Stats: counts per status + suggestion-attributed total.
-  const statusCounts = await db
-    .select({ status: challenges.status, n: sql<number>`count(*)::int` })
-    .from(challenges)
-    .groupBy(challenges.status);
-  const [{ fromSuggestions }] = await db
-    .select({ fromSuggestions: sql<number>`count(*)::int` })
-    .from(challenges)
-    .where(sql`${challenges.suggestionId} is not null`);
+    // Stats: counts per status + suggestion-attributed total.
+    const statusCounts = await db
+      .select({ status: challenges.status, n: sql<number>`count(*)::int` })
+      .from(challenges)
+      .groupBy(challenges.status);
+    const [{ fromSuggestions }] = await db
+      .select({ fromSuggestions: sql<number>`count(*)::int` })
+      .from(challenges)
+      .where(sql`${challenges.suggestionId} is not null`);
 
-  const stats = {
-    byStatus: Object.fromEntries(STATUSES.map((s) => [s, 0])) as Record<string, number>,
-    total: 0,
-    fromSuggestions,
-  };
-  for (const r of statusCounts) {
-    stats.byStatus[r.status] = r.n;
-    stats.total += r.n;
+    const stats = {
+      byStatus: Object.fromEntries(STATUSES.map((s) => [s, 0])) as Record<string, number>,
+      total: 0,
+      fromSuggestions,
+    };
+    for (const r of statusCounts) {
+      stats.byStatus[r.status] = r.n;
+      stats.total += r.n;
+    }
+
+    // List (filtered, newest first), finalize any ended ones, then enrich.
+    const rows = await db
+      .select()
+      .from(challenges)
+      .where(status ? eq(challenges.status, status) : undefined)
+      .orderBy(desc(challenges.createdAt))
+      .limit(limit);
+
+    const resolved = await resolveEndedChallenges(rows);
+
+    const userIds = [...new Set(rows.flatMap((c) => [c.challengerId, c.challengedId]))];
+    const userRows = userIds.length
+      ? await db.select({ id: users.id, username: users.username }).from(users).where(inArray(users.id, userIds))
+      : [];
+    const userMap = new Map(userRows.map((u) => [u.id, u.username]));
+
+    const list = await Promise.all(
+      rows.map(async (c) => {
+        const needsScores = c.status === "active" || c.status === "completed";
+        const cached = resolved.get(c.id);
+        const [challengerScore, challengedScore] = cached
+          ? [cached.challengerScore, cached.challengedScore]
+          : needsScores
+            ? await Promise.all([scoreChallenge(c.challengerId, c), scoreChallenge(c.challengedId, c)])
+            : [0, 0];
+        return {
+          ...c,
+          challengerUsername: userMap.get(c.challengerId) ?? null,
+          challengedUsername: userMap.get(c.challengedId) ?? null,
+          challengerScore,
+          challengedScore,
+        };
+      })
+    );
+
+    return NextResponse.json({ stats, challenges: list });
+  } catch (err) {
+    console.error("admin challenges GET db error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-
-  // List (filtered, newest first), finalize any ended ones, then enrich.
-  const rows = await db
-    .select()
-    .from(challenges)
-    .where(status ? eq(challenges.status, status) : undefined)
-    .orderBy(desc(challenges.createdAt))
-    .limit(limit);
-
-  const resolved = await resolveEndedChallenges(rows);
-
-  const userIds = [...new Set(rows.flatMap((c) => [c.challengerId, c.challengedId]))];
-  const userRows = userIds.length
-    ? await db.select({ id: users.id, username: users.username }).from(users).where(inArray(users.id, userIds))
-    : [];
-  const userMap = new Map(userRows.map((u) => [u.id, u.username]));
-
-  const list = await Promise.all(
-    rows.map(async (c) => {
-      const needsScores = c.status === "active" || c.status === "completed";
-      const cached = resolved.get(c.id);
-      const [challengerScore, challengedScore] = cached
-        ? [cached.challengerScore, cached.challengedScore]
-        : needsScores
-          ? await Promise.all([scoreChallenge(c.challengerId, c), scoreChallenge(c.challengedId, c)])
-          : [0, 0];
-      return {
-        ...c,
-        challengerUsername: userMap.get(c.challengerId) ?? null,
-        challengedUsername: userMap.get(c.challengedId) ?? null,
-        challengerScore,
-        challengedScore,
-      };
-    })
-  );
-
-  return NextResponse.json({ stats, challenges: list });
 }

--- a/app/api/admin/challenges/route.ts
+++ b/app/api/admin/challenges/route.ts
@@ -3,7 +3,7 @@ import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
 import { requireAdmin } from "@/lib/admin-auth";
 import { db } from "@/lib/db";
 import { challenges, users } from "@/lib/db/schema";
-import { scoreChallenge, resolveEndedChallenges } from "@/lib/challenges";
+import { scoreChallenge, resolveEndedChallenges, resolveExpiredPending } from "@/lib/challenges";
 
 const STATUSES = ["pending", "active", "completed", "declined", "cancelled"] as const;
 
@@ -33,6 +33,13 @@ export async function GET(req: NextRequest) {
       .from(challenges)
       .where(and(eq(challenges.status, "active"), lt(challenges.endsAt, now)));
     await resolveEndedChallenges(ended, now);
+
+    // Same self-heal for `pending` invites nobody acted on.
+    const expiredPending = await db
+      .select()
+      .from(challenges)
+      .where(and(eq(challenges.status, "pending"), lt(challenges.endsAt, now)));
+    await resolveExpiredPending(expiredPending, now);
 
     // Stats: counts per status + suggestion-attributed total.
     const statusCounts = await db

--- a/app/api/notes/[id]/route.ts
+++ b/app/api/notes/[id]/route.ts
@@ -17,14 +17,19 @@ export async function DELETE(
     return NextResponse.json({ error: "Invalid id" }, { status: 400 });
   }
 
-  const deleted = await db
-    .delete(verseNotes)
-    .where(and(eq(verseNotes.id, noteId), eq(verseNotes.userId, authed.userId)))
-    .returning();
+  try {
+    const deleted = await db
+      .delete(verseNotes)
+      .where(and(eq(verseNotes.id, noteId), eq(verseNotes.userId, authed.userId)))
+      .returning();
 
-  if (deleted.length === 0) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    if (deleted.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (err) {
+    console.error("notes DELETE db error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-
-  return new NextResponse(null, { status: 204 });
 }

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -5,6 +5,7 @@ import { verseNotes } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
 import { isValidRef } from "@/lib/quran-corpus";
 import { jsonError, parseJson } from "@/lib/http";
+import { consume, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
@@ -31,6 +32,11 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
+
+  const allowed = await consume(`notes:${authed.userId}`, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS);
+  if (!allowed) {
+    return jsonError("Too many notes created — try again later", 429);
+  }
 
   const body = await parseJson<{ ref?: string; note?: string }>(req);
   if (!body) return jsonError("Invalid request body", 400);

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -5,7 +5,7 @@ import { verseNotes } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
 import { isValidRef } from "@/lib/quran-corpus";
 import { jsonError, parseJson } from "@/lib/http";
-import { consume, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
+import { rateLimitOrNull } from "@/lib/rate-limit";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
@@ -33,10 +33,8 @@ export async function POST(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
 
-  const allowed = await consume(`notes:${authed.userId}`, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS);
-  if (!allowed) {
-    return jsonError("Too many notes created — try again later", 429);
-  }
+  const limited = await rateLimitOrNull(`notes:${authed.userId}`, "Too many notes created — try again later");
+  if (limited) return limited;
 
   const body = await parseJson<{ ref?: string; note?: string }>(req);
   if (!body) return jsonError("Invalid request body", 400);

--- a/app/api/share/[id]/route.ts
+++ b/app/api/share/[id]/route.ts
@@ -13,15 +13,24 @@ export async function GET(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  const rows = await db
-    .select()
-    .from(sharedCanvases)
-    .where(eq(sharedCanvases.id, id))
-    .limit(1);
+  try {
+    const rows = await db
+      .select()
+      .from(sharedCanvases)
+      .where(eq(sharedCanvases.id, id))
+      .limit(1);
 
-  if (rows.length === 0) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    try {
+      return NextResponse.json(JSON.parse(rows[0].data));
+    } catch {
+      return NextResponse.json({ error: "Corrupted canvas data" }, { status: 500 });
+    }
+  } catch (err) {
+    console.error("share GET db error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-
-  return NextResponse.json(JSON.parse(rows[0].data));
 }

--- a/app/api/share/[id]/route.ts
+++ b/app/api/share/[id]/route.ts
@@ -26,7 +26,8 @@ export async function GET(
 
     try {
       return NextResponse.json(JSON.parse(rows[0].data));
-    } catch {
+    } catch (err) {
+      console.error("share GET parse error:", err);
       return NextResponse.json({ error: "Corrupted canvas data" }, { status: 500 });
     }
   } catch (err) {

--- a/app/api/social/activity/route.ts
+++ b/app/api/social/activity/route.ts
@@ -37,55 +37,60 @@ export async function POST(req: NextRequest) {
   const today = todayUTC();
   const yesterday = yesterdayUTC();
 
-  // Insert the activity event
-  await db.insert(activityLog).values({
-    userId,
-    activityType: body.type,
-    verseRef: body.verse_ref ?? null,
-    activityDate: today,
-  });
+  try {
+    // Insert the activity event
+    await db.insert(activityLog).values({
+      userId,
+      activityType: body.type,
+      verseRef: body.verse_ref ?? null,
+      activityDate: today,
+    });
 
-  // Compute new streak
-  const lastDate = user.lastActivityDate; // "YYYY-MM-DD" or null
-  let newStreak = user.currentStreak;
-  let newLongest = user.longestStreak;
-  let isNewDay = false;
+    // Compute new streak
+    const lastDate = user.lastActivityDate; // "YYYY-MM-DD" or null
+    let newStreak = user.currentStreak;
+    let newLongest = user.longestStreak;
+    let isNewDay = false;
 
-  if (lastDate === today) {
-    // Already counted today — no streak change
-  } else {
-    isNewDay = true;
-    if (lastDate === yesterday) {
-      // Consecutive day — extend streak
-      newStreak = user.currentStreak + 1;
+    if (lastDate === today) {
+      // Already counted today — no streak change
     } else {
-      // Gap or first ever — reset
-      newStreak = 1;
+      isNewDay = true;
+      if (lastDate === yesterday) {
+        // Consecutive day — extend streak
+        newStreak = user.currentStreak + 1;
+      } else {
+        // Gap or first ever — reset
+        newStreak = 1;
+      }
+      newLongest = Math.max(newStreak, newLongest);
+
+      await db
+        .update(users)
+        .set({
+          currentStreak: newStreak,
+          longestStreak: newLongest,
+          lastActivityDate: today,
+          lastActiveAt: sql`now()`,
+        })
+        .where(eq(users.id, userId));
+
+      // Invalidate cache so next request re-reads fresh streak from DB
+      const rawAuth = req.headers.get("authorization");
+      const token = rawAuth?.startsWith("Bearer ") ? rawAuth.slice(7) : null;
+      if (token) invalidateTokenCache(token);
     }
-    newLongest = Math.max(newStreak, newLongest);
 
-    await db
-      .update(users)
-      .set({
-        currentStreak: newStreak,
-        longestStreak: newLongest,
-        lastActivityDate: today,
-        lastActiveAt: sql`now()`,
-      })
-      .where(eq(users.id, userId));
-
-    // Invalidate cache so next request re-reads fresh streak from DB
-    const rawAuth = req.headers.get("authorization");
-    const token = rawAuth?.startsWith("Bearer ") ? rawAuth.slice(7) : null;
-    if (token) invalidateTokenCache(token);
+    return NextResponse.json({
+      streak: newStreak,
+      longestStreak: newLongest,
+      isNewDay,
+      streakBroken: isNewDay && lastDate !== null && lastDate !== yesterday,
+    });
+  } catch (err) {
+    console.error("social/activity POST db error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-
-  return NextResponse.json({
-    streak: newStreak,
-    longestStreak: newLongest,
-    isNewDay,
-    streakBroken: isNewDay && lastDate !== null && lastDate !== yesterday,
-  });
 }
 
 // GET: current streak for the logged-in user (used on page load to hydrate store)

--- a/app/api/social/activity/route.ts
+++ b/app/api/social/activity/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db";
 import { activityLog, users } from "@/lib/db/schema";
 import { requireUser, invalidateTokenCache } from "@/lib/social-auth";
 import { todayUTC, yesterdayUTC, effectiveStreak } from "@/lib/streak";
-import { consume, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
+import { rateLimitOrNull, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
 
 // Activity pings fire on ordinary reading (each verse/connection), so a genuinely
 // engaged session can log far more than a typical "create a row" mutation —
@@ -17,10 +17,13 @@ export async function POST(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
 
-  const allowed = await consume(`activity:${authed.userId}`, ACTIVITY_LIMIT, MUTATION_WINDOW_SECONDS);
-  if (!allowed) {
-    return NextResponse.json({ error: "Too many activity events — try again later" }, { status: 429 });
-  }
+  const limited = await rateLimitOrNull(
+    `activity:${authed.userId}`,
+    "Too many activity events — try again later",
+    ACTIVITY_LIMIT,
+    MUTATION_WINDOW_SECONDS
+  );
+  if (limited) return limited;
 
   let body: { type?: string; verse_ref?: string };
   try {

--- a/app/api/social/activity/route.ts
+++ b/app/api/social/activity/route.ts
@@ -4,12 +4,23 @@ import { db } from "@/lib/db";
 import { activityLog, users } from "@/lib/db/schema";
 import { requireUser, invalidateTokenCache } from "@/lib/social-auth";
 import { todayUTC, yesterdayUTC, effectiveStreak } from "@/lib/streak";
+import { consume, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
+
+// Activity pings fire on ordinary reading (each verse/connection), so a genuinely
+// engaged session can log far more than a typical "create a row" mutation —
+// budget this route separately and higher than MUTATION_LIMIT.
+const ACTIVITY_LIMIT = 300;
 
 const VALID_TYPES = new Set(["verse_added", "connection_made", "hadith_read"]);
 
 export async function POST(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
+
+  const allowed = await consume(`activity:${authed.userId}`, ACTIVITY_LIMIT, MUTATION_WINDOW_SECONDS);
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many activity events — try again later" }, { status: 429 });
+  }
 
   let body: { type?: string; verse_ref?: string };
   try {

--- a/app/api/social/activity/route.ts
+++ b/app/api/social/activity/route.ts
@@ -32,60 +32,81 @@ export async function POST(req: NextRequest) {
   if (!body.type || !VALID_TYPES.has(body.type)) {
     return NextResponse.json({ error: "Invalid activity type" }, { status: 400 });
   }
+  // Narrow into locals: `body.type`'s non-undefined narrowing above doesn't
+  // survive into the transaction closure below (TS can't prove `body` is
+  // unmutated by the time the closure runs).
+  const activityType = body.type;
+  const verseRef = body.verse_ref ?? null;
 
-  const { userId, user } = authed;
+  const { userId } = authed;
   const today = todayUTC();
   const yesterday = yesterdayUTC();
 
   try {
-    // Insert the activity event
-    await db.insert(activityLog).values({
-      userId,
-      activityType: body.type,
-      verseRef: body.verse_ref ?? null,
-      activityDate: today,
+    // Insert + streak read/compute/write run in one transaction: the activity
+    // event and the streak update must land together (a mid-flight failure
+    // between two separate statements would otherwise log the activity without
+    // updating the streak), and the user row is re-read with a row lock here
+    // rather than trusting `authed.user` — that snapshot can be cached, so two
+    // concurrent POSTs computing `newStreak` from the same stale value would
+    // otherwise silently lose one of the increments.
+    const result = await db.transaction(async (tx) => {
+      await tx.insert(activityLog).values({
+        userId,
+        activityType,
+        verseRef,
+        activityDate: today,
+      });
+
+      const [freshUser] = await tx.select().from(users).where(eq(users.id, userId)).for("update");
+      if (!freshUser) throw new Error("user row missing during activity write");
+
+      const lastDate = freshUser.lastActivityDate; // "YYYY-MM-DD" or null
+      let newStreak = freshUser.currentStreak;
+      let newLongest = freshUser.longestStreak;
+      let isNewDay = false;
+
+      if (lastDate === today) {
+        // Already counted today — no streak change
+      } else {
+        isNewDay = true;
+        if (lastDate === yesterday) {
+          // Consecutive day — extend streak
+          newStreak = freshUser.currentStreak + 1;
+        } else {
+          // Gap or first ever — reset
+          newStreak = 1;
+        }
+        newLongest = Math.max(newStreak, newLongest);
+
+        await tx
+          .update(users)
+          .set({
+            currentStreak: newStreak,
+            longestStreak: newLongest,
+            lastActivityDate: today,
+            lastActiveAt: sql`now()`,
+          })
+          .where(eq(users.id, userId));
+      }
+
+      return { newStreak, newLongest, isNewDay, lastDate };
     });
 
-    // Compute new streak
-    const lastDate = user.lastActivityDate; // "YYYY-MM-DD" or null
-    let newStreak = user.currentStreak;
-    let newLongest = user.longestStreak;
-    let isNewDay = false;
-
-    if (lastDate === today) {
-      // Already counted today — no streak change
-    } else {
-      isNewDay = true;
-      if (lastDate === yesterday) {
-        // Consecutive day — extend streak
-        newStreak = user.currentStreak + 1;
-      } else {
-        // Gap or first ever — reset
-        newStreak = 1;
-      }
-      newLongest = Math.max(newStreak, newLongest);
-
-      await db
-        .update(users)
-        .set({
-          currentStreak: newStreak,
-          longestStreak: newLongest,
-          lastActivityDate: today,
-          lastActiveAt: sql`now()`,
-        })
-        .where(eq(users.id, userId));
-
-      // Invalidate cache so next request re-reads fresh streak from DB
+    if (result.isNewDay) {
+      // Invalidate cache so next request re-reads fresh streak from DB. Kept
+      // outside the transaction — it's a best-effort cache flush, not part of
+      // the consistency boundary.
       const rawAuth = req.headers.get("authorization");
       const token = rawAuth?.startsWith("Bearer ") ? rawAuth.slice(7) : null;
       if (token) invalidateTokenCache(token);
     }
 
     return NextResponse.json({
-      streak: newStreak,
-      longestStreak: newLongest,
-      isNewDay,
-      streakBroken: isNewDay && lastDate !== null && lastDate !== yesterday,
+      streak: result.newStreak,
+      longestStreak: result.newLongest,
+      isNewDay: result.isNewDay,
+      streakBroken: result.isNewDay && result.lastDate !== null && result.lastDate !== yesterday,
     });
   } catch (err) {
     console.error("social/activity POST db error:", err);

--- a/app/api/social/challenges/[id]/route.ts
+++ b/app/api/social/challenges/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { challenges } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
@@ -59,11 +59,18 @@ export async function PATCH(
         ? { status: "declined" as const }
         : { status: "cancelled" as const };
 
+  // Scope the WHERE to "still pending" — otherwise two concurrent calls (e.g.
+  // accept racing cancel) both pass the check above and the second write
+  // silently clobbers the first.
   const [updated] = await db
     .update(challenges)
     .set(setFields)
-    .where(eq(challenges.id, challengeId))
+    .where(and(eq(challenges.id, challengeId), eq(challenges.status, "pending")))
     .returning();
+
+  if (!updated) {
+    return NextResponse.json({ error: "Challenge is no longer pending" }, { status: 409 });
+  }
 
   return NextResponse.json(updated);
 }

--- a/app/api/social/challenges/route.ts
+++ b/app/api/social/challenges/route.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { challenges, challengeSuggestions, friendships, users } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
 import { DURATIONS, scoreChallenge, resolveEndedChallenges, resolveExpiredPending } from "@/lib/challenges";
+import { consume, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
@@ -106,6 +107,11 @@ export async function POST(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
   const { userId } = authed;
+
+  const allowed = await consume(`challenge:${userId}`, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS);
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many challenges created — try again later" }, { status: 429 });
+  }
 
   let body: { challengedUsername?: string; duration?: string; verseRef?: string; suggestionId?: number };
   try {

--- a/app/api/social/challenges/route.ts
+++ b/app/api/social/challenges/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { and, desc, eq, lt, or } from "drizzle-orm";
+import { and, desc, eq, gte, lt, or } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { challenges, challengeSuggestions, friendships, users } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
-import { DURATIONS, scoreChallenge, resolveEndedChallenges } from "@/lib/challenges";
+import { DURATIONS, scoreChallenge, resolveEndedChallenges, resolveExpiredPending } from "@/lib/challenges";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
@@ -31,6 +31,23 @@ export async function GET(req: NextRequest) {
         )
       );
     const resolvedScores = await resolveEndedChallenges(endedActive, now);
+
+    // Same self-heal for `pending` invites nobody acted on — otherwise an
+    // ignored invite permanently blocks the pair from a new challenge.
+    const expiredPending = await db
+      .select()
+      .from(challenges)
+      .where(
+        and(
+          or(
+            eq(challenges.challengerId, userId),
+            eq(challenges.challengedId, userId)
+          ),
+          eq(challenges.status, "pending"),
+          lt(challenges.endsAt, now)
+        )
+      );
+    await resolveExpiredPending(expiredPending, now);
 
     // Bound the per-user challenge list for the response (newest first). 200 is far
     // above any real user's volume; statuses are current after the resolution above.
@@ -141,7 +158,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "You must be friends to send a challenge" }, { status: 409 });
   }
 
-  // Block if an active or pending challenge already exists between them
+  // Block if an active or still-live pending challenge already exists between
+  // them. A pending row whose endsAt has passed is a stale, un-actioned
+  // invite — treat it as already expired here too, even if the lazy resolver
+  // (GET) hasn't written the "declined" status back yet.
+  const now = new Date();
   const [existing] = await db
     .select({ id: challenges.id })
     .from(challenges)
@@ -151,7 +172,7 @@ export async function POST(req: NextRequest) {
           and(eq(challenges.challengerId, userId), eq(challenges.challengedId, target.id)),
           and(eq(challenges.challengerId, target.id), eq(challenges.challengedId, userId))
         ),
-        or(eq(challenges.status, "pending"), eq(challenges.status, "active"))
+        or(eq(challenges.status, "active"), and(eq(challenges.status, "pending"), gte(challenges.endsAt, now)))
       )
     )
     .limit(1);

--- a/app/api/social/challenges/route.ts
+++ b/app/api/social/challenges/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db";
 import { challenges, challengeSuggestions, friendships, users } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
 import { DURATIONS, scoreChallenge, resolveEndedChallenges, resolveExpiredPending } from "@/lib/challenges";
-import { consume, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
+import { rateLimitOrNull } from "@/lib/rate-limit";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
@@ -108,10 +108,8 @@ export async function POST(req: NextRequest) {
   if (authed instanceof NextResponse) return authed;
   const { userId } = authed;
 
-  const allowed = await consume(`challenge:${userId}`, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS);
-  if (!allowed) {
-    return NextResponse.json({ error: "Too many challenges created — try again later" }, { status: 429 });
-  }
+  const limited = await rateLimitOrNull(`challenge:${userId}`, "Too many challenges created — try again later");
+  if (limited) return limited;
 
   let body: { challengedUsername?: string; duration?: string; verseRef?: string; suggestionId?: number };
   try {

--- a/app/api/social/friends/route.ts
+++ b/app/api/social/friends/route.ts
@@ -3,7 +3,7 @@ import { and, eq, or, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { friendships, users } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
-import { consume, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
+import { rateLimitOrNull } from "@/lib/rate-limit";
 import { isUniqueViolation } from "@/lib/http";
 
 export async function GET(req: NextRequest) {
@@ -71,10 +71,8 @@ export async function POST(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
 
-  const allowed = await consume(`friend-req:${authed.userId}`, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS);
-  if (!allowed) {
-    return NextResponse.json({ error: "Too many friend requests — try again later" }, { status: 429 });
-  }
+  const limited = await rateLimitOrNull(`friend-req:${authed.userId}`, "Too many friend requests — try again later");
+  if (limited) return limited;
 
   let body: { username?: string };
   try {

--- a/app/api/social/friends/route.ts
+++ b/app/api/social/friends/route.ts
@@ -3,6 +3,7 @@ import { and, eq, or, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { friendships, users } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
+import { consume, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
 
 /** Postgres unique-violation, possibly wrapped by the driver under `cause`. */
 function isUniqueViolation(err: unknown): boolean {
@@ -74,6 +75,11 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
+
+  const allowed = await consume(`friend-req:${authed.userId}`, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS);
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many friend requests — try again later" }, { status: 429 });
+  }
 
   let body: { username?: string };
   try {

--- a/app/api/social/friends/route.ts
+++ b/app/api/social/friends/route.ts
@@ -4,12 +4,7 @@ import { db } from "@/lib/db";
 import { friendships, users } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
 import { consume, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
-
-/** Postgres unique-violation, possibly wrapped by the driver under `cause`. */
-function isUniqueViolation(err: unknown): boolean {
-  const code = (err as { code?: string })?.code ?? (err as { cause?: { code?: string } })?.cause?.code;
-  return code === "23505";
-}
+import { isUniqueViolation } from "@/lib/http";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);

--- a/app/api/social/me/route.ts
+++ b/app/api/social/me/route.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
 import { effectiveStreak } from "@/lib/streak";
+import { isUniqueViolation } from "@/lib/http";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
@@ -63,15 +64,26 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
   }
 
-  const [updated] = await db
-    .update(users)
-    .set(updates)
-    .where(eq(users.id, authed.userId))
-    .returning();
+  try {
+    const [updated] = await db
+      .update(users)
+      .set(updates)
+      .where(eq(users.id, authed.userId))
+      .returning();
 
-  return NextResponse.json({
-    id: updated.id,
-    username: updated.username,
-    displayName: updated.displayName,
-  });
+    return NextResponse.json({
+      id: updated.id,
+      username: updated.username,
+      displayName: updated.displayName,
+    });
+  } catch (err) {
+    // The collision check above has a TOCTOU window: two concurrent PATCHes
+    // picking the same free username can both pass it, then race the UPDATE
+    // itself — catch that at the DB's unique constraint instead of 500ing.
+    if (isUniqueViolation(err)) {
+      return NextResponse.json({ error: "Username already taken" }, { status: 409 });
+    }
+    console.error("social/me PATCH db error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
 }

--- a/app/api/workspace/route.ts
+++ b/app/api/workspace/route.ts
@@ -3,7 +3,7 @@ import { desc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { savedWorkspaces } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
-import { consume, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
+import { rateLimitOrNull } from "@/lib/rate-limit";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
@@ -35,10 +35,8 @@ export async function POST(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
 
-  const allowed = await consume(`workspace:${authed.userId}`, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS);
-  if (!allowed) {
-    return NextResponse.json({ error: "Too many canvases saved — try again later" }, { status: 429 });
-  }
+  const limited = await rateLimitOrNull(`workspace:${authed.userId}`, "Too many canvases saved — try again later");
+  if (limited) return limited;
 
   let body: { name?: string; data?: unknown; nodeCount?: number };
   try {

--- a/app/api/workspace/route.ts
+++ b/app/api/workspace/route.ts
@@ -3,6 +3,7 @@ import { desc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { savedWorkspaces } from "@/lib/db/schema";
 import { requireUser } from "@/lib/social-auth";
+import { consume, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS } from "@/lib/rate-limit";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
@@ -33,6 +34,11 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
+
+  const allowed = await consume(`workspace:${authed.userId}`, MUTATION_LIMIT, MUTATION_WINDOW_SECONDS);
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many canvases saved — try again later" }, { status: 429 });
+  }
 
   let body: { name?: string; data?: unknown; nodeCount?: number };
   try {

--- a/app/bookmarks/error.tsx
+++ b/app/bookmarks/error.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+// Next 16 passes `unstable_retry`, not `reset`.
+export default function BookmarksError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/bookmarks/loading.tsx
+++ b/app/bookmarks/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/canvas/error.tsx
+++ b/app/canvas/error.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+// Next 16 passes `unstable_retry`, not `reset`.
+export default function CanvasError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/canvas/loading.tsx
+++ b/app/canvas/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/names/[slug]/error.tsx
+++ b/app/names/[slug]/error.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+// Next 16 passes `unstable_retry`, not `reset`.
+export default function NameError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} homeHref="/names" homeLabel="All names" />;
+}

--- a/app/names/[slug]/loading.tsx
+++ b/app/names/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/social/error.tsx
+++ b/app/social/error.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+// Next 16 passes `unstable_retry`, not `reset`.
+export default function SocialError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/social/loading.tsx
+++ b/app/social/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -49,7 +49,13 @@ export default function SocialPage() {
   const [loadingFriends, setLoadingFriends] = useState(false);
   const [loadingLeaderboard, setLoadingLeaderboard] = useState(false);
   const [loadingChallenges, setLoadingChallenges] = useState(false);
-  const [loadError, setLoadError] = useState(false);
+  // Tracked per section (not one shared flag) — otherwise a later-resolving
+  // fetch that succeeds would clear the banner even though a different
+  // section actually failed and is showing stale/missing data.
+  const [friendsError, setFriendsError] = useState(false);
+  const [leaderboardError, setLeaderboardError] = useState(false);
+  const [challengesError, setChallengesError] = useState(false);
+  const loadError = friendsError || leaderboardError || challengesError;
   const [profileTimedOut, setProfileTimedOut] = useState(false);
 
   // Picking a suggestion seeds the create form (remounted via key) and clears on send.
@@ -74,12 +80,12 @@ export default function SocialPage() {
         setFriends(data);
         // Keep the header badge in sync immediately after any friend action.
         setPendingFriendCount(countPendingReceived(data));
-        setLoadError(false);
+        setFriendsError(false);
       } else {
-        setLoadError(true);
+        setFriendsError(true);
       }
     } catch {
-      setLoadError(true);
+      setFriendsError(true);
     } finally {
       setLoadingFriends(false);
     }
@@ -94,12 +100,12 @@ export default function SocialPage() {
       });
       if (res.ok) {
         setLeaderboard(await res.json());
-        setLoadError(false);
+        setLeaderboardError(false);
       } else {
-        setLoadError(true);
+        setLeaderboardError(true);
       }
     } catch {
-      setLoadError(true);
+      setLeaderboardError(true);
     } finally {
       setLoadingLeaderboard(false);
     }
@@ -116,12 +122,12 @@ export default function SocialPage() {
         const data: EnrichedChallenge[] = await res.json();
         setChallengesList(data);
         setPendingChallengeCount(countIncomingChallenges(data, userId));
-        setLoadError(false);
+        setChallengesError(false);
       } else {
-        setLoadError(true);
+        setChallengesError(true);
       }
     } catch {
-      setLoadError(true);
+      setChallengesError(true);
     } finally {
       setLoadingChallenges(false);
     }

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -116,7 +116,12 @@ export default function SocialPage() {
         const data: EnrichedChallenge[] = await res.json();
         setChallengesList(data);
         setPendingChallengeCount(countIncomingChallenges(data, userId));
+        setLoadError(false);
+      } else {
+        setLoadError(true);
       }
+    } catch {
+      setLoadError(true);
     } finally {
       setLoadingChallenges(false);
     }
@@ -242,7 +247,7 @@ export default function SocialPage() {
               ))}
             </div>
 
-            {loadError && !loadingFriends && !loadingLeaderboard && (
+            {loadError && !loadingFriends && !loadingLeaderboard && !loadingChallenges && (
               <p className="mb-3 text-center text-xs text-error">
                 Couldn&apos;t load.{" "}
                 <button

--- a/app/workspaces/error.tsx
+++ b/app/workspaces/error.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+// Next 16 passes `unstable_retry`, not `reset`.
+export default function WorkspacesError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/workspaces/loading.tsx
+++ b/app/workspaces/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/workspaces/page.tsx
+++ b/app/workspaces/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { FolderOpen, Loader2, Trash2, Upload, Network } from "lucide-react";
+import { FolderOpen, Loader2, Trash2, Upload, Network, TriangleAlert } from "lucide-react";
 import { useAuthStore } from "@/store/auth";
 import { useCanvasStore, type SavedCanvas } from "@/store/canvas";
 import { Card, IconButton, Tooltip } from "@/components/ui";
@@ -24,6 +24,7 @@ export default function WorkspacesPage() {
 
   const [workspaces, setWorkspaces] = useState<WorkspaceMeta[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [loadingId, setLoadingId] = useState<number | null>(null);
   const [deletingId, setDeletingId] = useState<number | null>(null);
 
@@ -34,7 +35,14 @@ export default function WorkspacesPage() {
       const res = await fetch("/api/workspace", {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
-      if (res.ok) setWorkspaces(await res.json());
+      if (res.ok) {
+        setWorkspaces(await res.json());
+        setLoadError(false);
+      } else {
+        setLoadError(true);
+      }
+    } catch {
+      setLoadError(true);
     } finally {
       setLoading(false);
     }
@@ -97,6 +105,17 @@ export default function WorkspacesPage() {
         {loading ? (
           <div className="flex justify-center py-20">
             <Loader2 className="h-4 w-4 animate-spin text-teal" />
+          </div>
+        ) : loadError ? (
+          <div className="py-20 text-center">
+            <TriangleAlert className="mx-auto mb-4 h-8 w-8 text-error/60" />
+            <p className="text-sm text-text-muted">Couldn&apos;t load your saved canvases.</p>
+            <button
+              onClick={() => fetchWorkspaces()}
+              className="mt-4 cursor-pointer text-xs text-teal underline"
+            >
+              Retry
+            </button>
           </div>
         ) : workspaces.length === 0 ? (
           <div className="py-20 text-center">

--- a/components/admin/ChallengeSuggestionsManager.tsx
+++ b/components/admin/ChallengeSuggestionsManager.tsx
@@ -198,7 +198,10 @@ export function ChallengeSuggestionsManager() {
                 <Td className="font-mono text-xs text-text-muted">{s.verseRef ?? "—"}</Td>
                 <Td className="text-xs text-text-secondary">{s.suggestedDuration ?? "any"}</Td>
                 <Td>
-                  <button onClick={() => toggleActive(s)} title="Toggle active">
+                  <button
+                    onClick={() => toggleActive(s)}
+                    aria-label={`${s.isActive ? "Deactivate" : "Activate"} suggestion "${s.title}"`}
+                  >
                     <Pill tone={s.isActive ? "active" : "retired"}>{s.isActive ? "on" : "off"}</Pill>
                   </button>
                 </Td>

--- a/components/canvas/ExpandMenu.tsx
+++ b/components/canvas/ExpandMenu.tsx
@@ -40,6 +40,7 @@ const OPTIONS: Array<{
 
 export function ExpandMenu({ onSelect, onClose }: ExpandMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
+  const firstOptionRef = useRef<HTMLButtonElement>(null);
   const [openUp, setOpenUp] = useState(false);
 
   useEffect(() => {
@@ -50,6 +51,21 @@ export function ExpandMenu({ onSelect, onClose }: ExpandMenuProps) {
     }
   }, []);
 
+  useEffect(() => {
+    firstOptionRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   return (
     <div
       ref={menuRef}
@@ -58,14 +74,15 @@ export function ExpandMenu({ onSelect, onClose }: ExpandMenuProps) {
       onClick={(e) => e.stopPropagation()}
     >
       <div className="rounded-md border border-border overflow-hidden bg-surface-overlay shadow-sm">
-        {OPTIONS.map((opt) => (
+        {OPTIONS.map((opt, i) => (
           <button
             key={opt.kind}
+            ref={i === 0 ? firstOptionRef : undefined}
             onClick={() => {
               onSelect(opt.kind);
               onClose();
             }}
-            className="w-full flex items-center gap-2.5 px-3 py-2 text-left transition-colors cursor-pointer hover:bg-white/5"
+            className="w-full flex items-center gap-2.5 px-3 py-2 text-left transition-colors cursor-pointer hover:bg-white/5 focus-visible:outline-none focus-visible:bg-white/5"
           >
             <span
               className="w-5 h-5 rounded flex items-center justify-center text-xs font-mono shrink-0"

--- a/components/canvas/VerseNode.tsx
+++ b/components/canvas/VerseNode.tsx
@@ -40,20 +40,32 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
     setPendingExpand({ nodeId: id, ref: verse.ref, kind });
   };
 
+  const toggleSelected = () => {
+    if (selected) {
+      setSidebarContent(null);
+      setSelectedNode(null);
+    } else {
+      setSidebarContent({ type: "node", verse: verse as Verse });
+      setSelectedNode(id);
+    }
+  };
+
   return (
     <div
-      onClick={() => {
-        if (selected) {
-          setSidebarContent(null);
-          setSelectedNode(null);
-        } else {
-          setSidebarContent({ type: "node", verse: verse as Verse });
-          setSelectedNode(id);
+      role="button"
+      tabIndex={0}
+      aria-pressed={selected}
+      onClick={toggleSelected}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggleSelected();
         }
       }}
       className={cn(
         "relative w-72 rounded-lg border transition-colors duration-150 cursor-pointer select-none node-entrance",
         "bg-surface-raised border-border",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
         selected && "node-selected",
         isExpanding && "node-expanding",
         !selected && !isExpanding && "hover:border-text-muted"

--- a/components/canvas/VerseNode.tsx
+++ b/components/canvas/VerseNode.tsx
@@ -57,6 +57,11 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
       aria-pressed={selected}
       onClick={toggleSelected}
       onKeyDown={(e) => {
+        // Guard against bubbled keydowns from nested buttons (play/bookmark/
+        // expand) — those only stopPropagation on click/mousedown, so without
+        // this check, activating one of them via keyboard would also toggle
+        // node selection.
+        if (e.target !== e.currentTarget) return;
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           toggleSelected();

--- a/components/home/PersonalHome.tsx
+++ b/components/home/PersonalHome.tsx
@@ -50,6 +50,7 @@ export function PersonalHome({ verse }: { verse: Verse | null }) {
 
   const [continueCount, setContinueCount] = useState<number | null>(null);
   const [savedCount, setSavedCount] = useState<number | null>(null);
+  const [savedCountError, setSavedCountError] = useState(false);
 
   useEffect(() => {
     try {
@@ -66,9 +67,12 @@ export function PersonalHome({ verse }: { verse: Verse | null }) {
   useEffect(() => {
     if (!accessToken) return;
     fetch("/api/workspace", { headers: { Authorization: `Bearer ${accessToken}` } })
-      .then((r) => (r.ok ? r.json() : []))
+      .then((r) => {
+        if (!r.ok) throw new Error("workspace fetch failed");
+        return r.json();
+      })
       .then((ws: unknown[]) => setSavedCount(Array.isArray(ws) ? ws.length : 0))
-      .catch(() => {});
+      .catch(() => setSavedCountError(true));
   }, [accessToken]);
 
   const hasContinue = continueCount !== null && continueCount > 0;
@@ -120,7 +124,9 @@ export function PersonalHome({ verse }: { verse: Verse | null }) {
             subtitle={
               savedCount !== null
                 ? `${savedCount} saved canvas${savedCount === 1 ? "" : "es"}`
-                : "Your saved graphs"
+                : savedCountError
+                  ? "Couldn't load your saved canvases"
+                  : "Your saved graphs"
             }
           />
           <QuickLink

--- a/components/layout/RouteError.tsx
+++ b/components/layout/RouteError.tsx
@@ -25,8 +25,12 @@ export function RouteError({
   }, [error]);
 
   return (
-    <div className="flex min-h-[50vh] flex-1 flex-col items-center justify-center px-6 text-center">
-      <TriangleAlert className="mb-4 h-8 w-8 text-gold" />
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-[50vh] flex-1 flex-col items-center justify-center px-6 text-center"
+    >
+      <TriangleAlert aria-hidden="true" className="mb-4 h-8 w-8 text-gold" />
       <h2 className="text-lg font-semibold text-text-primary">This page failed to load</h2>
       <p className="mt-1.5 max-w-sm text-sm text-text-secondary">
         An unexpected error interrupted this section. You can try again, or go back.
@@ -39,14 +43,14 @@ export function RouteError({
           onClick={() => retry()}
           className="inline-flex items-center gap-1.5 rounded-md bg-gold px-4 py-2 text-sm font-medium text-ink transition-opacity hover:opacity-90"
         >
-          <RotateCw className="h-3.5 w-3.5" />
+          <RotateCw aria-hidden="true" className="h-3.5 w-3.5" />
           Try again
         </button>
         <Link
           href={homeHref}
           className="inline-flex items-center gap-1.5 rounded-md border border-border px-4 py-2 text-sm text-text-secondary transition-colors hover:border-gold-muted hover:text-gold"
         >
-          <Home className="h-3.5 w-3.5" />
+          <Home aria-hidden="true" className="h-3.5 w-3.5" />
           {homeLabel}
         </Link>
       </div>

--- a/components/layout/RouteError.tsx
+++ b/components/layout/RouteError.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { TriangleAlert, RotateCw, Home } from "lucide-react";
+
+/**
+ * Shared body for route-segment `error.tsx` boundaries. A segment's own
+ * layout stays mounted around this (Next only replaces the segment's content),
+ * so each caller passes the right "go back" destination for its section.
+ */
+export function RouteError({
+  error,
+  retry,
+  homeHref = "/",
+  homeLabel = "Home",
+}: {
+  error: Error & { digest?: string };
+  retry: () => void;
+  homeHref?: string;
+  homeLabel?: string;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-1 flex-col items-center justify-center px-6 text-center">
+      <TriangleAlert className="mb-4 h-8 w-8 text-gold" />
+      <h2 className="text-lg font-semibold text-text-primary">This page failed to load</h2>
+      <p className="mt-1.5 max-w-sm text-sm text-text-secondary">
+        An unexpected error interrupted this section. You can try again, or go back.
+      </p>
+      {error.digest && (
+        <p className="mt-2.5 font-mono text-xs text-text-muted">ref: {error.digest}</p>
+      )}
+      <div className="mt-5 flex items-center gap-2">
+        <button
+          onClick={() => retry()}
+          className="inline-flex items-center gap-1.5 rounded-md bg-gold px-4 py-2 text-sm font-medium text-ink transition-opacity hover:opacity-90"
+        >
+          <RotateCw className="h-3.5 w-3.5" />
+          Try again
+        </button>
+        <Link
+          href={homeHref}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border px-4 py-2 text-sm text-text-secondary transition-colors hover:border-gold-muted hover:text-gold"
+        >
+          <Home className="h-3.5 w-3.5" />
+          {homeLabel}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/RouteLoading.tsx
+++ b/components/layout/RouteLoading.tsx
@@ -3,8 +3,9 @@ import { Loader2 } from "lucide-react";
 /** Shared body for route-segment `loading.tsx` boundaries. */
 export function RouteLoading() {
   return (
-    <div className="flex min-h-[50vh] flex-1 items-center justify-center">
-      <Loader2 className="h-6 w-6 animate-spin text-teal" />
+    <div role="status" aria-live="polite" className="flex min-h-[50vh] flex-1 items-center justify-center">
+      <Loader2 aria-hidden="true" className="h-6 w-6 animate-spin text-teal" />
+      <span className="sr-only">Loading…</span>
     </div>
   );
 }

--- a/components/layout/RouteLoading.tsx
+++ b/components/layout/RouteLoading.tsx
@@ -1,0 +1,10 @@
+import { Loader2 } from "lucide-react";
+
+/** Shared body for route-segment `loading.tsx` boundaries. */
+export function RouteLoading() {
+  return (
+    <div className="flex min-h-[50vh] flex-1 items-center justify-center">
+      <Loader2 className="h-6 w-6 animate-spin text-teal" />
+    </div>
+  );
+}

--- a/lib/challenges.ts
+++ b/lib/challenges.ts
@@ -77,13 +77,20 @@ export async function resolveEndedChallenges(
         scoreChallenge(c.challengedId, c),
       ]);
       const winnerId = pickWinner(c, challengerScore, challengedScore);
-      await db
+      // Scope the write to the state just checked — a concurrent admin "end"
+      // (or a second caller racing this same self-heal) may have already
+      // transitioned this row; only count/mutate on an actual match instead
+      // of unconditionally overwriting whatever it raced against.
+      const [updated] = await db
         .update(challenges)
         .set({ status: "completed", winnerId })
-        .where(eq(challenges.id, c.id));
-      c.status = "completed";
-      c.winnerId = winnerId;
-      resolved.set(c.id, { challengerScore, challengedScore });
+        .where(and(eq(challenges.id, c.id), eq(challenges.status, "active")))
+        .returning();
+      if (updated) {
+        c.status = "completed";
+        c.winnerId = winnerId;
+        resolved.set(c.id, { challengerScore, challengedScore });
+      }
     }
   }
   return resolved;
@@ -106,9 +113,19 @@ export async function resolveExpiredPending(
   let resolvedCount = 0;
   for (const c of rows) {
     if (c.status === "pending" && c.endsAt < now) {
-      await db.update(challenges).set({ status: "declined" }).where(eq(challenges.id, c.id));
-      c.status = "declined";
-      resolvedCount++;
+      // Scope the write the same way as resolveEndedChallenges above — if the
+      // pair accepted/declined/cancelled this invite via the (already-guarded)
+      // PATCH route in the window between our SELECT and this UPDATE, only a
+      // still-pending row should be clobbered back to "declined".
+      const [updated] = await db
+        .update(challenges)
+        .set({ status: "declined" })
+        .where(and(eq(challenges.id, c.id), eq(challenges.status, "pending")))
+        .returning();
+      if (updated) {
+        c.status = "declined";
+        resolvedCount++;
+      }
     }
   }
   return resolvedCount;

--- a/lib/challenges.ts
+++ b/lib/challenges.ts
@@ -88,3 +88,28 @@ export async function resolveEndedChallenges(
   }
   return resolved;
 }
+
+/**
+ * Auto-expire `pending` invites nobody acted on. A pending challenge's
+ * `endsAt` is stamped at creation time (before the competition window even
+ * starts), so it doubles as the invite's expiry — past that point it's
+ * declined automatically. Without this, an ignored invite blocks the pair
+ * from ever creating a new challenge (see the "already exists between you"
+ * check in POST), the same lazy-expiry gap `resolveEndedChallenges` closes
+ * for `active` challenges. Mutates the passed rows in place (like its
+ * sibling above) so callers see up-to-date status without re-querying.
+ */
+export async function resolveExpiredPending(
+  rows: Challenge[],
+  now: Date = new Date()
+): Promise<number> {
+  let resolvedCount = 0;
+  for (const c of rows) {
+    if (c.status === "pending" && c.endsAt < now) {
+      await db.update(challenges).set({ status: "declined" }).where(eq(challenges.id, c.id));
+      c.status = "declined";
+      resolvedCount++;
+    }
+  }
+  return resolvedCount;
+}

--- a/lib/graph-service.ts
+++ b/lib/graph-service.ts
@@ -81,7 +81,12 @@ export async function getConnections(
         eq(connections.kind, kind),
         eq(connections.status, "active")
       )
-    );
+    )
+    // A single generation inserts ~12 edges (see discoverCandidates), but this
+    // has no upper bound enforced at write time — cap defensively so a future
+    // code path that inserts more edges per source ref can't turn this into an
+    // unbounded per-key list query, the same shape hardened elsewhere.
+    .limit(200);
 
   if (existing.length > 0) {
     return hydrate(existing, kind);

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -54,3 +54,9 @@ export function clientKey(req: Request): string {
   const candidate = parts[parts.length - 1] || "";
   return IP_PATTERN.test(candidate) ? candidate : "unknown";
 }
+
+/** Postgres unique-violation, possibly wrapped by the driver under `cause`. */
+export function isUniqueViolation(err: unknown): boolean {
+  const code = (err as { code?: string })?.code ?? (err as { cause?: { code?: string } })?.cause?.code;
+  return code === "23505";
+}

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -34,14 +34,23 @@ export async function parseJson<T>(req: NextRequest): Promise<T | null> {
 const IP_PATTERN = /^[0-9a-fA-F:.]{1,45}$/;
 
 /**
- * Best-effort client identifier for rate-limit bucketing, taken from
- * `x-forwarded-for` (first hop) or `x-real-ip`. Falls back to a single shared
- * "unknown" bucket rather than omitting the key: a paid path must always be
- * rate-limited, even when no usable IP is present.
+ * Best-effort client identifier for rate-limit bucketing. `x-real-ip` is set
+ * by our nginx from `$remote_addr` (the actual TCP peer) and is always
+ * overwritten by the proxy, so a client cannot forge it. `x-forwarded-for` is
+ * built with `$proxy_add_x_forwarded_for`, which *appends* our proxy's view
+ * of the client to whatever the client already sent — so the trustworthy
+ * value is the *last* entry, not the first (the first entry is fully
+ * attacker-controlled and would let a caller mint a fresh rate-limit bucket
+ * on every request). Falls back to a single shared "unknown" bucket rather
+ * than omitting the key: a paid path must always be rate-limited, even when
+ * no usable IP is present.
  */
 export function clientKey(req: Request): string {
+  const realIp = req.headers.get("x-real-ip")?.trim() || "";
+  if (IP_PATTERN.test(realIp)) return realIp;
+
   const fwd = req.headers.get("x-forwarded-for");
-  const candidate =
-    fwd?.split(",")[0]?.trim() || req.headers.get("x-real-ip")?.trim() || "";
+  const parts = fwd?.split(",").map((p) => p.trim()) ?? [];
+  const candidate = parts[parts.length - 1] || "";
   return IP_PATTERN.test(candidate) ? candidate : "unknown";
 }

--- a/lib/quran-corpus.ts
+++ b/lib/quran-corpus.ts
@@ -23,13 +23,21 @@ function rowToVerse(row: VerseRow): Verse {
   };
 }
 
+// The longest surah (2, Al-Baqarah) has 286 ayahs — no surah exceeds this, so
+// it's a safe generous upper bound without needing a full per-surah table.
+// isValidRef intentionally doesn't validate the exact per-surah count; refs
+// that pass this but don't exist (e.g. "114:200") simply fail to resolve
+// downstream (getVerse/getVerses return null/absent), same as any other
+// not-found ref.
+const MAX_AYAH = 286;
+
 /** A syntactically valid verse reference within Quran bounds (surah 1–114). */
 export function isValidRef(ref: string): boolean {
   const match = /^(\d+):(\d+)$/.exec(ref);
   if (!match) return false;
   const surah = parseInt(match[1], 10);
   const ayah = parseInt(match[2], 10);
-  return surah >= 1 && surah <= 114 && ayah >= 1;
+  return surah >= 1 && surah <= 114 && ayah >= 1 && ayah <= MAX_AYAH;
 }
 
 /** Returns the verse for a `"surah:ayah"` ref, or null if not in the corpus. */

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from "next/server";
 import { lt, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { rateLimits } from "@/lib/db/schema";
@@ -127,4 +128,21 @@ export async function consume(
     console.error("Rate limiter error (failing open):", err);
     return true;
   }
+}
+
+/**
+ * `consume` + "return a 429" was repeated near-identically across every
+ * mutation route (notes, friends, workspace, activity, challenges). Centralizes
+ * the limit/window pairing and the 429 envelope so future changes (Retry-After,
+ * per-route metrics) are a one-file edit. Returns `null` when the request is
+ * allowed, or the `NextResponse` the caller should return immediately.
+ */
+export async function rateLimitOrNull(
+  key: string,
+  message: string,
+  limit: number = MUTATION_LIMIT,
+  windowSeconds: number = MUTATION_WINDOW_SECONDS
+): Promise<NextResponse | null> {
+  const allowed = await consume(key, limit, windowSeconds);
+  return allowed ? null : NextResponse.json({ error: message }, { status: 429 });
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -38,6 +38,16 @@ export function positiveIntEnv(name: string, fallback: number): number {
 export const AI_GEN_LIMIT = positiveIntEnv("AI_GEN_RATE_LIMIT", 20);
 export const AI_GEN_WINDOW_SECONDS = positiveIntEnv("AI_GEN_RATE_WINDOW", 60);
 
+/**
+ * Default budget for cheap-but-abusable authenticated mutations (friend
+ * requests, notes, saved canvases, activity pings, challenge invites) — these
+ * have no per-generation cost like the AI path, but an authenticated user
+ * with no volume cap can still spam rows or degrade the DB. Generous enough
+ * that no real usage pattern hits it.
+ */
+export const MUTATION_LIMIT = positiveIntEnv("MUTATION_RATE_LIMIT", 60);
+export const MUTATION_WINDOW_SECONDS = positiveIntEnv("MUTATION_RATE_WINDOW", 600);
+
 /** Probability that a given `consume` call also prunes expired buckets. */
 const SWEEP_PROBABILITY = 0.01;
 /** Keep this many windows of history before a bucket is eligible for pruning. */

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,7 +15,37 @@ const nextConfig: NextConfig = {
   // edge. The extension-anchored source only matches asset files — never HTML
   // routes (which have no extension) or API routes — so pages are never cached.
   async headers() {
+    // Baseline security headers on every response. CSP starts in report-only
+    // mode: the app uses inline `style={{...}}` throughout the canvas UI (so
+    // style-src needs 'unsafe-inline' regardless), and we don't yet have a
+    // deployed report endpoint to validate script-src against real traffic —
+    // enforcing untested would risk breaking the OAuth/canvas flows in prod.
+    const securityHeaders = [
+      { key: "X-Frame-Options", value: "DENY" },
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+      { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains" },
+      {
+        key: "Content-Security-Policy-Report-Only",
+        value: [
+          "default-src 'self'",
+          "script-src 'self'",
+          "style-src 'self' 'unsafe-inline'",
+          "img-src 'self' data: blob:",
+          "font-src 'self' data:",
+          "connect-src 'self'",
+          "frame-ancestors 'none'",
+          "base-uri 'self'",
+          "form-action 'self' https://*.quran.foundation",
+        ].join("; "),
+      },
+    ];
     return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
       {
         source: "/:path*.(ico|png|jpg|jpeg|gif|svg|webp|avif|woff|woff2)",
         headers: [

--- a/next.config.ts
+++ b/next.config.ts
@@ -35,6 +35,7 @@ const nextConfig: NextConfig = {
           "img-src 'self' data: blob:",
           "font-src 'self' data:",
           "connect-src 'self'",
+          "object-src 'none'",
           "frame-ancestors 'none'",
           "base-uri 'self'",
           "form-action 'self' https://*.quran.foundation",


### PR DESCRIPTION
## Summary
Follow-up hardening pass from a full-project audit (config/infra, backend/API/DB, frontend/UX). Builds on the earlier hardening sprint and closes gaps it didn't fully cover.

**Security**
- Fixed rate-limit bypass: `clientKey()` trusted the client-controlled first hop of `X-Forwarded-For`; now trusts `X-Real-IP` (always overwritten by nginx) and falls back to the *last* `X-Forwarded-For` entry (the one nginx appends), not the spoofable first one.
- Added baseline security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, HSTS) plus a report-only CSP.
- Added per-user rate limiting to previously-unthrottled mutation endpoints (friend requests, notes, saved canvases, activity pings, challenge invites).

**Correctness**
- Added try/catch to 3 admin routes missing it (`admin/challenges`, `admin/challenges/finalize`, `admin/ai`) and a few minor routes (`notes/[id]` DELETE, `share/[id]` GET with a corrupted-data guard, `social/activity` POST).
- Fixed TOCTOU races on challenge status transitions (admin "end", user accept/decline/cancel) by scoping the `UPDATE` to the expected prior status and returning 409 on a lost race, instead of silently clobbering a concurrent write.
- Fixed the same TOCTOU shape on username updates (`social/me` PATCH) — a race now returns 409 instead of an unhandled 500.
- Extended lazy-expiry resolution to `pending` challenge invites (previously only `active` challenges self-healed), so an ignored invite no longer permanently blocks new challenges between that pair.
- Added defensive `.limit()` to `getConnections` and an upper bound on `isValidRef`'s ayah number.

**Frontend**
- Added per-route `loading.tsx`/`error.tsx` boundaries (admin, canvas, names/[slug], social, workspaces, bookmarks) — previously only the root had them.
- Fixed a silent error swallow in the social page's challenges fetch, and two places that conflated "load failed" with "genuinely empty."
- Fixed keyboard accessibility: canvas verse nodes are now focusable/activatable (with a guard against keydown bubbling from nested buttons), the expand menu closes on Escape and focuses its first option, and an admin toggle button has a proper `aria-label`.

**Misc**
- Gitignored an untracked `pics/` directory of ad hoc screenshots.

## Test plan
- [x] `bun run lint` — 0 errors (133 pre-existing warnings in unrelated vendored files)
- [x] `bun run typecheck` — clean
- [x] `bun run test:ci` — 416/416 passing
- [x] Pre-push integration tests (Testcontainers) — passing
- [ ] Manual verification of the rate-limit fix, TOCTOU race, and new loading/error boundaries in a running instance (not done in this session — recommend before merge)

Not merging — for review.