### PR TITLE
test(auth): cover refresh-token cache TTL expiry

### DIFF
--- a/__tests__/api/auth-refresh.test.ts
+++ b/__tests__/api/auth-refresh.test.ts
@@ -132,4 +132,36 @@ describe("POST /api/auth/refresh", () => {
     expect(secondBody.accessToken).toBe("access-8");
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
+
+  it("hits the token endpoint again once the cached result's TTL has expired", async () => {
+    vi.useFakeTimers();
+    try {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "access-9", refresh_token: "refresh-rotated-9" }),
+      });
+      const first = await POST(makeReq("refresh-ttl-9"));
+      expect(first.status).toBe(200);
+
+      // Just under the 30s TTL: still served from cache, no second call.
+      vi.advanceTimersByTime(29_000);
+      const stillCached = await POST(makeReq("refresh-ttl-9"));
+      expect(stillCached.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Past the TTL: cache entry is swept, so the token is re-sent upstream.
+      vi.advanceTimersByTime(2_000);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "access-9b", refresh_token: "refresh-rotated-9b" }),
+      });
+      const afterExpiry = await POST(makeReq("refresh-ttl-9"));
+      expect(afterExpiry.status).toBe(200);
+      const afterExpiryBody = await afterExpiry.json();
+      expect(afterExpiryBody.accessToken).toBe("access-9b");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Closes the last real gap under #120: the admin-route and refresh/signout coverage it originally flagged was already added by PRs #142/#143 and commit 09343fc, and `connections.test.ts` already covers the reviewed-filter / mark-reviewed PATCH mode.
- The one remaining untested branch: `app/api/auth/refresh/route.ts`'s single-flight cache sweeps `recent` entries older than `RESULT_TTL_MS` (30s) — nothing exercised that expiry path, only the cache-hit and no-cache-yet cases.
- Adds a test using `vi.useFakeTimers()` that confirms a request just under the TTL is served from cache (1 upstream call), and a request past the TTL re-hits the token endpoint (2nd upstream call).

## Test plan
- [x] `npx vitest run __tests__/api/auth-refresh.test.ts` — 10/10 passing
- [x] `npx vitest run __tests__/api/auth-refresh.test.ts __tests__/api/auth-signout.test.ts __tests__/api/auth-exchange.test.ts __tests__/api/admin/connections.test.ts` — 35/35 passing
- [x] `npx eslint __tests__/api/auth-refresh.test.ts` — clean