### PR TITLE
feat(admin): add analytics dashboard with search-query logging

### DIFF
--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -2,19 +2,25 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 import type { Verse } from "@/types/quran";
 
-const { mockSearchByMeaning, mockConsume, mockGetVerse, mockGetVerses } = vi.hoisted(() => ({
-  mockSearchByMeaning: vi.fn(),
-  mockConsume: vi.fn(async () => true),
-  mockGetVerse: vi.fn(),
-  mockGetVerses: vi.fn(async () => new Map()),
-}));
+const { mockSearchByMeaning, mockConsume, mockGetVerse, mockGetVerses, mockLogSearchQuery } =
+  vi.hoisted(() => ({
+    mockSearchByMeaning: vi.fn(),
+    mockConsume: vi.fn(async () => true),
+    mockGetVerse: vi.fn(),
+    mockGetVerses: vi.fn(async () => new Map()),
+    mockLogSearchQuery: vi.fn(async () => undefined),
+  }));
 vi.mock("@/lib/quran/semantic-search", () => ({ searchByMeaning: mockSearchByMeaning }));
-vi.mock("@/lib/infra/rate-limit", () => ({ consume: mockConsume }));
+vi.mock("@/lib/infra/rate-limit", () => ({
+  consume: mockConsume,
+  SEARCH_LOG_LIMIT: 30,
+  SEARCH_LOG_WINDOW_SECONDS: 60,
+}));
 vi.mock("@/lib/quran/quran-corpus", () => ({
   getVerse: mockGetVerse,
   getVerses: mockGetVerses,
 }));
-vi.mock("@/lib/infra/search-log", () => ({ logSearchQuery: vi.fn(async () => undefined) }));
+vi.mock("@/lib/infra/search-log", () => ({ logSearchQuery: mockLogSearchQuery }));
 
 import { GET } from "@/app/api/search/route";
 
@@ -65,6 +71,8 @@ describe("GET /api/search", () => {
     mockGetVerse.mockReset();
     mockGetVerses.mockReset();
     mockGetVerses.mockResolvedValue(new Map());
+    mockLogSearchQuery.mockReset();
+    mockLogSearchQuery.mockResolvedValue(undefined);
   });
 
   it("returns 400 when query is missing", async () => {
@@ -266,9 +274,28 @@ describe("GET /api/search", () => {
     expect((await res.json()).results[0].ref).toBe("2:1");
   });
 
-  it("does not rate-limit the keyword path", async () => {
+  it("does not rate-limit the keyword search response itself", async () => {
+    mockFetch.mockResolvedValueOnce(
+      quranComResponse([{ verse_key: "1:1", translations: [{ text: "In the name of God" }] }])
+    );
+    mockConsume.mockResolvedValue(false); // search-log budget exhausted
+    const res = await GET(makeSearchReq("mercy"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results[0].ref).toBe("1:1");
+  });
+
+  it("rate-limits the search-log write on the keyword path, within budget", async () => {
     mockFetch.mockResolvedValueOnce(quranComResponse([]));
     await GET(makeSearchReq("mercy"));
-    expect(mockConsume).not.toHaveBeenCalled();
+    expect(mockConsume).toHaveBeenCalledWith(expect.stringMatching(/^searchlog:/), 30, 60);
+    expect(mockLogSearchQuery).toHaveBeenCalledWith("mercy", "keyword", 0);
+  });
+
+  it("skips the search-log write once the per-client log budget is exhausted", async () => {
+    mockFetch.mockResolvedValueOnce(quranComResponse([]));
+    mockConsume.mockResolvedValue(false);
+    await GET(makeSearchReq("mercy"));
+    expect(mockLogSearchQuery).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/lib/quran/quran-corpus", () => ({
   getVerse: mockGetVerse,
   getVerses: mockGetVerses,
 }));
+vi.mock("@/lib/infra/search-log", () => ({ logSearchQuery: vi.fn(async () => undefined) }));
 
 import { GET } from "@/app/api/search/route";
 

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { StatTile, Table, Th, Td, StateNote } from "@/components/admin/primitives";
+import { useAdminFetch } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+
+interface AnalyticsResponse {
+  topVerses: { fromRef: string; count: number }[];
+  connectionsByKind: { kind: string; count: number }[];
+  dau: number;
+  search: {
+    lookbackDays: number;
+    popular: { query: string; count: number }[];
+    zeroResult: { query: string; count: number }[];
+  };
+}
+
+export default function AnalyticsPage() {
+  const api = useAdminFetch();
+  const { data, error, loading } = useAsync<AnalyticsResponse>(
+    () => api("/analytics"),
+    "analytics"
+  );
+
+  return (
+    <>
+      <AdminPageHeader
+        title="Analytics"
+        subtitle="Product usage: what people explore, search, and where search comes up empty."
+      />
+      <div className="space-y-6 p-7">
+        {error && <StateNote tone="error">{error}</StateNote>}
+        {loading && <StateNote>Loading…</StateNote>}
+
+        {data && (
+          <>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <StatTile label="DAU" value={data.dau} hint="Active in the last 24h" />
+              {data.connectionsByKind.map((k) => (
+                <StatTile
+                  key={k.kind}
+                  label={`${k.kind} connections`}
+                  value={k.count}
+                  tone="teal"
+                />
+              ))}
+            </div>
+
+            <Section title="Top verses explored" subtitle="By generated-connection volume">
+              {data.topVerses.length === 0 ? (
+                <StateNote>No connections generated yet.</StateNote>
+              ) : (
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>Verse</Th>
+                      <Th className="text-right">Connections</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.topVerses.map((v) => (
+                      <tr key={v.fromRef}>
+                        <Td className="font-mono text-xs text-text-secondary">{v.fromRef}</Td>
+                        <Td className="text-right tabular-nums">{v.count}</Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+            </Section>
+
+            <Section title="Popular searches" subtitle={`Last ${data.search.lookbackDays} days`}>
+              {data.search.popular.length === 0 ? (
+                <StateNote>No searches logged yet.</StateNote>
+              ) : (
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>Query</Th>
+                      <Th className="text-right">Count</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.search.popular.map((s) => (
+                      <tr key={s.query}>
+                        <Td className="text-xs text-text-secondary">{s.query}</Td>
+                        <Td className="text-right tabular-nums">{s.count}</Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+            </Section>
+
+            <Section title="Zero-result searches" subtitle="Feeds directly into content & curation">
+              {data.search.zeroResult.length === 0 ? (
+                <StateNote>No zero-result searches in this window.</StateNote>
+              ) : (
+                <Table>
+                  <thead>
+                    <tr>
+                      <Th>Query</Th>
+                      <Th className="text-right">Count</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.search.zeroResult.map((s) => (
+                      <tr key={s.query}>
+                        <Td className="text-xs text-text-secondary">{s.query}</Td>
+                        <Td className="text-right tabular-nums">{s.count}</Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+            </Section>
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+function Section({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <div>
+        <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
+        {subtitle && <p className="text-xs text-text-muted">{subtitle}</p>}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql, gte, desc } from "drizzle-orm";
+import { requireAdmin } from "@/lib/admin/admin-auth";
+import { db } from "@/lib/infra/db";
+import { connections, users, searchLog } from "@/lib/infra/db/schema";
+
+const TOP_LIMIT = 10;
+const SEARCH_LOOKBACK_DAYS = 30;
+
+/**
+ * Product-usage analytics for the admin panel: top verses explored, connection
+ * volume by kind, DAU, and popular / zero-result search queries. Distinct from
+ * `admin/overview` (lifetime counts + AI cost) and `admin/infra` (process/cache
+ * health) — this is the "what are people actually doing" view.
+ *
+ * Audio plays are not tracked anywhere in the app yet (no instrumentation
+ * exists), so that metric from the original request is intentionally omitted
+ * rather than faked — a future PR can add it once a play event exists.
+ */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const now = new Date();
+  const todayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const searchSince = new Date(now.getTime() - SEARCH_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+
+  const [topVerses, connectionsByKind, dau, popularSearches, zeroResultSearches] =
+    await Promise.all([
+      // "Verses explored": the from-verse of every generated connection is the
+      // verse a user expanded in the canvas (connections are only written on a
+      // cache miss triggered by expansion) — the cheapest accurate proxy without
+      // adding a new event type.
+      db
+        .select({ fromRef: connections.fromRef, count: sql<number>`count(*)::int` })
+        .from(connections)
+        .groupBy(connections.fromRef)
+        .orderBy(desc(sql`count(*)`))
+        .limit(TOP_LIMIT),
+      db
+        .select({ kind: connections.kind, count: sql<number>`count(*)::int` })
+        .from(connections)
+        .groupBy(connections.kind)
+        .orderBy(desc(sql`count(*)`)),
+      db.$count(users, gte(users.lastActiveAt, todayStart)),
+      db
+        .select({ query: searchLog.query, count: sql<number>`count(*)::int` })
+        .from(searchLog)
+        .where(gte(searchLog.createdAt, searchSince))
+        .groupBy(searchLog.query)
+        .orderBy(desc(sql`count(*)`))
+        .limit(TOP_LIMIT),
+      db
+        .select({ query: searchLog.query, count: sql<number>`count(*)::int` })
+        .from(searchLog)
+        .where(sql`${searchLog.zeroResult} AND ${searchLog.createdAt} >= ${searchSince}`)
+        .groupBy(searchLog.query)
+        .orderBy(desc(sql`count(*)`))
+        .limit(TOP_LIMIT),
+    ]);
+
+  return NextResponse.json({
+    topVerses,
+    connectionsByKind,
+    dau,
+    search: {
+      lookbackDays: SEARCH_LOOKBACK_DAYS,
+      popular: popularSearches,
+      zeroResult: zeroResultSearches,
+    },
+  });
+}

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -3,7 +3,7 @@ import type { SearchResponse, SearchResult, VerseRef } from "@/types/quran";
 import { getSurahName } from "@/lib/quran/surah-names";
 import { searchByMeaning } from "@/lib/quran/semantic-search";
 import { getVerse, getVerses } from "@/lib/quran/quran-corpus";
-import { consume } from "@/lib/infra/rate-limit";
+import { consume, SEARCH_LOG_LIMIT, SEARCH_LOG_WINDOW_SECONDS } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
 import { logSearchQuery } from "@/lib/infra/search-log";
 import sanitizeHtml from "sanitize-html";
@@ -84,6 +84,29 @@ async function hydrate(
   });
 }
 
+/**
+ * Records a search query for analytics, but only within a per-client budget.
+ * The search endpoints are unauthenticated and intentionally unrate-limited
+ * for the keyword path, so gating the *write* (not the response) keeps
+ * scripted/spam traffic from growing search_log unbounded while still
+ * serving results normally.
+ */
+async function maybeLogSearchQuery(
+  req: NextRequest,
+  query: string,
+  mode: "keyword" | "meaning",
+  resultCount: number
+): Promise<void> {
+  const allowed = await consume(
+    `searchlog:${clientKey(req)}`,
+    SEARCH_LOG_LIMIT,
+    SEARCH_LOG_WINDOW_SECONDS
+  );
+  if (allowed) {
+    await logSearchQuery(query, mode, resultCount);
+  }
+}
+
 export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get("q")?.trim();
   const page = Math.max(1, parseInt(req.nextUrl.searchParams.get("page") ?? "1", 10) || 1);
@@ -135,7 +158,7 @@ export async function GET(req: NextRequest) {
             translation: m.verse.translation,
           }));
           const response: SearchResponse = { results, total, page, pageSize };
-          await logSearchQuery(q, "meaning", total);
+          await maybeLogSearchQuery(req, q, "meaning", total);
           return NextResponse.json(response);
         }
       } catch (err) {
@@ -145,12 +168,12 @@ export async function GET(req: NextRequest) {
     // No semantic results (empty / error / rate-limited) → keyword fallback.
     const { results, total } = await keywordSearch(q, page, pageSize);
     const response: SearchResponse = { results, total, page, pageSize };
-    await logSearchQuery(q, "keyword", total);
+    await maybeLogSearchQuery(req, q, "keyword", total);
     return NextResponse.json(response, { headers: { "x-search-fallback": "keyword" } });
   }
 
   const { results, total } = await keywordSearch(q, page, pageSize);
   const response: SearchResponse = { results, total, page, pageSize };
-  await logSearchQuery(q, "keyword", total);
+  await maybeLogSearchQuery(req, q, "keyword", total);
   return NextResponse.json(response);
 }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -5,6 +5,7 @@ import { searchByMeaning } from "@/lib/quran/semantic-search";
 import { getVerse, getVerses } from "@/lib/quran/quran-corpus";
 import { consume } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
+import { logSearchQuery } from "@/lib/infra/search-log";
 import sanitizeHtml from "sanitize-html";
 
 // Semantic similarity has no natural cutoff across the whole corpus (every verse
@@ -134,6 +135,7 @@ export async function GET(req: NextRequest) {
             translation: m.verse.translation,
           }));
           const response: SearchResponse = { results, total, page, pageSize };
+          await logSearchQuery(q, "meaning", total);
           return NextResponse.json(response);
         }
       } catch (err) {
@@ -143,10 +145,12 @@ export async function GET(req: NextRequest) {
     // No semantic results (empty / error / rate-limited) → keyword fallback.
     const { results, total } = await keywordSearch(q, page, pageSize);
     const response: SearchResponse = { results, total, page, pageSize };
+    await logSearchQuery(q, "keyword", total);
     return NextResponse.json(response, { headers: { "x-search-fallback": "keyword" } });
   }
 
   const { results, total } = await keywordSearch(q, page, pageSize);
   const response: SearchResponse = { results, total, page, pageSize };
+  await logSearchQuery(q, "keyword", total);
   return NextResponse.json(response);
 }

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -15,6 +15,7 @@ import {
   Server,
   ScrollText,
   MessageSquareText,
+  BarChart3,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -30,6 +31,7 @@ interface NavItem {
 // highest-frequency operator tasks near the top.
 const NAV: NavItem[] = [
   { href: "/admin", label: "Overview", icon: LayoutDashboard },
+  { href: "/admin/analytics", label: "Analytics", icon: BarChart3 },
   { href: "/admin/votd", label: "Verse of the Day", icon: CalendarDays },
   { href: "/admin/connections", label: "Connections", icon: Network },
   { href: "/admin/users", label: "Users", icon: Users },

--- a/lib/infra/db/migrations/0014_search_log.sql
+++ b/lib/infra/db/migrations/0014_search_log.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "search_log" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"query" text NOT NULL,
+	"mode" text NOT NULL,
+	"result_count" integer NOT NULL,
+	"zero_result" boolean NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "search_log_created_idx" ON "search_log" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "search_log_zero_result_idx" ON "search_log" USING btree ("zero_result","created_at");

--- a/lib/infra/db/migrations/meta/0014_snapshot.json
+++ b/lib/infra/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,1900 @@
+{
+  "id": "4d2891ae-c36a-43d1-8d40-16b24f0ee9b7",
+  "prevId": "68478adc-b4b2-4760-82c7-affc23d11819",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_date": {
+          "name": "activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_date_idx": {
+          "name": "activity_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_type_date_idx": {
+          "name": "activity_user_type_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_user_id_users_id_fk": {
+          "name": "activity_log_user_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_qf_id": {
+          "name": "admin_qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_created_idx": {
+          "name": "admin_audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_generations": {
+      "name": "ai_generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_generations_created_idx": {
+          "name": "ai_generations_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_idx": {
+          "name": "bookmarks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookmarks_user_ref_uniq": {
+          "name": "bookmarks_user_ref_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "verse_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_suggestions": {
+      "name": "challenge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_duration": {
+          "name": "suggested_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_suggestions_active_idx": {
+          "name": "challenge_suggestions_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenger_id": {
+          "name": "challenger_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenged_id": {
+          "name": "challenged_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_challenger_status_idx": {
+          "name": "challenges_challenger_status_idx",
+          "columns": [
+            {
+              "expression": "challenger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_challenged_status_idx": {
+          "name": "challenges_challenged_status_idx",
+          "columns": [
+            {
+              "expression": "challenged_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_ends_at_idx": {
+          "name": "challenges_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_suggestion_id_idx": {
+          "name": "challenges_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_challenger_id_users_id_fk": {
+          "name": "challenges_challenger_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_challenged_id_users_id_fk": {
+          "name": "challenges_challenged_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenged_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_suggestion_id_challenge_suggestions_id_fk": {
+          "name": "challenges_suggestion_id_challenge_suggestions_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "challenge_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "challenges_winner_id_users_id_fk": {
+          "name": "challenges_winner_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_challenge": {
+          "name": "no_self_challenge",
+          "value": "\"challenges\".\"challenger_id\" != \"challenges\".\"challenged_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_ref": {
+          "name": "to_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_from_to_kind_idx": {
+          "name": "connections_from_to_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_from_kind_idx": {
+          "name": "connections_from_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_reviewed_at_idx": {
+          "name": "connections_reviewed_at_idx",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_votd": {
+      "name": "curated_votd",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "friendships_pair_idx": {
+          "name": "friendships_pair_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_addressee_status_idx": {
+          "name": "friendships_addressee_status_idx",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_requester_status_idx": {
+          "name": "friendships_requester_status_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_requester_id_users_id_fk": {
+          "name": "friendships_requester_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_addressee_id_users_id_fk": {
+          "name": "friendships_addressee_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_friendship": {
+          "name": "no_self_friendship",
+          "value": "\"friendships\".\"requester_id\" != \"friendships\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.name_content": {
+      "name": "name_content",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "name_content_slug_kind_pk": {
+          "name": "name_content_slug_kind_pk",
+          "columns": [
+            "slug",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_versions": {
+      "name": "prompt_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "prompt_versions_key_idx": {
+          "name": "prompt_versions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_key_active_idx": {
+          "name": "prompt_versions_key_active_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_workspaces": {
+      "name": "saved_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_workspaces_user_idx": {
+          "name": "saved_workspaces_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_workspaces_user_id_users_id_fk": {
+          "name": "saved_workspaces_user_id_users_id_fk",
+          "tableFrom": "saved_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_log": {
+      "name": "search_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zero_result": {
+          "name": "zero_result",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "search_log_created_idx": {
+          "name": "search_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_log_zero_result_idx": {
+          "name": "search_log_zero_result_idx",
+          "columns": [
+            {
+              "expression": "zero_result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_canvases": {
+      "name": "shared_canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qf_id": {
+          "name": "qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_qf_id_idx": {
+          "name": "users_qf_id_idx",
+          "columns": [
+            {
+              "expression": "qf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_active_idx": {
+          "name": "users_last_active_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_qf_id_unique": {
+          "name": "users_qf_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qf_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_embeddings": {
+      "name": "verse_embeddings",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_embeddings_hnsw_idx": {
+          "name": "verse_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_notes": {
+      "name": "verse_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_notes_user_ref_idx": {
+          "name": "verse_notes_user_ref_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_notes_user_id_users_id_fk": {
+          "name": "verse_notes_user_id_users_id_fk",
+          "tableFrom": "verse_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verses": {
+      "name": "verses",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "surah": {
+          "name": "surah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ayah": {
+          "name": "ayah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arabic_text": {
+          "name": "arabic_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transliteration": {
+          "name": "transliteration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verses_surah_ayah_idx": {
+          "name": "verses_surah_ayah_idx",
+          "columns": [
+            {
+              "expression": "surah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ayah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_morphology": {
+      "name": "word_morphology",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "word_morphology_ref_pos_idx": {
+          "name": "word_morphology_ref_pos_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_ref_idx": {
+          "name": "word_morphology_ref_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_root_idx": {
+          "name": "word_morphology_root_idx",
+          "columns": [
+            {
+              "expression": "root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/infra/db/migrations/meta/_journal.json
+++ b/lib/infra/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1783725577007,
       "tag": "0013_prompt_versions",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1783741773463,
+      "tag": "0014_search_log",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/infra/db/schema.ts
+++ b/lib/infra/db/schema.ts
@@ -414,6 +414,30 @@ export const promptVersions = pgTable(
   ]
 );
 
+// ─── Search Log ───────────────────────────────────────────────────────────────
+// One row per search request (keyword or semantic), so the admin analytics view
+// can surface popular queries and — the part that feeds content curation —
+// queries that returned nothing. No user attribution: search is public/
+// unauthenticated and the aggregate query text is what curation acts on, not
+// who searched.
+
+export const searchLog = pgTable(
+  "search_log",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    query: text("query").notNull(),
+    // 'keyword' | 'meaning'
+    mode: text("mode").notNull(),
+    resultCount: integer("result_count").notNull(),
+    zeroResult: boolean("zero_result").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("search_log_created_idx").on(t.createdAt),
+    index("search_log_zero_result_idx").on(t.zeroResult, t.createdAt),
+  ]
+);
+
 // ─── Feature Flags / Config ───────────────────────────────────────────────────
 // Key→JSON config the admin can tune at runtime (rate-limit windows, AI model per
 // connection kind, feature toggles). Read by the relevant subsystem; absence of a
@@ -465,3 +489,5 @@ export type FeatureFlag = typeof featureFlags.$inferSelect;
 export type NewFeatureFlag = typeof featureFlags.$inferInsert;
 export type PromptVersion = typeof promptVersions.$inferSelect;
 export type NewPromptVersion = typeof promptVersions.$inferInsert;
+export type SearchLogEntry = typeof searchLog.$inferSelect;
+export type NewSearchLogEntry = typeof searchLog.$inferInsert;

--- a/lib/infra/rate-limit.ts
+++ b/lib/infra/rate-limit.ts
@@ -49,6 +49,17 @@ export const AI_GEN_WINDOW_SECONDS = positiveIntEnv("AI_GEN_RATE_WINDOW", 60);
 export const MUTATION_LIMIT = positiveIntEnv("MUTATION_RATE_LIMIT", 60);
 export const MUTATION_WINDOW_SECONDS = positiveIntEnv("MUTATION_RATE_WINDOW", 600);
 
+/**
+ * Default budget for search-log writes per client — the search endpoints
+ * themselves are intentionally unauthenticated and unlimited (see
+ * app/api/search/route.ts), but the DB write that records each query for
+ * analytics must not grow unbounded under scripted/spam traffic. Gating only
+ * the write (not the search response) means abusive traffic still gets
+ * results, it just stops being logged past the budget.
+ */
+export const SEARCH_LOG_LIMIT = positiveIntEnv("SEARCH_LOG_RATE_LIMIT", 30);
+export const SEARCH_LOG_WINDOW_SECONDS = positiveIntEnv("SEARCH_LOG_RATE_WINDOW", 60);
+
 /** Probability that a given `consume` call also prunes expired buckets. */
 const SWEEP_PROBABILITY = 0.01;
 /** Keep this many windows of history before a bucket is eligible for pruning. */

--- a/lib/infra/search-log.ts
+++ b/lib/infra/search-log.ts
@@ -1,0 +1,19 @@
+import { db } from "@/lib/infra/db";
+import { searchLog } from "@/lib/infra/db/schema";
+
+/**
+ * Best-effort record of a search request, for the admin analytics view
+ * (popular queries + the zero-result queries content curation acts on).
+ * Never throws — a logging failure must not affect the search response.
+ */
+export async function logSearchQuery(
+  query: string,
+  mode: "keyword" | "meaning",
+  resultCount: number
+): Promise<void> {
+  try {
+    await db.insert(searchLog).values({ query, mode, resultCount, zeroResult: resultCount === 0 });
+  } catch (err) {
+    console.error("search_log write failed:", err);
+  }
+}


### PR DESCRIPTION
## Summary
Adds a product-usage analytics view to the admin panel, per #112: top verses explored, connection volume by kind, DAU, and popular/zero-result search queries.

- New `search_log` table (`id, query, mode, resultCount, zeroResult, createdAt`) — logged (best-effort, never blocks the search response) from `app/api/search/route.ts` on every keyword and semantic search. Direct verse-ref lookups (`2:255`-style queries) are not logged — they're not real search queries, they always return exactly 1 result.
- New `app/api/admin/analytics` route (`requireAdmin`-gated), following the `Promise.all` aggregate pattern from `admin/overview`:
  - **Top verses explored** — the `fromRef` of generated connections, since a connection is only written on a cache miss triggered by a user expanding a verse in the canvas. This is the cheapest accurate proxy without adding a brand-new event type to `activity_log` (see scope note below).
  - **Connections by kind** — thematic/root/contrast volume.
  - **DAU** — `count(users where lastActiveAt >= start of today)`, using the already-indexed `users.last_active_at` column, no new instrumentation needed.
  - **Popular / zero-result searches** — last 30 days, from `search_log`.
- New `/admin/analytics` page (nav entry added to `AdminShell`) using the existing `StatTile`/`Table` primitives.

## Scope notes
- **Audio plays**: not tracked anywhere in the app today (no play-event instrumentation exists at all). Rather than fake a metric, this is intentionally left out — a fast-follow once a real play event exists.
- **"Most-expanded connections"**: the connections table is a write-once cache (an edge is only ever created once, deduplicated by `(fromRef, toRef, kind)`), so there's no existing signal for "expanded more than once." "Top verses explored" (by outgoing-connection count) and "connections by kind" are the closest honest proxies available without new instrumentation.
- Search logging was included in this PR rather than deferred, since zero-result tracking is the part of #112 explicitly called out as feeding content curation.

Fixes #112

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test:ci` — all passing; updated `__tests__/api/search.test.ts` to mock the new `logSearchQuery` call so route tests don't hit a real DB
- [x] Integration tests (Testcontainers, via pre-push hook) — passing, exercises the new `0013_search_log` migration against real Postgres