### PR TITLE
fix(names): log and count upstream Quran API fetch failures

### DIFF
--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -3,6 +3,7 @@ import { callAI } from "@/lib/ai/ai";
 import { getNameBySlug } from "@/lib/names/divine-names";
 import { getSurahName } from "@/lib/quran/surah-names";
 import { getOrGenerateNameContent } from "@/lib/names/name-content";
+import { incr } from "@/lib/infra/metrics";
 import sanitizeHtml from "sanitize-html";
 import type { VerseRef } from "@/types/quran";
 
@@ -46,7 +47,11 @@ async function fetchVerseData(ref: string): Promise<Omit<NameVerse, "reason"> | 
       surahName,
       surahNameArabic,
     };
-  } catch {
+  } catch (err) {
+    // An upstream outage must not look identical to "no verse data" —
+    // log and count it so it's visible on /api/metrics, not silent.
+    console.error(`Name verses: alquran.cloud fetch failed for ${ref}:`, err);
+    incr("quran_api_fetch_error");
     return null;
   }
 }
@@ -66,7 +71,11 @@ async function searchVerseRefs(arabic: string): Promise<string[]> {
       .filter((r) => r.verse_key && /^\d+:\d+$/.test(r.verse_key))
       .map((r) => r.verse_key as string)
       .slice(0, 5);
-  } catch {
+  } catch (err) {
+    // Same reasoning as fetchVerseData: a failed search must be distinguishable
+    // from "genuinely no matching verses" in logs and /api/metrics.
+    console.error(`Name verses: quran.com search failed for "${arabic}":`, err);
+    incr("quran_search_api_error");
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- `fetchVerseData` (api.alquran.cloud) and `searchVerseRefs` (api.quran.com) in `app/api/names/[slug]/verses/route.ts` swallowed fetch errors completely — no log, no metric — so an upstream outage was indistinguishable from a genuine "no verses found" result (both returned `200 []`).
- Both catch blocks now `console.error` the failure and increment a metrics counter (`quran_api_fetch_error`, `quran_search_api_error`), matching the existing pattern used by `buildReasons`/`fallbackAIVerses` in the same file and the `incr()` convention used in `lib/infra/rate-limit.ts`.

## Test plan
- [x] `npm run typecheck` passes
- [x] `eslint` on the changed file passes with no warnings
- [x] Pre-commit hook (lint, typecheck, unit tests) passed
- [x] Pre-push hook (integration tests) passed
- [ ] Manual: force an upstream failure (e.g. block `api.alquran.cloud`/`api.quran.com`) and confirm `console.error` output and `quran_api_fetch_error`/`quran_search_api_error` appear on `/api/metrics`

Fixes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring for failures when retrieving Quran verse data or search results.
  * Errors are now recorded in logs and metrics while preserving existing fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->