### PR TITLE
feat(admin): wire feature flags to AI provider, rate limits, and maintenance mode

### DIFF
--- a/__tests__/api/admin/flags.test.ts
+++ b/__tests__/api/admin/flags.test.ts
@@ -4,6 +4,7 @@ import type { User } from "@/lib/infra/db/schema";
 
 vi.mock("@/lib/admin/admin-auth", () => ({ requireAdmin: vi.fn() }));
 vi.mock("@/lib/admin/admin-audit", () => ({ logAdminAction: vi.fn() }));
+vi.mock("@/lib/admin/feature-flags", () => ({ invalidateFlagCache: vi.fn() }));
 
 function makeDbChain(resolveWith: unknown = []) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,6 +39,7 @@ vi.mock("@/lib/infra/db", () => ({
 import { GET, PUT, DELETE } from "@/app/api/admin/flags/route";
 import { requireAdmin } from "@/lib/admin/admin-auth";
 import { logAdminAction } from "@/lib/admin/admin-audit";
+import { invalidateFlagCache } from "@/lib/admin/feature-flags";
 
 const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
 
@@ -66,6 +68,7 @@ beforeEach(() => {
   mockInsert.mockReturnValue(makeDbChain([]));
   mockDelete.mockReturnValue(makeDbChain([]));
   vi.mocked(logAdminAction).mockClear();
+  vi.mocked(invalidateFlagCache).mockClear();
 });
 
 describe("GET /api/admin/flags", () => {
@@ -133,6 +136,7 @@ describe("PUT /api/admin/flags", () => {
     expect(logAdminAction).toHaveBeenCalledWith(
       expect.objectContaining({ action: "flag.set", targetId: "new-canvas" })
     );
+    expect(invalidateFlagCache).toHaveBeenCalledWith("new-canvas");
   });
 
   it("accepts value: false (not treated as missing)", async () => {
@@ -156,5 +160,6 @@ describe("DELETE /api/admin/flags", () => {
     expect(logAdminAction).toHaveBeenCalledWith(
       expect.objectContaining({ action: "flag.delete", targetId: "new-canvas" })
     );
+    expect(invalidateFlagCache).toHaveBeenCalledWith("new-canvas");
   });
 });

--- a/__tests__/lib/admin/feature-flags.test.ts
+++ b/__tests__/lib/admin/feature-flags.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+function makeDbChain(resolveWith: unknown) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect } = vi.hoisted(() => ({ mockSelect: vi.fn() }));
+vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect } }));
+
+import {
+  getFlagString,
+  getFlagNumber,
+  getFlagBoolean,
+  invalidateFlagCache,
+} from "@/lib/admin/feature-flags";
+
+function rowWith(value: unknown) {
+  return [{ key: "k", value: JSON.stringify(value), updatedBy: null, updatedAt: new Date() }];
+}
+
+beforeEach(() => {
+  mockSelect.mockReset();
+  invalidateFlagCache();
+});
+
+describe("getFlagString", () => {
+  it("returns the fallback when no row exists", async () => {
+    mockSelect.mockReturnValue(makeDbChain([]));
+    expect(await getFlagString("ai_provider", "claude")).toBe("claude");
+  });
+
+  it("returns the stored string value", async () => {
+    mockSelect.mockReturnValue(makeDbChain(rowWith("gemini")));
+    expect(await getFlagString("ai_provider", "claude")).toBe("gemini");
+  });
+
+  it("falls back when the stored value isn't a string", async () => {
+    mockSelect.mockReturnValue(makeDbChain(rowWith(42)));
+    expect(await getFlagString("ai_provider", "claude")).toBe("claude");
+  });
+
+  it("caches the lookup within the TTL window", async () => {
+    mockSelect.mockReturnValue(makeDbChain(rowWith("gemini")));
+    await getFlagString("ai_provider", "claude");
+    await getFlagString("ai_provider", "claude");
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-queries after invalidateFlagCache", async () => {
+    mockSelect.mockReturnValue(makeDbChain(rowWith("gemini")));
+    await getFlagString("ai_provider", "claude");
+    invalidateFlagCache("ai_provider");
+    await getFlagString("ai_provider", "claude");
+    expect(mockSelect).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("getFlagNumber", () => {
+  it("returns the fallback when no row exists", async () => {
+    mockSelect.mockReturnValue(makeDbChain([]));
+    expect(await getFlagNumber("mutation_limit", 60)).toBe(60);
+  });
+
+  it("returns the stored positive number", async () => {
+    mockSelect.mockReturnValue(makeDbChain(rowWith(120)));
+    expect(await getFlagNumber("mutation_limit", 60)).toBe(120);
+  });
+
+  it("falls back for a non-positive or non-numeric stored value", async () => {
+    mockSelect.mockReturnValue(makeDbChain(rowWith(0)));
+    expect(await getFlagNumber("mutation_limit", 60)).toBe(60);
+    mockSelect.mockReturnValue(makeDbChain(rowWith("nope")));
+    invalidateFlagCache("mutation_limit");
+    expect(await getFlagNumber("mutation_limit", 60)).toBe(60);
+  });
+});
+
+describe("getFlagBoolean", () => {
+  it("returns the fallback when no row exists", async () => {
+    mockSelect.mockReturnValue(makeDbChain([]));
+    expect(await getFlagBoolean("maintenance_mode", false)).toBe(false);
+  });
+
+  it("returns the stored boolean value", async () => {
+    mockSelect.mockReturnValue(makeDbChain(rowWith(true)));
+    expect(await getFlagBoolean("maintenance_mode", false)).toBe(true);
+  });
+
+  it("falls back when the stored value isn't a boolean", async () => {
+    mockSelect.mockReturnValue(makeDbChain(rowWith("true")));
+    expect(await getFlagBoolean("maintenance_mode", false)).toBe(false);
+  });
+});

--- a/__tests__/lib/infra/rate-limit.test.ts
+++ b/__tests__/lib/infra/rate-limit.test.ts
@@ -8,6 +8,7 @@ const {
   mockDelete,
   mockRedisIncr,
   mockIncr,
+  mockGetFlagNumber,
 } = vi.hoisted(() => {
   const mockReturning = vi.fn();
   const mockOnConflict = vi.fn(() => ({ returning: mockReturning }));
@@ -19,6 +20,7 @@ const {
   // Postgres fallback path unchanged.
   const mockRedisIncr = vi.fn().mockResolvedValue(null);
   const mockIncr = vi.fn();
+  const mockGetFlagNumber = vi.fn(async (_key: string, fallback: number) => fallback);
   return {
     mockReturning,
     mockValues,
@@ -27,12 +29,14 @@ const {
     mockDelete,
     mockRedisIncr,
     mockIncr,
+    mockGetFlagNumber,
   };
 });
 
 vi.mock("@/lib/infra/db", () => ({ db: { insert: mockInsert, delete: mockDelete } }));
 vi.mock("@/lib/infra/redis", () => ({ redisIncrWithTtl: mockRedisIncr }));
 vi.mock("@/lib/infra/metrics", () => ({ incr: mockIncr }));
+vi.mock("@/lib/admin/feature-flags", () => ({ getFlagNumber: mockGetFlagNumber }));
 
 import {
   consume,
@@ -40,6 +44,10 @@ import {
   sweepRateLimits,
   RateLimitError,
   positiveIntEnv,
+  AI_GEN_LIMIT,
+  AI_GEN_WINDOW_SECONDS,
+  MUTATION_LIMIT,
+  MUTATION_WINDOW_SECONDS,
 } from "@/lib/infra/rate-limit";
 
 describe("rate-limit consume", () => {
@@ -50,6 +58,8 @@ describe("rate-limit consume", () => {
     mockRedisIncr.mockReset();
     mockRedisIncr.mockResolvedValue(null); // default: Postgres fallback path
     mockIncr.mockClear();
+    mockGetFlagNumber.mockReset();
+    mockGetFlagNumber.mockImplementation(async (_key: string, fallback: number) => fallback);
   });
 
   it("allows when count is within the limit", async () => {
@@ -116,12 +126,30 @@ describe("rate-limit consume", () => {
     expect(mockIncr).toHaveBeenCalledWith("ratelimit_redis_fallback");
     expect(mockIncr).toHaveBeenCalledWith("ratelimit_allow");
   });
+
+  // ─── Flag-aware defaults (new) ───────────────────────────────────────────────
+
+  it("resolves limit/window from the ai_gen_* flags when omitted", async () => {
+    mockGetFlagNumber.mockImplementation(async (key: string) => (key === "ai_gen_limit" ? 5 : 30));
+    mockRedisIncr.mockResolvedValue(6); // over the flagged limit of 5
+    expect(await consume("ip:1")).toBe(false);
+    expect(mockGetFlagNumber).toHaveBeenCalledWith("ai_gen_limit", AI_GEN_LIMIT);
+    expect(mockGetFlagNumber).toHaveBeenCalledWith("ai_gen_window_seconds", AI_GEN_WINDOW_SECONDS);
+  });
+
+  it("does not consult flags when limit/window are passed explicitly", async () => {
+    mockRedisIncr.mockResolvedValue(1);
+    await consume("ip:1", 20, 60);
+    expect(mockGetFlagNumber).not.toHaveBeenCalled();
+  });
 });
 
 describe("rateLimitOrNull", () => {
   beforeEach(() => {
     mockReturning.mockReset();
     mockRedisIncr.mockReset();
+    mockGetFlagNumber.mockReset();
+    mockGetFlagNumber.mockImplementation(async (_key: string, fallback: number) => fallback);
   });
 
   it("returns null (allowed) when under the limit", async () => {
@@ -136,6 +164,21 @@ describe("rateLimitOrNull", () => {
     expect(res!.status).toBe(429);
     const body = await res!.json();
     expect(body.error).toBe("Too many widgets");
+  });
+
+  it("resolves limit/window from the mutation_* flags when omitted", async () => {
+    mockGetFlagNumber.mockImplementation(async (key: string) =>
+      key === "mutation_limit" ? 2 : 600
+    );
+    mockRedisIncr.mockResolvedValue(3); // over the flagged limit of 2
+    const res = await rateLimitOrNull("ip:1", "Too many");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(429);
+    expect(mockGetFlagNumber).toHaveBeenCalledWith("mutation_limit", MUTATION_LIMIT);
+    expect(mockGetFlagNumber).toHaveBeenCalledWith(
+      "mutation_window_seconds",
+      MUTATION_WINDOW_SECONDS
+    );
   });
 });
 

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetFlagBoolean } = vi.hoisted(() => ({ mockGetFlagBoolean: vi.fn() }));
+vi.mock("@/lib/admin/feature-flags", () => ({ getFlagBoolean: mockGetFlagBoolean }));
+
+import { proxy } from "@/proxy";
+
+function req(path: string) {
+  return new NextRequest(`http://localhost${path}`);
+}
+
+beforeEach(() => {
+  mockGetFlagBoolean.mockReset();
+});
+
+describe("proxy (maintenance mode)", () => {
+  it("passes requests through when maintenance mode is off", async () => {
+    mockGetFlagBoolean.mockResolvedValue(false);
+    const res = await proxy(req("/"));
+    expect(res.status).toBe(200);
+  });
+
+  it("serves a 503 maintenance response when maintenance mode is on", async () => {
+    mockGetFlagBoolean.mockResolvedValue(true);
+    const res = await proxy(req("/"));
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("1800");
+    expect(await res.text()).toContain("maintenance");
+  });
+
+  it("checks the maintenance_mode flag with a false default", async () => {
+    mockGetFlagBoolean.mockResolvedValue(false);
+    await proxy(req("/"));
+    expect(mockGetFlagBoolean).toHaveBeenCalledWith("maintenance_mode", false);
+  });
+});

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Button, Input } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, StateNote, ConfirmButton } from "@/components/admin/primitives";
@@ -12,6 +12,156 @@ interface Flag {
   value: unknown;
   updatedBy: string | null;
   updatedAt: string;
+}
+
+/** Purpose-built controls for the settings that runtime code actually reads —
+ *  everything else stays in the generic key/value editor below. Each control
+ *  writes through the same `PUT /flags` route as the generic editor, so
+ *  logAdminAction coverage and cache invalidation are free. */
+function OperationalSettings({ flags, reload }: { flags: Flag[]; reload: () => void }) {
+  const api = useAdminFetch();
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const byKey = new Map(flags.map((f) => [f.key, f.value]));
+  const aiProviderRaw = byKey.get("ai_provider");
+  const aiProvider = typeof aiProviderRaw === "string" ? aiProviderRaw : "";
+  const maintenanceOn = byKey.get("maintenance_mode") === true;
+
+  // Uncontrolled: each number field reads its live DOM value on save and is
+  // reset (via `key`) whenever the flag list is reloaded from the server.
+  const aiGenLimitRef = useRef<HTMLInputElement>(null);
+  const aiGenWindowRef = useRef<HTMLInputElement>(null);
+  const mutationLimitRef = useRef<HTMLInputElement>(null);
+  const mutationWindowRef = useRef<HTMLInputElement>(null);
+
+  const setFlag = async (key: string, value: unknown) => {
+    setMsg(null);
+    try {
+      await api("/flags", { method: "PUT", json: { key, value } });
+      reload();
+    } catch (e) {
+      setMsg(e instanceof AdminApiError ? e.message : "Save failed.");
+    }
+  };
+
+  const setNumberFlag = (key: string, ref: React.RefObject<HTMLInputElement | null>) => {
+    const raw = ref.current?.value ?? "";
+    const n = Number(raw);
+    if (!raw.trim() || !Number.isFinite(n) || n <= 0) {
+      setMsg("Value must be a positive number.");
+      return;
+    }
+    void setFlag(key, n);
+  };
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border bg-surface p-5">
+      <h2 className="text-sm font-medium text-text-primary">Operational settings</h2>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="space-y-1.5">
+          <span className="text-xs text-text-secondary">AI provider</span>
+          <select
+            value={aiProvider}
+            onChange={(e) => setFlag("ai_provider", e.target.value)}
+            className="h-10 w-full rounded-md border border-border bg-surface px-3 text-sm text-text-primary hover:border-border-subtle focus:border-gold-muted"
+          >
+            <option value="">Default (env: AI_PROVIDER)</option>
+            <option value="claude">Claude</option>
+            <option value="gemini">Gemini</option>
+          </select>
+        </label>
+
+        <div className="space-y-1.5">
+          <span className="block text-xs text-text-secondary">Maintenance mode</span>
+          <Button
+            variant={maintenanceOn ? "primary" : "secondary"}
+            onClick={() => setFlag("maintenance_mode", !maintenanceOn)}
+          >
+            {maintenanceOn ? "On — click to disable" : "Off — click to enable"}
+          </Button>
+        </div>
+
+        <label className="space-y-1.5">
+          <span className="text-xs text-text-secondary">AI generation limit (per window)</span>
+          <div className="flex gap-2">
+            <Input
+              key={`ai_gen_limit:${numOrEmpty(byKey.get("ai_gen_limit"))}`}
+              ref={aiGenLimitRef}
+              defaultValue={numOrEmpty(byKey.get("ai_gen_limit"))}
+              placeholder="20"
+            />
+            <Button
+              variant="secondary"
+              onClick={() => setNumberFlag("ai_gen_limit", aiGenLimitRef)}
+            >
+              Save
+            </Button>
+          </div>
+        </label>
+
+        <label className="space-y-1.5">
+          <span className="text-xs text-text-secondary">AI generation window (seconds)</span>
+          <div className="flex gap-2">
+            <Input
+              key={`ai_gen_window_seconds:${numOrEmpty(byKey.get("ai_gen_window_seconds"))}`}
+              ref={aiGenWindowRef}
+              defaultValue={numOrEmpty(byKey.get("ai_gen_window_seconds"))}
+              placeholder="60"
+            />
+            <Button
+              variant="secondary"
+              onClick={() => setNumberFlag("ai_gen_window_seconds", aiGenWindowRef)}
+            >
+              Save
+            </Button>
+          </div>
+        </label>
+
+        <label className="space-y-1.5">
+          <span className="text-xs text-text-secondary">Mutation limit (per window)</span>
+          <div className="flex gap-2">
+            <Input
+              key={`mutation_limit:${numOrEmpty(byKey.get("mutation_limit"))}`}
+              ref={mutationLimitRef}
+              defaultValue={numOrEmpty(byKey.get("mutation_limit"))}
+              placeholder="60"
+            />
+            <Button
+              variant="secondary"
+              onClick={() => setNumberFlag("mutation_limit", mutationLimitRef)}
+            >
+              Save
+            </Button>
+          </div>
+        </label>
+
+        <label className="space-y-1.5">
+          <span className="text-xs text-text-secondary">Mutation window (seconds)</span>
+          <div className="flex gap-2">
+            <Input
+              key={`mutation_window_seconds:${numOrEmpty(byKey.get("mutation_window_seconds"))}`}
+              ref={mutationWindowRef}
+              defaultValue={numOrEmpty(byKey.get("mutation_window_seconds"))}
+              placeholder="600"
+            />
+            <Button
+              variant="secondary"
+              onClick={() => setNumberFlag("mutation_window_seconds", mutationWindowRef)}
+            >
+              Save
+            </Button>
+          </div>
+        </label>
+      </div>
+
+      {msg && <span className="text-xs text-error">{msg}</span>}
+    </div>
+  );
+}
+
+function numOrEmpty(v: unknown): string {
+  return typeof v === "number" ? String(v) : "";
 }
 
 export default function FlagsPage() {
@@ -67,6 +217,8 @@ export default function FlagsPage() {
         subtitle="Runtime config read by subsystems. A missing key falls back to its code default."
       />
       <div className="space-y-6 p-7">
+        {data && <OperationalSettings flags={data.flags} reload={reload} />}
+
         <div className="space-y-3 rounded-lg border border-border bg-surface p-5">
           <div className="grid gap-3 sm:grid-cols-[200px_1fr]">
             <label className="space-y-1.5">

--- a/app/api/admin/flags/route.ts
+++ b/app/api/admin/flags/route.ts
@@ -4,6 +4,7 @@ import { requireAdmin } from "@/lib/admin/admin-auth";
 import { logAdminAction } from "@/lib/admin/admin-audit";
 import { db } from "@/lib/infra/db";
 import { featureFlags } from "@/lib/infra/db/schema";
+import { invalidateFlagCache } from "@/lib/admin/feature-flags";
 
 const KEY_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
 
@@ -59,6 +60,7 @@ export async function PUT(req: NextRequest) {
     targetId: key,
     meta: { value: body.value },
   });
+  invalidateFlagCache(key);
 
   return NextResponse.json({ key, value: body.value });
 }
@@ -80,6 +82,7 @@ export async function DELETE(req: NextRequest) {
     targetType: "flag",
     targetId: key,
   });
+  invalidateFlagCache(key);
 
   return new NextResponse(null, { status: 204 });
 }

--- a/lib/admin/feature-flags.ts
+++ b/lib/admin/feature-flags.ts
@@ -1,0 +1,66 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/infra/db";
+import { featureFlags } from "@/lib/infra/db/schema";
+
+/**
+ * Reads runtime-tunable settings from the `feature_flags` table, falling back
+ * to the caller-supplied default when no row exists — so behavior is
+ * unchanged until an admin actually sets a flag. Short-TTL cached (mirrors
+ * lib/ai/prompt-registry.ts's getPrompt) so hot paths (AI provider select,
+ * rate-limit checks) don't hit the DB on every call.
+ */
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { value: string | null; expiresAt: number }>();
+
+async function readFlag(key: string): Promise<string | null> {
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+
+  const [row] = await db.select().from(featureFlags).where(eq(featureFlags.key, key)).limit(1);
+  const value = row?.value ?? null;
+  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  return value;
+}
+
+/** Reads a string-valued flag (stored as a JSON string), or `fallback` if unset/invalid. */
+export async function getFlagString(key: string, fallback: string): Promise<string> {
+  const raw = await readFlag(key);
+  if (raw === null) return fallback;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === "string" ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Reads a number-valued flag (stored as JSON), or `fallback` if unset/invalid/non-positive. */
+export async function getFlagNumber(key: string, fallback: number): Promise<number> {
+  const raw = await readFlag(key);
+  if (raw === null) return fallback;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === "number" && Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Reads a boolean-valued flag (stored as JSON), or `fallback` if unset/invalid. */
+export async function getFlagBoolean(key: string, fallback: boolean): Promise<boolean> {
+  const raw = await readFlag(key);
+  if (raw === null) return fallback;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === "boolean" ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Drops the cached lookup for `key`, or all keys if omitted — call after writing a flag. */
+export function invalidateFlagCache(key?: string): void {
+  if (key) cache.delete(key);
+  else cache.clear();
+}

--- a/lib/ai/ai.ts
+++ b/lib/ai/ai.ts
@@ -1,15 +1,24 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { GoogleGenerativeAI } from "@google/generative-ai";
+import { getFlagString } from "@/lib/admin/feature-flags";
 
 type Provider = "claude" | "gemini";
 
-const provider = (process.env.AI_PROVIDER ?? "claude") as Provider;
+const ENV_PROVIDER = (process.env.AI_PROVIDER ?? "claude") as Provider;
+
+/** Resolves the active provider: the `ai_provider` flag if set, else AI_PROVIDER env. */
+async function resolveProvider(): Promise<Provider> {
+  const flagged = await getFlagString("ai_provider", ENV_PROVIDER);
+  return flagged === "gemini" ? "gemini" : "claude";
+}
 
 /**
  * Calls the configured LLM provider and returns the raw text response.
- * Provider is selected by AI_PROVIDER env var ("claude" | "gemini", default: "claude").
+ * Provider is selected by the `ai_provider` admin flag, falling back to the
+ * AI_PROVIDER env var ("claude" | "gemini", default: "claude") when unset.
  */
 export async function callAI(prompt: string): Promise<string> {
+  const provider = await resolveProvider();
   if (provider === "gemini") return callGemini(prompt);
   return callClaude(prompt);
 }

--- a/lib/infra/rate-limit.ts
+++ b/lib/infra/rate-limit.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/infra/db";
 import { rateLimits } from "@/lib/infra/db/schema";
 import { redisIncrWithTtl } from "@/lib/infra/redis";
 import { incr } from "@/lib/infra/metrics";
+import { getFlagNumber } from "@/lib/admin/feature-flags";
 
 /**
  * Fixed-window rate limiter. Guards the expensive AI generation path so a single
@@ -82,12 +83,25 @@ function maybeSweep(windowSeconds: number): void {
  * Records a hit for `key` and returns true if still within `limit` for the
  * current window. Fails open (returns true) if the limiter itself errors — we
  * never want a limiter outage to take down the feature.
+ *
+ * When `limit`/`windowSeconds` are omitted, they resolve from the
+ * `ai_gen_limit` / `ai_gen_window_seconds` admin flags (falling back to
+ * AI_GEN_LIMIT / AI_GEN_WINDOW_SECONDS) so an operator can tune the AI-gen
+ * budget without a redeploy. Callers that pass explicit values (routes with
+ * their own budget) are unaffected by the flags.
  */
 export async function consume(
   key: string,
-  limit: number = AI_GEN_LIMIT,
-  windowSeconds: number = AI_GEN_WINDOW_SECONDS
+  limit?: number,
+  windowSeconds?: number
 ): Promise<boolean> {
+  const resolvedLimit = limit ?? (await getFlagNumber("ai_gen_limit", AI_GEN_LIMIT));
+  const resolvedWindow =
+    windowSeconds ?? (await getFlagNumber("ai_gen_window_seconds", AI_GEN_WINDOW_SECONDS));
+  return consumeWith(key, resolvedLimit, resolvedWindow);
+}
+
+async function consumeWith(key: string, limit: number, windowSeconds: number): Promise<boolean> {
   const bucket = Math.floor(Date.now() / 1000 / windowSeconds);
   const rowKey = `${key}:${bucket}`;
 
@@ -136,13 +150,21 @@ export async function consume(
  * the limit/window pairing and the 429 envelope so future changes (Retry-After,
  * per-route metrics) are a one-file edit. Returns `null` when the request is
  * allowed, or the `NextResponse` the caller should return immediately.
+ *
+ * When `limit`/`windowSeconds` are omitted, they resolve from the
+ * `mutation_limit` / `mutation_window_seconds` admin flags (falling back to
+ * MUTATION_LIMIT / MUTATION_WINDOW_SECONDS). Callers that pass explicit
+ * values (routes with their own budget) are unaffected by the flags.
  */
 export async function rateLimitOrNull(
   key: string,
   message: string,
-  limit: number = MUTATION_LIMIT,
-  windowSeconds: number = MUTATION_WINDOW_SECONDS
+  limit?: number,
+  windowSeconds?: number
 ): Promise<NextResponse | null> {
-  const allowed = await consume(key, limit, windowSeconds);
+  const resolvedLimit = limit ?? (await getFlagNumber("mutation_limit", MUTATION_LIMIT));
+  const resolvedWindow =
+    windowSeconds ?? (await getFlagNumber("mutation_window_seconds", MUTATION_WINDOW_SECONDS));
+  const allowed = await consumeWith(key, resolvedLimit, resolvedWindow);
   return allowed ? null : NextResponse.json({ error: message }, { status: 429 });
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getFlagBoolean } from "@/lib/admin/feature-flags";
+
+/**
+ * Maintenance mode, gated by the `maintenance_mode` admin flag. Runs on every
+ * matched request (Proxy defaults to the Node.js runtime, so the DB-backed
+ * flag read is safe here — see lib/admin/feature-flags.ts for its short-TTL
+ * cache). The matcher below already excludes the admin surface, auth, and
+ * health/metrics endpoints so an operator can always reach the flag to turn
+ * maintenance back off.
+ */
+export async function proxy(_request: NextRequest): Promise<NextResponse> {
+  const maintenance = await getFlagBoolean("maintenance_mode", false);
+  if (!maintenance) return NextResponse.next();
+
+  return new NextResponse(MAINTENANCE_HTML, {
+    status: 503,
+    headers: { "Content-Type": "text/html; charset=utf-8", "Retry-After": "1800" },
+  });
+}
+
+const MAINTENANCE_HTML = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Open Hikmah — Maintenance</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"></head>
+<body style="font-family: system-ui, sans-serif; display: flex; min-height: 100vh; align-items: center; justify-content: center; margin: 0; background: #0f1115; color: #e8e6df;">
+  <div style="text-align: center; padding: 2rem;">
+    <h1 style="font-size: 1.25rem; font-weight: 600;">Down for maintenance</h1>
+    <p style="color: #9a9890;">We'll be back shortly. Thanks for your patience.</p>
+  </div>
+</body>
+</html>`;
+
+export const config = {
+  matcher: [
+    "/((?!admin|api/admin|api/auth|api/health|api/metrics|api/csp-report|_next/static|_next/image|favicon.ico).*)",
+  ],
+};


### PR DESCRIPTION
## Summary

Fixes #113

The `feature_flags` table and its generic admin CRUD UI/API already existed, but nothing in the app actually read from it. This wires three specific runtime settings to it, plus adds purpose-built controls for them:

- **AI provider** (`ai_provider` flag): `lib/ai/ai.ts`'s `callAI()` now resolves the provider via `getFlagString("ai_provider", envDefault)` on each call, falling back to the `AI_PROVIDER` env var when unset.
- **Rate limits** (`ai_gen_limit`, `ai_gen_window_seconds`, `mutation_limit`, `mutation_window_seconds`): `consume()`/`rateLimitOrNull()` in `lib/infra/rate-limit.ts` now resolve their limit/window from these flags *only when the caller omits them*, falling back to the existing env constants. Routes that pass explicit values (e.g. `social/activity`'s custom per-route budget) are unaffected.
- **Maintenance mode** (`maintenance_mode` flag): new `proxy.ts` serves a 503 for all traffic except `/admin`, `/api/admin`, `/api/auth`, `/api/health`, `/api/metrics`, and `/api/csp-report`, so an operator can always reach the flag to turn it back off. Named `proxy.ts` rather than `middleware.ts` — this project's Next.js version deprecated and renamed the `middleware` file convention to `proxy` (confirmed via `node_modules/next/dist/docs/.../proxy.md`).

All three read through a new short-TTL cached helper, `lib/admin/feature-flags.ts` (`getFlagString`/`getFlagNumber`/`getFlagBoolean`), mirroring the caching pattern already used by `lib/ai/prompt-registry.ts`. `PUT`/`DELETE /api/admin/flags` now call `invalidateFlagCache()` so a write takes effect on the next request rather than waiting out the TTL.

Also adds an "Operational settings" section to `app/admin/flags/page.tsx` (AI provider dropdown, four rate-limit number fields, maintenance-mode toggle) above the existing generic key/value editor — all writing through the same `PUT /api/admin/flags` route, so `logAdminAction` coverage is free.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (0 errors; pre-existing unrelated warnings only)
- [x] `bun run test:ci` — full suite passes, including new tests for `lib/admin/feature-flags.ts`, `proxy.ts`, and the flag-aware defaults in `lib/infra/rate-limit.ts`
- [x] Pre-push Testcontainers integration suite passed
- [ ] Manual smoke test recommended before merge: toggle `maintenance_mode` on via the admin UI and confirm a non-admin route 503s while `/admin` stays reachable, then toggle it back off — I wasn't able to run the dev server against a live Postgres instance in this environment to verify end-to-end.