### PR TITLE
ci(e2e): cache Playwright browser binaries between runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,8 +204,24 @@ jobs:
       - name: Run migrations
         run: bun run db:migrate
 
-      - name: Install Playwright browsers
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('./node_modules/@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers (with system deps)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
 
       - name: E2E tests
         run: bun run test:e2e


### PR DESCRIPTION
## Summary

- The e2e job's \`Install Playwright browsers\` step downloads ~293 MiB (Chromium 177 MiB + Chrome Headless Shell 114 MiB + FFmpeg 2.3 MiB) from \`cdn.playwright.dev\` on **every single run**, with zero caching — confirmed via \`gh run view --log\` on a recent run.
- Adds \`actions/cache\` for \`~/.cache/ms-playwright\`, keyed on the actually-resolved \`@playwright/test\` version (read from \`node_modules\` post-install, not \`package.json\`'s caret range, so the key can't silently go stale). On a cache hit, skips the browser download and only runs the fast (~10s) system-dependencies install via \`playwright install-deps\`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests
- [x] CI/infra

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run typecheck` passes locally
- [x] YAML validated by parsing with `js-yaml` locally, confirmed step order and structure
- [ ] New tests added for new functionality — not applicable, CI-config-only change
- Will confirm the cache actually hits by watching this PR's first run (expected cache miss, full download) versus a second push (expected cache hit, download skipped) — will report back in this PR

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added
- [x] `README.md` updated if the feature changes the public interface