### PR TITLE
feat(canvas): highlight duplicate verses and orient to newly-added nodes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -164,6 +164,28 @@
     animation: nodeEntrance var(--duration-base, 200ms)
       var(--ease-standard, cubic-bezier(0.2, 0, 0, 1)) both;
   }
+
+  .node-pulse {
+    animation: nodePulse 1.5s ease-out;
+  }
+}
+
+@keyframes nodePulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-teal) 55%, transparent);
+  }
+  20% {
+    box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-teal) 0%, transparent);
+  }
+  40% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-teal) 45%, transparent);
+  }
+  60% {
+    box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-teal) 0%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
 }
 
 @keyframes fadeIn {

--- a/components/canvas/HikmahCanvas.tsx
+++ b/components/canvas/HikmahCanvas.tsx
@@ -63,11 +63,13 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
   const onEdgesChange = useCanvasStore((s) => s.onEdgesChange);
   const pendingExpand = useCanvasStore((s) => s.pendingExpand);
   const pendingAutoExpand = useCanvasStore((s) => s.pendingAutoExpand);
+  const pendingPanToNodeId = useCanvasStore((s) => s.pendingPanToNodeId);
   const addVerseNode = useCanvasStore((s) => s.addVerseNode);
   const addConnectionEdge = useCanvasStore((s) => s.addConnectionEdge);
   const setExpandingNode = useCanvasStore((s) => s.setExpandingNode);
   const setPendingExpand = useCanvasStore((s) => s.setPendingExpand);
   const setPendingAutoExpand = useCanvasStore((s) => s.setPendingAutoExpand);
+  const setPendingPanToNode = useCanvasStore((s) => s.setPendingPanToNode);
   const setOpenExpandNodeId = useCanvasStore((s) => s.setOpenExpandNodeId);
   const setSidebarContent = useCanvasStore((s) => s.setSidebarContent);
   const setViewport = useCanvasStore((s) => s.setViewport);
@@ -188,6 +190,21 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
       sourceNode.position
     );
   }, [pendingAutoExpand, setPendingAutoExpand, getNodeById, runExpansion]);
+
+  // Search-added verses have no fixed relationship to the current view, so pan
+  // to them after they land — expansion-added nodes already appear near their
+  // source via findFreeSlot and don't need the camera to move.
+  useEffect(() => {
+    if (!pendingPanToNodeId) return;
+    const nodeId = pendingPanToNodeId;
+    setPendingPanToNode(null);
+    const node = getNodeById(nodeId);
+    if (!node) return;
+    reactFlow.setCenter(node.position.x + NODE_WIDTH / 2, node.position.y + NODE_HEIGHT / 2, {
+      zoom: reactFlow.getZoom(),
+      duration: 400,
+    });
+  }, [pendingPanToNodeId, setPendingPanToNode, getNodeById, reactFlow]);
 
   const handleEdgeClick = useCallback(
     (_: React.MouseEvent, edge: Edge) => {

--- a/components/canvas/VerseNode.tsx
+++ b/components/canvas/VerseNode.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import { memo } from "react";
-import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { Handle, Position, useReactFlow, type NodeProps } from "@xyflow/react";
 import type { Verse, EdgeKind } from "@/types/quran";
 import { useCanvasStore } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
 import { cn } from "@/lib/utils";
-import { Loader2, Plus, Heart, Volume2 } from "lucide-react";
+import { Loader2, Plus, Heart, Volume2, Copy } from "lucide-react";
 import { IconButton, Tooltip } from "@/components/ui";
 import { ExpandMenu } from "./ExpandMenu";
 import { useAudioStore } from "@/store/audio";
+import { NODE_WIDTH, NODE_HEIGHT } from "@/lib/canvas/canvas-layout";
 
 type VerseNodeData = Verse & { isRoot?: boolean; isLoading?: boolean };
 
@@ -18,10 +19,15 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
 
   const expandingNodeId = useCanvasStore((s) => s.expandingNodeId);
   const openExpandNodeId = useCanvasStore((s) => s.openExpandNodeId);
+  const newlyAddedNodeId = useCanvasStore((s) => s.newlyAddedNodeId);
   const setSelectedNode = useCanvasStore((s) => s.setSelectedNode);
   const setOpenExpandNodeId = useCanvasStore((s) => s.setOpenExpandNodeId);
   const setSidebarContent = useCanvasStore((s) => s.setSidebarContent);
   const setPendingExpand = useCanvasStore((s) => s.setPendingExpand);
+  const setNewlyAddedNode = useCanvasStore((s) => s.setNewlyAddedNode);
+  const getDuplicateNodeIds = useCanvasStore((s) => s.getDuplicateNodeIds);
+  const getNodeById = useCanvasStore((s) => s.getNodeById);
+  const reactFlow = useReactFlow();
 
   const isBookmarked = useAuthStore((s) => s.isBookmarked(verse.ref));
   const toggleBookmark = useAuthStore((s) => s.toggleBookmark);
@@ -35,9 +41,25 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
 
   const isExpanding = expandingNodeId === id;
   const expandMenuOpen = openExpandNodeId === id;
+  const isPulsing = newlyAddedNodeId === id;
+  const otherDuplicateIds = getDuplicateNodeIds(verse.ref).filter((did) => did !== id);
+  const hasDuplicate = otherDuplicateIds.length > 0;
 
   const handleExpandSelect = (kind: EdgeKind) => {
     setPendingExpand({ nodeId: id, ref: verse.ref, kind });
+  };
+
+  const jumpToDuplicate = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const targetId = otherDuplicateIds[0];
+    const targetNode = getNodeById(targetId);
+    if (!targetNode) return;
+    reactFlow.setCenter(
+      targetNode.position.x + NODE_WIDTH / 2,
+      targetNode.position.y + NODE_HEIGHT / 2,
+      { zoom: reactFlow.getZoom(), duration: 400 }
+    );
+    setNewlyAddedNode(targetId);
   };
 
   const toggleSelected = () => {
@@ -73,6 +95,7 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
         selected && "node-selected",
         isExpanding && "node-expanding",
+        isPulsing && "node-pulse",
         !selected && !isExpanding && "hover:border-text-muted"
       )}
     >
@@ -81,6 +104,20 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
         position={Position.Left}
         className="!w-2 !h-2 !bg-border !border-border-subtle"
       />
+
+      {hasDuplicate && (
+        <Tooltip label="Also open elsewhere on canvas — click to jump">
+          <button
+            type="button"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={jumpToDuplicate}
+            aria-label="Jump to duplicate verse card"
+            className="absolute -top-2 -left-2 z-10 flex h-5 w-5 items-center justify-center rounded-full border border-gold bg-surface-raised text-gold shadow-sm transition-colors hover:bg-gold/10"
+          >
+            <Copy className="h-3 w-3" />
+          </button>
+        </Tooltip>
+      )}
 
       <div className="p-3 space-y-2.5">
         <div className="flex items-center justify-between gap-2">

--- a/components/search/SearchDialog.tsx
+++ b/components/search/SearchDialog.tsx
@@ -42,6 +42,7 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
 
   const addVerseNode = useCanvasStore((s) => s.addVerseNode);
   const setPendingAutoExpand = useCanvasStore((s) => s.setPendingAutoExpand);
+  const setPendingPanToNode = useCanvasStore((s) => s.setPendingPanToNode);
   const hasNode = useCanvasStore((s) => s.hasNode);
   const nodes = useCanvasStore((s) => s.nodes);
   const viewport = useCanvasStore((s) => s.viewport);
@@ -124,12 +125,9 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
 
   const mapConnections = useCallback(
     (verse: Verse) => {
-      // Defensive: triggers are already disabled for added verses, but never stack
-      // a duplicate node regardless of how this is reached.
-      if (hasNode(verse.ref)) {
-        onClose();
-        return;
-      }
+      // Re-adding a verse already on canvas is allowed — the user may want to try
+      // a different expansion (root/theme/contrast) on a second copy. Both copies
+      // get a duplicate badge (VerseNode) so the user can tell they're linked.
       const isFirst = nodes.length === 0;
       // First node anchors at the origin; later searches drop into the nearest
       // empty slot beside the *visible* part of the graph, never overlapping.
@@ -150,18 +148,18 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
       const nodeId = addVerseNode({ ...verse, isRoot: isFirst }, position);
       if (isFirst) {
         setPendingAutoExpand(nodeId);
+      } else {
+        // The user has no way to know where a search-added verse landed on a
+        // populated canvas, so pan the camera to it.
+        setPendingPanToNode(nodeId);
       }
       onClose();
     },
-    [nodes, viewport, hasNode, addVerseNode, setPendingAutoExpand, onClose]
+    [nodes, viewport, addVerseNode, setPendingAutoExpand, setPendingPanToNode, onClose]
   );
 
   const loadSeedVerse = useCallback(
     async (ref: string) => {
-      if (hasNode(ref)) {
-        onClose();
-        return;
-      }
       setLoading(true);
       try {
         const res = await fetch(`/api/verse/${ref.replace(":", "/")}`);
@@ -174,7 +172,7 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
         setLoading(false);
       }
     },
-    [hasNode, onClose, mapConnections]
+    [mapConnections]
   );
 
   const viewAllResults = useCallback(() => {
@@ -391,7 +389,7 @@ function VerseCard({
   const [submitting, setSubmitting] = useState(false);
 
   const handleClick = async () => {
-    if (submitting || alreadyAdded) return;
+    if (submitting) return;
     setSubmitting(true);
     try {
       onMapConnections();
@@ -417,27 +415,20 @@ function VerseCard({
         {verse.translation}
       </p>
 
-      {alreadyAdded ? (
-        <Button variant="secondary" size="sm" disabled className="w-full">
+      <Button
+        variant={alreadyAdded ? "secondary" : "primary"}
+        size="sm"
+        onClick={handleClick}
+        disabled={submitting}
+        className="w-full"
+      >
+        {submitting ? (
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        ) : (
           <Network className="w-3.5 h-3.5" />
-          Already on canvas
-        </Button>
-      ) : (
-        <Button
-          variant="primary"
-          size="sm"
-          onClick={handleClick}
-          disabled={submitting}
-          className="w-full"
-        >
-          {submitting ? (
-            <Loader2 className="w-3.5 h-3.5 animate-spin" />
-          ) : (
-            <Network className="w-3.5 h-3.5" />
-          )}
-          Map Connections
-        </Button>
-      )}
+        )}
+        {alreadyAdded ? "Already on canvas — add again" : "Map Connections"}
+      </Button>
     </div>
   );
 }
@@ -454,10 +445,9 @@ function SearchResultRow({
   return (
     <button
       onClick={onSelect}
-      disabled={alreadyAdded}
       className={cn(
         "w-full flex items-start gap-3 px-3 py-2.5 rounded-lg text-left transition-colors",
-        "hover:bg-surface-raised disabled:opacity-50 disabled:cursor-not-allowed"
+        "hover:bg-surface-raised"
       )}
     >
       <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0 mt-0.5 bg-surface-overlay">

--- a/store/canvas.ts
+++ b/store/canvas.ts
@@ -83,6 +83,8 @@ interface CanvasStore {
   sidebarContent: SidebarContent | null;
   pendingExpand: PendingExpand | null;
   pendingAutoExpand: string | null;
+  pendingPanToNodeId: string | null;
+  newlyAddedNodeId: string | null;
   viewport: CanvasViewport;
 
   setNodes: (nodes: Node[]) => void;
@@ -99,9 +101,12 @@ interface CanvasStore {
   setSidebarContent: (content: SidebarContent | null) => void;
   setPendingExpand: (action: PendingExpand | null) => void;
   setPendingAutoExpand: (nodeId: string | null) => void;
+  setPendingPanToNode: (nodeId: string | null) => void;
+  setNewlyAddedNode: (nodeId: string | null) => void;
   hasNode: (ref: string) => boolean;
   getNodeByRef: (ref: string) => Node | undefined;
   getNodeById: (id: string) => Node | undefined;
+  getDuplicateNodeIds: (ref: string) => string[];
   reset: () => void;
   restoreCanvas: (saved: SavedCanvas) => void;
   appendWorkspace: (saved: SavedCanvas) => void;
@@ -109,6 +114,11 @@ interface CanvasStore {
 
 let nodeIdCounter = 0;
 const nextId = () => `node-${++nodeIdCounter}`;
+
+// Pulse duration must exceed the CSS `.node-pulse` animation length (1.5s) so the
+// highlight class isn't stripped mid-animation.
+const NEWLY_ADDED_PULSE_MS = 1600;
+let newlyAddedTimeout: ReturnType<typeof setTimeout> | null = null;
 
 export const useCanvasStore = create<CanvasStore>((set, get) => ({
   nodes: [],
@@ -119,6 +129,8 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
   sidebarContent: null,
   pendingExpand: null,
   pendingAutoExpand: null,
+  pendingPanToNodeId: null,
+  newlyAddedNodeId: null,
   viewport: { x: 0, y: 0, zoom: 1 },
 
   setNodes: (nodes) => set({ nodes }),
@@ -144,6 +156,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
     set((s) => ({
       nodes: [...s.nodes, { id, type: "verse", position: pos, data: { ...verse } } as Node],
     }));
+    get().setNewlyAddedNode(id);
     return id;
   },
 
@@ -177,12 +190,28 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
   setSidebarContent: (content) => set({ sidebarContent: content }),
   setPendingExpand: (action) => set({ pendingExpand: action }),
   setPendingAutoExpand: (nodeId) => set({ pendingAutoExpand: nodeId }),
+  setPendingPanToNode: (nodeId) => set({ pendingPanToNodeId: nodeId }),
+
+  setNewlyAddedNode: (nodeId) => {
+    if (newlyAddedTimeout) clearTimeout(newlyAddedTimeout);
+    set({ newlyAddedNodeId: nodeId });
+    if (nodeId) {
+      newlyAddedTimeout = setTimeout(() => {
+        set((s) => (s.newlyAddedNodeId === nodeId ? { newlyAddedNodeId: null } : {}));
+      }, NEWLY_ADDED_PULSE_MS);
+    }
+  },
 
   hasNode: (ref) => get().nodes.some((n) => (n.data as unknown as Verse)?.ref === ref),
 
   getNodeByRef: (ref) => get().nodes.find((n) => (n.data as unknown as Verse)?.ref === ref),
 
   getNodeById: (id) => get().nodes.find((n) => n.id === id),
+
+  getDuplicateNodeIds: (ref) =>
+    get()
+      .nodes.filter((n) => (n.data as unknown as Verse)?.ref === ref)
+      .map((n) => n.id),
 
   reset: () =>
     set({
@@ -194,6 +223,8 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
       sidebarContent: null,
       pendingExpand: null,
       pendingAutoExpand: null,
+      pendingPanToNodeId: null,
+      newlyAddedNodeId: null,
     }),
 
   restoreCanvas: (saved: SavedCanvas) => {
@@ -212,6 +243,8 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
       sidebarContent: null,
       pendingExpand: null,
       pendingAutoExpand: null,
+      pendingPanToNodeId: null,
+      newlyAddedNodeId: null,
     });
   },
 


### PR DESCRIPTION
## Summary
- Re-adding a verse already on canvas is no longer silently blocked in search/seed flows — both copies now get a small duplicate badge, clicking it pans + pulses to the other copy.
- New nodes pulse briefly on arrival; search-added verses also pan the camera to where they landed, so the user doesn't have to hunt for a card that appeared off-screen.
- Expansion-added nodes (theme/root/contrast) get the pulse too, but no camera pan, since `findFreeSlot` already places them near their source.

## Scope note
This covers 2 of the 3 ideas discussed on #87. A third idea — clicking the same expansion kind (theme/root/contrast) again on a verse to fetch *additional* results instead of the same cached set — needs backend changes (`/api/connections`, `graph-service.ts`, `connection-discovery.ts`) and is being filed as a separate follow-up issue rather than bundled here. Relates to #87, does not close it.

## Test plan
- [x] `npm run typecheck` and `npm run lint` pass
- [x] Manually drove the canvas via Playwright against a local dev server:
  - Added a verse, confirmed camera pans to it and it pulses on arrival
  - Re-added the same verse — second card appears, both show the duplicate badge, clicking either pans + pulses to the other
  - Confirmed existing behaviors (fitView toolbar, node-entrance fade-in, node-expanding border, edge dedup) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results can now add duplicate verses to the canvas.
  * Added a button to jump between duplicate verse cards.
  * Newly added verses are automatically highlighted and brought into view.
  * Added a visual pulse animation to highlight newly added nodes.
* **Bug Fixes**
  * Improved canvas navigation after adding verses from search results.
  * Duplicate verses remain interactive instead of appearing disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->