### PR TITLE
feat(security): add CSP violation-report endpoint

### DIFF
--- a/app/api/csp-report/route.ts
+++ b/app/api/csp-report/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { incr } from "@/lib/infra/metrics";
+
+// Browsers POST violation reports here; never cache.
+export const dynamic = "force-dynamic";
+
+// Reports are attacker-influenced (a page under CSP attack controls what gets
+// reported) — cap body size defensively before parsing.
+const MAX_BODY_BYTES = 32 * 1024;
+
+/** Shape of a single entry in the modern `application/reports+json` batch format. */
+interface ReportsApiEntry {
+  type?: string;
+  body?: Record<string, unknown>;
+}
+
+/**
+ * Accepts CSP violation reports in both the legacy `application/csp-report`
+ * format (single object under `csp-report`) and the modern Reporting API
+ * `application/reports+json` format (array of report entries). Logs a
+ * structured summary and bumps a counter; never reflects the payload back.
+ */
+export async function POST(req: NextRequest) {
+  const contentLength = req.headers.get("content-length");
+  if (contentLength && Number(contentLength) > MAX_BODY_BYTES) {
+    return new NextResponse(null, { status: 413 });
+  }
+
+  const text = await req.text();
+  if (text.length > MAX_BODY_BYTES) {
+    return new NextResponse(null, { status: 413 });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    incr("csp.violation.unparseable");
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const violations = extractViolations(parsed);
+  for (const violation of violations) {
+    incr("csp.violation");
+    console.error("csp-violation", violation);
+  }
+
+  return new NextResponse(null, { status: 204 });
+}
+
+function extractViolations(parsed: unknown): Record<string, unknown>[] {
+  if (Array.isArray(parsed)) {
+    // application/reports+json: array of { type: "csp-violation", body: {...} }
+    return (parsed as ReportsApiEntry[])
+      .filter((entry) => entry?.type === "csp-violation" && entry.body)
+      .map((entry) => entry.body as Record<string, unknown>);
+  }
+  if (parsed && typeof parsed === "object" && "csp-report" in parsed) {
+    // application/csp-report: legacy { "csp-report": {...} }
+    return [(parsed as { "csp-report": Record<string, unknown> })["csp-report"]];
+  }
+  return [];
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -17,9 +17,11 @@ const nextConfig: NextConfig = {
   async headers() {
     // Baseline security headers on every response. CSP starts in report-only
     // mode: the app uses inline `style={{...}}` throughout the canvas UI (so
-    // style-src needs 'unsafe-inline' regardless), and we don't yet have a
-    // deployed report endpoint to validate script-src against real traffic —
-    // enforcing untested would risk breaking the OAuth/canvas flows in prod.
+    // style-src needs 'unsafe-inline' regardless), and we want a monitoring
+    // window against real traffic — via the /api/csp-report endpoint wired
+    // below — before flipping script-src enforcement on and risking the
+    // OAuth/canvas flows in prod. Flip to `Content-Security-Policy` once that
+    // endpoint has been observed clean for a while.
     const securityHeaders = [
       { key: "X-Frame-Options", value: "DENY" },
       { key: "X-Content-Type-Options", value: "nosniff" },
@@ -39,7 +41,15 @@ const nextConfig: NextConfig = {
           "frame-ancestors 'none'",
           "base-uri 'self'",
           "form-action 'self' https://*.quran.foundation",
+          "report-uri /api/csp-report",
+          "report-to csp-endpoint",
         ].join("; "),
+      },
+      {
+        // Pairs with the `report-to` CSP directive above (the modern
+        // Reporting API); report-uri is kept alongside it for older browsers.
+        key: "Reporting-Endpoints",
+        value: 'csp-endpoint="/api/csp-report"',
       },
     ];
     return [


### PR DESCRIPTION
## Summary
- Adds `POST /api/csp-report`, accepting both the legacy `application/csp-report` format and the modern Reporting API `application/reports+json` format. Violations are logged (`console.error`) and counted via the existing `lib/infra/metrics.ts` counter registry (`csp.violation`), visible at `/api/metrics`.
- Wires `report-uri`/`report-to` into the existing `Content-Security-Policy-Report-Only` header, plus a `Reporting-Endpoints` header for the modern Reporting API.
- Updates the inline comment in `next.config.ts` to reflect that the missing piece (a report endpoint) is now in place.

## Scope note
This intentionally does **not** flip the header from `Content-Security-Policy-Report-Only` to enforced `Content-Security-Policy`. That flip is a deliberate follow-up once the endpoint has collected real production traffic for a monitoring window — enforcing blind, with no visibility into what might break (OAuth/canvas flows), is the risk the report-only mode exists to avoid. Refs #125; will close it in the follow-up PR that does the flip.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new warnings/errors
- [x] Local dev server: POSTed a legacy `csp-report` payload → `204`, counter `csp.violation` incremented
- [x] Local dev server: POSTed a `reports+json` batch payload → `204`, counter incremented
- [x] Local dev server: POSTed unparseable body → `204`, counted separately as `csp.violation.unparseable`, no error thrown
- [x] Confirmed `Content-Security-Policy-Report-Only` and new `Reporting-Endpoints` headers present on page responses, header still report-only