### PR TITLE
test: add unit tests for lib/tafsir.ts sanitizer (#119)

### DIFF
--- a/__tests__/lib/tafsir.test.ts
+++ b/__tests__/lib/tafsir.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { htmlToTafsirBlocks } from "@/lib/tafsir";
+
+describe("htmlToTafsirBlocks", () => {
+  it("extracts plain paragraph, div, and heading blocks with tags stripped", () => {
+    const blocks = htmlToTafsirBlocks("<h2>Title</h2><p>Body <b>text</b></p><div>Plain div</div>");
+    expect(blocks).toEqual([
+      { arabic: false, text: "Title" },
+      { arabic: false, text: "Body text" },
+      { arabic: false, text: "Plain div" },
+    ]);
+  });
+
+  it('marks class="...arabic..." blocks as arabic: true and others as false', () => {
+    const blocks = htmlToTafsirBlocks(
+      '<div class="foo arabic bar">quoted</div><div class="arabicish">not a match</div>'
+    );
+    // Word-boundary regex: "arabic" must appear as a whole class token, so
+    // "arabicish" must NOT be classified as arabic.
+    expect(blocks).toEqual([
+      { arabic: true, text: "quoted" },
+      { arabic: false, text: "not a match" },
+    ]);
+  });
+
+  it("decodes entity-encoded markup to literal text, never letting it survive as unescaped angle brackets", () => {
+    const blocks = htmlToTafsirBlocks("<div>&lt;script&gt;alert(1)&lt;/script&gt;</div>");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].text).toBe("alert(1)");
+    expect(blocks[0].text).not.toMatch(/[<>]/);
+  });
+
+  it("neutralizes a reconstructed-tag bypass attempt (no < or > survives, for any adversarial input)", () => {
+    // The classic hide-a-tag-inside-a-tag trick: a single-pass strip would
+    // leave "<script>" behind once the outer layer is removed. The
+    // strip-until-stable loop must catch it.
+    const blocks = htmlToTafsirBlocks("<div><scr<script>ipt>alert(1)</scr</script>ipt></div>");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].text).not.toMatch(/[<>]/);
+    // The residual text is inert (no markup delimiters left), even though
+    // the words "alert(1)" remain as plain text.
+    expect(blocks[0].text).toBe("iptalert(1)ipt");
+  });
+
+  it("falls back to a single English block when no recognized block tags are present", () => {
+    const blocks = htmlToTafsirBlocks("just plain text, no block tags <b>bold</b> inline");
+    expect(blocks).toEqual([{ arabic: false, text: "just plain text, no block tags bold inline" }]);
+  });
+
+  it("skips empty and whitespace-only blocks instead of pushing empty-string entries", () => {
+    const blocks = htmlToTafsirBlocks("<div></div><p>   </p><div>Real content</div>");
+    expect(blocks).toEqual([{ arabic: false, text: "Real content" }]);
+  });
+
+  it("preserves document order across mixed English and Arabic blocks", () => {
+    const blocks = htmlToTafsirBlocks(
+      '<h2>Title</h2><p>Body <b>text</b></p><div class="arabic">قرآن</div>'
+    );
+    expect(blocks).toEqual([
+      { arabic: false, text: "Title" },
+      { arabic: false, text: "Body text" },
+      { arabic: true, text: "قرآن" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Added `__tests__/lib/tafsir.test.ts` with unit tests covering `lib/tafsir.ts`'s HTML sanitization logic
- Tests verify the core XSS-prevention guarantee: no `<`/`>` survives in output, including against an entity-encoding bypass and a reconstructed-tag bypass attempt
- Closes #119

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [x] Tests

## AI / Theological changes
- [x] No AI or theological changes in this PR

**Details** (if applicable):
N/A

## Testing
- [ ] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [x] New tests added for new functionality
- [ ] Tested in browser (for UI changes)

## Checklist
- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface
