### PR TITLE
fix(home): add heading to auth loading state

### DIFF
--- a/__tests__/components/home/AuthLoadingSkeleton.test.tsx
+++ b/__tests__/components/home/AuthLoadingSkeleton.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AuthLoadingSkeleton } from "@/components/home/AuthLoadingSkeleton";
+
+describe("AuthLoadingSkeleton", () => {
+  it("keeps the home page heading available while auth restores", () => {
+    render(<AuthLoadingSkeleton />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Open Hikmah home" })).toBeInTheDocument();
+  });
+});

--- a/components/home/AuthLoadingSkeleton.tsx
+++ b/components/home/AuthLoadingSkeleton.tsx
@@ -3,6 +3,8 @@
 export function AuthLoadingSkeleton() {
   return (
     <main className="mx-auto w-full max-w-[1180px] flex-1 px-6 py-10 md:px-12">
+      <h1 className="sr-only">Open Hikmah home</h1>
+
       {/* Greeting */}
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- add an `h1` to the authenticated loading skeleton on the home page
- cover the loading state heading in the component test

## Tests
- bun install --frozen-lockfile
- bun run format:check
- bun run lint
- bun run typecheck
- bun run test:ci
- bun run build
- targeted home a11y Playwright test
- pre-push integration tests

Fixes #150
