### PR TITLE
test(e2e): add search flow coverage (issue #146)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,9 @@
   --color-gold-muted: #8a6d2c;
   --color-teal: #0d9488;
   --color-teal-dim: #0f766e;
+  /* Lighter than --color-teal specifically for small text on dark surfaces —
+     plain teal text fails WCAG AA contrast (4.35:1) at this size/weight. */
+  --color-teal-bright: #2dd4bf;
 
   /* Surface layers */
   --color-bg: #0a0f1a;

--- a/components/search/SearchModeToggle.tsx
+++ b/components/search/SearchModeToggle.tsx
@@ -24,7 +24,7 @@ export function SearchModeToggle({ mode, onChange, className }: SearchModeToggle
           aria-pressed={mode === m}
           className={cn(
             "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-            mode === m ? "bg-teal/15 text-teal" : "text-text-muted hover:text-text-secondary"
+            mode === m ? "bg-teal/15 text-teal-bright" : "text-text-muted hover:text-text-secondary"
           )}
         >
           {m === "keyword" ? "Keyword" : "By meaning"}

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -41,6 +41,11 @@ test.describe("accessibility", () => {
     await scanAndAssert(page, "social");
   });
 
+  test("search page has no serious a11y violations", async ({ page }) => {
+    await gotoAndSettle(page, "/search?q=2:255");
+    await scanAndAssert(page, "search");
+  });
+
   test("today page has no serious a11y violations", async ({ authenticatedPage: page }) => {
     await gotoAndSettle(page, "/today");
     await scanAndAssert(page, "today");

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("search page", () => {
+  test("ref shortcut shows the exact verse with a Map on Canvas link", async ({ page }) => {
+    await page.goto("/search?q=2:255&type=keyword");
+
+    await expect(page.getByText("2:255", { exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: /map on canvas/i })).toHaveAttribute(
+      "href",
+      "/canvas?verse=2:255"
+    );
+  });
+
+  test("keyword search returns results for a common query", async ({ page }) => {
+    await page.goto("/search");
+
+    await page.getByPlaceholder(/search topics/i).fill("mercy");
+    await expect(page.getByText(/showing \d+ results? for/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("link", { name: /map on canvas/i }).first()).toBeVisible();
+  });
+
+  test("by-meaning mode falls back to keyword search when embeddings are unavailable", async ({
+    page,
+  }) => {
+    await page.goto("/search?q=mercy&type=keyword");
+
+    await page.getByRole("button", { name: "By meaning" }).click();
+    await expect(page.getByText(/showing keyword matches/i)).toBeVisible({ timeout: 15000 });
+  });
+});
+
+test.describe("search dialog (canvas)", () => {
+  test("Cmd+K ref shortcut adds the verse to canvas", async ({ authenticatedPage: page }) => {
+    await page.goto("/canvas");
+
+    await page.getByRole("button", { name: /search verses/i }).click();
+    await page.getByPlaceholder(/search topics/i).fill("2:255");
+    await page.getByRole("button", { name: /map connections/i }).click();
+
+    await expect(page.getByText("2:255")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `e2e/search.spec.ts` covering the two search surfaces: the standalone `/search` page and the canvas Cmd+K `SearchDialog`.
- Scenarios: the local ref-shortcut path (`2:255`, no external dependency), live keyword search against quran.com, and by-meaning mode's fallback-to-keyword UX (deterministic in CI since `GEMINI_API_KEY` is a placeholder there).
- Adds `/search` to the a11y route list (`e2e/a11y.spec.ts`) — it was a first-class, nav-linked route missing from axe coverage.
- That new a11y test caught a real, pre-existing WCAG AA violation: `SearchModeToggle`'s active "Keyword" pill was `text-teal` on a teal-tinted dark background (4.35:1, needs 4.5:1). Fixed with a new `--color-teal-bright` token (`app/globals.css`) used only for this text-on-dark case.

Closes #146

## Test plan
- [x] `bunx playwright test e2e/search.spec.ts` — all 4 new tests pass locally
- [x] `bunx playwright test e2e/a11y.spec.ts -g search` — passes after the contrast fix
- [x] Full `bunx playwright test` — 17/17 pass, no regressions
- [x] Full `npx vitest run` — 540/540 unit/integration tests pass
- [x] `bun run lint` / `bun run format:check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)