### PR TITLE
test: add coverage for admin names/infra/ai routes

### DIFF
--- a/__tests__/api/admin/ai.test.ts
+++ b/__tests__/api/admin/ai.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+function makeRejectingChain(error: Error) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (_res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.reject(error).then(_res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect } }));
+
+import { GET } from "@/app/api/admin/ai/route";
+import { requireAdmin } from "@/lib/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function get() {
+  return new NextRequest("http://localhost/api/admin/ai", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+
+// The route fires 5 db.select(...) queries in this literal Promise.all order:
+// totals, monthTotals, byModel, byKind, daily.
+function queueQueries(results: [unknown, unknown, unknown, unknown, unknown]) {
+  results.forEach((r) => mockSelect.mockReturnValueOnce(makeDbChain(r)));
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReset();
+  mockSelect.mockReturnValue(makeDbChain([]));
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("GET /api/admin/ai", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("aggregates totals, byModel, byKind, and daily series", async () => {
+    queueQueries([
+      [{ gens: 50, tokens: 100000 }],
+      [{ gens: 10, tokens: 20000 }],
+      [{ model: "claude-sonnet-5", gens: 50, tokens: 100000 }],
+      [{ kind: "reflection", gens: 50, tokens: 100000 }],
+      [{ day: "2026-06-01", gens: 5, tokens: 9000 }],
+    ]);
+
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toEqual({ gens: 50, tokens: 100000, estCostUsd: null });
+    expect(body.monthToDate).toEqual({ gens: 10, tokens: 20000, estCostUsd: null });
+    expect(body.byModel).toEqual([{ model: "claude-sonnet-5", gens: 50, tokens: 100000 }]);
+    expect(body.byKind).toEqual([{ kind: "reflection", gens: 50, tokens: 100000 }]);
+    expect(body.daily).toEqual([{ day: "2026-06-01", gens: 5, tokens: 9000 }]);
+    expect(body.pricePer1k).toBeNull();
+  });
+
+  it("defaults totals to zero when there are no generations at all", async () => {
+    queueQueries([[], [], [], [], []]);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.total.estCostUsd).toBeNull();
+    expect(body.pricePer1k).toBeNull();
+  });
+
+  it("treats an unset AI_USD_PER_1K_TOKENS as null pricing (not a fabricated cost)", async () => {
+    vi.stubEnv("AI_USD_PER_1K_TOKENS", "");
+    queueQueries([[{ gens: 1, tokens: 1000 }], [], [], [], []]);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.pricePer1k).toBeNull();
+    expect(body.total.estCostUsd).toBeNull();
+  });
+
+  it("treats an invalid AI_USD_PER_1K_TOKENS string as null pricing", async () => {
+    vi.stubEnv("AI_USD_PER_1K_TOKENS", "not-a-number");
+    queueQueries([[{ gens: 1, tokens: 1000 }], [], [], [], []]);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.pricePer1k).toBeNull();
+  });
+
+  it("treats a configured 0 as a real price, not unset", async () => {
+    vi.stubEnv("AI_USD_PER_1K_TOKENS", "0");
+    queueQueries([[{ gens: 1, tokens: 1000 }], [], [], [], []]);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.pricePer1k).toBe(0);
+    expect(body.total.estCostUsd).toBe(0);
+  });
+
+  it("computes an estimated cost from tokens and a configured price", async () => {
+    vi.stubEnv("AI_USD_PER_1K_TOKENS", "0.01");
+    queueQueries([[{ gens: 1, tokens: 100000 }], [], [], [], []]);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.pricePer1k).toBe(0.01);
+    expect(body.total.estCostUsd).toBe(1);
+  });
+
+  it("returns 500 without leaking internals when a query rejects", async () => {
+    mockSelect.mockReturnValueOnce(makeRejectingChain(new Error("connection lost")));
+    const res = await GET(get());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Internal server error");
+  });
+});

--- a/__tests__/api/admin/infra.test.ts
+++ b/__tests__/api/admin/infra.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockCount, mockDelete } = vi.hoisted(() => ({
+  mockCount: vi.fn(() => Promise.resolve(0)),
+  mockDelete: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { $count: mockCount, delete: mockDelete } }));
+
+const { mockRedisEnabled, mockGetRedis } = vi.hoisted(() => ({
+  mockRedisEnabled: vi.fn(() => false),
+  mockGetRedis: vi.fn(() => null),
+}));
+vi.mock("@/lib/redis", () => ({ redisEnabled: mockRedisEnabled, getRedis: mockGetRedis }));
+
+const { mockCounterSnapshot, mockUptimeSeconds } = vi.hoisted(() => ({
+  mockCounterSnapshot: vi.fn(() => ({})),
+  mockUptimeSeconds: vi.fn(() => 123),
+}));
+vi.mock("@/lib/metrics", () => ({
+  counterSnapshot: mockCounterSnapshot,
+  uptimeSeconds: mockUptimeSeconds,
+}));
+
+const { mockTokenCache, mockClearTokenCache, mockClearJwksCache } = vi.hoisted(() => ({
+  mockTokenCache: new Map(),
+  mockClearTokenCache: vi.fn(() => 0),
+  mockClearJwksCache: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/lib/social-auth", () => ({
+  tokenCache: mockTokenCache,
+  clearTokenCache: mockClearTokenCache,
+  clearJwksCache: mockClearJwksCache,
+}));
+
+import { GET, POST } from "@/app/api/admin/infra/route";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function get() {
+  return new NextRequest("http://localhost/api/admin/infra", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+function post(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/infra", {
+    method: "POST",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockCount.mockReset();
+  mockCount.mockImplementation(() => Promise.resolve(0));
+  mockDelete.mockReturnValue(makeDbChain([]));
+  mockRedisEnabled.mockReturnValue(false);
+  mockGetRedis.mockReturnValue(null);
+  mockClearTokenCache.mockClear();
+  mockClearJwksCache.mockClear();
+  vi.mocked(logAdminAction).mockClear();
+});
+
+describe("GET /api/admin/infra", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns an infra snapshot with rate limit row count and metrics", async () => {
+    mockCount.mockImplementation(() => Promise.resolve(7));
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rateLimitRows).toBe(7);
+    expect(body.uptimeSeconds).toBe(123);
+    expect(body.redis).toBe("disabled");
+  });
+
+  it('reports redis as "up" when the client responds to ping', async () => {
+    mockRedisEnabled.mockReturnValue(true);
+    mockGetRedis.mockReturnValue({ ping: vi.fn().mockResolvedValue("PONG") } as never);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.redis).toBe("up");
+  });
+
+  it('reports redis as "down" when ping throws', async () => {
+    mockRedisEnabled.mockReturnValue(true);
+    mockGetRedis.mockReturnValue({ ping: vi.fn().mockRejectedValue(new Error("x")) } as never);
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.redis).toBe("down");
+  });
+});
+
+describe("POST /api/admin/infra", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/infra", {
+      method: "POST",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await POST(req)).status).toBe(400);
+  });
+
+  it("returns 400 for an unknown action", async () => {
+    const res = await POST(post({ action: "bogus" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("flushes the token cache and logs the action", async () => {
+    mockClearTokenCache.mockReturnValue(5);
+    const res = await POST(post({ action: "flush-tokens" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cleared).toBe(5);
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "infra.flush-tokens" })
+    );
+  });
+
+  it("flushes the JWKS cache", async () => {
+    const res = await POST(post({ action: "flush-jwks" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(mockClearJwksCache).toHaveBeenCalled();
+  });
+
+  it("resets rate limits and reports the deleted count", async () => {
+    mockDelete.mockReturnValue(makeDbChain([{ key: "a" }, { key: "b" }]));
+    const res = await POST(post({ action: "reset-ratelimits" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deleted).toBe(2);
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "infra.reset-ratelimits" })
+    );
+  });
+});

--- a/__tests__/api/admin/names.test.ts
+++ b/__tests__/api/admin/names.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/db/schema";
+
+vi.mock("@/lib/admin-auth", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/admin-audit", () => ({ logAdminAction: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockUpdate, mockDelete } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockUpdate: vi.fn(() => makeDbChain([])),
+  mockDelete: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/db", () => ({ db: { select: mockSelect, update: mockUpdate, delete: mockDelete } }));
+
+import { GET, PATCH, DELETE } from "@/app/api/admin/names/route";
+import { requireAdmin } from "@/lib/admin-auth";
+import { logAdminAction } from "@/lib/admin-audit";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function get() {
+  return new NextRequest("http://localhost/api/admin/names", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+function patch(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/names", {
+    method: "PATCH",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+function del(query?: string) {
+  const url = query
+    ? `http://localhost/api/admin/names?${query}`
+    : "http://localhost/api/admin/names";
+  return new NextRequest(url, { method: "DELETE", headers: { Authorization: "Bearer t" } });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([]));
+  mockUpdate.mockReturnValue(makeDbChain([]));
+  mockDelete.mockReturnValue(makeDbChain([]));
+  vi.mocked(logAdminAction).mockClear();
+});
+
+describe("GET /api/admin/names", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns rows with parsed data and falls back to raw string on bad JSON", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([
+        {
+          slug: "ar-rahman",
+          kind: "reflection",
+          data: JSON.stringify({ text: "hi" }),
+          model: "claude",
+          version: 1,
+          updatedAt: new Date("2026-01-01"),
+        },
+        {
+          slug: "ar-rahim",
+          kind: "reflection",
+          data: "not-json",
+          model: "claude",
+          version: 1,
+          updatedAt: new Date("2026-01-01"),
+        },
+      ])
+    );
+    const res = await GET(get());
+    const body = await res.json();
+    expect(body.rows[0].data).toEqual({ text: "hi" });
+    expect(body.rows[1].data).toBe("not-json");
+  });
+});
+
+describe("PATCH /api/admin/names", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/names", {
+      method: "PATCH",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await PATCH(req)).status).toBe(400);
+  });
+
+  it("returns 400 for a missing slug or invalid kind", async () => {
+    expect((await PATCH(patch({ slug: "", kind: "verses", data: {} }))).status).toBe(400);
+    expect((await PATCH(patch({ slug: "ar-rahman", kind: "bogus", data: {} }))).status).toBe(400);
+  });
+
+  it("returns 400 when data is missing", async () => {
+    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when there's no cached row for that slug/kind", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([]));
+    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses", data: { a: 1 } }));
+    expect(res.status).toBe(404);
+  });
+
+  it("updates the cached content and logs the action", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([{ slug: "ar-rahman", kind: "verses" }]));
+    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses", data: { a: 1 } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ a: 1 });
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "name.edit", targetId: "ar-rahman/verses" })
+    );
+  });
+});
+
+describe("DELETE /api/admin/names", () => {
+  it("returns 400 for a missing slug or kind", async () => {
+    expect((await DELETE(del())).status).toBe(400);
+    expect((await DELETE(del("slug=ar-rahman"))).status).toBe(400);
+  });
+
+  it("returns 400 for an invalid kind", async () => {
+    expect((await DELETE(del("slug=ar-rahman&kind=bogus"))).status).toBe(400);
+  });
+
+  it("invalidates the cache entry and logs the action", async () => {
+    const res = await DELETE(del("slug=ar-rahman&kind=verses"));
+    expect(res.status).toBe(204);
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "name.invalidate", targetId: "ar-rahman/verses" })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `app/api/admin/names/route.ts`: cached-content edit/invalidate validation (slug/kind/data) and the 404-no-cached-row case.
- `app/api/admin/infra/route.ts`: all 3 maintenance actions (`flush-tokens`, `flush-jwks`, `reset-ratelimits`), the 3 redis-status branches, and the unknown-action 400.
- `app/api/admin/ai/route.ts`: the 5 parallel aggregate queries (totals/monthToDate/byModel/byKind/daily), the `AI_USD_PER_1K_TOKENS` price-parsing edge cases (unset vs. invalid vs. a real configured `0` — all handled distinctly, never fabricating a price), and the route's own top-level try/catch → 500 on a DB failure (the only admin route with that pattern).

Part of #120. Targets the tracking branch `test-coverage/120` (see #140), not `main`.

## Test plan

- [x] `bun run test:ci` — 27 new tests passing, full suite green
- [x] `bun run typecheck` — clean