### PR TITLE
fix: switch CodeQL from default setup to advanced setup for fork PRs

### DIFF
--- a/.github/workflows/codeql-upload.yml
+++ b/.github/workflows/codeql-upload.yml
@@ -1,0 +1,62 @@
+name: CodeQL SARIF upload (fork PRs)
+
+# Fork PRs' `pull_request` runs can't upload SARIF directly (read-only token,
+# same restriction bundle-size-comment.yml works around). workflow_run runs in
+# the base repo's context, so it gets a normal write token even when triggered
+# by a fork PR's CodeQL run — this downloads the SARIF codeql.yml published as
+# an artifact and uploads it against the fork PR's actual head commit.
+on:
+  workflow_run:
+    workflows: ["CodeQL"]
+    types: [completed]
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  upload:
+    name: Upload SARIF (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, actions]
+    steps:
+      - name: Download SARIF artifact
+        id: download-sarif
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: codeql-sarif-${{ matrix.language }}
+          path: sarif-results
+
+      - name: Download PR metadata
+        if: steps.download-sarif.outcome == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: codeql-pr-metadata-${{ matrix.language }}
+          path: pr-metadata
+
+      - name: Read PR metadata
+        if: steps.download-sarif.outcome == 'success'
+        id: pr
+        run: |
+          echo "number=$(cat pr-metadata/pr-number.txt)" >> "$GITHUB_OUTPUT"
+          echo "sha=$(cat pr-metadata/pr-sha.txt)" >> "$GITHUB_OUTPUT"
+
+      - uses: github/codeql-action/upload-sarif@v3
+        if: steps.download-sarif.outcome == 'success'
+        with:
+          sarif_file: sarif-results
+          category: "/language:${{ matrix.language }}"
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          sha: ${{ steps.pr.outputs.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  schedule:
+    # Matches the cadence the prior default-setup config used.
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, actions]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      # Fork PRs get a read-only GITHUB_TOKEN on `pull_request` events, so this job
+      # can't upload SARIF itself (needs `security-events: write`) in that case —
+      # same restriction already hit and fixed for bundle-size-comment.yml. For
+      # same-repo pushes/PRs, upload directly; for fork PRs, keep the SARIF as a
+      # local file and hand it to codeql-upload.yml (workflow_run, base-repo
+      # context) instead.
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+          upload: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          output: sarif-results
+
+      - name: Upload SARIF artifact (fork PRs only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-sarif-${{ matrix.language }}
+          path: sarif-results
+          retention-days: 1
+
+      - name: Save PR metadata (fork PRs only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          mkdir -p pr-metadata
+          echo "${{ github.event.pull_request.number }}" > pr-metadata/pr-number.txt
+          echo "${{ github.event.pull_request.head.sha }}" > pr-metadata/pr-sha.txt
+
+      - name: Upload PR metadata (fork PRs only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-pr-metadata-${{ matrix.language }}
+          path: pr-metadata
+          retention-days: 1


### PR DESCRIPTION
## Summary

Fixes #156 — CodeQL's required status check permanently blocks fork PRs from merging because GitHub's **default setup** for code scanning never analyzes pull requests from forks. Confirmed via the `code-scanning/analyses` API: same-repo PRs and every push to `main` get scanned, but PR #145 (a fork PR) had zero analyses across its entire history.

## Changes

- `.github/workflows/codeql.yml` — advanced-setup CodeQL, triggered on `push`/`pull_request`/weekly `schedule` (same cadence the old default setup used). Uploads SARIF directly for same-repo pushes/PRs (normal write token). For fork PRs — which get a read-only `GITHUB_TOKEN` on `pull_request` events regardless of declared `permissions:`, same restriction already hit and fixed for the bundle-size PR comment — it publishes the SARIF output + PR head SHA/number as a workflow artifact instead of trying to upload directly.
- `.github/workflows/codeql-upload.yml` — triggered on `workflow_run` (runs in the base repo's context, so it gets a normal write token even for fork-triggered runs). Downloads the artifact and calls `github/codeql-action/upload-sarif` against the fork PR's actual head commit. Same two-workflow pattern as `ci.yml` + `bundle-size-comment.yml`.

## Before merging

Default setup and advanced setup can't both be active for the same language(s) — **default setup needs to be disabled** (Settings → Code security → Code scanning, or via `PATCH /repos/OpenHikmah/openhikmah-web/code-scanning/default-setup` with `state: not-configured`) at/around merge time, otherwise this workflow's analyze step will fail with a conflict error. Happy to do this via API right when you're ready to merge — just say the word.

## Testing

- Both new workflow YAML files validated for syntax (`js-yaml` parse, no errors).
- `bun run lint` passes (no JS/TS changes, YAML-only diff).
- Could not fully dry-run the fork-PR SARIF-artifact path locally (needs an actual fork PR event) — the `workflow_run` → artifact-download → `upload-sarif` mechanism mirrors the already-verified-working `bundle-size-comment.yml` pattern from #145, but should be watched on the next real fork PR to confirm end-to-end.