### PR TITLE
feat(canvas): resizable ayah side panel

### DIFF
--- a/components/layout/ContextSidebar.tsx
+++ b/components/layout/ContextSidebar.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useCanvasStore } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
 import { useState, useEffect } from "react";
+import { useSidebarResize } from "@/hooks/useSidebarResize";
 import type { EdgeKind } from "@/types/quran";
 import { Card } from "@/components/ui";
 import { InteractiveArabic } from "@/components/morphology/InteractiveArabic";
@@ -257,6 +258,17 @@ const KIND_BADGE: Record<EdgeKind, string> = {
 export function ContextSidebar() {
   const sidebarContent = useCanvasStore((s) => s.sidebarContent);
   const setSidebarContent = useCanvasStore((s) => s.setSidebarContent);
+  const { width, onHandlePointerDown, isResizing } = useSidebarResize();
+
+  const [isDesktop, setIsDesktop] = useState(
+    () => typeof window !== "undefined" && window.matchMedia("(min-width: 640px)").matches
+  );
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 640px)");
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
 
   return (
     <AnimatePresence>
@@ -267,8 +279,20 @@ export function ContextSidebar() {
           animate={{ x: 0, opacity: 1 }}
           exit={{ x: "100%", opacity: 0 }}
           transition={{ duration: 0.15, ease: "easeOut" }}
-          className="pointer-events-auto absolute top-0 right-0 z-40 flex h-full w-full flex-col border-l border-border bg-surface sm:w-72"
+          style={isDesktop ? { width } : undefined}
+          className="pointer-events-auto absolute top-0 right-0 z-40 flex h-full w-full flex-col border-l border-border bg-surface"
         >
+          {isDesktop && (
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Resize panel"
+              onPointerDown={onHandlePointerDown}
+              className={`absolute left-0 top-0 h-full w-1.5 -translate-x-1/2 cursor-col-resize transition-colors ${
+                isResizing ? "bg-gold-muted/60" : "hover:bg-gold-muted/40"
+              }`}
+            />
+          )}
           {/* Header */}
           <div className="flex h-10 shrink-0 items-center justify-between border-b border-border px-4">
             <span className="text-xs text-text-muted">

--- a/hooks/useSidebarResize.ts
+++ b/hooks/useSidebarResize.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useCanvasStore, DEFAULT_SIDEBAR_WIDTH } from "@/store/canvas";
+
+const MIN_WIDTH = DEFAULT_SIDEBAR_WIDTH;
+const MAX_WIDTH_CAP = 720;
+const MAX_WIDTH_VIEWPORT_RATIO = 0.6;
+
+/**
+ * Drag-to-resize for the right-anchored ContextSidebar. The panel is pinned to
+ * the screen's right edge, so dragging the handle left must widen it — width
+ * grows by the negative of the pointer's deltaX from drag start.
+ */
+export function useSidebarResize() {
+  const width = useCanvasStore((s) => s.sidebarWidth);
+  const setSidebarWidth = useCanvasStore((s) => s.setSidebarWidth);
+  const [isResizing, setIsResizing] = useState(false);
+  const dragStartRef = useRef({ x: 0, width: 0 });
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const handleMove = (e: PointerEvent) => {
+      const maxWidth = Math.min(MAX_WIDTH_CAP, window.innerWidth * MAX_WIDTH_VIEWPORT_RATIO);
+      const delta = e.clientX - dragStartRef.current.x;
+      const next = Math.min(maxWidth, Math.max(MIN_WIDTH, dragStartRef.current.width - delta));
+      setSidebarWidth(next);
+    };
+    const handleUp = () => setIsResizing(false);
+
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    const prevUserSelect = document.body.style.userSelect;
+    const prevCursor = document.body.style.cursor;
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+      document.body.style.userSelect = prevUserSelect;
+      document.body.style.cursor = prevCursor;
+    };
+  }, [isResizing, setSidebarWidth]);
+
+  const onHandlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      dragStartRef.current = { x: e.clientX, width };
+      setIsResizing(true);
+    },
+    [width]
+  );
+
+  return { width, onHandlePointerDown, isResizing };
+}

--- a/store/canvas.ts
+++ b/store/canvas.ts
@@ -86,6 +86,7 @@ interface CanvasStore {
   pendingPanToNodeId: string | null;
   newlyAddedNodeId: string | null;
   viewport: CanvasViewport;
+  sidebarWidth: number;
 
   setNodes: (nodes: Node[]) => void;
   setEdges: (edges: Edge[]) => void;
@@ -103,6 +104,7 @@ interface CanvasStore {
   setPendingAutoExpand: (nodeId: string | null) => void;
   setPendingPanToNode: (nodeId: string | null) => void;
   setNewlyAddedNode: (nodeId: string | null) => void;
+  setSidebarWidth: (width: number) => void;
   hasNode: (ref: string) => boolean;
   getNodeByRef: (ref: string) => Node | undefined;
   getNodeById: (id: string) => Node | undefined;
@@ -116,6 +118,8 @@ interface CanvasStore {
 
 let nodeIdCounter = 0;
 const nextId = () => `node-${++nodeIdCounter}`;
+
+export const DEFAULT_SIDEBAR_WIDTH = 288;
 
 // Pulse duration must exceed the CSS `.node-pulse` animation length (1.5s) so the
 // highlight class isn't stripped mid-animation.
@@ -134,6 +138,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
   pendingPanToNodeId: null,
   newlyAddedNodeId: null,
   viewport: { x: 0, y: 0, zoom: 1 },
+  sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
 
   setNodes: (nodes) => set({ nodes }),
   setEdges: (edges) => set({ edges }),
@@ -193,6 +198,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
   setPendingExpand: (action) => set({ pendingExpand: action }),
   setPendingAutoExpand: (nodeId) => set({ pendingAutoExpand: nodeId }),
   setPendingPanToNode: (nodeId) => set({ pendingPanToNodeId: nodeId }),
+  setSidebarWidth: (width) => set({ sidebarWidth: width }),
 
   setNewlyAddedNode: (nodeId) => {
     if (newlyAddedTimeout) clearTimeout(newlyAddedTimeout);


### PR DESCRIPTION
## Summary
- The ayah side panel on /canvas was fixed at 288px with no way to widen it, cramping tafsir/translation text.
- Adds a draggable left-edge handle (desktop only) to widen/narrow the panel, clamped between 288px and 60% of viewport width (max 720px).
- Width is tracked in the canvas store so it's retained while switching between verses/edges in the same session.
- Mobile (fullscreen panel) is untouched — no handle rendered below the `sm` breakpoint.

Closes #187

## Test plan
- [x] `npx vitest run` — all 540 tests pass
- [x] Manually verified in browser (Playwright): drag widens/narrows the panel, clamps correctly at both min (288px) and max (~60vw, cap 720px) bounds
- [x] Verified `cursor: col-resize` and text-selection suppression while dragging
- [x] Verified mobile viewport (390px) still renders fullscreen panel with no resize handle
- [x] Verified no coupling/regression needed in react-flow (`fitView` unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)