### PR TITLE
feat: add dedicated /search results page with pagination

### DIFF
--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -1,48 +1,57 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import type { Verse } from "@/types/quran";
 
-const { mockSearchByMeaning, mockConsume } = vi.hoisted(() => ({
+const { mockSearchByMeaning, mockConsume, mockGetVerse, mockGetVerses } = vi.hoisted(() => ({
   mockSearchByMeaning: vi.fn(),
   mockConsume: vi.fn(async () => true),
+  mockGetVerse: vi.fn(),
+  mockGetVerses: vi.fn(async () => new Map()),
 }));
 vi.mock("@/lib/quran/semantic-search", () => ({ searchByMeaning: mockSearchByMeaning }));
 vi.mock("@/lib/infra/rate-limit", () => ({ consume: mockConsume }));
+vi.mock("@/lib/quran/quran-corpus", () => ({
+  getVerse: mockGetVerse,
+  getVerses: mockGetVerses,
+}));
 
 import { GET } from "@/app/api/search/route";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-function makeSearchReq(q: string) {
-  return new NextRequest(`http://localhost/api/search?q=${encodeURIComponent(q)}`);
+function makeSearchReq(q: string, extra = "") {
+  return new NextRequest(`http://localhost/api/search?q=${encodeURIComponent(q)}${extra}`);
 }
 
-function makeMeaningReq(q: string, headers: Record<string, string> = {}) {
-  return new NextRequest(`http://localhost/api/search?q=${encodeURIComponent(q)}&mode=meaning`, {
-    headers,
-  });
+function makeMeaningReq(q: string, headers: Record<string, string> = {}, extra = "") {
+  return new NextRequest(
+    `http://localhost/api/search?q=${encodeURIComponent(q)}&mode=meaning${extra}`,
+    { headers }
+  );
 }
 
-function semanticMatch(ref: string, translation: string) {
+function verse(ref: string, translation: string): Verse {
   const [s, a] = ref.split(":");
   return {
-    verse: {
-      surah: Number(s),
-      ayah: Number(a),
-      ref,
-      arabicText: "ar",
-      translation,
-      surahName: "Surah",
-      surahNameArabic: "سورة",
-    },
-    similarity: 0.9,
+    surah: Number(s),
+    ayah: Number(a),
+    ref: ref as Verse["ref"],
+    arabicText: "ar",
+    translation,
+    surahName: "Surah",
+    surahNameArabic: "سورة",
   };
 }
 
-function quranComResponse(results: unknown[]) {
+function semanticMatch(ref: string, translation: string) {
+  return { verse: verse(ref, translation), similarity: 0.9 };
+}
+
+function quranComResponse(results: unknown[], total?: number) {
   return {
     ok: true,
-    json: async () => ({ search: { results } }),
+    json: async () => ({ search: { results, total_results: total ?? results.length } }),
   };
 }
 
@@ -52,6 +61,9 @@ describe("GET /api/search", () => {
     mockSearchByMeaning.mockReset();
     mockConsume.mockReset();
     mockConsume.mockResolvedValue(true);
+    mockGetVerse.mockReset();
+    mockGetVerses.mockReset();
+    mockGetVerses.mockResolvedValue(new Map());
   });
 
   it("returns 400 when query is missing", async () => {
@@ -61,22 +73,23 @@ describe("GET /api/search", () => {
   });
 
   it("returns single SearchResult for ref-format query", async () => {
+    mockGetVerse.mockResolvedValueOnce(verse("2:255", "Allah - there is no deity except Him..."));
     const req = makeSearchReq("2:255");
     const res = await GET(req);
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(Array.isArray(body)).toBe(true);
-    expect(body).toHaveLength(1);
-    expect(body[0].ref).toBe("2:255");
-    expect(body[0].surahName).toBe("Al-Baqarah");
+    expect(body.results).toHaveLength(1);
+    expect(body.total).toBe(1);
+    expect(body.results[0].ref).toBe("2:255");
     expect(mockFetch).not.toHaveBeenCalled(); // no external call for ref lookup
   });
 
   it("includes correct surahNameArabic for ref-format query", async () => {
+    mockGetVerse.mockResolvedValueOnce(null);
     const req = makeSearchReq("1:1");
     const res = await GET(req);
-    const [result] = await res.json();
-    expect(result.surahNameArabic).toBe("الفاتحة");
+    const body = await res.json();
+    expect(body.results[0].surahNameArabic).toBe("الفاتحة");
   });
 
   it("calls quran.com for text query and returns results", async () => {
@@ -97,10 +110,21 @@ describe("GET /api/search", () => {
     const res = await GET(req);
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(Array.isArray(body)).toBe(true);
-    expect(body).toHaveLength(2);
-    expect(body[0].ref).toBe("2:30");
-    expect(body[1].ref).toBe("6:165");
+    expect(body.results).toHaveLength(2);
+    expect(body.results[0].ref).toBe("2:30");
+    expect(body.results[1].ref).toBe("6:165");
+    expect(body.total).toBe(2);
+  });
+
+  it("forwards page/pageSize to quran.com and returns them in the response", async () => {
+    mockFetch.mockResolvedValueOnce(quranComResponse([], 42));
+    const res = await GET(makeSearchReq("salam", "&page=2&pageSize=20"));
+    const body = await res.json();
+    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining("size=20"), expect.anything());
+    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining("page=2"), expect.anything());
+    expect(body.page).toBe(2);
+    expect(body.pageSize).toBe(20);
+    expect(body.total).toBe(42);
   });
 
   it("strips HTML tags from snippets", async () => {
@@ -115,10 +139,10 @@ describe("GET /api/search", () => {
 
     const req = makeSearchReq("alif");
     const res = await GET(req);
-    const [result] = await res.json();
-    expect(result.snippet).not.toContain("<em>");
-    expect(result.snippet).not.toContain("<strong>");
-    expect(result.snippet).toContain("Alif");
+    const body = await res.json();
+    expect(body.results[0].snippet).not.toContain("<em>");
+    expect(body.results[0].snippet).not.toContain("<strong>");
+    expect(body.results[0].snippet).toContain("Alif");
   });
 
   it("filters out results without valid verse_key", async () => {
@@ -133,24 +157,28 @@ describe("GET /api/search", () => {
     const req = makeSearchReq("test");
     const res = await GET(req);
     const body = await res.json();
-    expect(body).toHaveLength(1);
-    expect(body[0].ref).toBe("2:1");
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].ref).toBe("2:1");
   });
 
-  it("returns empty array when quran.com returns non-ok", async () => {
+  it("returns empty results when quran.com returns non-ok", async () => {
     mockFetch.mockResolvedValueOnce({ ok: false });
     const req = makeSearchReq("test");
     const res = await GET(req);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual([]);
+    const body = await res.json();
+    expect(body.results).toEqual([]);
+    expect(body.total).toBe(0);
   });
 
-  it("returns empty array when fetch throws", async () => {
+  it("returns empty results when fetch throws", async () => {
     mockFetch.mockRejectedValueOnce(new Error("network error"));
     const req = makeSearchReq("test");
     const res = await GET(req);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual([]);
+    const body = await res.json();
+    expect(body.results).toEqual([]);
+    expect(body.total).toBe(0);
   });
 
   it("mode=meaning uses semantic search and maps matches to SearchResults", async () => {
@@ -162,16 +190,31 @@ describe("GET /api/search", () => {
     const res = await GET(makeMeaningReq("staying strong through hardship"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.map((r: { ref: string }) => r.ref)).toEqual(["94:5", "2:286"]);
-    expect(body[0].snippet).toContain("hardship");
+    expect(body.results.map((r: { ref: string }) => r.ref)).toEqual(["94:5", "2:286"]);
+    expect(body.results[0].snippet).toContain("hardship");
     expect(mockFetch).not.toHaveBeenCalled(); // no quran.com call in meaning mode
   });
 
+  it("mode=meaning paginates the capped ranked list in memory", async () => {
+    const matches = Array.from({ length: 30 }, (_, i) =>
+      semanticMatch(`1:${i + 1}`, `verse ${i + 1}`)
+    );
+    mockSearchByMeaning.mockResolvedValueOnce(matches);
+
+    const res = await GET(makeMeaningReq("mercy", {}, "&page=2&pageSize=10"));
+    const body = await res.json();
+    expect(body.results).toHaveLength(10);
+    expect(body.results[0].ref).toBe("1:11");
+    expect(body.total).toBe(30);
+    expect(body.page).toBe(2);
+  });
+
   it("mode=meaning still answers ref-format queries directly", async () => {
+    mockGetVerse.mockResolvedValueOnce(null);
     const res = await GET(makeMeaningReq("2:255"));
     const body = await res.json();
-    expect(body).toHaveLength(1);
-    expect(body[0].ref).toBe("2:255");
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].ref).toBe("2:255");
     expect(mockSearchByMeaning).not.toHaveBeenCalled();
   });
 
@@ -184,7 +227,7 @@ describe("GET /api/search", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("x-search-fallback")).toBe("keyword");
     const body = await res.json();
-    expect(body.map((r: { ref: string }) => r.ref)).toEqual(["1:3"]);
+    expect(body.results.map((r: { ref: string }) => r.ref)).toEqual(["1:3"]);
   });
 
   it("mode=meaning falls back to keyword when semantic search is empty (not seeded)", async () => {
@@ -195,7 +238,7 @@ describe("GET /api/search", () => {
     const res = await GET(makeMeaningReq("mercy"));
     expect(res.status).toBe(200);
     expect(res.headers.get("x-search-fallback")).toBe("keyword");
-    expect((await res.json())[0].ref).toBe("1:1");
+    expect((await res.json()).results[0].ref).toBe("1:1");
   });
 
   it("mode=meaning rate-limits under the last (proxy-appended) hop of x-forwarded-for", async () => {
@@ -219,7 +262,7 @@ describe("GET /api/search", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("x-search-fallback")).toBe("keyword");
     expect(mockSearchByMeaning).not.toHaveBeenCalled();
-    expect((await res.json())[0].ref).toBe("2:1");
+    expect((await res.json()).results[0].ref).toBe("2:1");
   });
 
   it("does not rate-limit the keyword path", async () => {

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,27 +1,48 @@
 import { NextRequest, NextResponse } from "next/server";
-import type { SearchResult, VerseRef } from "@/types/quran";
+import type { SearchResponse, SearchResult, VerseRef } from "@/types/quran";
 import { getSurahName } from "@/lib/quran/surah-names";
 import { searchByMeaning } from "@/lib/quran/semantic-search";
+import { getVerse, getVerses } from "@/lib/quran/quran-corpus";
 import { consume } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
 import sanitizeHtml from "sanitize-html";
 
-/** Keyword search via the quran.com full-text API. Returns [] on any failure. */
-async function keywordSearch(q: string): Promise<SearchResult[]> {
+// Semantic similarity has no natural cutoff across the whole corpus (every verse
+// has *some* similarity score), so we cap how many ranked matches we'll ever
+// paginate through — otherwise "page 40" would show near-random, irrelevant verses.
+const SEMANTIC_RESULT_CAP = 100;
+
+interface KeywordSearchResult {
+  results: SearchResult[];
+  total: number;
+}
+
+/** Keyword search via the quran.com full-text API. Returns empty on any failure. */
+async function keywordSearch(
+  q: string,
+  page: number,
+  pageSize: number
+): Promise<KeywordSearchResult> {
   try {
-    const url = `https://api.quran.com/api/v4/search?q=${encodeURIComponent(q)}&size=10&language=en&page=1`;
+    const url = `https://api.quran.com/api/v4/search?q=${encodeURIComponent(q)}&size=${pageSize}&language=en&page=${page}`;
     const res = await fetch(url, {
       headers: { Accept: "application/json" },
       next: { revalidate: 300 },
     });
     if (!res.ok) {
       console.error(`Search API error: ${res.status} ${res.statusText}`);
-      return [];
+      return { results: [], total: 0 };
     }
     const data = await res.json();
-    return (data?.search?.results ?? [])
-      .filter((r: { verse_key?: string }) => r.verse_key && /^\d+:\d+$/.test(r.verse_key))
-      .map((r: { verse_key: string; translations?: Array<{ text?: string }> }) => {
+    const rawResults = (data?.search?.results ?? []) as Array<{
+      verse_key?: string;
+      translations?: Array<{ text?: string }>;
+    }>;
+    const results = rawResults
+      .filter((r): r is { verse_key: string; translations?: Array<{ text?: string }> } =>
+        Boolean(r.verse_key && /^\d+:\d+$/.test(r.verse_key))
+      )
+      .map((r) => {
         const [surahStr] = r.verse_key.split(":");
         const surahNum = parseInt(surahStr, 10);
         const [surahName, surahNameArabic] = getSurahName(surahNum);
@@ -34,33 +55,59 @@ async function keywordSearch(q: string): Promise<SearchResult[]> {
           surahName,
           surahNameArabic,
           snippet,
-        } satisfies SearchResult;
+        };
       });
+    return {
+      results: await hydrate(results),
+      total: data?.search?.total_results ?? results.length,
+    };
   } catch (err) {
     console.error("Keyword search error:", err);
-    return [];
+    return { results: [], total: 0 };
   }
+}
+
+/** Fills in `arabicText`/`translation` from our own corpus so the full-text view
+ *  always shows the same text as the rest of the app, regardless of source. */
+async function hydrate(
+  partial: Array<Omit<SearchResult, "arabicText" | "translation">>
+): Promise<SearchResult[]> {
+  const verseMap = await getVerses(partial.map((r) => r.ref));
+  return partial.map((r) => {
+    const verse = verseMap.get(r.ref);
+    return {
+      ...r,
+      arabicText: verse?.arabicText ?? "",
+      translation: verse?.translation ?? r.snippet,
+    };
+  });
 }
 
 export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get("q")?.trim();
+  const page = Math.max(1, parseInt(req.nextUrl.searchParams.get("page") ?? "1", 10) || 1);
+  const pageSize = Math.max(
+    1,
+    parseInt(req.nextUrl.searchParams.get("pageSize") ?? "10", 10) || 10
+  );
 
   if (!q) {
     return NextResponse.json({ error: "Missing query" }, { status: 400 });
   }
 
   if (/^\d+:\d+$/.test(q)) {
-    const [surahStr, ayahStr] = q.split(":");
-    const surahNum = parseInt(surahStr, 10);
-    const ayahNum = parseInt(ayahStr, 10);
-    const [surahName, surahNameArabic] = getSurahName(surahNum);
+    const verse = await getVerse(q);
+    const [surahName, surahNameArabic] = getSurahName(parseInt(q.split(":")[0], 10));
     const result: SearchResult = {
       ref: q as VerseRef,
-      surahName,
-      surahNameArabic,
-      snippet: `${surahName} ${ayahNum}`,
+      surahName: verse?.surahName ?? surahName,
+      surahNameArabic: verse?.surahNameArabic ?? surahNameArabic,
+      snippet: verse?.translation ?? `${surahName} ${q.split(":")[1]}`,
+      arabicText: verse?.arabicText ?? "",
+      translation: verse?.translation ?? "",
     };
-    return NextResponse.json([result]);
+    const response: SearchResponse = { results: [result], total: 1, page: 1, pageSize };
+    return NextResponse.json(response);
   }
 
   // Semantic ("by meaning") mode — ranks the local corpus by embedding similarity.
@@ -73,24 +120,33 @@ export async function GET(req: NextRequest) {
     const allowed = await consume(`search:${clientKey(req)}`);
     if (allowed) {
       try {
-        const matches = await searchByMeaning(q, 10);
+        const matches = await searchByMeaning(q, SEMANTIC_RESULT_CAP);
         if (matches.length > 0) {
-          const results: SearchResult[] = matches.map((m) => ({
+          const total = Math.min(SEMANTIC_RESULT_CAP, matches.length);
+          const start = (page - 1) * pageSize;
+          const pageMatches = matches.slice(start, start + pageSize);
+          const results: SearchResult[] = pageMatches.map((m) => ({
             ref: m.verse.ref,
             surahName: m.verse.surahName,
             surahNameArabic: m.verse.surahNameArabic,
             snippet: m.verse.translation.slice(0, 140),
+            arabicText: m.verse.arabicText,
+            translation: m.verse.translation,
           }));
-          return NextResponse.json(results);
+          const response: SearchResponse = { results, total, page, pageSize };
+          return NextResponse.json(response);
         }
       } catch (err) {
         console.error("Semantic search route error:", err);
       }
     }
     // No semantic results (empty / error / rate-limited) → keyword fallback.
-    const results = await keywordSearch(q);
-    return NextResponse.json(results, { headers: { "x-search-fallback": "keyword" } });
+    const { results, total } = await keywordSearch(q, page, pageSize);
+    const response: SearchResponse = { results, total, page, pageSize };
+    return NextResponse.json(response, { headers: { "x-search-fallback": "keyword" } });
   }
 
-  return NextResponse.json(await keywordSearch(q));
+  const { results, total } = await keywordSearch(q, page, pageSize);
+  const response: SearchResponse = { results, total, page, pageSize };
+  return NextResponse.json(response);
 }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -88,7 +88,7 @@ export async function GET(req: NextRequest) {
   const page = Math.max(1, parseInt(req.nextUrl.searchParams.get("page") ?? "1", 10) || 1);
   const pageSize = Math.max(
     1,
-    parseInt(req.nextUrl.searchParams.get("pageSize") ?? "10", 10) || 10
+    Math.min(parseInt(req.nextUrl.searchParams.get("pageSize") ?? "10", 10) || 10, 50)
   );
 
   if (!q) {

--- a/app/search/SearchPageClient.tsx
+++ b/app/search/SearchPageClient.tsx
@@ -30,6 +30,7 @@ export function SearchPageClient() {
   const [inputValue, setInputValue] = useState(q);
   const [data, setData] = useState<SearchResponse | null>(null);
   const [loading, setLoading] = useState(!!q.trim());
+  const [error, setError] = useState(false);
   const [fellBackToKeyword, setFellBackToKeyword] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -59,6 +60,7 @@ export function SearchPageClient() {
     const controller = new AbortController();
     abortRef.current = controller;
     setLoading(true);
+    setError(false);
     setFellBackToKeyword(false);
 
     fetch(
@@ -76,8 +78,10 @@ export function SearchPageClient() {
         setData(json);
       })
       .catch((err) => {
-        if ((err as Error).name !== "AbortError")
+        if ((err as Error).name !== "AbortError") {
+          setError(true);
           setData({ results: [], total: 0, page, pageSize: PAGE_SIZE });
+        }
       })
       .finally(() => {
         if (!controller.signal.aborted) setLoading(false);
@@ -145,6 +149,10 @@ export function SearchPageClient() {
                 <div className="h-4 w-3/4 rounded bg-surface-overlay" />
               </div>
             ))}
+          </div>
+        ) : error ? (
+          <div className="py-20 text-center">
+            <p className="text-sm text-text-muted">Something went wrong. Try again.</p>
           </div>
         ) : !data || data.results.length === 0 ? (
           <div className="py-20 text-center">

--- a/app/search/SearchPageClient.tsx
+++ b/app/search/SearchPageClient.tsx
@@ -29,7 +29,7 @@ export function SearchPageClient() {
 
   const [inputValue, setInputValue] = useState(q);
   const [data, setData] = useState<SearchResponse | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(!!q.trim());
   const [fellBackToKeyword, setFellBackToKeyword] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -39,6 +39,14 @@ export function SearchPageClient() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setInputValue(q);
   }, [q]);
+
+  // Clear pending debounce on unmount to avoid a stale navigation firing
+  // after the user has already clicked away (e.g. to "Map on Canvas").
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     abortRef.current?.abort();
@@ -109,6 +117,7 @@ export function SearchPageClient() {
           <Input
             value={inputValue}
             onChange={(e) => onInputChange(e.target.value)}
+            aria-label="Search verses"
             placeholder={
               mode === "meaning"
                 ? "Describe a meaning, e.g. trusting God in hardship…"

--- a/app/search/SearchPageClient.tsx
+++ b/app/search/SearchPageClient.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { Search, Network, Heart, BookOpen } from "lucide-react";
+import { LandingHeader } from "@/components/layout/LandingHeader";
+import { NavBar } from "@/components/layout/NavBar";
+import { SearchModeToggle, type SearchMode } from "@/components/search/SearchModeToggle";
+import { Card, Input, IconButton, Tooltip, Pagination, buttonVariants } from "@/components/ui";
+import { useAuthStore } from "@/store/auth";
+import { cn } from "@/lib/utils";
+import type { SearchResponse, SearchResult } from "@/types/quran";
+
+const PAGE_SIZE = 20;
+
+function buildHref(q: string, mode: SearchMode, page: number) {
+  const params = new URLSearchParams({ q, type: mode, page: String(page) });
+  return `/search?${params.toString()}`;
+}
+
+export function SearchPageClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const q = searchParams.get("q") ?? "";
+  const mode: SearchMode = searchParams.get("type") === "meaning" ? "meaning" : "keyword";
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10) || 1);
+
+  const [inputValue, setInputValue] = useState(q);
+  const [data, setData] = useState<SearchResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [fellBackToKeyword, setFellBackToKeyword] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep the input in sync when navigating via browser back/forward.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setInputValue(q);
+  }, [q]);
+
+  useEffect(() => {
+    abortRef.current?.abort();
+    const trimmed = q.trim();
+    if (!trimmed) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setData(null);
+      return;
+    }
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setFellBackToKeyword(false);
+
+    fetch(
+      `/api/search?q=${encodeURIComponent(trimmed)}${
+        mode === "meaning" ? "&mode=meaning" : ""
+      }&page=${page}&pageSize=${PAGE_SIZE}`,
+      { signal: controller.signal }
+    )
+      .then(async (res) => {
+        if (!res.ok) throw new Error();
+        const json: SearchResponse = await res.json();
+        setFellBackToKeyword(
+          mode === "meaning" && res.headers.get("x-search-fallback") === "keyword"
+        );
+        setData(json);
+      })
+      .catch((err) => {
+        if ((err as Error).name !== "AbortError")
+          setData({ results: [], total: 0, page, pageSize: PAGE_SIZE });
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [q, mode, page]);
+
+  const navigate = useCallback(
+    (nextQ: string, nextMode: SearchMode, nextPage: number) => {
+      if (!nextQ.trim()) {
+        router.replace("/search");
+        return;
+      }
+      router.replace(buildHref(nextQ.trim(), nextMode, nextPage));
+    },
+    [router]
+  );
+
+  const onInputChange = (value: string) => {
+    setInputValue(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => navigate(value, mode, 1), 400);
+  };
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / data.pageSize)) : 1;
+
+  return (
+    <div className="min-h-screen bg-bg pb-[calc(72px+env(safe-area-inset-bottom))] text-text-primary md:pb-0">
+      <LandingHeader />
+      <NavBar />
+
+      <div className="mx-auto w-full max-w-[800px] px-6 py-10">
+        {/* Search bar */}
+        <div className="mb-4 flex items-center gap-3">
+          <Search className="h-4 w-4 shrink-0 text-text-muted" />
+          <Input
+            value={inputValue}
+            onChange={(e) => onInputChange(e.target.value)}
+            placeholder={
+              mode === "meaning"
+                ? "Describe a meaning, e.g. trusting God in hardship…"
+                : "Search topics, or enter a ref like 2:255…"
+            }
+            className="flex-1"
+          />
+        </div>
+        <SearchModeToggle mode={mode} onChange={(m) => navigate(q, m, 1)} className="mb-6" />
+
+        {!q.trim() ? (
+          <div className="py-20 text-center">
+            <Search className="mx-auto mb-4 h-8 w-8 text-text-muted/40" />
+            <p className="text-sm text-text-muted">Enter a search term to get started.</p>
+          </div>
+        ) : loading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="animate-pulse rounded-xl border border-border bg-surface p-5">
+                <div className="mb-4 flex items-center gap-2">
+                  <div className="h-5 w-14 rounded bg-surface-overlay" />
+                  <div className="h-4 w-24 rounded bg-surface-overlay" />
+                </div>
+                <div className="mb-2 h-5 w-full rounded bg-surface-overlay" />
+                <div className="h-4 w-3/4 rounded bg-surface-overlay" />
+              </div>
+            ))}
+          </div>
+        ) : !data || data.results.length === 0 ? (
+          <div className="py-20 text-center">
+            <BookOpen className="mx-auto mb-4 h-8 w-8 text-text-muted/40" />
+            <p className="text-sm text-text-muted">
+              {mode === "meaning" ? "No verses matched that meaning." : "No results found."}
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="mb-4 text-sm text-text-muted">
+              Showing <span className="font-medium text-text-primary">{data.total}</span> result
+              {data.total === 1 ? "" : "s"} for &ldquo;{q}&rdquo;
+            </p>
+            {fellBackToKeyword && (
+              <p className="mb-4 text-xs text-text-muted">
+                Showing keyword matches — semantic search is warming up.
+              </p>
+            )}
+            <div className="space-y-3">
+              {data.results.map((result) => (
+                <ResultCard key={result.ref} result={result} />
+              ))}
+            </div>
+            <Pagination
+              page={page}
+              totalPages={totalPages}
+              href={(p) => buildHref(q, mode, p)}
+              className="mt-8"
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ResultCard({ result }: { result: SearchResult }) {
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const isBookmarked = useAuthStore((s) => s.isBookmarked(result.ref));
+  const toggleBookmark = useAuthStore((s) => s.toggleBookmark);
+
+  return (
+    <Card className="p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="rounded border border-gold bg-gold/[0.08] px-1.5 py-0.5 font-mono text-xs text-gold">
+            {result.ref}
+          </span>
+          <span className="text-xs text-text-muted">{result.surahName}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {accessToken && (
+            <Tooltip label={isBookmarked ? "Remove bookmark" : "Bookmark verse"}>
+              <IconButton
+                tone="gold"
+                size="xs"
+                onClick={() => toggleBookmark(result.ref)}
+                aria-label={isBookmarked ? "Remove bookmark" : "Bookmark verse"}
+                className={cn(isBookmarked && "border-gold-muted text-gold")}
+              >
+                <Heart fill={isBookmarked ? "currentColor" : "none"} />
+              </IconButton>
+            </Tooltip>
+          )}
+          <Link
+            href={`/canvas?verse=${result.ref}`}
+            className={buttonVariants({ variant: "primary", size: "sm" })}
+          >
+            <Network className="w-3.5 h-3.5" />
+            Map on Canvas
+          </Link>
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        <p className="font-arabic text-right text-lg leading-loose text-text-primary">
+          {result.arabicText}
+        </p>
+        <p className="text-sm leading-relaxed text-text-secondary">{result.translation}</p>
+      </div>
+    </Card>
+  );
+}

--- a/app/search/error.tsx
+++ b/app/search/error.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+// Next 16 passes `unstable_retry`, not `reset`.
+export default function SearchError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/search/loading.tsx
+++ b/app/search/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { RouteLoading } from "@/components/layout/RouteLoading";
+import { SearchPageClient } from "./SearchPageClient";
+
+export const metadata: Metadata = {
+  title: "Search — Open Hikmah",
+  description: "Search the Quran by keyword or by meaning, with full Arabic text and translation.",
+};
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={<RouteLoading />}>
+      <SearchPageClient />
+    </Suspense>
+  );
+}

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { LayoutTemplate, Sparkles } from "lucide-react";
+import { LayoutTemplate, Sparkles, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCanvasStore } from "@/store/canvas";
 
@@ -11,6 +11,7 @@ import { useCanvasStore } from "@/store/canvas";
 // here — so there is exactly one home for each destination.
 const ITEMS = [
   { href: "/canvas", label: "Canvas", icon: LayoutTemplate },
+  { href: "/search", label: "Search", icon: Search },
   { href: "/names", label: "Asma’ul Husna", icon: Sparkles },
 ] as const;
 

--- a/components/search/SearchDialog.tsx
+++ b/components/search/SearchDialog.tsx
@@ -1,23 +1,20 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
 import * as Dialog from "@radix-ui/react-dialog";
-import { Search, X, Loader2, BookOpen, Network } from "lucide-react";
+import { Search, X, Loader2, BookOpen, Network, CornerDownLeft } from "lucide-react";
 import { useCanvasStore } from "@/store/canvas";
 import { findFreeSlot, viewportCenter, NODE_WIDTH, NODE_HEIGHT } from "@/lib/canvas/canvas-layout";
-import type { Verse, SearchResult } from "@/types/quran";
+import type { Verse, SearchResult, SearchResponse } from "@/types/quran";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui";
+import { SearchModeToggle, type SearchMode } from "@/components/search/SearchModeToggle";
 
 interface SearchDialogProps {
   open: boolean;
   onClose: () => void;
 }
-
-// Keyword → Quran.com text search. Meaning → semantic (embedding) search over the
-// local corpus. A bare reference like 2:255 short-circuits to a direct preview in
-// either mode.
-type SearchMode = "keyword" | "meaning";
 
 const SEED_VERSES: Array<{ ref: string; label: string }> = [
   { ref: "1:1", label: "Al-Fatiha — Opening" },
@@ -29,10 +26,12 @@ const SEED_VERSES: Array<{ ref: string; label: string }> = [
 ];
 
 export function SearchDialog({ open, onClose }: SearchDialogProps) {
+  const router = useRouter();
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [previewVerse, setPreviewVerse] = useState<Verse | null>(null);
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [totalResults, setTotalResults] = useState(0);
   const [isSearching, setIsSearching] = useState(false);
   const [previewError, setPreviewError] = useState(false);
   const [mode, setMode] = useState<SearchMode>("keyword");
@@ -74,6 +73,7 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
     async (q: string, signal: AbortSignal, searchMode: SearchMode) => {
       setIsSearching(true);
       setSearchResults([]);
+      setTotalResults(0);
       setFellBackToKeyword(false);
       try {
         const url = `/api/search?q=${encodeURIComponent(q)}${
@@ -81,16 +81,18 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
         }`;
         const res = await fetch(url, { signal });
         if (!res.ok) throw new Error();
-        const results: SearchResult[] = await res.json();
+        const data: SearchResponse = await res.json();
         // In "by meaning" mode the server falls back to keyword search when
         // semantic results aren't available; flag it so we can tell the user.
         setFellBackToKeyword(
           searchMode === "meaning" && res.headers.get("x-search-fallback") === "keyword"
         );
-        setSearchResults(results);
+        setSearchResults(data.results);
+        setTotalResults(data.total);
       } catch (err) {
         if ((err as Error).name !== "AbortError") {
           setSearchResults([]);
+          setTotalResults(0);
         }
       } finally {
         if (!signal.aborted) setIsSearching(false);
@@ -175,6 +177,13 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
     [hasNode, onClose, mapConnections]
   );
 
+  const viewAllResults = useCallback(() => {
+    const trimmed = query.trim();
+    if (!trimmed || /^\d+:\d+$/.test(trimmed)) return;
+    router.push(`/search?q=${encodeURIComponent(trimmed)}&type=${mode}`);
+    onClose();
+  }, [query, mode, router, onClose]);
+
   const busy = loading || isSearching;
   const showSeedVerses = !query.trim();
   const showPreview = !!previewVerse && !loading;
@@ -191,6 +200,7 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
           setQuery("");
           setPreviewVerse(null);
           setSearchResults([]);
+          setTotalResults(0);
           setPreviewError(false);
           setLoading(false);
           setIsSearching(false);
@@ -226,11 +236,15 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
                     if (debounceRef.current) clearTimeout(debounceRef.current);
                     setPreviewVerse(null);
                     setSearchResults([]);
+                    setTotalResults(0);
                     setPreviewError(false);
                     setLoading(false);
                     setIsSearching(false);
                     setFellBackToKeyword(false);
                   }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && showResults) viewAllResults();
                 }}
                 placeholder={
                   mode === "meaning"
@@ -250,29 +264,11 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
             </div>
 
             {/* Mode toggle — keyword (Quran.com text) vs by-meaning (semantic) */}
-            <div className="flex items-center gap-1.5 border-b border-border px-3 py-2">
-              {(["keyword", "meaning"] as SearchMode[]).map((m) => (
-                <button
-                  key={m}
-                  type="button"
-                  onClick={() => setMode(m)}
-                  aria-pressed={mode === m}
-                  className={cn(
-                    "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-                    mode === m
-                      ? "bg-teal/15 text-teal"
-                      : "text-text-muted hover:text-text-secondary"
-                  )}
-                >
-                  {m === "keyword" ? "Keyword" : "By meaning"}
-                </button>
-              ))}
-              {mode === "meaning" && (
-                <span className="ml-auto text-[10px] text-text-muted">
-                  semantic · finds related ideas
-                </span>
-              )}
-            </div>
+            <SearchModeToggle
+              mode={mode}
+              onChange={setMode}
+              className="border-b border-border px-3 py-2"
+            />
 
             {/* Content area */}
             <div className="max-h-[60vh] overflow-y-auto">
@@ -358,6 +354,24 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
                 </div>
               )}
             </div>
+
+            {showResults && totalResults > searchResults.length && (
+              <button
+                type="button"
+                onClick={viewAllResults}
+                className="w-full flex items-center justify-between gap-2 border-t border-border px-4 py-2.5 text-left transition-colors hover:bg-surface-raised"
+              >
+                <span className="text-xs font-medium text-teal">
+                  View all {totalResults} results for &ldquo;{query.trim()}&rdquo;
+                </span>
+                <span className="flex items-center gap-1.5 text-[11px] text-text-muted">
+                  Press
+                  <kbd className="flex items-center gap-1 rounded border border-border bg-surface-overlay px-1.5 py-0.5 font-mono">
+                    <CornerDownLeft className="w-3 h-3" /> Enter
+                  </kbd>
+                </span>
+              </button>
+            )}
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/components/search/SearchModeToggle.tsx
+++ b/components/search/SearchModeToggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+// Keyword → Quran.com text search. Meaning → semantic (embedding) search over the
+// local corpus. Shared between the Command Modal and the /search page so the
+// toggle UI/state is identical in both places.
+export type SearchMode = "keyword" | "meaning";
+
+interface SearchModeToggleProps {
+  mode: SearchMode;
+  onChange: (mode: SearchMode) => void;
+  className?: string;
+}
+
+export function SearchModeToggle({ mode, onChange, className }: SearchModeToggleProps) {
+  return (
+    <div className={cn("flex items-center gap-1.5", className)}>
+      {(["keyword", "meaning"] as SearchMode[]).map((m) => (
+        <button
+          key={m}
+          type="button"
+          onClick={() => onChange(m)}
+          aria-pressed={mode === m}
+          className={cn(
+            "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+            mode === m ? "bg-teal/15 text-teal" : "text-text-muted hover:text-text-secondary"
+          )}
+        >
+          {m === "keyword" ? "Keyword" : "By meaning"}
+        </button>
+      ))}
+      {mode === "meaning" && (
+        <span className="ml-auto text-[10px] text-text-muted">semantic · finds related ideas</span>
+      )}
+    </div>
+  );
+}

--- a/components/ui/Pagination.tsx
+++ b/components/ui/Pagination.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface PaginationProps {
+  page: number;
+  totalPages: number;
+  /** Builds the href for a given page number, e.g. `(p) => `/search?q=x&page=${p}`` */
+  href: (page: number) => string;
+  className?: string;
+}
+
+const SIBLINGS = 1;
+
+/** Page numbers to render, with `"ellipsis"` markers where a run is collapsed. */
+function pageRange(page: number, totalPages: number): Array<number | "ellipsis"> {
+  const pages = new Set<number>([1, totalPages]);
+  for (let p = page - SIBLINGS; p <= page + SIBLINGS; p++) {
+    if (p >= 1 && p <= totalPages) pages.add(p);
+  }
+  const sorted = [...pages].sort((a, b) => a - b);
+  const result: Array<number | "ellipsis"> = [];
+  sorted.forEach((p, i) => {
+    if (i > 0 && p - sorted[i - 1] > 1) result.push("ellipsis");
+    result.push(p);
+  });
+  return result;
+}
+
+export function Pagination({ page, totalPages, href, className }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <nav
+      aria-label="Pagination"
+      className={cn("flex items-center justify-center gap-1", className)}
+    >
+      <PageLink
+        page={page - 1}
+        href={href}
+        disabled={page <= 1}
+        aria-label="Previous page"
+        className="px-2"
+      >
+        <ChevronLeft className="w-4 h-4" />
+      </PageLink>
+
+      {pageRange(page, totalPages).map((p, i) =>
+        p === "ellipsis" ? (
+          <span key={`ellipsis-${i}`} className="px-2 text-sm text-text-muted">
+            …
+          </span>
+        ) : (
+          <PageLink key={p} page={p} href={href} active={p === page}>
+            {p}
+          </PageLink>
+        )
+      )}
+
+      <PageLink
+        page={page + 1}
+        href={href}
+        disabled={page >= totalPages}
+        aria-label="Next page"
+        className="px-2"
+      >
+        <ChevronRight className="w-4 h-4" />
+      </PageLink>
+    </nav>
+  );
+}
+
+function PageLink({
+  page,
+  href: buildHref,
+  active,
+  disabled,
+  className,
+  children,
+  ...props
+}: {
+  page: number;
+  href: (page: number) => string;
+  active?: boolean;
+  disabled?: boolean;
+  className?: string;
+  children: React.ReactNode;
+} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "href">) {
+  const base =
+    "inline-flex h-8 min-w-8 items-center justify-center rounded-md border text-sm font-mono transition-colors";
+
+  if (disabled) {
+    return (
+      <span className={cn(base, "border-border text-text-muted/40 cursor-not-allowed", className)}>
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      href={buildHref(page)}
+      className={cn(
+        base,
+        active
+          ? "border-teal bg-teal/15 text-teal"
+          : "border-border text-text-secondary hover:border-gold-muted hover:text-gold",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -5,3 +5,4 @@ export { Card, cardVariants, type CardProps } from "./Card";
 export { Tooltip, TooltipProvider } from "./Tooltip";
 export { Input } from "./Input";
 export { ReflectionNote } from "./ReflectionNote";
+export { Pagination, type PaginationProps } from "./Pagination";

--- a/types/quran.ts
+++ b/types/quran.ts
@@ -39,6 +39,15 @@ export interface SearchResult {
   surahName: string;
   surahNameArabic: string;
   snippet: string;
+  arabicText: string;
+  translation: string;
+}
+
+export interface SearchResponse {
+  results: SearchResult[];
+  total: number;
+  page: number;
+  pageSize: number;
 }
 
 export type SidebarContent =


### PR DESCRIPTION
## Summary
Issue #76 asked for a dedicated `/search` page for deep reading (full Arabic + full translation, paginated), reachable from the Command Modal, since the modal's truncated previews create friction for users who want to browse/compare full verses before mapping them to the canvas.

- **Command Modal (⌘K)**: extracted the Keyword/By-meaning toggle into a shared `SearchModeToggle` component, and added a sticky footer — "View all N results for '...'" — that appears when there are more results than the modal shows. Pressing Enter (or clicking the footer) navigates to `/search?q=...&type=...`.
- **New `/search` page**: single-column reading layout (max-width 800px) with its own search bar and the same mode toggle (inheriting state via URL params), full Arabic text + full translation per result (no truncation), and real pagination (20 results/page) via a new reusable `Pagination` component.
- **Per-result actions**: a primary "Map on Canvas" button (`/canvas?verse=...`, reusing the existing cross-page verse-loading convention — no canvas-side changes needed) and a bookmark toggle shown **only when signed in**, per the issue spec.
- Added `/search` to the main nav.

## Notable implementation details for reviewers
- **`/api/search` response shape changed**: it used to return a bare `SearchResult[]`; it now returns `{ results, total, page, pageSize }` so the new page can paginate and show a total count. `SearchDialog` (the modal) was updated to match. `SearchResult` also gained `arabicText`/`translation` fields, hydrated from our own DB corpus (`getVerses`) rather than quran.com's translation, so the full-text view stays consistent with the rest of the app.
- **Semantic ("by meaning") search is capped at the top 100 ranked matches.** Similarity search has no natural relevance cutoff across the whole corpus (every verse has *some* similarity score), so without a cap, later pages would show increasingly irrelevant results. Keyword mode pages through quran.com's own paginated API and isn't capped.
- No global ⌘K listener exists outside `/canvas` today (that's how the Command Modal already worked before this PR) — this PR doesn't change that; it only adds the new page and improves the modal's own out-flow.

Closes #76

## Test plan
- [x] Unit tests updated/passing for the new `/api/search` response shape and pagination (keyword page/pageSize forwarding, semantic in-memory pagination + cap)
- [x] `bun run typecheck` / `bun run lint` / `bun run test:ci` all pass locally
- [ ] CI checks pass on the PR
- [ ] Manually verify: ⌘K → type a query → footer count appears → Enter navigates to `/search`; pagination changes results for both modes; "Map on Canvas" loads the verse as root node; bookmark icon only shows when signed in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Search page with Keyword/By meaning modes, debounced URL-driven navigation, result counts, and paginated navigation.
  * Added a reusable pagination component and a Search mode toggle; updated the navigation and Search dialog to support “view all results”.
* **Bug Fixes**
  * Updated `/api/search` to return a consistent paginated response shape (`results`, `total`, `page`, `pageSize`), including sanitized snippets and keyword fallback when meaning search can’t complete.
* **Tests**
  * Expanded/reworked search API tests for the new response contract and edge cases.
* **Chores**
  * Added Search route loading/error UI and exported the new `SearchResponse` type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->