### PR TITLE
test: add coverage for admin users/connections/flags routes

### DIFF
--- a/__tests__/api/admin/connections.test.ts
+++ b/__tests__/api/admin/connections.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockUpdate } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockUpdate: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, update: mockUpdate } }));
+
+import { GET, PATCH } from "@/app/api/admin/connections/route";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+const connectionRow = {
+  id: 7,
+  fromRef: "2:255",
+  toRef: "24:35",
+  kind: "thematic",
+  status: "active",
+  createdAt: new Date("2026-01-01"),
+};
+
+function get(query?: string) {
+  const url = query
+    ? `http://localhost/api/admin/connections?${query}`
+    : "http://localhost/api/admin/connections";
+  return new NextRequest(url, { headers: { Authorization: "Bearer t" } });
+}
+function patch(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/connections", {
+    method: "PATCH",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([]));
+  mockUpdate.mockReturnValue(makeDbChain([]));
+  vi.mocked(logAdminAction).mockClear();
+});
+
+describe("GET /api/admin/connections", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for an unknown status filter", async () => {
+    const res = await GET(get("status=bogus"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an unknown kind filter", async () => {
+    const res = await GET(get("kind=bogus"));
+    expect(res.status).toBe(400);
+  });
+
+  it("lists connections with valid filters", async () => {
+    mockSelect.mockReturnValue(makeDbChain([connectionRow]));
+    const res = await GET(get("status=active&kind=thematic"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connections).toEqual([
+      { ...connectionRow, createdAt: connectionRow.createdAt.toISOString() },
+    ]);
+  });
+});
+
+describe("PATCH /api/admin/connections", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/connections", {
+      method: "PATCH",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await PATCH(req)).status).toBe(400);
+  });
+
+  it("returns 400 for a non-integer id", async () => {
+    const res = await PATCH(patch({ id: "abc", status: "flagged" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid status", async () => {
+    const res = await PATCH(patch({ id: 7, status: "bogus" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the connection doesn't exist", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([]));
+    const res = await PATCH(patch({ id: 7, status: "flagged" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("updates the status and logs the action", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([{ ...connectionRow, status: "flagged" }]));
+    const res = await PATCH(patch({ id: 7, status: "flagged" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connection.status).toBe("flagged");
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "connection.status", targetId: "7" })
+    );
+  });
+});

--- a/__tests__/api/admin/flags.test.ts
+++ b/__tests__/api/admin/flags.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockInsert, mockDelete } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockInsert: vi.fn(() => makeDbChain([])),
+  mockDelete: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, insert: mockInsert, delete: mockDelete } }));
+
+import { GET, PUT, DELETE } from "@/app/api/admin/flags/route";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function get() {
+  return new NextRequest("http://localhost/api/admin/flags", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+function put(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/flags", {
+    method: "PUT",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+function del(key?: string) {
+  const url = key
+    ? `http://localhost/api/admin/flags?key=${key}`
+    : "http://localhost/api/admin/flags";
+  return new NextRequest(url, { method: "DELETE", headers: { Authorization: "Bearer t" } });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([]));
+  mockInsert.mockReturnValue(makeDbChain([]));
+  mockDelete.mockReturnValue(makeDbChain([]));
+  vi.mocked(logAdminAction).mockClear();
+});
+
+describe("GET /api/admin/flags", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns flags with parsed JSON values", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([
+        {
+          key: "new-canvas",
+          value: JSON.stringify({ enabled: true }),
+          updatedBy: "qf-admin",
+          updatedAt: new Date("2026-01-01"),
+        },
+      ])
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.flags[0].value).toEqual({ enabled: true });
+  });
+
+  it("falls back to the raw string when a value isn't valid JSON", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([{ key: "bad", value: "not-json", updatedBy: "qf-admin", updatedAt: new Date() }])
+    );
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.flags[0].value).toBe("not-json");
+  });
+});
+
+describe("PUT /api/admin/flags", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/flags", {
+      method: "PUT",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await PUT(req)).status).toBe(400);
+  });
+
+  it("returns 400 for an invalid key", async () => {
+    expect((await PUT(put({ key: "Bad Key!", value: true }))).status).toBe(400);
+    expect((await PUT(put({ key: "", value: true }))).status).toBe(400);
+  });
+
+  it("returns 400 when value is missing", async () => {
+    const res = await PUT(put({ key: "valid-key" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("upserts a valid flag and logs the action", async () => {
+    const res = await PUT(put({ key: "new-canvas", value: { enabled: true } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.key).toBe("new-canvas");
+    expect(body.value).toEqual({ enabled: true });
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "flag.set", targetId: "new-canvas" })
+    );
+  });
+
+  it("accepts value: false (not treated as missing)", async () => {
+    const res = await PUT(put({ key: "some-flag", value: false }));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("DELETE /api/admin/flags", () => {
+  it("returns 400 for a missing key", async () => {
+    expect((await DELETE(del())).status).toBe(400);
+  });
+
+  it("returns 400 for an invalid key", async () => {
+    expect((await DELETE(del("Bad Key!"))).status).toBe(400);
+  });
+
+  it("deletes a valid key and logs the action", async () => {
+    const res = await DELETE(del("new-canvas"));
+    expect(res.status).toBe(204);
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "flag.delete", targetId: "new-canvas" })
+    );
+  });
+});

--- a/__tests__/api/admin/users.test.ts
+++ b/__tests__/api/admin/users.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn(), isAdminQfId: vi.fn(() => false) }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+vi.mock("@/lib/social-auth", () => ({ clearTokenCache: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockUpdate } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockUpdate: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, update: mockUpdate } }));
+
+import { GET, PATCH } from "@/app/api/admin/users/route";
+import { requireAdmin, isAdminQfId } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+import { clearTokenCache } from "@/lib/social-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+const targetUser = {
+  id: 42,
+  qfId: "qf-42",
+  username: "someone",
+  displayName: "Someone",
+  createdAt: new Date("2026-01-01"),
+  lastActiveAt: new Date("2026-01-02"),
+  currentStreak: 3,
+  longestStreak: 10,
+  disabledAt: null,
+};
+
+function get(query?: string) {
+  const url = query
+    ? `http://localhost/api/admin/users?${query}`
+    : "http://localhost/api/admin/users";
+  return new NextRequest(url, { headers: { Authorization: "Bearer t" } });
+}
+function patch(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/users", {
+    method: "PATCH",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  vi.mocked(isAdminQfId).mockReturnValue(false);
+  mockSelect.mockReturnValue(makeDbChain([]));
+  mockUpdate.mockReturnValue(makeDbChain([]));
+  vi.mocked(logAdminAction).mockClear();
+  vi.mocked(clearTokenCache).mockClear();
+});
+
+describe("GET /api/admin/users", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("lists users with an isAdmin flag computed per row", async () => {
+    mockSelect.mockReturnValue(makeDbChain([targetUser]));
+    vi.mocked(isAdminQfId).mockReturnValue(true);
+
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].isAdmin).toBe(true);
+    expect(body.users[0].username).toBe("someone");
+  });
+});
+
+describe("PATCH /api/admin/users", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/users", {
+      method: "PATCH",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await PATCH(req)).status).toBe(400);
+  });
+
+  it("returns 400 when id or disabled has the wrong type", async () => {
+    expect((await PATCH(patch({ id: "42", disabled: true }))).status).toBe(400);
+    expect((await PATCH(patch({ id: 42, disabled: "yes" }))).status).toBe(400);
+  });
+
+  it("returns 404 when the target user doesn't exist", async () => {
+    mockSelect.mockReturnValue(makeDbChain([]));
+    const res = await PATCH(patch({ id: 42, disabled: true }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when attempting to disable an admin account", async () => {
+    mockSelect.mockReturnValue(makeDbChain([targetUser]));
+    vi.mocked(isAdminQfId).mockReturnValue(true);
+
+    const res = await PATCH(patch({ id: 42, disabled: true }));
+    expect(res.status).toBe(403);
+  });
+
+  it("disables a non-admin user, clears the token cache, and logs the action", async () => {
+    mockSelect.mockReturnValue(makeDbChain([targetUser]));
+    mockUpdate.mockReturnValue(makeDbChain([{ id: 42, disabledAt: new Date("2026-06-01") }]));
+
+    const res = await PATCH(patch({ id: 42, disabled: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(42);
+    expect(clearTokenCache).toHaveBeenCalled();
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "user.disable", targetId: "42" })
+    );
+  });
+
+  it("re-enables a user and logs user.enable", async () => {
+    mockSelect.mockReturnValue(makeDbChain([{ ...targetUser, disabledAt: new Date() }]));
+    mockUpdate.mockReturnValue(makeDbChain([{ id: 42, disabledAt: null }]));
+
+    const res = await PATCH(patch({ id: 42, disabled: false }));
+    expect(res.status).toBe(200);
+    expect(logAdminAction).toHaveBeenCalledWith(expect.objectContaining({ action: "user.enable" }));
+  });
+
+  it("returns 404 if the row disappears between the select and the update", async () => {
+    mockSelect.mockReturnValue(makeDbChain([targetUser]));
+    mockUpdate.mockReturnValue(makeDbChain([]));
+
+    const res = await PATCH(patch({ id: 42, disabled: true }));
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Mutation admin routes gated by `requireAdmin` and logged via `logAdminAction`:
- `app/api/admin/users/route.ts`: list w/ isAdmin flag, disable/enable incl. the self/admin-lockout guard (403) and `clearTokenCache` side effect, and the disappeared-between-select-and-update race (404).
- `app/api/admin/connections/route.ts`: status filter validation, status transition + 404.
- `app/api/admin/flags/route.ts`: key regex validation, upsert incl. `value: false` (must not be treated as missing), delete.

Part of #120. Targets the tracking branch `test-coverage/120` (see #140), not `main`.

## Test plan

- [x] `bun run test:ci` — 29 new tests passing, full suite green
- [x] `bun run typecheck` — clean