### PR TITLE
test(e2e): extend a11y axe scan to the /admin/* surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
       DEV_AUTH_TOKEN: e2e-dev-token
       DEV_AUTH_QF_ID: e2e-dev-qf-id
+      ADMIN_QF_IDS: e2e-dev-qf-id
       ANTHROPIC_API_KEY: sk-ant-placeholder
       AI_PROVIDER: claude
       GEMINI_API_KEY: placeholder-gemini-key

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -76,3 +76,31 @@ test.describe("accessibility", () => {
     await scanAndAssert(page, "onboarding");
   });
 });
+
+// `/admin/*` is gated client-side by AdminGate, which shows an "Authorising…"
+// spinner while it fetches /api/admin/me, then renders the real page (with its
+// <h1> from AdminPageHeader) once that resolves — so a scan right after
+// domcontentloaded would race the spinner. Wait for the heading first. Requires
+// the e2e dev-bypass identity to also be listed in ADMIN_QF_IDS.
+const ADMIN_PAGES = [
+  { path: "/admin", label: "admin overview" },
+  { path: "/admin/votd", label: "admin votd" },
+  { path: "/admin/connections", label: "admin connections" },
+  { path: "/admin/users", label: "admin users" },
+  { path: "/admin/challenges", label: "admin challenges" },
+  { path: "/admin/ai", label: "admin ai" },
+  { path: "/admin/flags", label: "admin flags" },
+  { path: "/admin/names", label: "admin names" },
+  { path: "/admin/infra", label: "admin infra" },
+  { path: "/admin/audit", label: "admin audit" },
+];
+
+test.describe("admin accessibility", () => {
+  for (const { path, label } of ADMIN_PAGES) {
+    test(`${label} page has no serious a11y violations`, async ({ authenticatedPage: page }) => {
+      await gotoAndSettle(page, path);
+      await page.getByRole("heading", { level: 1 }).waitFor();
+      await scanAndAssert(page, label);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Closes #151. `e2e/a11y.spec.ts` already covered every route the issue named (`/today`, `/names`, `/names/[slug]`, `/bookmarks`, `/workspaces`, `/onboarding`, alongside home/canvas/social) as of prior incremental commits — the only real remaining gap was the entire `/admin/*` surface (10 pages), which the issue itself flagged as needing scoping since it requires an admin identity.
- `requireAdmin` (`lib/admin/admin-auth.ts`) is purely env-var gated via `ADMIN_QF_IDS`, so no new session-mocking infra was needed — added `ADMIN_QF_IDS: e2e-dev-qf-id` to the e2e CI job env so the existing dev-bypass identity (`DEV_AUTH_QF_ID: e2e-dev-qf-id`) is also recognized as an admin.
- Added a `test.describe("admin accessibility", ...)` block scanning all 10 admin pages, reusing the existing `authenticatedPage` fixture, `gotoAndSettle`/`scanAndAssert` helpers, and the serious/critical-blocks-moderate/minor-warns severity split unchanged.
- Admin pages are gated client-side by `AdminGate`, which shows an "Authorising…" spinner while it resolves `/api/admin/me` before rendering real content — a plain `domcontentloaded` wait would race that, so each admin test waits for the page's `<h1>` (rendered by the shared `AdminPageHeader`) before running axe.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [x] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally for this PR's diff
- [x] New tests added for new functionality — ran the full `e2e/a11y.spec.ts` locally (20/20 passing, including all 10 new admin-page scans) with `ADMIN_QF_IDS` aligned to the local dev-bypass identity

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — not needed, `ADMIN_QF_IDS`/`DEV_AUTH_*` are already documented there; only the CI workflow env needed the addition
- [x] `README.md` updated if the feature changes the public interface