### PR TITLE
test: Playwright e2e suite (#133)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,54 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    needs: [lint-typecheck-test]
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      DEV_AUTH_TOKEN: e2e-dev-token
+      DEV_AUTH_QF_ID: e2e-dev-qf-id
+      ANTHROPIC_API_KEY: sk-ant-placeholder
+      AI_PROVIDER: claude
+      GEMINI_API_KEY: placeholder-gemini-key
+      GEMINI_MODEL: gemini-2.0-flash
+      NEXT_PUBLIC_QF_CLIENT_ID: placeholder-client-id
+      QF_API_BASE: https://placeholder.example.com
+      QF_AUTH_BASE: https://placeholder.example.com
+      QF_CLIENT_SECRET: placeholder-secret
+      NEXT_PUBLIC_APP_URL: http://localhost:3100
+      NEXT_PUBLIC_QF_AUTH_BASE: https://placeholder.example.com
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run migrations
+        run: bun run db:migrate
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: bun run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ hosting.md
 /.claude/skills/
 
 /local/
+test-results/
+playwright-report/

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "zustand": "^5.0.13",
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@testcontainers/postgresql": "^12.0.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -336,6 +337,8 @@
     "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -1025,7 +1028,7 @@
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1390,6 +1393,10 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1869,7 +1876,11 @@
 
     "tsx/esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
+    "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/e2e/canvas.spec.ts
+++ b/e2e/canvas.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("canvas", () => {
+  test("adding a seed verse shows it on the canvas, and Clear removes it", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/canvas");
+
+    await page.getByRole("button", { name: /search verses/i }).click();
+    await page.getByRole("button", { name: /ayat al-kursi/i }).click();
+
+    await expect(page.getByText("2:255")).toBeVisible();
+
+    await page.getByRole("button", { name: /clear/i }).click();
+
+    await expect(page.getByRole("button", { name: /search verses/i })).toBeVisible();
+    await expect(page.getByText("2:255")).toHaveCount(0);
+  });
+});

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,42 @@
+import { test as base, type Page } from "@playwright/test";
+
+async function loginAsDevUser(page: Page): Promise<void> {
+  const token = process.env.DEV_AUTH_TOKEN;
+  if (!token) {
+    throw new Error("DEV_AUTH_TOKEN must be set in the environment for e2e auth to work");
+  }
+
+  await page.goto("/");
+
+  // Wait for React hydration to complete and window.__devLogin to be available
+  try {
+    await page.waitForFunction(
+      () => {
+        const w = window as unknown as { __devLogin?: unknown };
+        return typeof w.__devLogin === "function";
+      },
+      { timeout: 5000 }
+    );
+  } catch {
+    throw new Error(
+      "window.__devLogin is unavailable — is the app running with NODE_ENV=production?"
+    );
+  }
+
+  await page.evaluate(async (t) => {
+    const w = window as unknown as { __devLogin: (token: string) => Promise<void> };
+    await w.__devLogin(t);
+  }, token);
+
+  await page.waitForFunction(() => sessionStorage.getItem("__devToken") !== null);
+}
+
+export const test = base.extend<{ authenticatedPage: Page }>({
+  authenticatedPage: async ({ page }, use) => {
+    await loginAsDevUser(page);
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- Playwright fixture callback param, not a React hook
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/social.spec.ts
+++ b/e2e/social.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("social", () => {
+  test("leaderboard empty state links to the Friends tab", async ({ authenticatedPage: page }) => {
+    await page.goto("/social");
+
+    await expect(page.getByText("Add friends to see them here.")).toBeVisible();
+    await page.getByRole("button", { name: /go to friends/i }).click();
+
+    await expect(page.getByPlaceholder("Search by username…")).toBeVisible();
+  });
+
+  test("searching a nonexistent username shows an empty result", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/social");
+    await page.getByRole("button", { name: /^friends$/i }).click();
+
+    await page.getByPlaceholder("Search by username…").fill("zzz-nonexistent-user-zzz");
+    await expect(page.getByText("No users found.")).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:e2e": "playwright test",
     "embed": "bun scripts/embed-corpus.mjs",
+    "db:migrate": "bun scripts/migrate.mjs",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest",
     "test:ci": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:e2e": "playwright test",
     "embed": "bun scripts/embed-corpus.mjs",
     "prepare": "husky"
   },
@@ -52,6 +53,7 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@testcontainers/postgresql": "^12.0.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 3100;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    // Must be `next dev`, not a production build: the dev-login auth bypass
+    // (lib/social-auth.ts:36-50) requires NODE_ENV !== "production", which
+    // `next build && next start` cannot satisfy.
+    command: `bun run dev -- -p ${PORT}`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -1,22 +1,18 @@
-// Standalone migration runner — safe to execute in the production container.
-// Uses drizzle-orm's migrate() directly; does not need drizzle-kit or drizzle.config.ts.
+import { join } from "node:path";
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const migrationsFolder = join(__dirname, "../lib/db/migrations");
-
-if (!process.env.DATABASE_URL) {
-  console.error("DATABASE_URL is not set");
+const url = process.env.DATABASE_URL;
+if (!url) {
+  console.error("DATABASE_URL is required");
   process.exit(1);
 }
 
-const sql = postgres(process.env.DATABASE_URL, { max: 1 });
-const db = drizzle(sql);
-
-await migrate(db, { migrationsFolder });
-console.log("Migrations applied successfully");
-await sql.end();
+const sql = postgres(url, { max: 1 });
+try {
+  await migrate(drizzle(sql), { migrationsFolder: join(process.cwd(), "lib/db/migrations") });
+  console.log("Migrations applied");
+} finally {
+  await sql.end();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     // Integration tests need Docker (Testcontainers) and run via
     // vitest.integration.config.ts — keep them out of the fast unit suite.
-    exclude: ["node_modules", ".next", "__tests__/integration/**"],
+    exclude: ["node_modules", ".next", "__tests__/integration/**", "e2e/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
Closes #133. Part of #137.

Adds a Playwright e2e suite:
- `playwright.config.ts` — runs against `next dev` (not a production build — the dev-login auth bypass this suite relies on requires `NODE_ENV !== "production"`, which only `next dev` satisfies).
- `e2e/fixtures/auth.ts` — logs a test in via the app's existing `window.__devLogin` dev-bypass helper.
- `e2e/canvas.spec.ts` — adds a seed verse via search, verifies it renders, clears the canvas.
- `e2e/social.spec.ts` — leaderboard empty-state → Friends tab flow, and a nonexistent-username search.
- New `e2e` CI job (`.github/workflows/ci.yml`), running against a `pgvector/pgvector:pg16` service container.

Search-flow e2e coverage is intentionally deferred — filed as #146.

All 3 specs verified passing locally (both individually and together, matching CI's single-worker concurrency) against a real Postgres instance before pushing.