### PR TITLE
fix(ci): enforce fail-on-severity gate in dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -34,6 +34,6 @@ jobs:
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always
-        #   fail-on-severity: moderate
+          fail-on-severity: moderate
         #   deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
         #   retry-on-snapshot-warnings: true


### PR DESCRIPTION
## Summary
- Uncomments `fail-on-severity: moderate` in `.github/workflows/dependency-review.yml` so the Dependency Review check actually blocks PRs that introduce moderate+ severity vulnerable dependencies, instead of only reporting them.

## Follow-up (manual, outside this PR)
- Confirm the "Dependency Review" check is configured as a **required status check** in repo branch protection settings — this is a GitHub setting, not something version-controlled, so it needs to be verified/set separately.

## Test plan
- [x] Reviewed the YAML diff for correct indentation/validity
- [ ] After merge, open a throwaway PR that bumps a dependency with a known moderate+ vuln and confirm the check fails

Fixes #121