### PR TITLE
feat(ai): add prompt versioning for connection generator

### DIFF
--- a/__tests__/lib/ai/connection-generator.test.ts
+++ b/__tests__/lib/ai/connection-generator.test.ts
@@ -13,6 +13,18 @@ vi.mock("@/lib/quran/quran-corpus", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/quran/quran-corpus")>();
   return { ...actual, getVerses: mockGetVerses };
 });
+// No active DB prompt version in these tests — always fall back to the
+// hardcoded template, exercising the same rendering path a real generation uses.
+vi.mock("@/lib/ai/prompt-registry", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/ai/prompt-registry")>();
+  return {
+    ...actual,
+    getPrompt: vi.fn(async (_key: string, fallback: string) => ({
+      template: fallback,
+      version: null,
+    })),
+  };
+});
 
 import { generateConnections, generateGroundedConnections } from "@/lib/ai/connection-generator";
 

--- a/app/admin/prompts/page.tsx
+++ b/app/admin/prompts/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui";
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { Table, Th, Td, Pill, StateNote } from "@/components/admin/primitives";
+import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+import { cn } from "@/lib/utils";
+
+interface PromptVersionRow {
+  id: number;
+  key: string;
+  template: string;
+  createdBy: string | null;
+  createdAt: string;
+  active: boolean;
+}
+
+const PROMPT_KEYS = ["connection.legacy", "connection.selection"] as const;
+
+export default function PromptsPage() {
+  const api = useAdminFetch();
+  const [key, setKey] = useState<(typeof PROMPT_KEYS)[number]>(PROMPT_KEYS[0]);
+  const [draft, setDraft] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const { data, error, loading, reload } = useAsync<{ versions: PromptVersionRow[] }>(
+    () => api(`/prompts?key=${encodeURIComponent(key)}`),
+    `prompts:${key}`
+  );
+
+  const active = data?.versions.find((v) => v.active) ?? null;
+
+  const createVersion = async () => {
+    if (!draft.trim()) return;
+    setActionError(null);
+    setSaving(true);
+    try {
+      await api("/prompts", { method: "POST", json: { key, template: draft } });
+      setDraft("");
+      reload();
+    } catch (e) {
+      setActionError(e instanceof AdminApiError ? e.message : "Failed to save prompt version.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const rollback = async (id: number) => {
+    setActionError(null);
+    try {
+      await api("/prompts/rollback", { method: "POST", json: { id } });
+      reload();
+    } catch (e) {
+      setActionError(e instanceof AdminApiError ? e.message : "Failed to roll back.");
+    }
+  };
+
+  return (
+    <>
+      <AdminPageHeader
+        title="Prompts"
+        subtitle="Versioned templates for the AI connection generator. No active version means the hardcoded fallback is used."
+      />
+      <div className="space-y-4 p-7">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
+            Slot
+          </span>
+          <div className="flex gap-1">
+            {PROMPT_KEYS.map((k) => (
+              <button
+                key={k}
+                onClick={() => setKey(k)}
+                className={cn(
+                  "rounded border px-2 py-1 text-xs transition-colors",
+                  key === k
+                    ? "border-gold-muted bg-gold/10 text-gold"
+                    : "border-border text-text-secondary hover:border-gold-muted"
+                )}
+              >
+                {k}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {error && <StateNote tone="error">{error}</StateNote>}
+        {actionError && <StateNote tone="error">{actionError}</StateNote>}
+
+        <div className="space-y-2 rounded-lg border border-border bg-surface p-4">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-secondary">New version for {key}</span>
+            {active === null && !loading && (
+              <span className="text-xs text-text-muted">
+                Currently using the hardcoded fallback template.
+              </span>
+            )}
+          </div>
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={
+              active
+                ? active.template
+                : "e.g. Reference: {{fromRef}}\nArabic: {{arabicText}}\n... Task: {{task}} ..."
+            }
+            rows={10}
+            className="w-full rounded-md border border-border bg-bg px-3 py-2 font-mono text-xs text-text-primary focus:border-gold-muted"
+          />
+          <div className="flex justify-end">
+            <Button size="sm" variant="primary" disabled={saving} onClick={createVersion}>
+              {saving ? "Saving…" : "Create & activate"}
+            </Button>
+          </div>
+        </div>
+
+        {loading && <StateNote>Loading…</StateNote>}
+        {data && data.versions.length === 0 && (
+          <StateNote>No versions yet for this slot — using the hardcoded fallback.</StateNote>
+        )}
+
+        {data && data.versions.length > 0 && (
+          <Table>
+            <thead>
+              <tr>
+                <Th>Status</Th>
+                <Th>Template</Th>
+                <Th>Created by</Th>
+                <Th>Created</Th>
+                <Th className="text-right">Actions</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.versions.map((v) => (
+                <tr key={v.id}>
+                  <Td>
+                    <Pill tone={v.active ? "active" : "neutral"}>
+                      {v.active ? "active" : "inactive"}
+                    </Pill>
+                  </Td>
+                  <Td className="max-w-md font-mono text-xs text-text-secondary">
+                    <span className="line-clamp-2">{v.template}</span>
+                  </Td>
+                  <Td className="whitespace-nowrap text-xs text-text-secondary">
+                    {v.createdBy ?? "—"}
+                  </Td>
+                  <Td className="whitespace-nowrap text-xs text-text-secondary">
+                    {new Date(v.createdAt).toLocaleString()}
+                  </Td>
+                  <Td>
+                    <div className="flex justify-end">
+                      {!v.active && (
+                        <Button size="sm" variant="secondary" onClick={() => rollback(v.id)}>
+                          Roll back to this
+                        </Button>
+                      )}
+                    </div>
+                  </Td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/api/admin/prompts/rollback/route.ts
+++ b/app/api/admin/prompts/rollback/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { requireAdmin } from "@/lib/admin/admin-auth";
+import { logAdminAction } from "@/lib/admin/admin-audit";
+import { db } from "@/lib/infra/db";
+import { promptVersions } from "@/lib/infra/db/schema";
+import { invalidatePromptCache, type PromptKey } from "@/lib/ai/prompt-registry";
+
+/**
+ * Roll back to a prior prompt version: `{ id }`. Reactivates that row and
+ * deactivates whatever else was active for the same key — a rollback is just
+ * "make an old version active again", not a data change to the row itself.
+ */
+export async function POST(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  let body: { id?: number };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  if (!Number.isInteger(body.id)) {
+    return NextResponse.json({ error: "Invalid version id" }, { status: 400 });
+  }
+  const id = body.id as number;
+
+  const activated = await db.transaction(async (tx) => {
+    const [target] = await tx.select().from(promptVersions).where(eq(promptVersions.id, id));
+    if (!target) return null;
+
+    await tx
+      .update(promptVersions)
+      .set({ active: false })
+      .where(and(eq(promptVersions.key, target.key), eq(promptVersions.active, true)));
+
+    const [row] = await tx
+      .update(promptVersions)
+      .set({ active: true })
+      .where(eq(promptVersions.id, id))
+      .returning();
+    return row;
+  });
+
+  if (!activated) {
+    return NextResponse.json({ error: "Prompt version not found" }, { status: 404 });
+  }
+
+  invalidatePromptCache(activated.key as PromptKey);
+
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: "prompt.version.rollback",
+    targetType: "prompt_version",
+    targetId: String(id),
+    meta: { key: activated.key },
+  });
+
+  return NextResponse.json({ version: activated });
+}

--- a/app/api/admin/prompts/route.ts
+++ b/app/api/admin/prompts/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, desc, eq } from "drizzle-orm";
+import { requireAdmin } from "@/lib/admin/admin-auth";
+import { logAdminAction } from "@/lib/admin/admin-audit";
+import { db } from "@/lib/infra/db";
+import { promptVersions } from "@/lib/infra/db/schema";
+import { PROMPT_KEYS, invalidatePromptCache, type PromptKey } from "@/lib/ai/prompt-registry";
+
+/** All prompt versions, newest first, optionally filtered by `?key=`. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const key = req.nextUrl.searchParams.get("key");
+  if (key && !(PROMPT_KEYS as readonly string[]).includes(key)) {
+    return NextResponse.json({ error: "Invalid prompt key" }, { status: 400 });
+  }
+
+  const rows = await db
+    .select()
+    .from(promptVersions)
+    .where(key ? eq(promptVersions.key, key) : undefined)
+    .orderBy(desc(promptVersions.createdAt));
+
+  return NextResponse.json({ keys: PROMPT_KEYS, versions: rows });
+}
+
+/**
+ * Create a new prompt version for `key` and make it the active one, deactivating
+ * whatever was previously active for that key. Body: `{ key, template }`.
+ */
+export async function POST(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  let body: { key?: string; template?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const key = body.key as PromptKey | undefined;
+  if (!key || !(PROMPT_KEYS as readonly string[]).includes(key)) {
+    return NextResponse.json({ error: "Invalid prompt key" }, { status: 400 });
+  }
+  const template = body.template?.trim();
+  if (!template) {
+    return NextResponse.json({ error: "Missing template" }, { status: 400 });
+  }
+
+  const created = await db.transaction(async (tx) => {
+    await tx
+      .update(promptVersions)
+      .set({ active: false })
+      .where(and(eq(promptVersions.key, key), eq(promptVersions.active, true)));
+
+    const [row] = await tx
+      .insert(promptVersions)
+      .values({ key, template, createdBy: auth.user.qfId, active: true })
+      .returning();
+    return row;
+  });
+
+  invalidatePromptCache(key);
+
+  await logAdminAction({
+    adminQfId: auth.user.qfId,
+    action: "prompt.version.create",
+    targetType: "prompt_version",
+    targetId: String(created.id),
+    meta: { key },
+  });
+
+  return NextResponse.json({ version: created });
+}

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -14,6 +14,7 @@ import {
   BookOpen,
   Server,
   ScrollText,
+  MessageSquareText,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -34,6 +35,7 @@ const NAV: NavItem[] = [
   { href: "/admin/users", label: "Users", icon: Users },
   { href: "/admin/challenges", label: "Challenges", icon: Swords },
   { href: "/admin/ai", label: "AI & Cost", icon: Coins },
+  { href: "/admin/prompts", label: "Prompts", icon: MessageSquareText },
   { href: "/admin/flags", label: "Feature Flags", icon: Flag },
   { href: "/admin/names", label: "Names Content", icon: BookOpen },
   { href: "/admin/infra", label: "Infra", icon: Server },

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -1,4 +1,5 @@
 import { callAI } from "@/lib/ai/ai";
+import { getPrompt, renderTemplate } from "@/lib/ai/prompt-registry";
 import { db } from "@/lib/infra/db";
 import { aiGenerations } from "@/lib/infra/db/schema";
 import { isValidRef, getVerses } from "@/lib/quran/quran-corpus";
@@ -35,25 +36,23 @@ const KIND_SELECTION: Record<EdgeKind, string> = {
     "Select the 3 candidates that present the clearest contrasting theological concept to the source verse — opposing states such as ease/hardship, gratitude/ingratitude, mercy/punishment.",
 };
 
-function buildPrompt(
-  fromRef: string,
-  arabicText: string,
-  translation: string,
-  kind: EdgeKind
-): string {
-  return `You are a classical Islamic scholar grounded in the Maturidi/Hanafi tradition (Ahl al-Sunnah wal-Jama'ah).
+// Fallback templates used when no active prompt_versions row exists for the
+// key (see lib/ai/prompt-registry.ts). `{{placeholders}}` are filled per-call
+// via renderTemplate — this is also the format an admin's DB-stored override
+// must follow.
+const LEGACY_FALLBACK_TEMPLATE = `You are a classical Islamic scholar grounded in the Maturidi/Hanafi tradition (Ahl al-Sunnah wal-Jama'ah).
 
 Given this Quran verse:
-Reference: ${fromRef}
-Arabic: ${arabicText}
-Translation: ${translation}
+Reference: {{fromRef}}
+Arabic: {{arabicText}}
+Translation: {{translation}}
 
-Task: ${KIND_INSTRUCTIONS[kind]}
+Task: {{task}}
 
 Rules:
 - Return EXACTLY 3 different verses (not the source verse).
 - Verse references must be real and accurate (format: surah:ayah, e.g. 2:255).
-- Each reason must be one concise sentence explaining the ${kind} connection in classical Islamic terms.
+- Each reason must be one concise sentence explaining the {{kind}} connection in classical Islamic terms.
 - Maintain strict Tanzih (divine transcendence). Avoid Tashbih (anthropomorphism).
 - Return ONLY a valid JSON array. No prose, no markdown, no explanation outside the JSON.
 
@@ -63,6 +62,22 @@ Output format:
   { "ref": "surah:ayah", "reason": "one-sentence theological justification" },
   { "ref": "surah:ayah", "reason": "one-sentence theological justification" }
 ]`;
+
+async function buildPrompt(
+  fromRef: string,
+  arabicText: string,
+  translation: string,
+  kind: EdgeKind
+): Promise<{ text: string; promptVersion: number | null }> {
+  const { template, version } = await getPrompt("connection.legacy", LEGACY_FALLBACK_TEMPLATE);
+  const text = renderTemplate(template, {
+    fromRef,
+    arabicText,
+    translation,
+    task: KIND_INSTRUCTIONS[kind],
+    kind,
+  });
+  return { text, promptVersion: version };
 }
 
 function parseRawConnections(text: string): Array<{ ref: string; reason: string }> {
@@ -91,11 +106,12 @@ export async function generateConnections(
   kind: EdgeKind
 ): Promise<ConnectionResult[]> {
   const model = process.env.ANTHROPIC_MODEL ?? null;
-  const text = await callAI(buildPrompt(fromRef, arabicText, translation, kind));
+  const { text: prompt, promptVersion } = await buildPrompt(fromRef, arabicText, translation, kind);
+  const text = await callAI(prompt);
 
   // Best-effort audit log — never fail generation because logging failed.
   try {
-    await db.insert(aiGenerations).values({ fromRef, kind, model });
+    await db.insert(aiGenerations).values({ fromRef, kind, model, promptVersion });
   } catch (err) {
     console.error("ai_generations log failed:", err);
   }
@@ -129,31 +145,22 @@ export async function generateConnections(
     .filter((c): c is ConnectionResult => c !== null);
 }
 
-function buildSelectionPrompt(
-  fromRef: string,
-  arabicText: string,
-  translation: string,
-  kind: EdgeKind,
-  candidates: Verse[]
-): string {
-  const list = candidates.map((v) => `- ${v.ref} — ${v.translation}`).join("\n");
-
-  return `You are a classical Islamic scholar grounded in the Maturidi/Hanafi tradition (Ahl al-Sunnah wal-Jama'ah).
+const SELECTION_FALLBACK_TEMPLATE = `You are a classical Islamic scholar grounded in the Maturidi/Hanafi tradition (Ahl al-Sunnah wal-Jama'ah).
 
 Source verse:
-Reference: ${fromRef}
-Arabic: ${arabicText}
-Translation: ${translation}
+Reference: {{fromRef}}
+Arabic: {{arabicText}}
+Translation: {{translation}}
 
-Below is a list of CANDIDATE verses, each pre-selected from canonical data as potentially related. Your task: ${KIND_SELECTION[kind]}
+Below is a list of CANDIDATE verses, each pre-selected from canonical data as potentially related. Your task: {{task}}
 
 Candidates:
-${list}
+{{candidates}}
 
 Rules:
 - Choose ONLY from the candidate references listed above. Do NOT introduce any verse that is not in the list.
 - Return at most 3, fewer if fewer are genuinely appropriate.
-- Each reason must be one concise sentence explaining the ${kind} connection in classical Islamic terms.
+- Each reason must be one concise sentence explaining the {{kind}} connection in classical Islamic terms.
 - Maintain strict Tanzih (divine transcendence). Avoid Tashbih (anthropomorphism).
 - Return ONLY a valid JSON array. No prose, no markdown, no explanation outside the JSON.
 
@@ -161,6 +168,28 @@ Output format:
 [
   { "ref": "surah:ayah", "reason": "one-sentence theological justification" }
 ]`;
+
+async function buildSelectionPrompt(
+  fromRef: string,
+  arabicText: string,
+  translation: string,
+  kind: EdgeKind,
+  candidates: Verse[]
+): Promise<{ text: string; promptVersion: number | null }> {
+  const list = candidates.map((v) => `- ${v.ref} — ${v.translation}`).join("\n");
+  const { template, version } = await getPrompt(
+    "connection.selection",
+    SELECTION_FALLBACK_TEMPLATE
+  );
+  const text = renderTemplate(template, {
+    fromRef,
+    arabicText,
+    translation,
+    task: KIND_SELECTION[kind],
+    candidates: list,
+    kind,
+  });
+  return { text, promptVersion: version };
 }
 
 function toResult(verse: Verse, reason: string, kind: EdgeKind): ConnectionResult {
@@ -197,12 +226,17 @@ export async function generateGroundedConnections(
   if (candidates.length === 0) return [];
 
   const model = process.env.ANTHROPIC_MODEL ?? null;
-  const text = await callAI(
-    buildSelectionPrompt(fromRef, arabicText, translation, kind, candidates)
+  const { text: prompt, promptVersion } = await buildSelectionPrompt(
+    fromRef,
+    arabicText,
+    translation,
+    kind,
+    candidates
   );
+  const text = await callAI(prompt);
 
   try {
-    await db.insert(aiGenerations).values({ fromRef, kind, model });
+    await db.insert(aiGenerations).values({ fromRef, kind, model, promptVersion });
   } catch (err) {
     console.error("ai_generations log failed:", err);
   }

--- a/lib/ai/prompt-registry.ts
+++ b/lib/ai/prompt-registry.ts
@@ -1,0 +1,55 @@
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "@/lib/infra/db";
+import { promptVersions } from "@/lib/infra/db/schema";
+
+/** The prompt slots a version can target — see connection-generator.ts. */
+export const PROMPT_KEYS = ["connection.legacy", "connection.selection"] as const;
+export type PromptKey = (typeof PROMPT_KEYS)[number];
+
+interface ResolvedPrompt {
+  template: string;
+  /** The `prompt_versions.id` that produced this template, or null if the
+   *  hardcoded fallback was used (no active DB version for this key). */
+  version: number | null;
+}
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { value: ResolvedPrompt; expiresAt: number }>();
+
+/**
+ * Resolves the active DB-stored template for `key`, falling back to the
+ * caller-supplied hardcoded template when no active version exists — so
+ * prompt behavior is unchanged until an admin actually creates a version.
+ * Short-TTL cached (mirrors the admin-allowlist memoization in
+ * lib/admin/admin-auth.ts) so a hot generation path doesn't hit the DB on
+ * every call.
+ */
+export async function getPrompt(key: PromptKey, fallback: string): Promise<ResolvedPrompt> {
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+
+  const [row] = await db
+    .select()
+    .from(promptVersions)
+    .where(and(eq(promptVersions.key, key), eq(promptVersions.active, true)))
+    .orderBy(desc(promptVersions.createdAt))
+    .limit(1);
+
+  const value: ResolvedPrompt = row
+    ? { template: row.template, version: row.id }
+    : { template: fallback, version: null };
+
+  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  return value;
+}
+
+/** Fills `{{name}}` placeholders in a template from `vars`. Unknown placeholders render empty. */
+export function renderTemplate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) => vars[name] ?? "");
+}
+
+/** Drops the cached lookup for `key`, or all keys if omitted — call after writing a new version. */
+export function invalidatePromptCache(key?: PromptKey): void {
+  if (key) cache.delete(key);
+  else cache.clear();
+}

--- a/lib/infra/db/migrations/0013_prompt_versions.sql
+++ b/lib/infra/db/migrations/0013_prompt_versions.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "prompt_versions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"key" text NOT NULL,
+	"template" text NOT NULL,
+	"created_by" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"active" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ai_generations" ADD COLUMN "prompt_version" integer;--> statement-breakpoint
+CREATE INDEX "prompt_versions_key_idx" ON "prompt_versions" USING btree ("key");--> statement-breakpoint
+CREATE INDEX "prompt_versions_key_active_idx" ON "prompt_versions" USING btree ("key","active");

--- a/lib/infra/db/migrations/meta/0013_snapshot.json
+++ b/lib/infra/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1813 @@
+{
+  "id": "68478adc-b4b2-4760-82c7-affc23d11819",
+  "prevId": "f603be5f-b5d5-49cd-9496-77f5af5661b8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_date": {
+          "name": "activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_date_idx": {
+          "name": "activity_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_type_date_idx": {
+          "name": "activity_user_type_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_user_id_users_id_fk": {
+          "name": "activity_log_user_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_qf_id": {
+          "name": "admin_qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_created_idx": {
+          "name": "admin_audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_generations": {
+      "name": "ai_generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_generations_created_idx": {
+          "name": "ai_generations_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_idx": {
+          "name": "bookmarks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookmarks_user_ref_uniq": {
+          "name": "bookmarks_user_ref_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "verse_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_suggestions": {
+      "name": "challenge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_duration": {
+          "name": "suggested_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_suggestions_active_idx": {
+          "name": "challenge_suggestions_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenger_id": {
+          "name": "challenger_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenged_id": {
+          "name": "challenged_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_challenger_status_idx": {
+          "name": "challenges_challenger_status_idx",
+          "columns": [
+            {
+              "expression": "challenger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_challenged_status_idx": {
+          "name": "challenges_challenged_status_idx",
+          "columns": [
+            {
+              "expression": "challenged_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_ends_at_idx": {
+          "name": "challenges_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_suggestion_id_idx": {
+          "name": "challenges_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_challenger_id_users_id_fk": {
+          "name": "challenges_challenger_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_challenged_id_users_id_fk": {
+          "name": "challenges_challenged_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenged_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_suggestion_id_challenge_suggestions_id_fk": {
+          "name": "challenges_suggestion_id_challenge_suggestions_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "challenge_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "challenges_winner_id_users_id_fk": {
+          "name": "challenges_winner_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_challenge": {
+          "name": "no_self_challenge",
+          "value": "\"challenges\".\"challenger_id\" != \"challenges\".\"challenged_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_ref": {
+          "name": "to_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_from_to_kind_idx": {
+          "name": "connections_from_to_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_from_kind_idx": {
+          "name": "connections_from_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_reviewed_at_idx": {
+          "name": "connections_reviewed_at_idx",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_votd": {
+      "name": "curated_votd",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "friendships_pair_idx": {
+          "name": "friendships_pair_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_addressee_status_idx": {
+          "name": "friendships_addressee_status_idx",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_requester_status_idx": {
+          "name": "friendships_requester_status_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_requester_id_users_id_fk": {
+          "name": "friendships_requester_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_addressee_id_users_id_fk": {
+          "name": "friendships_addressee_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_friendship": {
+          "name": "no_self_friendship",
+          "value": "\"friendships\".\"requester_id\" != \"friendships\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.name_content": {
+      "name": "name_content",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "name_content_slug_kind_pk": {
+          "name": "name_content_slug_kind_pk",
+          "columns": [
+            "slug",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_versions": {
+      "name": "prompt_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "prompt_versions_key_idx": {
+          "name": "prompt_versions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_key_active_idx": {
+          "name": "prompt_versions_key_active_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_workspaces": {
+      "name": "saved_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_workspaces_user_idx": {
+          "name": "saved_workspaces_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_workspaces_user_id_users_id_fk": {
+          "name": "saved_workspaces_user_id_users_id_fk",
+          "tableFrom": "saved_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_canvases": {
+      "name": "shared_canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qf_id": {
+          "name": "qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_qf_id_idx": {
+          "name": "users_qf_id_idx",
+          "columns": [
+            {
+              "expression": "qf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_active_idx": {
+          "name": "users_last_active_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_qf_id_unique": {
+          "name": "users_qf_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qf_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_embeddings": {
+      "name": "verse_embeddings",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_embeddings_hnsw_idx": {
+          "name": "verse_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_notes": {
+      "name": "verse_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_notes_user_ref_idx": {
+          "name": "verse_notes_user_ref_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_notes_user_id_users_id_fk": {
+          "name": "verse_notes_user_id_users_id_fk",
+          "tableFrom": "verse_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verses": {
+      "name": "verses",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "surah": {
+          "name": "surah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ayah": {
+          "name": "ayah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arabic_text": {
+          "name": "arabic_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transliteration": {
+          "name": "transliteration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verses_surah_ayah_idx": {
+          "name": "verses_surah_ayah_idx",
+          "columns": [
+            {
+              "expression": "surah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ayah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_morphology": {
+      "name": "word_morphology",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "word_morphology_ref_pos_idx": {
+          "name": "word_morphology_ref_pos_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_ref_idx": {
+          "name": "word_morphology_ref_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_root_idx": {
+          "name": "word_morphology_root_idx",
+          "columns": [
+            {
+              "expression": "root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/infra/db/migrations/meta/_journal.json
+++ b/lib/infra/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1783694440297,
       "tag": "0012_overrated_king_cobra",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1783725577007,
+      "tag": "0013_prompt_versions",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/infra/db/schema.ts
+++ b/lib/infra/db/schema.ts
@@ -272,6 +272,10 @@ export const aiGenerations = pgTable(
     kind: text("kind").notNull(),
     model: text("model"),
     tokens: integer("tokens"),
+    // FK-less reference to prompt_versions.id — null means the hardcoded
+    // fallback template was used (no active DB version for the key at the
+    // time). See lib/ai/prompt-registry.ts.
+    promptVersion: integer("prompt_version"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [index("ai_generations_created_idx").on(t.createdAt)]
@@ -386,6 +390,30 @@ export const adminAuditLog = pgTable(
   (t) => [index("admin_audit_created_idx").on(t.createdAt)]
 );
 
+// ─── Prompt Versions ──────────────────────────────────────────────────────────
+// Versioned, DB-stored prompt templates for the AI connection generator (see
+// lib/ai/prompt-registry.ts, lib/ai/connection-generator.ts). `key` picks the
+// prompt slot ("connection.legacy" | "connection.selection"); only one row per
+// key is `active` at a time — creating a new version or rolling back both flip
+// `active` on exactly one row per key. Absence of an active row for a key means
+// "use the hardcoded fallback template", so this table can start empty.
+
+export const promptVersions = pgTable(
+  "prompt_versions",
+  {
+    id: serial("id").primaryKey(),
+    key: text("key").notNull(),
+    template: text("template").notNull(),
+    createdBy: text("created_by"), // admin qfId
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    active: boolean("active").notNull().default(false),
+  },
+  (t) => [
+    index("prompt_versions_key_idx").on(t.key),
+    index("prompt_versions_key_active_idx").on(t.key, t.active),
+  ]
+);
+
 // ─── Feature Flags / Config ───────────────────────────────────────────────────
 // Key→JSON config the admin can tune at runtime (rate-limit windows, AI model per
 // connection kind, feature toggles). Read by the relevant subsystem; absence of a
@@ -435,3 +463,5 @@ export type AdminAuditEntry = typeof adminAuditLog.$inferSelect;
 export type NewAdminAuditEntry = typeof adminAuditLog.$inferInsert;
 export type FeatureFlag = typeof featureFlags.$inferSelect;
 export type NewFeatureFlag = typeof featureFlags.$inferInsert;
+export type PromptVersion = typeof promptVersions.$inferSelect;
+export type NewPromptVersion = typeof promptVersions.$inferInsert;


### PR DESCRIPTION
## Summary
Adds versioning + audit trail for the AI prompts that drive connection generation (`lib/ai/connection-generator.ts`), per the gap described in #192: today a prompt edit is an untracked code change, with no way to see what prompt version produced a given connection and no rollback path.

- New `prompt_versions` table (`id, key, template, createdBy, createdAt, active`). One row per version; exactly one `active` row per `key` at a time.
- `lib/ai/prompt-registry.ts`: `getPrompt(key, fallback)` looks up the active DB version for a key, short-TTL cached, falling back to the current hardcoded template when no active version exists — so behavior is unchanged until an admin actually creates one.
- `buildPrompt`/`buildSelectionPrompt` in `connection-generator.ts` are now template-driven (`{{fromRef}}`, `{{arabicText}}`, `{{translation}}`, `{{task}}`, `{{kind}}`, `{{candidates}}` placeholders), keyed as `connection.legacy` / `connection.selection` — the same two prompt slots the issue calls out. The hardcoded strings are preserved as the fallback templates.
- New `prompt_version` column on `ai_generations`, set on every generation, so a connection's generation row can be traced back to the exact prompt template that produced it.
- Admin UI: new `/admin/prompts` page (nav entry added to `AdminShell`) — view version history per slot, create a new version (activates it, deactivates the prior one), and roll back to any prior version.
- `app/api/admin/prompts` (`GET`/`POST`) and `app/api/admin/prompts/rollback` (`POST`) — both `requireAdmin`-gated, both log `prompt.version.create` / `prompt.version.rollback` to the existing `adminAuditLog` via `logAdminAction`.

Fixes #192

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test:ci` — 552/552 passing (updated `connection-generator.test.ts` to mock `getPrompt`, exercising the same fallback-template rendering path production code uses when no DB version is active)
- [x] Integration tests (Testcontainers, via pre-push hook) — passing against a real Postgres instance, which applies the new `0013_prompt_versions` migration as part of the run
- [ ] Not manually exercised against a live dev DB (no local Postgres instance available in this environment) — coverage here is unit + Testcontainers-backed integration tests only. Worth a manual admin-UI smoke test before merge: create a prompt version, trigger a connection generation, confirm the DB template (not the fallback) was used and `prompt_version` is recorded on the `ai_generations` row; then roll back and confirm it reverts.