### PR TITLE
fix(canvas): add focus trap and focus-return to ExpandMenu/CanvasTour

### DIFF
--- a/__tests__/components/canvas/CanvasTour.test.tsx
+++ b/__tests__/components/canvas/CanvasTour.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { CanvasTour } from "@/components/canvas/CanvasTour";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("CanvasTour", () => {
+  it("focuses the primary action (not the dismiss button) when it appears", async () => {
+    render(<CanvasTour />);
+    await vi.waitFor(() => {
+      expect(screen.getByRole("button", { name: "Next" })).toBe(document.activeElement);
+    });
+  });
+
+  it("traps Tab within the card, wrapping from the last control back to the first", async () => {
+    render(<CanvasTour />);
+    const primary = await screen.findByRole("button", { name: "Next" });
+    const dismiss = screen.getByRole("button", { name: "Dismiss tour" });
+
+    await act(async () => {
+      primary.focus();
+    });
+    fireEvent.keyDown(primary, { key: "Tab" });
+    expect(document.activeElement).toBe(dismiss);
+
+    fireEvent.keyDown(dismiss, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(primary);
+  });
+
+  it("returns focus to the pre-tour active element once dismissed", async () => {
+    const outside = document.createElement("button");
+    outside.textContent = "outside";
+    document.body.appendChild(outside);
+    await act(async () => {
+      outside.focus();
+    });
+
+    render(<CanvasTour />);
+    await screen.findByRole("button", { name: "Next" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss tour" }));
+
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(outside);
+    });
+
+    document.body.removeChild(outside);
+  });
+});

--- a/__tests__/components/canvas/ExpandMenu.test.tsx
+++ b/__tests__/components/canvas/ExpandMenu.test.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ExpandMenu } from "@/components/canvas/ExpandMenu";
+
+function Harness({ initialOpen = true }: { initialOpen?: boolean }) {
+  const [open, setOpen] = useState(initialOpen);
+  return (
+    <div>
+      <button data-testid="trigger" onClick={() => setOpen(true)}>
+        Expand connections
+      </button>
+      {open && <ExpandMenu onSelect={vi.fn()} onClose={() => setOpen(false)} existingCounts={{}} />}
+    </div>
+  );
+}
+
+describe("ExpandMenu", () => {
+  it("traps Tab within the three options, wrapping last to first and first to last", async () => {
+    render(<Harness />);
+    const options = screen.getAllByRole("button", { name: /By / });
+    expect(options).toHaveLength(3);
+    const [first, , last] = options;
+
+    await act(async () => {
+      last.focus();
+    });
+    fireEvent.keyDown(last, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+
+    fireEvent.keyDown(first, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("focuses the first option on open", () => {
+    render(<Harness />);
+    const options = screen.getAllByRole("button", { name: /By / });
+    expect(document.activeElement).toBe(options[0]);
+  });
+
+  it("returns focus to the trigger when the menu closes", async () => {
+    render(<Harness initialOpen={false} />);
+    const trigger = screen.getByTestId("trigger");
+    await act(async () => {
+      trigger.focus();
+    });
+    expect(document.activeElement).toBe(trigger);
+
+    fireEvent.click(trigger);
+    expect(screen.getAllByRole("button", { name: /By / })).toHaveLength(3);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+});

--- a/components/canvas/CanvasTour.tsx
+++ b/components/canvas/CanvasTour.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Search, Network, MessageSquareText, X } from "lucide-react";
+import { FocusScope } from "@radix-ui/react-focus-scope";
 import { Card, Button } from "@/components/ui";
 
 const TOUR_KEY = "open-hikmah-tour-seen";
@@ -56,10 +57,9 @@ export function CanvasTour() {
     setShow(false);
   };
 
-  // Move focus to the primary action when the tour appears, and let Escape dismiss.
+  // Let Escape dismiss. Initial/returned focus is handled by FocusScope below.
   useEffect(() => {
     if (!show) return;
-    primaryRef.current?.focus();
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") dismiss();
     };
@@ -75,64 +75,75 @@ export function CanvasTour() {
 
   return (
     <div className="pointer-events-none absolute bottom-[calc(70px+env(safe-area-inset-bottom))] left-1/2 z-50 w-[min(360px,calc(100vw-2rem))] -translate-x-1/2 md:bottom-6 md:left-6 md:translate-x-0">
-      <Card
-        variant="floating"
-        role="dialog"
-        aria-labelledby="canvas-tour-title"
-        aria-describedby="canvas-tour-body"
-        className="pointer-events-auto animate-[fadeIn_200ms_ease-out] p-5"
+      <FocusScope
+        asChild
+        trapped
+        loop
+        onMountAutoFocus={(e) => {
+          e.preventDefault();
+          primaryRef.current?.focus();
+        }}
       >
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex items-center gap-2 text-gold">
-            <Icon className="h-4 w-4" />
-            <span className="text-[11px] font-mono uppercase tracking-[0.16em] text-text-muted">
-              Getting started · {step + 1}/{STEPS.length}
-            </span>
-          </div>
-          <button
-            onClick={dismiss}
-            aria-label="Dismiss tour"
-            className="-mr-1 -mt-1 cursor-pointer rounded p-1 text-text-muted transition-colors hover:text-text-secondary"
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        </div>
-
-        <p id="canvas-tour-title" className="mt-3 text-sm font-medium text-text-primary">
-          {current.title}
-        </p>
-        <p id="canvas-tour-body" className="mt-1.5 text-xs leading-relaxed text-text-secondary">
-          {current.body}
-        </p>
-
-        <div className="mt-4 flex items-center justify-between gap-3">
-          <div className="flex gap-1.5">
-            {STEPS.map((_, i) => (
-              <span
-                key={i}
-                className={`h-1.5 w-1.5 rounded-full transition-colors ${
-                  i === step ? "bg-gold" : "bg-border"
-                }`}
-              />
-            ))}
-          </div>
-          <div className="flex items-center gap-2">
-            {!isLast && (
-              <Button variant="ghost" size="sm" onClick={dismiss}>
-                Skip
-              </Button>
-            )}
-            <Button
-              ref={primaryRef}
-              variant="primary"
-              size="sm"
-              onClick={() => (isLast ? dismiss() : setStep((s) => s + 1))}
+        <Card
+          variant="floating"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="canvas-tour-title"
+          aria-describedby="canvas-tour-body"
+          className="pointer-events-auto animate-[fadeIn_200ms_ease-out] p-5"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-center gap-2 text-gold">
+              <Icon className="h-4 w-4" />
+              <span className="text-[11px] font-mono uppercase tracking-[0.16em] text-text-muted">
+                Getting started · {step + 1}/{STEPS.length}
+              </span>
+            </div>
+            <button
+              onClick={dismiss}
+              aria-label="Dismiss tour"
+              className="-mr-1 -mt-1 cursor-pointer rounded p-1 text-text-muted transition-colors hover:text-text-secondary"
             >
-              {isLast ? "Got it" : "Next"}
-            </Button>
+              <X className="h-3.5 w-3.5" />
+            </button>
           </div>
-        </div>
-      </Card>
+
+          <p id="canvas-tour-title" className="mt-3 text-sm font-medium text-text-primary">
+            {current.title}
+          </p>
+          <p id="canvas-tour-body" className="mt-1.5 text-xs leading-relaxed text-text-secondary">
+            {current.body}
+          </p>
+
+          <div className="mt-4 flex items-center justify-between gap-3">
+            <div className="flex gap-1.5">
+              {STEPS.map((_, i) => (
+                <span
+                  key={i}
+                  className={`h-1.5 w-1.5 rounded-full transition-colors ${
+                    i === step ? "bg-gold" : "bg-border"
+                  }`}
+                />
+              ))}
+            </div>
+            <div className="flex items-center gap-2">
+              {!isLast && (
+                <Button variant="ghost" size="sm" onClick={dismiss}>
+                  Skip
+                </Button>
+              )}
+              <Button
+                ref={primaryRef}
+                variant="primary"
+                size="sm"
+                onClick={() => (isLast ? dismiss() : setStep((s) => s + 1))}
+              >
+                {isLast ? "Got it" : "Next"}
+              </Button>
+            </div>
+          </div>
+        </Card>
+      </FocusScope>
     </div>
   );
 }

--- a/components/canvas/ExpandMenu.tsx
+++ b/components/canvas/ExpandMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useEffect, useState } from "react";
+import { FocusScope } from "@radix-ui/react-focus-scope";
 import type { EdgeKind } from "@/types/quran";
 
 interface ExpandMenuProps {
@@ -41,7 +42,6 @@ const OPTIONS: Array<{
 
 export function ExpandMenu({ onSelect, onClose, existingCounts }: ExpandMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
-  const firstOptionRef = useRef<HTMLButtonElement>(null);
   const [openUp, setOpenUp] = useState(false);
 
   useEffect(() => {
@@ -50,10 +50,6 @@ export function ExpandMenu({ onSelect, onClose, existingCounts }: ExpandMenuProp
     if (rect.bottom > window.innerHeight - 16) {
       setOpenUp(true);
     }
-  }, []);
-
-  useEffect(() => {
-    firstOptionRef.current?.focus();
   }, []);
 
   useEffect(() => {
@@ -68,44 +64,45 @@ export function ExpandMenu({ onSelect, onClose, existingCounts }: ExpandMenuProp
   }, [onClose]);
 
   return (
-    <div
-      ref={menuRef}
-      className={`absolute left-1/2 z-50 w-48 -translate-x-1/2 ${openUp ? "bottom-full mb-1" : "top-full mt-1"}`}
-      onMouseDown={(e) => e.stopPropagation()}
-      onClick={(e) => e.stopPropagation()}
-    >
-      <div className="rounded-md border border-border overflow-hidden bg-surface-overlay shadow-sm">
-        {OPTIONS.map((opt, i) => (
-          <button
-            key={opt.kind}
-            ref={i === 0 ? firstOptionRef : undefined}
-            onClick={() => {
-              onSelect(opt.kind);
-              onClose();
-            }}
-            className="w-full flex items-center gap-2.5 px-3 py-2 text-left transition-colors cursor-pointer hover:bg-white/5 focus-visible:outline-none focus-visible:bg-white/5"
-          >
-            <span
-              className="w-5 h-5 rounded flex items-center justify-center text-xs font-mono shrink-0"
-              style={{
-                background: `color-mix(in srgb, ${opt.color} 12%, transparent)`,
-                color: opt.color,
+    <FocusScope asChild trapped loop>
+      <div
+        ref={menuRef}
+        className={`absolute left-1/2 z-50 w-48 -translate-x-1/2 ${openUp ? "bottom-full mb-1" : "top-full mt-1"}`}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="rounded-md border border-border overflow-hidden bg-surface-overlay shadow-sm">
+          {OPTIONS.map((opt) => (
+            <button
+              key={opt.kind}
+              onClick={() => {
+                onSelect(opt.kind);
+                onClose();
               }}
+              className="w-full flex items-center gap-2.5 px-3 py-2 text-left transition-colors cursor-pointer hover:bg-white/5 focus-visible:outline-none focus-visible:bg-white/5"
             >
-              {opt.icon}
-            </span>
-            <div className="min-w-0">
-              <p className="text-xs font-medium text-text-primary">
-                {opt.label}
-                {!!existingCounts?.[opt.kind] && (
-                  <span className="text-text-muted"> ({existingCounts[opt.kind]} found)</span>
-                )}
-              </p>
-              <p className="text-xs text-text-muted">{opt.description}</p>
-            </div>
-          </button>
-        ))}
+              <span
+                className="w-5 h-5 rounded flex items-center justify-center text-xs font-mono shrink-0"
+                style={{
+                  background: `color-mix(in srgb, ${opt.color} 12%, transparent)`,
+                  color: opt.color,
+                }}
+              >
+                {opt.icon}
+              </span>
+              <div className="min-w-0">
+                <p className="text-xs font-medium text-text-primary">
+                  {opt.label}
+                  {!!existingCounts?.[opt.kind] && (
+                    <span className="text-text-muted"> ({existingCounts[opt.kind]} found)</span>
+                  )}
+                </p>
+                <p className="text-xs text-text-muted">{opt.description}</p>
+              </div>
+            </button>
+          ))}
+        </div>
       </div>
-    </div>
+    </FocusScope>
   );
 }


### PR DESCRIPTION
## Summary

- Closes #179. `ExpandMenu.tsx` and `CanvasTour.tsx` hand-roll their own popup UI — they move initial focus and close on Escape, but neither trapped Tab within the open widget nor restored focus to the triggering element on close, so keyboard users could Tab out into the page behind an open menu/tour and lose their place once it closed.
- Wraps both in `@radix-ui/react-focus-scope`'s `FocusScope` (`trapped loop`, `asChild` to avoid extra DOM nodes) instead of hand-rolling Tab-cycling logic — it's already a transitive dependency via `@radix-ui/react-dialog`/`react-popover`, and its default unmount behavior restores focus to whatever was focused before the widget opened, which is exactly what both components need (no manual trigger-ref plumbing).
- `CanvasTour` keeps its deliberate "focus the primary action, not the first tabbable element" behavior via `onMountAutoFocus` override, and gets the `aria-modal="true"` its existing `role="dialog"` was missing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (552/552)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally for this PR's diff
- [x] New tests added for new functionality — `__tests__/components/canvas/ExpandMenu.test.tsx` and `CanvasTour.test.tsx` cover Tab-wrap trapping and focus-return-on-close for both components

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added
- [x] `README.md` updated if the feature changes the public interface