### PR TITLE
ci(deps): add Dependabot config for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "CI/CD"
+      - "dependencies"


### PR DESCRIPTION
## Summary
fix #124 
- No `.github/dependabot.yml` existed — dependency drift was only ever caught reactively by `dependency-review.yml`, and only on PRs that happened to touch a manifest.
- Adds weekly `npm`-ecosystem updates (this repo's single `package.json`/`bun.lock`, no workspaces) and `github-actions`-ecosystem updates (covers every `uses:` across `.github/workflows/*.yml`), each labeled for easy triage using labels that already exist in the repo (`dependencies`, `CI/CD`).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (546/546)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally *for this PR's diff* — `.github/dependabot.yml` itself is Prettier-clean; the repo-wide `format:check` also flags some pre-existing `.superpowers/sdd/*.md` files unrelated to this change and already unformatted on `main`
- [ ] New tests added for new functionality

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added
- [x] `README.md` updated if the feature changes the public interface