### PR TITLE
chore(ci): wire up PR gates as an actual merge requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,8 @@
 - [ ] `bun run lint` passes locally
 - [ ] `bun run format:check` passes locally
 - [ ] New tests added for new functionality
-- [ ] Tested in browser (for UI changes)
+
+_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._
 
 ## Checklist
 


### PR DESCRIPTION
## Summary
- All four #137 sub-issues (e2e, format check, a11y, bundle-size) are already implemented in CI, but weren't actually gating merges — required status checks on `main` were empty.
- Set `lint-typecheck-test`, `integration`, `build`, and `e2e` as required status checks on `main` directly via the GitHub API (not something committed in-repo).
- Updated `.github/PULL_REQUEST_TEMPLATE.md`'s Testing checklist: replaced the manual "Tested in browser" item with a note that e2e/a11y/bundle-size checks now run automatically in CI.

Part of #137 — the tracking issue can be closed once this PR merges.

## Test plan
- [x] `gh api repos/OpenHikmah/openhikmah-web/branches/main/protection/required_status_checks` confirms all 4 job names are now required
- [x] `npx prettier --check` passes on the template
- [x] Reviewed the diff — no other template sections touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)