### PR TITLE
test: add coverage for admin me/audit/overview routes

### DIFF
--- a/__tests__/api/admin/audit.test.ts
+++ b/__tests__/api/admin/audit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = [], onLimit?: (n: number) => void) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        if (prop === "limit" && onLimit) return (n: number) => (onLimit(n), chain);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect } }));
+
+import { GET } from "@/app/api/admin/audit/route";
+import { requireAdmin } from "@/lib/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function req(limit?: string) {
+  const url = limit
+    ? `http://localhost/api/admin/audit?limit=${limit}`
+    : "http://localhost/api/admin/audit";
+  return new NextRequest(url, { headers: { Authorization: "Bearer t" } });
+}
+
+const row = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 1,
+  adminQfId: "qf-admin",
+  action: "user.disable",
+  targetType: "user",
+  targetId: "42",
+  meta: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([]));
+});
+
+describe("GET /api/admin/audit", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns entries with parsed meta", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([row({ meta: JSON.stringify({ from: "active", to: "flagged" }) })])
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].meta).toEqual({ from: "active", to: "flagged" });
+  });
+
+  it("falls back to the raw string when meta isn't valid JSON", async () => {
+    mockSelect.mockReturnValue(makeDbChain([row({ meta: "not-json" })]));
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.entries[0].meta).toBe("not-json");
+  });
+
+  it("returns null meta as-is", async () => {
+    mockSelect.mockReturnValue(makeDbChain([row({ meta: null })]));
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.entries[0].meta).toBeNull();
+  });
+
+  it("falls back to the default limit of 100 for a non-numeric limit", async () => {
+    let capturedLimit: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
+    await GET(req("abc"));
+    expect(capturedLimit).toBe(100);
+  });
+
+  it("falls back to the default limit of 100 for a negative limit", async () => {
+    let capturedLimit: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
+    await GET(req("-5"));
+    expect(capturedLimit).toBe(100);
+  });
+
+  it("caps an oversized limit at 500", async () => {
+    let capturedLimit: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
+    const res = await GET(req("10000"));
+    expect(res.status).toBe(200);
+    expect(capturedLimit).toBe(500);
+  });
+
+  it("honors a valid custom limit within the cap", async () => {
+    let capturedLimit: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
+    await GET(req("25"));
+    expect(capturedLimit).toBe(25);
+  });
+});

--- a/__tests__/api/admin/me.test.ts
+++ b/__tests__/api/admin/me.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+
+import { GET } from "@/app/api/admin/me/route";
+import { requireAdmin } from "@/lib/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin", username: "admin_user" } as User };
+
+function req() {
+  return new NextRequest("http://localhost/api/admin/me", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+
+describe("GET /api/admin/me", () => {
+  it("returns the admin identity", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(admin);
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ qfId: "qf-admin", username: "admin_user" });
+  });
+
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the guard's own 401 for an unauthenticated caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/api/admin/overview.test.ts
+++ b/__tests__/api/admin/overview.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockCount } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockCount: vi.fn(() => Promise.resolve(0)),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, $count: mockCount } }));
+
+const { mockRedisEnabled, mockGetRedis } = vi.hoisted(() => ({
+  mockRedisEnabled: vi.fn(() => false),
+  mockGetRedis: vi.fn(() => null),
+}));
+vi.mock("@/lib/redis", () => ({
+  redisEnabled: mockRedisEnabled,
+  getRedis: mockGetRedis,
+}));
+
+import { GET } from "@/app/api/admin/overview/route";
+import { requireAdmin } from "@/lib/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function req() {
+  return new NextRequest("http://localhost/api/admin/overview", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+
+// The route calls db.$count 6 times, in this literal order:
+// totalUsers, disabledUsers, totalConnections, flaggedConnections, curatedTotal, curatedUpcoming
+function queueCounts(counts: [number, number, number, number, number, number]) {
+  counts.forEach((n) => mockCount.mockImplementationOnce(() => Promise.resolve(n)));
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([{ gens: 0, tokens: 0 }]));
+  mockCount.mockReset();
+  mockCount.mockImplementation(() => Promise.resolve(0));
+  mockRedisEnabled.mockReturnValue(false);
+  mockGetRedis.mockReturnValue(null);
+});
+
+describe("GET /api/admin/overview", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(404);
+  });
+
+  it("aggregates users, connections, votd, and AI stats", async () => {
+    queueCounts([100, 5, 40, 3, 30, 2]);
+    mockSelect.mockReturnValue(makeDbChain([{ gens: 12, tokens: 4500 }]));
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toEqual({ total: 100, disabled: 5 });
+    expect(body.connections).toEqual({ total: 40, flagged: 3 });
+    expect(body.votd).toEqual({ total: 30, upcoming: 2 });
+    expect(body.aiMonthToDate).toEqual({ generations: 12, tokens: 4500 });
+  });
+
+  it("defaults AI stats to zero when there are no generations this month", async () => {
+    mockSelect.mockReturnValue(makeDbChain([]));
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.aiMonthToDate).toEqual({ generations: 0, tokens: 0 });
+  });
+
+  it('reports redis as "disabled" when no Redis client is configured', async () => {
+    mockRedisEnabled.mockReturnValue(false);
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.redis).toBe("disabled");
+  });
+
+  it('reports redis as "up" when the client responds to ping', async () => {
+    mockRedisEnabled.mockReturnValue(true);
+    mockGetRedis.mockReturnValue({ ping: vi.fn().mockResolvedValue("PONG") } as never);
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.redis).toBe("up");
+  });
+
+  it('reports redis as "down" when ping fails', async () => {
+    mockRedisEnabled.mockReturnValue(true);
+    mockGetRedis.mockReturnValue({
+      ping: vi.fn().mockRejectedValue(new Error("timeout")),
+    } as never);
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.redis).toBe("down");
+  });
+});


### PR DESCRIPTION
## Summary

Read-only admin routes (no `logAdminAction` call):
- `app/api/admin/me/route.ts`: identity check, admin gate 401/404.
- `app/api/admin/audit/route.ts`: limit clamping (default 100, cap 500, invalid falls back to default), and the `meta` JSON-parse-or-raw-string fallback.
- `app/api/admin/overview/route.ts`: aggregate counts across users/connections/votd/AI generations, and the three `redisStatus()` branches (disabled/up/down).

Part of #120. Targets the tracking branch `test-coverage/120` (see #140), not `main`.

## Test plan

- [x] `bun run test:ci` — 17 new tests passing, full suite green
- [x] `bun run typecheck` — clean