### PR TITLE
Add CI concurrency cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: ["**"]
   pull_request:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least privilege by default. Jobs that need to report back to PRs override this explicitly.
 permissions:
   contents: read


### PR DESCRIPTION
Fixes #128.

Adds a top-level CI concurrency group so newer pushes cancel stale runs for the same ref.

Verification:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML OK"'`\n- `actionlint .github/workflows/ci.yml`