### PR TITLE
feat(connections): fetch new results on repeat theme/root/contrast expansion

### DIFF
--- a/__tests__/api/connections.test.ts
+++ b/__tests__/api/connections.test.ts
@@ -98,7 +98,10 @@ function transResp(text = "A noble verse.") {
   return { ok: true, json: async () => ({ data: { text } }) };
 }
 
-function makeRequest(body: Record<string, string>, headers: Record<string, string> = {}) {
+function makeRequest(
+  body: Record<string, string | string[]>,
+  headers: Record<string, string> = {}
+) {
   return new NextRequest("http://localhost/api/connections", {
     method: "POST",
     body: JSON.stringify(body),
@@ -294,5 +297,59 @@ describe("POST /api/connections", () => {
     expect(mockInsert).not.toHaveBeenCalled();
     // The mocked Anthropic client was never constructed/used for a hit.
     expect(anthropic.default).toBeDefined();
+  });
+
+  it("returns 400 for a non-array excludeRefs", async () => {
+    const req = makeRequest({
+      fromRef: "1:1",
+      kind: "thematic",
+      arabicText: "x",
+      translation: "y",
+      excludeRefs: "2:255" as unknown as string[],
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an excludeRefs entry that isn't a valid ref", async () => {
+    const req = makeRequest({
+      fromRef: "1:1",
+      kind: "thematic",
+      arabicText: "x",
+      translation: "y",
+      excludeRefs: ["2:255", "garbage"],
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an oversized excludeRefs list", async () => {
+    const req = makeRequest({
+      fromRef: "1:1",
+      kind: "thematic",
+      arabicText: "x",
+      translation: "y",
+      excludeRefs: Array.from({ length: 101 }, (_, i) => `2:${i + 1}`),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with an empty array (not a 500) when excludeRefs exhausts a repeat request", async () => {
+    // Cache hit path would normally return the stored edge, but with excludeRefs
+    // matching it, the DB filter should exclude it — simulate that by returning
+    // an empty result set even though this is technically a "hit" scenario.
+    mockSelect.mockReturnValue(makeDbChain([]));
+    const req = makeRequest({
+      fromRef: "2:255",
+      kind: "thematic",
+      arabicText: "x",
+      translation: "y",
+      excludeRefs: ["3:18", "112:1"],
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual([]);
   });
 });

--- a/__tests__/integration/connection-discovery.integration.test.ts
+++ b/__tests__/integration/connection-discovery.integration.test.ts
@@ -68,4 +68,15 @@ describe("connection discovery — root (integration, real Postgres)", () => {
   it("returns [] for a verse with no morphology seeded", async () => {
     expect(await discoverCandidates("9:9", "root", 10)).toEqual([]);
   });
+
+  it("excludes refs already surfaced to the caller, e.g. a repeat 'get more' request", async () => {
+    const out = await discoverCandidates("1:1", "root", 10, ["3:3"]);
+    expect(out).not.toContain("3:3");
+    expect(out).toContain("2:2");
+  });
+
+  it("returns [] when every remaining candidate has already been excluded", async () => {
+    const out = await discoverCandidates("1:1", "root", 10, ["3:3", "2:2"]);
+    expect(out).toEqual([]);
+  });
 });

--- a/__tests__/integration/graph.integration.test.ts
+++ b/__tests__/integration/graph.integration.test.ts
@@ -17,8 +17,13 @@ import { getConnections } from "@/lib/ai/graph-service";
 import { consume } from "@/lib/infra/rate-limit";
 
 async function reset() {
+  // word_morphology is included even though this file never seeds it — root
+  // discovery reads real DB state, and another integration file (connection-
+  // discovery) seeds roots for ref "1:1" used here too. Since files share one
+  // container and run serially (not parallel) but each only cleans up its own
+  // tables, leftover rows would otherwise leak into this file's "root" test.
   await db.execute(
-    sql`TRUNCATE verses, connections, ai_generations, rate_limits RESTART IDENTITY CASCADE`
+    sql`TRUNCATE verses, connections, ai_generations, rate_limits, word_morphology RESTART IDENTITY CASCADE`
   );
 }
 

--- a/__tests__/integration/semantic-search.integration.test.ts
+++ b/__tests__/integration/semantic-search.integration.test.ts
@@ -84,4 +84,13 @@ describe("semantic search (integration, real pgvector)", () => {
   it("semanticCandidates returns nearest refs excluding the source", async () => {
     expect(await semanticCandidates("1:1", 5)).toEqual(["2:2", "3:3"]);
   });
+
+  it("semanticCandidates excludes additional refs already surfaced to the caller", async () => {
+    expect(await semanticCandidates("1:1", 5, ["2:2"])).toEqual(["3:3"]);
+  });
+
+  it("similarVerses excludes additional refs already surfaced to the caller", async () => {
+    const out = await similarVerses("1:1", 5, ["2:2"]);
+    expect(out.map((m) => m.verse.ref)).toEqual(["3:3"]);
+  });
 });

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -199,7 +199,7 @@ describe("getConnections", () => {
 
     const out = await getConnections("1:1", "thematic", source);
 
-    expect(mockDiscover).toHaveBeenCalledWith("1:1", "thematic");
+    expect(mockDiscover).toHaveBeenCalledWith("1:1", "thematic", undefined, []);
     expect(mockGenerateGrounded).toHaveBeenCalledTimes(1);
     expect(mockGenerateGrounded).toHaveBeenCalledWith("1:1", "ar", "tr", "thematic", [
       "2:255",
@@ -219,6 +219,39 @@ describe("getConnections", () => {
 
     expect(mockGenerateGrounded).not.toHaveBeenCalled();
     expect(mockGenerate).toHaveBeenCalledWith("1:1", "ar", "tr", "root");
+    expect(out).toHaveLength(1);
+  });
+
+  it("threads excludeRefs into discoverCandidates on a miss", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    mockDiscover.mockResolvedValue(["3:18"]);
+    mockGenerateGrounded.mockResolvedValue([result("3:18")]);
+
+    await getConnections("1:1", "thematic", source, { excludeRefs: ["2:255"] });
+
+    expect(mockDiscover).toHaveBeenCalledWith("1:1", "thematic", undefined, ["2:255"]);
+  });
+
+  it("returns [] without falling back to legacy generation when excludeRefs exhausts candidates", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    mockDiscover.mockResolvedValue([]); // nothing left to offer beyond excludeRefs
+
+    const out = await getConnections("1:1", "thematic", source, { excludeRefs: ["2:255", "3:18"] });
+
+    expect(mockGenerate).not.toHaveBeenCalled();
+    expect(mockGenerateGrounded).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(out).toEqual([]);
+  });
+
+  it("still falls back to legacy generation on a true first-time miss (no excludeRefs)", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    mockDiscover.mockResolvedValue([]); // no grounding data seeded yet
+    mockGenerate.mockResolvedValue([result("2:255")]);
+
+    const out = await getConnections("1:1", "thematic", source);
+
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
     expect(out).toHaveLength(1);
   });
 
@@ -284,6 +317,25 @@ describe("getConnections — single-flight de-duplication", () => {
     expect(b).toBe(a); // followers receive the very same resolved array
     expect(c).toBe(a);
     expect(mockInsert).toHaveBeenCalledTimes(1); // persisted once, not per-caller
+  });
+
+  it("does NOT coalesce a plain request with a 'get more' request (different excludeRefs)", async () => {
+    // Grounding available only for the "get more" (excludeRefs) request, so if the
+    // two requests wrongly shared a single-flight key, only one of the two
+    // generation paths below would ever run.
+    mockDiscover.mockImplementation(
+      async (_ref: string, _kind: string, _limit?: number, excl?: string[]) =>
+        excl && excl.length > 0 ? ["3:18"] : []
+    );
+    mockGenerate.mockImplementation(async () => [result("2:255")]);
+    mockGenerateGrounded.mockImplementation(async () => [result("3:18")]);
+
+    await Promise.all([
+      getConnections("1:1", "thematic", source),
+      getConnections("1:1", "thematic", source, { excludeRefs: ["2:255"] }),
+    ]);
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+    expect(mockGenerateGrounded).toHaveBeenCalledTimes(1);
   });
 
   it("does NOT coalesce different verse+kind keys", async () => {

--- a/__tests__/store/canvas.test.ts
+++ b/__tests__/store/canvas.test.ts
@@ -166,6 +166,81 @@ describe("canvas store", () => {
     expect(useCanvasStore.getState().pendingAutoExpand).toBe("node-10");
   });
 
+  it("getExpansionRefs returns refs of same-kind children of a node", () => {
+    const sourceId = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    const themeTarget = { ...baseVerse, ref: "1:1" as const, surah: 1, ayah: 1 };
+    const rootTarget = { ...baseVerse, ref: "3:3" as const, surah: 3, ayah: 3 };
+    const themeId = useCanvasStore.getState().addVerseNode(themeTarget, { x: 300, y: 0 });
+    const rootId = useCanvasStore.getState().addVerseNode(rootTarget, { x: 600, y: 0 });
+
+    useCanvasStore.getState().addConnectionEdge({
+      id: "e1",
+      source: sourceId,
+      target: themeId,
+      type: "hikmah",
+      data: { kind: "thematic", label: "t" },
+    });
+    useCanvasStore.getState().addConnectionEdge({
+      id: "e2",
+      source: sourceId,
+      target: rootId,
+      type: "hikmah",
+      data: { kind: "root", label: "r" },
+    });
+
+    expect(useCanvasStore.getState().getExpansionRefs(sourceId, "thematic")).toEqual(["1:1"]);
+    expect(useCanvasStore.getState().getExpansionRefs(sourceId, "root")).toEqual(["3:3"]);
+    expect(useCanvasStore.getState().getExpansionRefs(sourceId, "contrast")).toEqual([]);
+  });
+
+  it("getExpansionRefs is directed — a node's own incoming edges don't count", () => {
+    const sourceId = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    const targetId = useCanvasStore
+      .getState()
+      .addVerseNode({ ...baseVerse, ref: "1:1" as const, surah: 1, ayah: 1 }, { x: 300, y: 0 });
+    useCanvasStore.getState().addConnectionEdge({
+      id: "e1",
+      source: sourceId,
+      target: targetId,
+      type: "hikmah",
+      data: { kind: "thematic", label: "t" },
+    });
+
+    expect(useCanvasStore.getState().getExpansionRefs(targetId, "thematic")).toEqual([]);
+  });
+
+  it("getExpansionCounts groups edges by kind for a given source node", () => {
+    const sourceId = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    const a = useCanvasStore
+      .getState()
+      .addVerseNode({ ...baseVerse, ref: "1:1" as const, surah: 1, ayah: 1 }, { x: 300, y: 0 });
+    const b = useCanvasStore
+      .getState()
+      .addVerseNode({ ...baseVerse, ref: "3:3" as const, surah: 3, ayah: 3 }, { x: 600, y: 0 });
+
+    useCanvasStore.getState().addConnectionEdge({
+      id: "e1",
+      source: sourceId,
+      target: a,
+      type: "hikmah",
+      data: { kind: "thematic", label: "t" },
+    });
+    useCanvasStore.getState().addConnectionEdge({
+      id: "e2",
+      source: sourceId,
+      target: b,
+      type: "hikmah",
+      data: { kind: "thematic", label: "t" },
+    });
+
+    expect(useCanvasStore.getState().getExpansionCounts(sourceId)).toEqual({ thematic: 2 });
+  });
+
+  it("getExpansionCounts returns an empty object for a node with no expansions", () => {
+    const id = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    expect(useCanvasStore.getState().getExpansionCounts(id)).toEqual({});
+  });
+
   it("reset clears all state", () => {
     useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
     useCanvasStore.getState().setSelectedNode("x");

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -5,15 +5,23 @@ import { RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
 import type { EdgeKind } from "@/types/quran";
 
+const MAX_EXCLUDE_REFS = 100;
+
 export async function POST(req: NextRequest) {
-  let body: { fromRef?: string; kind?: string; arabicText?: string; translation?: string };
+  let body: {
+    fromRef?: string;
+    kind?: string;
+    arabicText?: string;
+    translation?: string;
+    excludeRefs?: unknown;
+  };
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 
-  const { fromRef, kind, arabicText, translation } = body;
+  const { fromRef, kind, arabicText, translation, excludeRefs: rawExcludeRefs } = body;
 
   if (!fromRef || !kind || !arabicText || !translation) {
     return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
@@ -27,15 +35,29 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid fromRef" }, { status: 400 });
   }
 
+  let excludeRefs: string[] = [];
+  if (rawExcludeRefs !== undefined) {
+    if (
+      !Array.isArray(rawExcludeRefs) ||
+      rawExcludeRefs.length > MAX_EXCLUDE_REFS ||
+      !rawExcludeRefs.every((r) => typeof r === "string" && isValidRef(r))
+    ) {
+      return NextResponse.json({ error: "Invalid excludeRefs" }, { status: 400 });
+    }
+    excludeRefs = rawExcludeRefs;
+  }
+
   try {
     const results = await getConnections(
       fromRef,
       kind as EdgeKind,
       { arabicText, translation },
-      { clientKey: clientKey(req) }
+      { clientKey: clientKey(req), excludeRefs }
     );
 
-    if (results.length === 0) {
+    // A "get more" request (excludeRefs non-empty) legitimately can run out of
+    // fresh connections — that's not a server error, just nothing left to give.
+    if (results.length === 0 && excludeRefs.length === 0) {
       return NextResponse.json({ error: "Could not resolve any verses" }, { status: 500 });
     }
 

--- a/components/canvas/ExpandMenu.tsx
+++ b/components/canvas/ExpandMenu.tsx
@@ -6,6 +6,7 @@ import type { EdgeKind } from "@/types/quran";
 interface ExpandMenuProps {
   onSelect: (kind: EdgeKind) => void;
   onClose: () => void;
+  existingCounts?: Partial<Record<EdgeKind, number>>;
 }
 
 const OPTIONS: Array<{
@@ -38,7 +39,7 @@ const OPTIONS: Array<{
   },
 ];
 
-export function ExpandMenu({ onSelect, onClose }: ExpandMenuProps) {
+export function ExpandMenu({ onSelect, onClose, existingCounts }: ExpandMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const firstOptionRef = useRef<HTMLButtonElement>(null);
   const [openUp, setOpenUp] = useState(false);
@@ -94,7 +95,12 @@ export function ExpandMenu({ onSelect, onClose }: ExpandMenuProps) {
               {opt.icon}
             </span>
             <div className="min-w-0">
-              <p className="text-xs font-medium text-text-primary">{opt.label}</p>
+              <p className="text-xs font-medium text-text-primary">
+                {opt.label}
+                {!!existingCounts?.[opt.kind] && (
+                  <span className="text-text-muted"> ({existingCounts[opt.kind]} found)</span>
+                )}
+              </p>
               <p className="text-xs text-text-muted">{opt.description}</p>
             </div>
           </button>

--- a/components/canvas/HikmahCanvas.tsx
+++ b/components/canvas/HikmahCanvas.tsx
@@ -26,6 +26,13 @@ import type { ConnectionResult, Verse } from "@/types/quran";
 const nodeTypes = { verse: VerseNode };
 const edgeTypes = { hikmah: HikmahEdge };
 
+/** Signals a repeat "get more" expansion that genuinely has nothing further to
+ *  give, so the catch block can show a distinct message instead of the generic
+ *  fetch-failure one — kept as a throw (rather than an inline early return)
+ *  so runExpansion has a single setState call site, which the effects that
+ *  invoke it directly depend on for the react-hooks lint rule to stay clean. */
+class ExhaustedExpansionError extends Error {}
+
 function radialPos(
   src: { x: number; y: number },
   i: number,
@@ -75,6 +82,7 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
   const setViewport = useCanvasStore((s) => s.setViewport);
   const getNodeById = useCanvasStore((s) => s.getNodeById);
   const hasNode = useCanvasStore((s) => s.hasNode);
+  const getExpansionRefs = useCanvasStore((s) => s.getExpansionRefs);
 
   const runExpansion = useCallback(
     async (
@@ -90,15 +98,22 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
       setExpandingNode(nodeId);
 
       try {
+        const excludeRefs = getExpansionRefs(nodeId, kind);
         const res = await fetch("/api/connections", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ fromRef: ref, kind, arabicText, translation }),
+          body: JSON.stringify({ fromRef: ref, kind, arabicText, translation, excludeRefs }),
         });
 
         if (!res.ok) throw new Error("Connections API failed");
 
         const connections: ConnectionResult[] = await res.json();
+
+        // A repeat "get more" request can legitimately run dry — that's not a
+        // fetch failure, just nothing further to surface for this kind.
+        if (connections.length === 0 && excludeRefs.length > 0) {
+          throw new ExhaustedExpansionError();
+        }
 
         for (let i = 0; i < connections.length; i++) {
           await new Promise<void>((resolve) => setTimeout(resolve, 350 * i));
@@ -151,9 +166,14 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
           reactFlow.fitView({ padding: 0.35, maxZoom: 1, duration: 600 });
         }
       } catch (err) {
-        console.error("Expansion failed:", err);
+        const exhausted = err instanceof ExhaustedExpansionError;
+        if (!exhausted) console.error("Expansion failed:", err);
         if (mountedRef.current) {
-          setExpansionError("Could not find connections. Try a different type.");
+          setExpansionError(
+            exhausted
+              ? "No more connections of this type."
+              : "Could not find connections. Try a different type."
+          );
           setTimeout(() => setExpansionError(null), 3500);
         }
       } finally {
@@ -161,7 +181,7 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
         expandingRef.current = false;
       }
     },
-    [addVerseNode, addConnectionEdge, setExpandingNode, hasNode, reactFlow]
+    [addVerseNode, addConnectionEdge, setExpandingNode, hasNode, getExpansionRefs, reactFlow]
   );
 
   useEffect(() => {

--- a/components/canvas/VerseNode.tsx
+++ b/components/canvas/VerseNode.tsx
@@ -26,6 +26,7 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
   const setPendingExpand = useCanvasStore((s) => s.setPendingExpand);
   const setNewlyAddedNode = useCanvasStore((s) => s.setNewlyAddedNode);
   const getDuplicateNodeIds = useCanvasStore((s) => s.getDuplicateNodeIds);
+  const getExpansionCounts = useCanvasStore((s) => s.getExpansionCounts);
   const getNodeById = useCanvasStore((s) => s.getNodeById);
   const reactFlow = useReactFlow();
 
@@ -44,6 +45,7 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
   const isPulsing = newlyAddedNodeId === id;
   const otherDuplicateIds = getDuplicateNodeIds(verse.ref).filter((did) => did !== id);
   const hasDuplicate = otherDuplicateIds.length > 0;
+  const expansionCounts = getExpansionCounts(id);
 
   const handleExpandSelect = (kind: EdgeKind) => {
     setPendingExpand({ nodeId: id, ref: verse.ref, kind });
@@ -218,7 +220,11 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
       </div>
 
       {expandMenuOpen && (
-        <ExpandMenu onSelect={handleExpandSelect} onClose={() => setOpenExpandNodeId(null)} />
+        <ExpandMenu
+          onSelect={handleExpandSelect}
+          onClose={() => setOpenExpandNodeId(null)}
+          existingCounts={expansionCounts}
+        />
       )}
 
       {isExpanding && (

--- a/lib/ai/connection-discovery.ts
+++ b/lib/ai/connection-discovery.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNotNull, ne, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, ne, notInArray, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { wordMorphology } from "@/lib/infra/db/schema";
 import { semanticCandidates } from "@/lib/quran/semantic-search";
@@ -21,7 +21,11 @@ import type { EdgeKind } from "@/types/quran";
  */
 
 /** Verses sharing an Arabic root with the source verse, most-shared first. */
-async function rootCandidates(fromRef: string, limit: number): Promise<string[]> {
+async function rootCandidates(
+  fromRef: string,
+  limit: number,
+  excludeRefs: string[] = []
+): Promise<string[]> {
   const srcRoots = await db
     .selectDistinct({ root: wordMorphology.root })
     .from(wordMorphology)
@@ -34,7 +38,13 @@ async function rootCandidates(fromRef: string, limit: number): Promise<string[]>
   const rows = await db
     .select({ ref: wordMorphology.ref, shared: sharedRoots })
     .from(wordMorphology)
-    .where(and(inArray(wordMorphology.root, roots), ne(wordMorphology.ref, fromRef)))
+    .where(
+      and(
+        inArray(wordMorphology.root, roots),
+        ne(wordMorphology.ref, fromRef),
+        ...(excludeRefs.length > 0 ? [notInArray(wordMorphology.ref, excludeRefs)] : [])
+      )
+    )
     .groupBy(wordMorphology.ref)
     .orderBy(desc(sharedRoots))
     .limit(limit);
@@ -43,15 +53,17 @@ async function rootCandidates(fromRef: string, limit: number): Promise<string[]>
 }
 
 /**
- * Returns up to `limit` real candidate refs for the given source verse and kind.
+ * Returns up to `limit` real candidate refs for the given source verse and kind,
+ * skipping any ref already in `excludeRefs` (refs the caller has already seen).
  * Empty array means "no grounding data available for this verse" — not an error.
  */
 export async function discoverCandidates(
   fromRef: string,
   kind: EdgeKind,
-  limit = 12
+  limit = 12,
+  excludeRefs: string[] = []
 ): Promise<string[]> {
-  if (kind === "root") return rootCandidates(fromRef, limit);
+  if (kind === "root") return rootCandidates(fromRef, limit, excludeRefs);
   // thematic + contrast both start from semantic neighbors.
-  return semanticCandidates(fromRef, limit);
+  return semanticCandidates(fromRef, limit, excludeRefs);
 }

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, notInArray } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { connections, type Connection } from "@/lib/infra/db/schema";
 import { generateConnections, generateGroundedConnections } from "@/lib/ai/connection-generator";
@@ -33,6 +33,10 @@ interface GetConnectionsOptions {
    *  When set and the client is over budget, a miss throws RateLimitError.
    *  Cache hits are never rate-limited. */
   clientKey?: string;
+  /** Refs already shown to the caller for this fromRef+kind — excluded from
+   *  both the cache read and any fresh generation, so a repeat "get more"
+   *  request surfaces genuinely new connections instead of the same set. */
+  excludeRefs?: string[];
 }
 
 /** Hydrate stored edges (which carry only refs + reason) into full results. */
@@ -69,6 +73,8 @@ export async function getConnections(
   source: SourceVerse,
   options: GetConnectionsOptions = {}
 ): Promise<ConnectionResult[]> {
+  const excludeRefs = options.excludeRefs ?? [];
+
   const existing = await db
     .select()
     .from(connections)
@@ -76,7 +82,8 @@ export async function getConnections(
       and(
         eq(connections.fromRef, fromRef),
         eq(connections.kind, kind),
-        eq(connections.status, "active")
+        eq(connections.status, "active"),
+        ...(excludeRefs.length > 0 ? [notInArray(connections.toRef, excludeRefs)] : [])
       )
     )
     // A single generation inserts ~12 edges (see discoverCandidates), but this
@@ -100,7 +107,9 @@ export async function getConnections(
   // Single-flight: if an identical generation is already running, join it rather
   // than starting a second AI call. The get→set below MUST stay synchronous (no
   // await between them) or two concurrent callers could both become the leader.
-  const key = `${fromRef}:${kind}`;
+  // The exclude set is folded into the key so a "get more" request never
+  // coalesces with a plain repeat request for the same verse+kind.
+  const key = `${fromRef}:${kind}:${[...excludeRefs].sort().join(",")}`;
   const pending = inFlight.get(key);
   if (pending) {
     incr("gen_coalesced");
@@ -108,7 +117,7 @@ export async function getConnections(
   }
 
   incr("gen_started");
-  const work = generateAndPersist(fromRef, kind, source);
+  const work = generateAndPersist(fromRef, kind, source, excludeRefs);
   inFlight.set(key, work);
   try {
     return await work;
@@ -127,9 +136,15 @@ export async function getConnections(
 async function generateAndPersist(
   fromRef: string,
   kind: EdgeKind,
-  source: SourceVerse
+  source: SourceVerse,
+  excludeRefs: string[] = []
 ): Promise<ConnectionResult[]> {
-  const candidates = await discoverCandidates(fromRef, kind);
+  const candidates = await discoverCandidates(fromRef, kind, undefined, excludeRefs);
+  // The legacy ungrounded path has no notion of excludeRefs — it would just
+  // regenerate a similar set from memory, defeating the point of "get more."
+  // Only fall back to it on a true first-time miss (no grounding data seeded
+  // for this verse yet); once a caller is asking for more, an empty candidate
+  // pool means the grounded data is genuinely exhausted, not unavailable.
   const generated =
     candidates.length > 0
       ? await generateGroundedConnections(
@@ -139,7 +154,9 @@ async function generateAndPersist(
           kind,
           candidates
         )
-      : await generateConnections(fromRef, source.arabicText, source.translation, kind);
+      : excludeRefs.length > 0
+        ? []
+        : await generateConnections(fromRef, source.arabicText, source.translation, kind);
 
   if (generated.length > 0) {
     const model = process.env.ANTHROPIC_MODEL ?? null;

--- a/lib/quran/semantic-search.ts
+++ b/lib/quran/semantic-search.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { cosineDistance, desc, eq, ne, sql, type SQL } from "drizzle-orm";
+import { cosineDistance, desc, eq, notInArray, sql, type SQL } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { verseEmbeddings } from "@/lib/infra/db/schema";
 import { embed } from "@/lib/ai/ai";
@@ -57,10 +57,11 @@ export interface SemanticMatch {
 async function nearest(
   queryVec: number[],
   limit: number,
-  excludeRef?: string
+  excludeRefs: string[] = []
 ): Promise<Array<{ ref: string; similarity: number }>> {
   const similarity = sql<number>`1 - (${cosineDistance(verseEmbeddings.embedding, queryVec)})`;
-  const where: SQL | undefined = excludeRef ? ne(verseEmbeddings.ref, excludeRef) : undefined;
+  const where: SQL | undefined =
+    excludeRefs.length > 0 ? notInArray(verseEmbeddings.ref, excludeRefs) : undefined;
   return db
     .select({ ref: verseEmbeddings.ref, similarity })
     .from(verseEmbeddings)
@@ -87,15 +88,23 @@ export async function searchByMeaning(query: string, limit = 10): Promise<Semant
   return hydrate(await nearest(queryVec, limit));
 }
 
-/** Find verses semantically nearest to a given verse (excluding itself). */
-export async function similarVerses(ref: string, limit = 5): Promise<SemanticMatch[]> {
+/**
+ * Find verses semantically nearest to a given verse (excluding itself, and any
+ * additional `excludeRefs` — e.g. verses already surfaced to the caller for
+ * this source+kind, so a repeat request returns something new).
+ */
+export async function similarVerses(
+  ref: string,
+  limit = 5,
+  excludeRefs: string[] = []
+): Promise<SemanticMatch[]> {
   const self = await db
     .select({ embedding: verseEmbeddings.embedding })
     .from(verseEmbeddings)
     .where(eq(verseEmbeddings.ref, ref))
     .limit(1);
   if (!self[0]) return [];
-  return hydrate(await nearest(self[0].embedding, limit, ref));
+  return hydrate(await nearest(self[0].embedding, limit, [ref, ...excludeRefs]));
 }
 
 /**
@@ -103,7 +112,11 @@ export async function similarVerses(ref: string, limit = 5): Promise<SemanticMat
  * in meaning to `ref`, as plain refs (the generator hydrates + articulates).
  * Returns [] when the source verse has no stored embedding.
  */
-export async function semanticCandidates(ref: string, limit = 10): Promise<string[]> {
-  const matches = await similarVerses(ref, limit);
+export async function semanticCandidates(
+  ref: string,
+  limit = 10,
+  excludeRefs: string[] = []
+): Promise<string[]> {
+  const matches = await similarVerses(ref, limit, excludeRefs);
   return matches.map((m) => m.verse.ref);
 }

--- a/store/canvas.ts
+++ b/store/canvas.ts
@@ -107,6 +107,8 @@ interface CanvasStore {
   getNodeByRef: (ref: string) => Node | undefined;
   getNodeById: (id: string) => Node | undefined;
   getDuplicateNodeIds: (ref: string) => string[];
+  getExpansionRefs: (nodeId: string, kind: EdgeKind) => string[];
+  getExpansionCounts: (nodeId: string) => Partial<Record<EdgeKind, number>>;
   reset: () => void;
   restoreCanvas: (saved: SavedCanvas) => void;
   appendWorkspace: (saved: SavedCanvas) => void;
@@ -212,6 +214,27 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
     get()
       .nodes.filter((n) => (n.data as unknown as Verse)?.ref === ref)
       .map((n) => n.id),
+
+  // Expansion edges are always directed source(nodeId) -> target(newNode), so a
+  // simple source+kind filter is sufficient — no need to check the reverse edge.
+  getExpansionRefs: (nodeId, kind) => {
+    const { edges, getNodeById } = get();
+    return edges
+      .filter((e) => e.source === nodeId && (e.data as { kind?: EdgeKind })?.kind === kind)
+      .map((e) => (getNodeById(e.target)?.data as unknown as Verse)?.ref)
+      .filter((ref) => !!ref) as string[];
+  },
+
+  getExpansionCounts: (nodeId) => {
+    const counts: Partial<Record<EdgeKind, number>> = {};
+    for (const e of get().edges) {
+      if (e.source !== nodeId) continue;
+      const kind = (e.data as { kind?: EdgeKind })?.kind;
+      if (!kind) continue;
+      counts[kind] = (counts[kind] ?? 0) + 1;
+    }
+    return counts;
+  },
 
   reset: () =>
     set({


### PR DESCRIPTION
## Summary
- Clicking the same expansion kind (theme/root/contrast) again on a verse now surfaces genuinely new connections instead of the same cached/regenerated set. An `excludeRefs` list threads through `/api/connections` → `getConnections` (DB cache-hit filter + single-flight key widening) → `discoverCandidates` (root + semantic) → `nearest`/`similarVerses`/`semanticCandidates`.
- The legacy (ungrounded) generation fallback is skipped when `excludeRefs` is non-empty and no grounded candidates remain — otherwise it would just regenerate a similar set from memory, ignoring the exclusions.
- When a repeat request genuinely runs out of new connections, the UI shows a distinct "No more connections of this type." message instead of the generic fetch-failure one.
- The `+` expand menu now shows a "(N found)" hint per kind (theme/root/contrast) so users know before clicking whether they've already expanded that kind.
- Also fixed a flaky pre-existing integration test: `graph.integration.test.ts`'s reset() didn't truncate `word_morphology`, so leftover rows from `connection-discovery.integration.test.ts` (shared Testcontainers DB, serial file execution) could intermittently pollute its "root" kind test.

## Scope note
This is the deferred third piece from #87 — see #185 for the original ask. Fully implements it; no further follow-up planned.

## Test plan
- [x] `npm run typecheck` and `npm run lint` — clean
- [x] Full unit suite: 540 tests passing, including new coverage for `excludeRefs` in the API route, `graph-service` (cache exclusion, single-flight key widening, legacy-fallback skip), and new `store/canvas.ts` selectors (`getExpansionRefs`, `getExpansionCounts`)
- [x] Integration suite (real Postgres via Testcontainers): 16 tests passing, including new real-DB coverage for excludeRefs in root discovery (`connection-discovery.integration.test.ts`) and semantic discovery (`semantic-search.integration.test.ts`); ran repeatedly to confirm no flakiness after the isolation fix
- [ ] Could not exercise the live AI-backed expansion end-to-end in the browser — the local dev environment's Anthropic API key has an empty credit balance (infra limitation, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “get more” expansion support that avoids showing previously surfaced connections.
  * Expansion menus now display the number of existing connections for each option.
  * Added clearer handling when no additional expansion results are available.

* **Bug Fixes**
  * Prevented duplicate results during repeated connection and semantic searches.
  * Added validation for excluded references and improved empty-result responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->