### PR TITLE
test: axe a11y checks (#135)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,7 +20,7 @@
   /* Text */
   --color-text-primary: #f0f4f8;
   --color-text-secondary: #8899aa;
-  --color-text-muted: #4a5a6a;
+  --color-text-muted: #84a0b8;
   /* Ink — dark text that sits on bright fills (gold buttons, badges). */
   --color-ink: #1a1305;
 

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "zustand": "^5.0.13",
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@testcontainers/postgresql": "^12.0.1",
@@ -71,6 +72,8 @@
     "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.12.1", "", { "dependencies": { "axe-core": "~4.12.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -682,7 +685,7 @@
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
-    "axe-core": ["axe-core@4.12.0", "", {}, "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg=="],
+    "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 
     "axios": ["axios@1.17.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw=="],
 
@@ -1827,6 +1830,8 @@
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-plugin-jsx-a11y/axe-core": ["axe-core@4.12.0", "", {}, "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,0 +1,37 @@
+import AxeBuilder from "@axe-core/playwright";
+import type { Page } from "@playwright/test";
+import { test, expect } from "./fixtures/auth";
+
+const BLOCKING_IMPACTS = new Set(["serious", "critical"]);
+
+async function scanAndAssert(page: Page, label: string): Promise<void> {
+  const results = await new AxeBuilder({ page }).analyze();
+  const blocking = results.violations.filter((v) => BLOCKING_IMPACTS.has(v.impact ?? ""));
+  const advisory = results.violations.filter((v) => !BLOCKING_IMPACTS.has(v.impact ?? ""));
+
+  if (advisory.length > 0) {
+    console.warn(
+      `[a11y] ${label}: ${advisory.length} moderate/minor violation(s), not failing the build:`,
+      advisory.map((v) => `${v.id} (${v.impact})`).join(", ")
+    );
+  }
+
+  expect(blocking, `${label}: serious/critical a11y violations`).toEqual([]);
+}
+
+test.describe("accessibility", () => {
+  test("home page has no serious a11y violations", async ({ page }) => {
+    await page.goto("/");
+    await scanAndAssert(page, "home");
+  });
+
+  test("canvas page has no serious a11y violations", async ({ authenticatedPage: page }) => {
+    await page.goto("/canvas");
+    await scanAndAssert(page, "canvas");
+  });
+
+  test("social page has no serious a11y violations", async ({ authenticatedPage: page }) => {
+    await page.goto("/social");
+    await scanAndAssert(page, "social");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@testcontainers/postgresql": "^12.0.1",


### PR DESCRIPTION
Closes #135. Part of #137. Depends on the e2e scaffolding from #133 (merged into this parent branch).

Adds `@axe-core/playwright` and `e2e/a11y.spec.ts`, scanning home, canvas, and social for serious/critical accessibility violations (moderate/minor findings log as warnings, per #135's suggested rollout policy).

Running this for real caught a genuine WCAG AA contrast failure: `--color-text-muted` (`#4a5a6a`) measured 2.24-2.7:1 against the app's dark backgrounds, well under the required 4.5:1. Fixed in a separate commit by widening it to `#84a0b8` (7.03/5.83/5.33 against the three backgrounds the violation touched), verified with a screenshot for visual regressions and a recomputed contrast check.

All 6 e2e specs (2 social, 1 canvas, 3 a11y) verified passing together locally under CI-equivalent single-worker settings before pushing.