### PR TITLE
fix(deps): switch dependabot ecosystem from npm to bun

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- The repo uses bun (`packageManager: bun@1`, `bun.lock`), but `.github/dependabot.yml` used `package-ecosystem: "npm"`, which only bumps `package.json` and never touches `bun.lock`.
- CI runs `bun install --frozen-lockfile`, which fails whenever the lockfile is out of sync — meaning every npm-ecosystem Dependabot PR was guaranteed to fail CI regardless of the dependency bumped.
- Confirmed against all 5 currently open npm-ecosystem PRs (#199, #202, #203, #204, #205): all fail identically with `error: lockfile had changes, but lockfile is frozen`. The 5 github-actions-ecosystem PRs are unaffected.
- Switching to `package-ecosystem: "bun"` lets Dependabot update `bun.lock` alongside `package.json` in the same PR.

## Test plan
- [ ] Merge this PR
- [ ] Close the now-stale npm-ecosystem PRs (#199, #202, #203, #204, #205) — tracked separately
- [ ] Confirm the next Dependabot run produces PRs that update both `package.json` and `bun.lock`, and that CI passes