### PR TITLE
test: add coverage for admin and auth routes (#120)

### DIFF
--- a/__tests__/api/admin/ai.test.ts
+++ b/__tests__/api/admin/ai.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+function makeRejectingChain(error: Error) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (_res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.reject(error).then(_res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect } }));
+
+import { GET } from "@/app/api/admin/ai/route";
+import { requireAdmin } from "@/lib/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function get() {
+  return new NextRequest("http://localhost/api/admin/ai", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+
+// The route fires 5 db.select(...) queries in this literal Promise.all order:
+// totals, monthTotals, byModel, byKind, daily.
+function queueQueries(results: [unknown, unknown, unknown, unknown, unknown]) {
+  results.forEach((r) => mockSelect.mockReturnValueOnce(makeDbChain(r)));
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReset();
+  mockSelect.mockReturnValue(makeDbChain([]));
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("GET /api/admin/ai", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("aggregates totals, byModel, byKind, and daily series", async () => {
+    queueQueries([
+      [{ gens: 50, tokens: 100000 }],
+      [{ gens: 10, tokens: 20000 }],
+      [{ model: "claude-sonnet-5", gens: 50, tokens: 100000 }],
+      [{ kind: "reflection", gens: 50, tokens: 100000 }],
+      [{ day: "2026-06-01", gens: 5, tokens: 9000 }],
+    ]);
+
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toEqual({ gens: 50, tokens: 100000, estCostUsd: null });
+    expect(body.monthToDate).toEqual({ gens: 10, tokens: 20000, estCostUsd: null });
+    expect(body.byModel).toEqual([{ model: "claude-sonnet-5", gens: 50, tokens: 100000 }]);
+    expect(body.byKind).toEqual([{ kind: "reflection", gens: 50, tokens: 100000 }]);
+    expect(body.daily).toEqual([{ day: "2026-06-01", gens: 5, tokens: 9000 }]);
+    expect(body.pricePer1k).toBeNull();
+  });
+
+  it("defaults totals to zero when there are no generations at all", async () => {
+    queueQueries([[], [], [], [], []]);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.total.estCostUsd).toBeNull();
+    expect(body.pricePer1k).toBeNull();
+  });
+
+  it("treats an unset AI_USD_PER_1K_TOKENS as null pricing (not a fabricated cost)", async () => {
+    vi.stubEnv("AI_USD_PER_1K_TOKENS", "");
+    queueQueries([[{ gens: 1, tokens: 1000 }], [], [], [], []]);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.pricePer1k).toBeNull();
+    expect(body.total.estCostUsd).toBeNull();
+  });
+
+  it("treats an invalid AI_USD_PER_1K_TOKENS string as null pricing", async () => {
+    vi.stubEnv("AI_USD_PER_1K_TOKENS", "not-a-number");
+    queueQueries([[{ gens: 1, tokens: 1000 }], [], [], [], []]);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.pricePer1k).toBeNull();
+  });
+
+  it("treats a configured 0 as a real price, not unset", async () => {
+    vi.stubEnv("AI_USD_PER_1K_TOKENS", "0");
+    queueQueries([[{ gens: 1, tokens: 1000 }], [], [], [], []]);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.pricePer1k).toBe(0);
+    expect(body.total.estCostUsd).toBe(0);
+  });
+
+  it("computes an estimated cost from tokens and a configured price", async () => {
+    vi.stubEnv("AI_USD_PER_1K_TOKENS", "0.01");
+    queueQueries([[{ gens: 1, tokens: 100000 }], [], [], [], []]);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.pricePer1k).toBe(0.01);
+    expect(body.total.estCostUsd).toBe(1);
+  });
+
+  it("returns 500 without leaking internals when a query rejects", async () => {
+    mockSelect.mockReturnValueOnce(makeRejectingChain(new Error("connection lost")));
+    const res = await GET(get());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Internal server error");
+  });
+});

--- a/__tests__/api/admin/audit.test.ts
+++ b/__tests__/api/admin/audit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = [], onLimit?: (n: number) => void) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        if (prop === "limit" && onLimit) return (n: number) => (onLimit(n), chain);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect } }));
+
+import { GET } from "@/app/api/admin/audit/route";
+import { requireAdmin } from "@/lib/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function req(limit?: string) {
+  const url = limit
+    ? `http://localhost/api/admin/audit?limit=${limit}`
+    : "http://localhost/api/admin/audit";
+  return new NextRequest(url, { headers: { Authorization: "Bearer t" } });
+}
+
+const row = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 1,
+  adminQfId: "qf-admin",
+  action: "user.disable",
+  targetType: "user",
+  targetId: "42",
+  meta: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([]));
+});
+
+describe("GET /api/admin/audit", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns entries with parsed meta", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([row({ meta: JSON.stringify({ from: "active", to: "flagged" }) })])
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].meta).toEqual({ from: "active", to: "flagged" });
+  });
+
+  it("falls back to the raw string when meta isn't valid JSON", async () => {
+    mockSelect.mockReturnValue(makeDbChain([row({ meta: "not-json" })]));
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.entries[0].meta).toBe("not-json");
+  });
+
+  it("returns null meta as-is", async () => {
+    mockSelect.mockReturnValue(makeDbChain([row({ meta: null })]));
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.entries[0].meta).toBeNull();
+  });
+
+  it("falls back to the default limit of 100 for a non-numeric limit", async () => {
+    let capturedLimit: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
+    await GET(req("abc"));
+    expect(capturedLimit).toBe(100);
+  });
+
+  it("falls back to the default limit of 100 for a negative limit", async () => {
+    let capturedLimit: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
+    await GET(req("-5"));
+    expect(capturedLimit).toBe(100);
+  });
+
+  it("caps an oversized limit at 500", async () => {
+    let capturedLimit: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
+    const res = await GET(req("10000"));
+    expect(res.status).toBe(200);
+    expect(capturedLimit).toBe(500);
+  });
+
+  it("honors a valid custom limit within the cap", async () => {
+    let capturedLimit: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
+    await GET(req("25"));
+    expect(capturedLimit).toBe(25);
+  });
+});

--- a/__tests__/api/admin/connections.test.ts
+++ b/__tests__/api/admin/connections.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockUpdate } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockUpdate: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, update: mockUpdate } }));
+
+import { GET, PATCH } from "@/app/api/admin/connections/route";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+const connectionRow = {
+  id: 7,
+  fromRef: "2:255",
+  toRef: "24:35",
+  kind: "thematic",
+  status: "active",
+  createdAt: new Date("2026-01-01"),
+};
+
+function get(query?: string) {
+  const url = query
+    ? `http://localhost/api/admin/connections?${query}`
+    : "http://localhost/api/admin/connections";
+  return new NextRequest(url, { headers: { Authorization: "Bearer t" } });
+}
+function patch(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/connections", {
+    method: "PATCH",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([]));
+  mockUpdate.mockReturnValue(makeDbChain([]));
+  vi.mocked(logAdminAction).mockClear();
+});
+
+describe("GET /api/admin/connections", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for an unknown status filter", async () => {
+    const res = await GET(get("status=bogus"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an unknown kind filter", async () => {
+    const res = await GET(get("kind=bogus"));
+    expect(res.status).toBe(400);
+  });
+
+  it("lists connections with valid filters", async () => {
+    mockSelect.mockReturnValue(makeDbChain([connectionRow]));
+    const res = await GET(get("status=active&kind=thematic"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connections).toEqual([
+      { ...connectionRow, createdAt: connectionRow.createdAt.toISOString() },
+    ]);
+  });
+});
+
+describe("PATCH /api/admin/connections", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/connections", {
+      method: "PATCH",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await PATCH(req)).status).toBe(400);
+  });
+
+  it("returns 400 for a non-integer id", async () => {
+    const res = await PATCH(patch({ id: "abc", status: "flagged" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid status", async () => {
+    const res = await PATCH(patch({ id: 7, status: "bogus" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the connection doesn't exist", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([]));
+    const res = await PATCH(patch({ id: 7, status: "flagged" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("updates the status and logs the action", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([{ ...connectionRow, status: "flagged" }]));
+    const res = await PATCH(patch({ id: 7, status: "flagged" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connection.status).toBe("flagged");
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "connection.status", targetId: "7" })
+    );
+  });
+});

--- a/__tests__/api/admin/flags.test.ts
+++ b/__tests__/api/admin/flags.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockInsert, mockDelete } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockInsert: vi.fn(() => makeDbChain([])),
+  mockDelete: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, insert: mockInsert, delete: mockDelete } }));
+
+import { GET, PUT, DELETE } from "@/app/api/admin/flags/route";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function get() {
+  return new NextRequest("http://localhost/api/admin/flags", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+function put(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/flags", {
+    method: "PUT",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+function del(key?: string) {
+  const url = key
+    ? `http://localhost/api/admin/flags?key=${key}`
+    : "http://localhost/api/admin/flags";
+  return new NextRequest(url, { method: "DELETE", headers: { Authorization: "Bearer t" } });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([]));
+  mockInsert.mockReturnValue(makeDbChain([]));
+  mockDelete.mockReturnValue(makeDbChain([]));
+  vi.mocked(logAdminAction).mockClear();
+});
+
+describe("GET /api/admin/flags", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns flags with parsed JSON values", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([
+        {
+          key: "new-canvas",
+          value: JSON.stringify({ enabled: true }),
+          updatedBy: "qf-admin",
+          updatedAt: new Date("2026-01-01"),
+        },
+      ])
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.flags[0].value).toEqual({ enabled: true });
+  });
+
+  it("falls back to the raw string when a value isn't valid JSON", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([{ key: "bad", value: "not-json", updatedBy: "qf-admin", updatedAt: new Date() }])
+    );
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.flags[0].value).toBe("not-json");
+  });
+});
+
+describe("PUT /api/admin/flags", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/flags", {
+      method: "PUT",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await PUT(req)).status).toBe(400);
+  });
+
+  it("returns 400 for an invalid key", async () => {
+    expect((await PUT(put({ key: "Bad Key!", value: true }))).status).toBe(400);
+    expect((await PUT(put({ key: "", value: true }))).status).toBe(400);
+  });
+
+  it("returns 400 when value is missing", async () => {
+    const res = await PUT(put({ key: "valid-key" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("upserts a valid flag and logs the action", async () => {
+    const res = await PUT(put({ key: "new-canvas", value: { enabled: true } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.key).toBe("new-canvas");
+    expect(body.value).toEqual({ enabled: true });
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "flag.set", targetId: "new-canvas" })
+    );
+  });
+
+  it("accepts value: false (not treated as missing)", async () => {
+    const res = await PUT(put({ key: "some-flag", value: false }));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("DELETE /api/admin/flags", () => {
+  it("returns 400 for a missing key", async () => {
+    expect((await DELETE(del())).status).toBe(400);
+  });
+
+  it("returns 400 for an invalid key", async () => {
+    expect((await DELETE(del("Bad Key!"))).status).toBe(400);
+  });
+
+  it("deletes a valid key and logs the action", async () => {
+    const res = await DELETE(del("new-canvas"));
+    expect(res.status).toBe(204);
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "flag.delete", targetId: "new-canvas" })
+    );
+  });
+});

--- a/__tests__/api/admin/infra.test.ts
+++ b/__tests__/api/admin/infra.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockCount, mockDelete } = vi.hoisted(() => ({
+  mockCount: vi.fn(() => Promise.resolve(0)),
+  mockDelete: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { $count: mockCount, delete: mockDelete } }));
+
+const { mockRedisEnabled, mockGetRedis } = vi.hoisted(() => ({
+  mockRedisEnabled: vi.fn(() => false),
+  mockGetRedis: vi.fn(() => null),
+}));
+vi.mock("@/lib/redis", () => ({ redisEnabled: mockRedisEnabled, getRedis: mockGetRedis }));
+
+const { mockCounterSnapshot, mockUptimeSeconds } = vi.hoisted(() => ({
+  mockCounterSnapshot: vi.fn(() => ({})),
+  mockUptimeSeconds: vi.fn(() => 123),
+}));
+vi.mock("@/lib/metrics", () => ({
+  counterSnapshot: mockCounterSnapshot,
+  uptimeSeconds: mockUptimeSeconds,
+}));
+
+const { mockTokenCache, mockClearTokenCache, mockClearJwksCache } = vi.hoisted(() => ({
+  mockTokenCache: new Map(),
+  mockClearTokenCache: vi.fn(() => 0),
+  mockClearJwksCache: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/lib/social-auth", () => ({
+  tokenCache: mockTokenCache,
+  clearTokenCache: mockClearTokenCache,
+  clearJwksCache: mockClearJwksCache,
+}));
+
+import { GET, POST } from "@/app/api/admin/infra/route";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function get() {
+  return new NextRequest("http://localhost/api/admin/infra", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+function post(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/infra", {
+    method: "POST",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockCount.mockReset();
+  mockCount.mockImplementation(() => Promise.resolve(0));
+  mockDelete.mockReturnValue(makeDbChain([]));
+  mockRedisEnabled.mockReturnValue(false);
+  mockGetRedis.mockReturnValue(null);
+  mockClearTokenCache.mockClear();
+  mockClearJwksCache.mockClear();
+  vi.mocked(logAdminAction).mockClear();
+});
+
+describe("GET /api/admin/infra", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns an infra snapshot with rate limit row count and metrics", async () => {
+    mockCount.mockImplementation(() => Promise.resolve(7));
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rateLimitRows).toBe(7);
+    expect(body.uptimeSeconds).toBe(123);
+    expect(body.redis).toBe("disabled");
+  });
+
+  it('reports redis as "up" when the client responds to ping', async () => {
+    mockRedisEnabled.mockReturnValue(true);
+    mockGetRedis.mockReturnValue({ ping: vi.fn().mockResolvedValue("PONG") } as never);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.redis).toBe("up");
+  });
+
+  it('reports redis as "down" when ping throws', async () => {
+    mockRedisEnabled.mockReturnValue(true);
+    mockGetRedis.mockReturnValue({ ping: vi.fn().mockRejectedValue(new Error("x")) } as never);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.redis).toBe("down");
+  });
+});
+
+describe("POST /api/admin/infra", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/infra", {
+      method: "POST",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await POST(req)).status).toBe(400);
+  });
+
+  it("returns 400 for an unknown action", async () => {
+    const res = await POST(post({ action: "bogus" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("flushes the token cache and logs the action", async () => {
+    mockClearTokenCache.mockReturnValue(5);
+    const res = await POST(post({ action: "flush-tokens" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cleared).toBe(5);
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "infra.flush-tokens" })
+    );
+  });
+
+  it("flushes the JWKS cache", async () => {
+    const res = await POST(post({ action: "flush-jwks" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(mockClearJwksCache).toHaveBeenCalled();
+  });
+
+  it("resets rate limits and reports the deleted count", async () => {
+    mockDelete.mockReturnValue(makeDbChain([{ key: "a" }, { key: "b" }]));
+    const res = await POST(post({ action: "reset-ratelimits" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deleted).toBe(2);
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "infra.reset-ratelimits" })
+    );
+  });
+});

--- a/__tests__/api/admin/me.test.ts
+++ b/__tests__/api/admin/me.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+
+import { GET } from "@/app/api/admin/me/route";
+import { requireAdmin } from "@/lib/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin", username: "admin_user" } as User };
+
+function req() {
+  return new NextRequest("http://localhost/api/admin/me", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+
+describe("GET /api/admin/me", () => {
+  it("returns the admin identity", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(admin);
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ qfId: "qf-admin", username: "admin_user" });
+  });
+
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the guard's own 401 for an unauthenticated caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/api/admin/names.test.ts
+++ b/__tests__/api/admin/names.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockUpdate, mockDelete } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockUpdate: vi.fn(() => makeDbChain([])),
+  mockDelete: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, update: mockUpdate, delete: mockDelete } }));
+
+import { GET, PATCH, DELETE } from "@/app/api/admin/names/route";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function get() {
+  return new NextRequest("http://localhost/api/admin/names", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+function patch(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/names", {
+    method: "PATCH",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+function del(query?: string) {
+  const url = query
+    ? `http://localhost/api/admin/names?${query}`
+    : "http://localhost/api/admin/names";
+  return new NextRequest(url, { method: "DELETE", headers: { Authorization: "Bearer t" } });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([]));
+  mockUpdate.mockReturnValue(makeDbChain([]));
+  mockDelete.mockReturnValue(makeDbChain([]));
+  vi.mocked(logAdminAction).mockClear();
+});
+
+describe("GET /api/admin/names", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns rows with parsed data and falls back to raw string on bad JSON", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([
+        {
+          slug: "ar-rahman",
+          kind: "reflection",
+          data: JSON.stringify({ text: "hi" }),
+          model: "claude",
+          version: 1,
+          updatedAt: new Date("2026-01-01"),
+        },
+        {
+          slug: "ar-rahim",
+          kind: "reflection",
+          data: "not-json",
+          model: "claude",
+          version: 1,
+          updatedAt: new Date("2026-01-01"),
+        },
+      ])
+    );
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.rows[0].data).toEqual({ text: "hi" });
+    expect(body.rows[1].data).toBe("not-json");
+  });
+});
+
+describe("PATCH /api/admin/names", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/names", {
+      method: "PATCH",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await PATCH(req)).status).toBe(400);
+  });
+
+  it("returns 400 for a missing slug or invalid kind", async () => {
+    expect((await PATCH(patch({ slug: "", kind: "verses", data: {} }))).status).toBe(400);
+    expect((await PATCH(patch({ slug: "ar-rahman", kind: "bogus", data: {} }))).status).toBe(400);
+  });
+
+  it("returns 400 when data is missing", async () => {
+    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when there's no cached row for that slug/kind", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([]));
+    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses", data: { a: 1 } }));
+    expect(res.status).toBe(404);
+  });
+
+  it("updates the cached content and logs the action", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([{ slug: "ar-rahman", kind: "verses" }]));
+    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses", data: { a: 1 } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ a: 1 });
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "name.edit", targetId: "ar-rahman/verses" })
+    );
+  });
+});
+
+describe("DELETE /api/admin/names", () => {
+  it("returns 400 for a missing slug or kind", async () => {
+    expect((await DELETE(del())).status).toBe(400);
+    expect((await DELETE(del("slug=ar-rahman"))).status).toBe(400);
+  });
+
+  it("returns 400 for an invalid kind", async () => {
+    expect((await DELETE(del("slug=ar-rahman&kind=bogus"))).status).toBe(400);
+  });
+
+  it("invalidates the cache entry and logs the action", async () => {
+    const res = await DELETE(del("slug=ar-rahman&kind=verses"));
+    expect(res.status).toBe(204);
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "name.invalidate", targetId: "ar-rahman/verses" })
+    );
+  });
+});

--- a/__tests__/api/admin/overview.test.ts
+++ b/__tests__/api/admin/overview.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockCount } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockCount: vi.fn(() => Promise.resolve(0)),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, $count: mockCount } }));
+
+const { mockRedisEnabled, mockGetRedis } = vi.hoisted(() => ({
+  mockRedisEnabled: vi.fn(() => false),
+  mockGetRedis: vi.fn(() => null),
+}));
+vi.mock("@/lib/redis", () => ({
+  redisEnabled: mockRedisEnabled,
+  getRedis: mockGetRedis,
+}));
+
+import { GET } from "@/app/api/admin/overview/route";
+import { requireAdmin } from "@/lib/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function req() {
+  return new NextRequest("http://localhost/api/admin/overview", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+
+// The route calls db.$count 6 times, in this literal order:
+// totalUsers, disabledUsers, totalConnections, flaggedConnections, curatedTotal, curatedUpcoming
+function queueCounts(counts: [number, number, number, number, number, number]) {
+  counts.forEach((n) => mockCount.mockImplementationOnce(() => Promise.resolve(n)));
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([{ gens: 0, tokens: 0 }]));
+  mockCount.mockReset();
+  mockCount.mockImplementation(() => Promise.resolve(0));
+  mockRedisEnabled.mockReturnValue(false);
+  mockGetRedis.mockReturnValue(null);
+});
+
+describe("GET /api/admin/overview", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(404);
+  });
+
+  it("aggregates users, connections, votd, and AI stats", async () => {
+    queueCounts([100, 5, 40, 3, 30, 2]);
+    mockSelect.mockReturnValue(makeDbChain([{ gens: 12, tokens: 4500 }]));
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toEqual({ total: 100, disabled: 5 });
+    expect(body.connections).toEqual({ total: 40, flagged: 3 });
+    expect(body.votd).toEqual({ total: 30, upcoming: 2 });
+    expect(body.aiMonthToDate).toEqual({ generations: 12, tokens: 4500 });
+  });
+
+  it("defaults AI stats to zero when there are no generations this month", async () => {
+    mockSelect.mockReturnValue(makeDbChain([]));
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.aiMonthToDate).toEqual({ generations: 0, tokens: 0 });
+  });
+
+  it('reports redis as "disabled" when no Redis client is configured', async () => {
+    mockRedisEnabled.mockReturnValue(false);
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.redis).toBe("disabled");
+  });
+
+  it('reports redis as "up" when the client responds to ping', async () => {
+    mockRedisEnabled.mockReturnValue(true);
+    mockGetRedis.mockReturnValue({ ping: vi.fn().mockResolvedValue("PONG") } as never);
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.redis).toBe("up");
+  });
+
+  it('reports redis as "down" when ping fails', async () => {
+    mockRedisEnabled.mockReturnValue(true);
+    mockGetRedis.mockReturnValue({
+      ping: vi.fn().mockRejectedValue(new Error("timeout")),
+    } as never);
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.redis).toBe("down");
+  });
+});

--- a/__tests__/api/admin/users.test.ts
+++ b/__tests__/api/admin/users.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn(), isAdminQfId: vi.fn(() => false) }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+vi.mock("@/lib/social-auth", () => ({ clearTokenCache: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockUpdate } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockUpdate: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, update: mockUpdate } }));
+
+import { GET, PATCH } from "@/app/api/admin/users/route";
+import { requireAdmin, isAdminQfId } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+import { clearTokenCache } from "@/lib/social-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+const targetUser = {
+  id: 42,
+  qfId: "qf-42",
+  username: "someone",
+  displayName: "Someone",
+  createdAt: new Date("2026-01-01"),
+  lastActiveAt: new Date("2026-01-02"),
+  currentStreak: 3,
+  longestStreak: 10,
+  disabledAt: null,
+};
+
+function get(query?: string) {
+  const url = query
+    ? `http://localhost/api/admin/users?${query}`
+    : "http://localhost/api/admin/users";
+  return new NextRequest(url, { headers: { Authorization: "Bearer t" } });
+}
+function patch(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/users", {
+    method: "PATCH",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  vi.mocked(isAdminQfId).mockReturnValue(false);
+  mockSelect.mockReturnValue(makeDbChain([]));
+  mockUpdate.mockReturnValue(makeDbChain([]));
+  vi.mocked(logAdminAction).mockClear();
+  vi.mocked(clearTokenCache).mockClear();
+});
+
+describe("GET /api/admin/users", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("lists users with an isAdmin flag computed per row", async () => {
+    mockSelect.mockReturnValue(makeDbChain([targetUser]));
+    vi.mocked(isAdminQfId).mockReturnValue(true);
+
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].isAdmin).toBe(true);
+    expect(body.users[0].username).toBe("someone");
+  });
+});
+
+describe("PATCH /api/admin/users", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/users", {
+      method: "PATCH",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await PATCH(req)).status).toBe(400);
+  });
+
+  it("returns 400 when id or disabled has the wrong type", async () => {
+    expect((await PATCH(patch({ id: "42", disabled: true }))).status).toBe(400);
+    expect((await PATCH(patch({ id: 42, disabled: "yes" }))).status).toBe(400);
+  });
+
+  it("returns 404 when the target user doesn't exist", async () => {
+    mockSelect.mockReturnValue(makeDbChain([]));
+    const res = await PATCH(patch({ id: 42, disabled: true }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when attempting to disable an admin account", async () => {
+    mockSelect.mockReturnValue(makeDbChain([targetUser]));
+    vi.mocked(isAdminQfId).mockReturnValue(true);
+
+    const res = await PATCH(patch({ id: 42, disabled: true }));
+    expect(res.status).toBe(403);
+  });
+
+  it("disables a non-admin user, clears the token cache, and logs the action", async () => {
+    mockSelect.mockReturnValue(makeDbChain([targetUser]));
+    mockUpdate.mockReturnValue(makeDbChain([{ id: 42, disabledAt: new Date("2026-06-01") }]));
+
+    const res = await PATCH(patch({ id: 42, disabled: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(42);
+    expect(clearTokenCache).toHaveBeenCalled();
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "user.disable", targetId: "42" })
+    );
+  });
+
+  it("re-enables a user and logs user.enable", async () => {
+    mockSelect.mockReturnValue(makeDbChain([{ ...targetUser, disabledAt: new Date() }]));
+    mockUpdate.mockReturnValue(makeDbChain([{ id: 42, disabledAt: null }]));
+
+    const res = await PATCH(patch({ id: 42, disabled: false }));
+    expect(res.status).toBe(200);
+    expect(logAdminAction).toHaveBeenCalledWith(expect.objectContaining({ action: "user.enable" }));
+  });
+
+  it("returns 404 if the row disappears between the select and the update", async () => {
+    mockSelect.mockReturnValue(makeDbChain([targetUser]));
+    mockUpdate.mockReturnValue(makeDbChain([]));
+
+    const res = await PATCH(patch({ id: 42, disabled: true }));
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/api/auth-refresh.test.ts
+++ b/__tests__/api/auth-refresh.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/auth/refresh/route";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function makeReq(refreshToken?: string) {
+  return new NextRequest("http://localhost/api/auth/refresh", {
+    method: "POST",
+    headers: refreshToken ? { Cookie: `qf_refresh_token=${refreshToken}` } : {},
+  });
+}
+
+describe("POST /api/auth/refresh", () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it("returns 401 when there is no refresh cookie", async () => {
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/no session/i);
+  });
+
+  it("returns 200 with a new access token and rotates the cookie", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "access-1", refresh_token: "refresh-rotated-1" }),
+    });
+
+    const res = await POST(makeReq("refresh-old-1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accessToken).toBe("access-1");
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("qf_refresh_token=refresh-rotated-1");
+    expect(setCookie.toLowerCase()).toContain("httponly");
+  });
+
+  it("re-stamps the same refresh token when the provider doesn't rotate", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "access-2" }),
+    });
+
+    const res = await POST(makeReq("refresh-same-2"));
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("qf_refresh_token=refresh-same-2");
+  });
+
+  it("returns 401 and clears the cookie on invalid_grant", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "invalid_grant" }),
+    });
+
+    const res = await POST(makeReq("refresh-invalid-3"));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/session expired/i);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("qf_refresh_token=;");
+  });
+
+  it("returns 503 and keeps the cookie on a transient upstream failure", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+
+    const res = await POST(makeReq("refresh-transient-4"));
+    expect(res.status).toBe(503);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("returns 503 for a non-invalid_grant error response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "server_error" }),
+    });
+
+    const res = await POST(makeReq("refresh-servererr-5"));
+    expect(res.status).toBe(503);
+  });
+
+  it("does not cache a transient failure, so a retry hits the token endpoint again", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+    const first = await POST(makeReq("refresh-retry-6"));
+    expect(first.status).toBe(503);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "access-6", refresh_token: "refresh-rotated-6" }),
+    });
+    const second = await POST(makeReq("refresh-retry-6"));
+    expect(second.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent requests for the same token into a single upstream call", async () => {
+    let resolveFetch!: (value: unknown) => void;
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const p1 = POST(makeReq("refresh-concurrent-7"));
+    const p2 = POST(makeReq("refresh-concurrent-7"));
+
+    resolveFetch({
+      ok: true,
+      json: async () => ({ access_token: "access-7", refresh_token: "refresh-rotated-7" }),
+    });
+
+    const [res1, res2] = await Promise.all([p1, p2]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+  });
+
+  it("serves a just-completed result to a request arriving right after, without a second upstream call", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "access-8", refresh_token: "refresh-rotated-8" }),
+    });
+
+    const first = await POST(makeReq("refresh-cached-8"));
+    expect(first.status).toBe(200);
+
+    const second = await POST(makeReq("refresh-cached-8"));
+    expect(second.status).toBe(200);
+    const secondBody = await second.json();
+    expect(secondBody.accessToken).toBe("access-8");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/api/auth-signout.test.ts
+++ b/__tests__/api/auth-signout.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/auth/signout/route";
+
+const { mockInvalidateTokenCache } = vi.hoisted(() => ({
+  mockInvalidateTokenCache: vi.fn(),
+}));
+vi.mock("@/lib/social-auth", () => ({
+  invalidateTokenCache: mockInvalidateTokenCache,
+}));
+
+function makeReq(bearerToken?: string) {
+  return new NextRequest("http://localhost/api/auth/signout", {
+    method: "POST",
+    headers: bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {},
+  });
+}
+
+describe("POST /api/auth/signout", () => {
+  beforeEach(() => mockInvalidateTokenCache.mockReset());
+
+  it("invalidates the token cache and clears the refresh cookie when a Bearer token is present", async () => {
+    const res = await POST(makeReq("access-token-123"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(mockInvalidateTokenCache).toHaveBeenCalledWith("access-token-123");
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("qf_refresh_token=;");
+  });
+
+  it("still succeeds and clears the cookie when no Authorization header is present", async () => {
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(mockInvalidateTokenCache).not.toHaveBeenCalled();
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("qf_refresh_token=;");
+  });
+
+  it("does not invalidate the cache for a malformed (non-Bearer) Authorization header", async () => {
+    const req = new NextRequest("http://localhost/api/auth/signout", {
+      method: "POST",
+      headers: { Authorization: "Basic sometoken" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockInvalidateTokenCache).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Tracking PR for #120 — most privileged/mutating admin routes and 2 auth routes (`refresh`, `signout`) have no dedicated test coverage. This branch is the merge target for the child PRs below; nothing lands directly here except their merges.

Part of #120.

## Child PRs

- [x] Auth routes (`refresh`, `signout`) — #141
- [x] Admin read-only routes (`me`, `overview`, `audit`) — #142
- [x] Admin write routes (`users`, `connections`, `flags`) — #143
- [x] Admin remaining routes (`names`, `infra`, `ai`) — #144

Each child branches off `test-coverage/120` and PRs into it. Once all four are merged in, this PR goes ready-for-review and merges into `main`, closing #120.