### PR TITLE
fix: validate shared-canvas node shape and harden the OG image handler

### DIFF
--- a/__tests__/api/share.test.ts
+++ b/__tests__/api/share.test.ts
@@ -125,6 +125,15 @@ describe("GET /api/share/[id]/opengraph-image", () => {
     await expect(imageReq(VALID_ID)).resolves.toBeDefined();
   });
 
+  it("falls back instead of throwing when .verse is present but missing required fields", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([
+        { id: VALID_ID, data: JSON.stringify({ v: 1, nodes: [{ verse: { ref: "2:255" } }] }) },
+      ])
+    );
+    await expect(imageReq(VALID_ID)).resolves.toBeDefined();
+  });
+
   it("renders normally for well-formed stored data", async () => {
     mockSelect.mockReturnValue(
       makeDbChain([

--- a/__tests__/api/share.test.ts
+++ b/__tests__/api/share.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        if (prop === "catch")
+          return (rej: (e: unknown) => unknown) => Promise.resolve(resolveWith).catch(rej);
+        if (prop === Symbol.toStringTag) return "MockChain";
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockInsert, mockDelete, mockRateLimitOrNull } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockInsert: vi.fn(() => makeDbChain([])),
+  mockDelete: vi.fn(() => makeDbChain([])),
+  mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: mockSelect,
+    insert: mockInsert,
+    delete: mockDelete,
+  },
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimitOrNull: mockRateLimitOrNull,
+}));
+
+import { POST } from "@/app/api/share/route";
+import Image from "@/app/api/share/[id]/opengraph-image";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const validVerse = {
+  surah: 2,
+  ayah: 255,
+  ref: "2:255",
+  arabicText: "arabic",
+  translation: "Allah - there is no deity except Him.",
+  surahName: "Al-Baqarah",
+  surahNameArabic: "البقرة",
+};
+
+function postReq(body: unknown) {
+  return new NextRequest("http://localhost/api/share", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_ID = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  mockSelect.mockReset().mockReturnValue(makeDbChain([]));
+  mockInsert.mockReset().mockReturnValue(makeDbChain([]));
+  mockDelete.mockReset().mockReturnValue(makeDbChain([]));
+  mockRateLimitOrNull.mockReset().mockResolvedValue(null);
+});
+
+describe("POST /api/share", () => {
+  it("returns 400 when a node is missing .verse", async () => {
+    const res = await POST(postReq({ v: 1, nodes: [{}] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid canvas/i);
+  });
+
+  it("returns 400 when a node's verse is missing required fields", async () => {
+    const res = await POST(postReq({ v: 1, nodes: [{ verse: { ref: "2:255" } }] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with an id for a well-formed canvas", async () => {
+    const res = await POST(postReq({ v: 1, nodes: [{ verse: validVerse }] }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.id).toBe("string");
+    expect(mockInsert).toHaveBeenCalled();
+  });
+
+  it("returns 429 when the rate limiter reports over-limit", async () => {
+    mockRateLimitOrNull.mockResolvedValue(
+      NextResponse.json({ error: "Too many requests" }, { status: 429 })
+    );
+    const res = await POST(postReq({ v: 1, nodes: [{ verse: validVerse }] }));
+    expect(res.status).toBe(429);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/share/[id]/opengraph-image", () => {
+  function imageReq(id: string) {
+    return Image({ params: Promise.resolve({ id }) });
+  }
+
+  it("falls back instead of throwing when stored data is invalid JSON", async () => {
+    mockSelect.mockReturnValue(makeDbChain([{ id: VALID_ID, data: "not-json" }]));
+    await expect(imageReq(VALID_ID)).resolves.toBeDefined();
+  });
+
+  it("falls back instead of throwing when a node is missing .verse", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([{ id: VALID_ID, data: JSON.stringify({ v: 1, nodes: [{}] }) }])
+    );
+    await expect(imageReq(VALID_ID)).resolves.toBeDefined();
+  });
+
+  it("renders normally for well-formed stored data", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([
+        { id: VALID_ID, data: JSON.stringify({ v: 1, nodes: [{ verse: validVerse }] }) },
+      ])
+    );
+    await expect(imageReq(VALID_ID)).resolves.toBeDefined();
+  });
+});

--- a/app/api/share/[id]/opengraph-image.tsx
+++ b/app/api/share/[id]/opengraph-image.tsx
@@ -35,11 +35,18 @@ export default async function Image({ params }: { params: Promise<{ id: string }
 
   if (!rows[0]) return fallback();
 
-  const canvas = JSON.parse(rows[0].data) as SavedCanvas;
+  let canvas: SavedCanvas;
+  try {
+    canvas = JSON.parse(rows[0].data) as SavedCanvas;
+  } catch (err) {
+    console.error("share opengraph-image parse error:", err);
+    return fallback();
+  }
   if (!canvas?.nodes?.length) return fallback();
 
   const first = canvas.nodes[0];
   const count = canvas.nodes.length;
+  if (!first?.verse) return fallback();
 
   return new ImageResponse(
     renderOgCard({

--- a/app/api/share/[id]/opengraph-image.tsx
+++ b/app/api/share/[id]/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { sharedCanvases } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { renderOgCard, clampBody, OG_SIZE, OG_CONTENT_TYPE } from "@/lib/og-card";
+import { isValidNode } from "@/lib/share-canvas";
 import type { SavedCanvas } from "@/store/canvas";
 
 export const alt = "Shared canvas — Open Hikmah";
@@ -46,7 +47,7 @@ export default async function Image({ params }: { params: Promise<{ id: string }
 
   const first = canvas.nodes[0];
   const count = canvas.nodes.length;
-  if (!first?.verse) return fallback();
+  if (!isValidNode(first)) return fallback();
 
   return new ImageResponse(
     renderOgCard({

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -4,22 +4,12 @@ import { db } from "@/lib/db";
 import { sharedCanvases } from "@/lib/db/schema";
 import { clientKey } from "@/lib/http";
 import { rateLimitOrNull } from "@/lib/rate-limit";
+import { isValidNode } from "@/lib/share-canvas";
 
 const MAX_BYTES = 512 * 1024; // 512 KB
 const RATE_LIMIT = 10;
 const WINDOW_SECONDS = 60 * 60; // 1 hour
 const TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
-
-/** The fields the OG image handler and canvas renderer actually read from `verse`. */
-function isValidNode(node: unknown): boolean {
-  if (typeof node !== "object" || node === null) return false;
-  const verse = (node as { verse?: unknown }).verse;
-  if (typeof verse !== "object" || verse === null) return false;
-  const { ref, surahName, translation } = verse as Record<string, unknown>;
-  return (
-    typeof ref === "string" && typeof surahName === "string" && typeof translation === "string"
-  );
-}
 
 export async function POST(req: Request) {
   const limited = await rateLimitOrNull(

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -3,32 +3,34 @@ import { lt } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { sharedCanvases } from "@/lib/db/schema";
 import { clientKey } from "@/lib/http";
+import { rateLimitOrNull } from "@/lib/rate-limit";
 
 const MAX_BYTES = 512 * 1024; // 512 KB
 const RATE_LIMIT = 10;
-const WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const WINDOW_SECONDS = 60 * 60; // 1 hour
 const TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
-const ipBuckets = new Map<string, { count: number; windowStart: number }>();
+/** The fields the OG image handler and canvas renderer actually read from `verse`. */
+function isValidNode(node: unknown): boolean {
+  if (typeof node !== "object" || node === null) return false;
+  const verse = (node as { verse?: unknown }).verse;
+  if (typeof verse !== "object" || verse === null) return false;
+  const { ref, surahName, translation } = verse as Record<string, unknown>;
+  return (
+    typeof ref === "string" && typeof surahName === "string" && typeof translation === "string"
+  );
+}
 
 export async function POST(req: Request) {
-  const ip = clientKey(req);
+  const limited = await rateLimitOrNull(
+    `share:${clientKey(req)}`,
+    "Too many requests",
+    RATE_LIMIT,
+    WINDOW_SECONDS
+  );
+  if (limited) return limited;
+
   const now = Date.now();
-  const bucket = ipBuckets.get(ip);
-  if (!bucket || now - bucket.windowStart > WINDOW_MS) {
-    ipBuckets.set(ip, { count: 1, windowStart: now });
-    // Opportunistically evict expired buckets so the map can't grow unbounded.
-    if (Math.random() < 0.05) {
-      for (const [key, b] of ipBuckets) {
-        if (now - b.windowStart > WINDOW_MS) ipBuckets.delete(key);
-      }
-    }
-  } else {
-    bucket.count += 1;
-    if (bucket.count > RATE_LIMIT) {
-      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
-    }
-  }
   let body: unknown;
   try {
     const text = await req.text();
@@ -45,7 +47,8 @@ export async function POST(req: Request) {
     body === null ||
     (body as { v?: unknown }).v !== 1 ||
     !Array.isArray((body as { nodes?: unknown }).nodes) ||
-    (body as { nodes: unknown[] }).nodes.length === 0
+    (body as { nodes: unknown[] }).nodes.length === 0 ||
+    !(body as { nodes: unknown[] }).nodes.every(isValidNode)
   ) {
     return NextResponse.json({ error: "Invalid canvas" }, { status: 400 });
   }
@@ -53,7 +56,7 @@ export async function POST(req: Request) {
   if (Math.random() < 0.05) {
     db.delete(sharedCanvases)
       .where(lt(sharedCanvases.createdAt, new Date(now - TTL_MS)))
-      .catch(() => {});
+      .catch((err) => console.error("share TTL cleanup error:", err));
   }
 
   const id = crypto.randomUUID();

--- a/lib/share-canvas.ts
+++ b/lib/share-canvas.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared shape check for a stored/incoming shared-canvas node, used by both
+ * `POST /api/share` (reject malformed nodes before storing) and the OG image
+ * handler (guard against already-stored malformed data, e.g. from before this
+ * check existed). Validates the fields both consumers actually read from
+ * `verse` — `ref`, `surahName`, `translation`.
+ */
+export function isValidNode(node: unknown): boolean {
+  if (typeof node !== "object" || node === null) return false;
+  const verse = (node as { verse?: unknown }).verse;
+  if (typeof verse !== "object" || verse === null) return false;
+  const { ref, surahName, translation } = verse as Record<string, unknown>;
+  return (
+    typeof ref === "string" && typeof surahName === "string" && typeof translation === "string"
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #118. `POST /api/share` only validated the outer `{v, nodes}` shape, so a node missing `.verse` (e.g. `{"v":1,"nodes":[{}]}`) was accepted and stored. The OG image handler (`app/api/share/[id]/opengraph-image.tsx`) then crashed reading `first.verse.ref` on `undefined`, instead of falling back like every other malformed-data case already handled in that file.

## Changes

- **`app/api/share/route.ts`**
  - Reject nodes whose `.verse` is missing, or missing the fields actually read downstream (`ref`, `surahName`, `translation`) — same 400/`"Invalid canvas"` response already used for the outer-shape check.
  - Replaced the module-level `ipBuckets` Map with the shared Redis-backed rate limiter (`lib/rate-limit.ts`, via `rateLimitOrNull`), matching every other rate-limited route (e.g. `app/api/workspace`). Same 10/hour budget as before — this was previously enforced independently per process, which under-enforces on a multi-instance deployment.
  - Logs the previously-silent TTL-cleanup delete failure (`.catch(() => {})` → `.catch((err) => console.error(...))`), matching the logging convention elsewhere in the codebase.
- **`app/api/share/[id]/opengraph-image.tsx`**
  - Wrapped `JSON.parse(rows[0].data)` in a `try/catch` → `fallback()`, matching the sibling `GET /api/share/[id]/route.ts`'s handling of the identical parse.
  - Guards `first?.verse` before reading its fields → `fallback()` if absent.
- **`__tests__/api/share.test.ts`** (new) — covers: 400 on a node missing/malformed `.verse`, 200 happy path (regression guard), 429 via a mocked rate limiter; and for the OG image handler, fallback (not a thrown error) on invalid JSON and on a node missing `.verse`, plus a normal-render regression guard.

## Testing
- `bun run test:ci` — full suite green (517/517), including the 7 new tests.
- `bun run typecheck` — clean.
- `bun run lint` / `bun run format:check` — clean on all touched files.
- Manually traced the issue's exact repro (`{"v":1,"nodes":[{}]}`) against the final code: `POST` now returns 400 instead of storing it; if such a row already existed from before this fix, the OG route now returns the fallback card instead of throwing.