### PR TITLE
chore(ci): add CODEOWNERS for security-sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# CODEOWNERS routes review requests for security- and infra-sensitive paths
+# to a maintainer, so contributor PRs touching these areas get guaranteed
+# maintainer eyes rather than just any approving review.
+#
+# Note: this file alone does not block merges. Branch protection on `main`
+# must also enable "Require review from Code Owners" (repo Settings) for
+# these entries to be enforced.
+
+# Admin API routes
+/app/api/admin/ @nazarli-shabnam
+
+# Admin auth/audit logic
+/lib/admin/ @nazarli-shabnam
+
+# OAuth callback handling
+/app/callback/ @nazarli-shabnam
+
+# Auth logic (PKCE, social auth)
+/lib/auth/ @nazarli-shabnam
+
+# Security headers / CSP config
+/next.config.ts @nazarli-shabnam
+
+# CI itself
+/.github/workflows/ @nazarli-shabnam
+
+# Ownership rules for this file
+/.github/CODEOWNERS @nazarli-shabnam


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` mapping security- and infra-sensitive paths (admin API, admin auth/audit, OAuth callback, auth logic, `next.config.ts`, CI workflows, and CODEOWNERS itself) to `@nazarli-shabnam`.
- Updates the paths from the original issue to reflect the recent `lib/` restructure (e.g. `lib/admin-auth.ts` → `lib/admin/`).

## Follow-up (manual, outside this repo)
- Enable "Require review from Code Owners" in branch protection settings for `main` so this file is actually enforced.

Closes #123

## Test plan
- [x] `git status`/`git diff` confirm only `.github/CODEOWNERS` is added
- [x] Pre-commit and pre-push hooks (lint, typecheck, unit tests, integration tests) passed locally
- [ ] CI checks pass on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code ownership rules for sensitive application, authentication, configuration, and workflow areas.
  * Clarified that code owner review is only enforced when branch protection requires it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->