### PR TITLE
feat(admin): job-runner UI for corpus/morphology/embedding backfills

### DIFF
--- a/__tests__/api/admin/jobs.test.ts
+++ b/__tests__/api/admin/jobs.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/infra/db/schema";
+
+vi.mock("@/lib/admin/admin-auth", () => ({
+  requireAdmin: vi.fn(),
+  rateLimitAdminMutation: vi.fn(() => null),
+}));
+vi.mock("@/lib/admin/admin-audit", () => ({ logAdminAction: vi.fn() }));
+
+const { mockGetJobsStatus, mockEmbedCoverage, mockStartJob } = vi.hoisted(() => ({
+  mockGetJobsStatus: vi.fn<() => Promise<unknown[]>>(() => Promise.resolve([])),
+  mockEmbedCoverage: vi.fn(() => Promise.resolve({ embedded: 0, total: 0 })),
+  mockStartJob: vi.fn(() => Promise.resolve({ runId: 1 })),
+}));
+vi.mock("@/lib/admin/job-runner", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/admin/job-runner")>("@/lib/admin/job-runner");
+  return {
+    JOBS: actual.JOBS,
+    getJobsStatus: mockGetJobsStatus,
+    embedCoverage: mockEmbedCoverage,
+    startJob: mockStartJob,
+  };
+});
+
+import { GET, POST } from "@/app/api/admin/jobs/route";
+import { requireAdmin } from "@/lib/admin/admin-auth";
+import { logAdminAction } from "@/lib/admin/admin-audit";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function get() {
+  return new NextRequest("http://localhost/api/admin/jobs", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+function post(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/jobs", {
+    method: "POST",
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockGetJobsStatus.mockClear().mockResolvedValue([]);
+  mockEmbedCoverage.mockClear().mockResolvedValue({ embedded: 0, total: 0 });
+  mockStartJob.mockClear().mockResolvedValue({ runId: 1 });
+  vi.mocked(logAdminAction).mockClear();
+});
+
+describe("GET /api/admin/jobs", () => {
+  it("returns the guard's own response for a non-admin caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(get());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns job statuses and embedding coverage", async () => {
+    mockGetJobsStatus.mockResolvedValue([
+      {
+        id: "seed-quran",
+        label: "Seed Quran corpus",
+        status: "never-run",
+        startedAt: null,
+        completedAt: null,
+        error: null,
+        logTail: null,
+      },
+    ]);
+    mockEmbedCoverage.mockResolvedValue({ embedded: 6000, total: 6236 });
+
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobs).toHaveLength(1);
+    expect(body.embedCoverage).toEqual({ embedded: 6000, total: 6236 });
+  });
+});
+
+describe("POST /api/admin/jobs", () => {
+  it("returns 400 for a malformed body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/jobs", {
+      method: "POST",
+      headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await POST(req)).status).toBe(400);
+  });
+
+  it("returns 400 for an unknown job id", async () => {
+    const res = await POST(post({ jobId: "bogus" }));
+    expect(res.status).toBe(400);
+    expect(mockStartJob).not.toHaveBeenCalled();
+  });
+
+  it("starts a valid job and logs the action", async () => {
+    const res = await POST(post({ jobId: "seed-morphology" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.runId).toBe(1);
+    expect(mockStartJob).toHaveBeenCalledWith("seed-morphology", "qf-admin");
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "job.start", targetId: "seed-morphology" })
+    );
+  });
+
+  it("returns 400 (not 500) when startJob rejects, e.g. a job already running", async () => {
+    mockStartJob.mockRejectedValue(new Error('Job "seed-quran" is already running'));
+    const res = await POST(post({ jobId: "seed-quran" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/already running/);
+  });
+});

--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+function makeDbChain(resolveWith: unknown) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockInsert, mockSelect, mockUpdate } = vi.hoisted(() => ({
+  mockInsert: vi.fn(),
+  mockSelect: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+vi.mock("@/lib/infra/db", () => ({
+  db: { insert: mockInsert, select: mockSelect, update: mockUpdate },
+}));
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+}
+
+const { mockSpawn, lastChild } = vi.hoisted(() => ({
+  mockSpawn: vi.fn(),
+  lastChild: { current: null as FakeChildProcess | null },
+}));
+vi.mock("node:child_process", () => ({
+  spawn: mockSpawn,
+  default: { spawn: mockSpawn },
+}));
+
+import { startJob, embedCoverage, JOBS } from "@/lib/admin/job-runner";
+
+beforeEach(() => {
+  mockInsert.mockReset().mockReturnValue(makeDbChain([{ id: 42 }]));
+  mockSelect.mockReset().mockReturnValue(makeDbChain([{ total: 0 }]));
+  mockUpdate.mockReset().mockReturnValue(makeDbChain([]));
+  mockSpawn.mockReset().mockImplementation(() => {
+    const child = new FakeChildProcess();
+    lastChild.current = child;
+    return child;
+  });
+});
+
+// `running` is module-level state in job-runner.ts (by design — it's the
+// in-process "is a job running right now" guard). Close out whatever the test
+// started so the guard doesn't leak into the next test.
+afterEach(() => {
+  lastChild.current?.emit("close", 0);
+});
+
+describe("startJob", () => {
+  it("rejects an unknown job id", async () => {
+    await expect(startJob("bogus", "qf-admin")).rejects.toThrow("Unknown job");
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it("rejects embed-corpus when GEMINI_API_KEY is missing", async () => {
+    const prev = process.env.GEMINI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    try {
+      await expect(startJob("embed-corpus", "qf-admin")).rejects.toThrow("GEMINI_API_KEY");
+      expect(mockSpawn).not.toHaveBeenCalled();
+    } finally {
+      if (prev !== undefined) process.env.GEMINI_API_KEY = prev;
+    }
+  });
+
+  it("spawns the job's script via bun and records a running job_runs row", async () => {
+    const { runId } = await startJob("seed-morphology", "qf-admin");
+    expect(runId).toBe(42);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "bun",
+      ["scripts/seed-morphology.mjs"],
+      expect.objectContaining({ cwd: process.cwd() })
+    );
+    expect(mockInsert).toHaveBeenCalled();
+  });
+
+  it("rejects starting a second job while one is already running", async () => {
+    await startJob("seed-morphology", "qf-admin");
+    await expect(startJob("seed-quran", "qf-admin")).rejects.toThrow("already running");
+  });
+
+  it("clears the running guard once the child process closes", async () => {
+    await startJob("seed-morphology", "qf-admin");
+    lastChild.current?.emit("close", 0);
+    // Flush the microtask queue so the close handler's async db.update resolves.
+    await Promise.resolve();
+    await Promise.resolve();
+    const { runId } = await startJob("seed-quran", "qf-admin");
+    expect(runId).toBe(42);
+  });
+});
+
+describe("JOBS", () => {
+  it("registers exactly the three backfill scripts from issue #114", () => {
+    expect(JOBS.map((j) => j.id)).toEqual(["seed-quran", "seed-morphology", "embed-corpus"]);
+  });
+});
+
+describe("embedCoverage", () => {
+  it("returns embedded/total counts from the verses and verse_embeddings tables", async () => {
+    mockSelect
+      .mockReturnValueOnce(makeDbChain([{ total: 6236 }]))
+      .mockReturnValueOnce(makeDbChain([{ embedded: 6000 }]));
+    const coverage = await embedCoverage();
+    expect(coverage).toEqual({ embedded: 6000, total: 6236 });
+  });
+});

--- a/app/admin/jobs/page.tsx
+++ b/app/admin/jobs/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { AdminPageHeader } from "@/components/admin/AdminShell";
+import { JobRunner } from "@/components/admin/JobRunner";
+
+export default function JobsPage() {
+  return (
+    <>
+      <AdminPageHeader
+        title="Jobs"
+        subtitle="Trigger and monitor the corpus seed, morphology seed, and embedding backfills."
+      />
+      <div className="p-7">
+        <JobRunner />
+      </div>
+    </>
+  );
+}

--- a/app/api/admin/jobs/route.ts
+++ b/app/api/admin/jobs/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin, rateLimitAdminMutation } from "@/lib/admin/admin-auth";
+import { logAdminAction } from "@/lib/admin/admin-audit";
+import { JOBS, getJobsStatus, embedCoverage, startJob } from "@/lib/admin/job-runner";
+
+/** Job list + latest run status, plus the embedding-coverage check. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const [jobs, coverage] = await Promise.all([getJobsStatus(), embedCoverage()]);
+    return NextResponse.json({ jobs, embedCoverage: coverage });
+  } catch (err) {
+    console.error("admin jobs GET error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+/** Trigger a backfill job: body `{ jobId }`. */
+export async function POST(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+  const limited = await rateLimitAdminMutation(auth);
+  if (limited) return limited;
+
+  let body: { jobId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const jobId = body.jobId;
+  if (!jobId || !JOBS.some((j) => j.id === jobId)) {
+    return NextResponse.json({ error: "Unknown job" }, { status: 400 });
+  }
+
+  try {
+    const { runId } = await startJob(jobId, auth.user.qfId);
+    await logAdminAction({
+      adminQfId: auth.user.qfId,
+      action: "job.start",
+      targetType: "job",
+      targetId: jobId,
+      meta: { runId },
+    });
+    return NextResponse.json({ runId });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to start job";
+    // Already-running / missing-env are expected client errors, not server faults.
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -16,6 +16,7 @@ import {
   ScrollText,
   MessageSquareText,
   BarChart3,
+  PlayCircle,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -41,6 +42,7 @@ const NAV: NavItem[] = [
   { href: "/admin/flags", label: "Feature Flags", icon: Flag },
   { href: "/admin/names", label: "Names Content", icon: BookOpen },
   { href: "/admin/infra", label: "Infra", icon: Server },
+  { href: "/admin/jobs", label: "Jobs", icon: PlayCircle },
   { href: "/admin/audit", label: "Audit Log", icon: ScrollText },
 ];
 

--- a/components/admin/JobRunner.tsx
+++ b/components/admin/JobRunner.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
+import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
+
+interface JobStatus {
+  id: "seed-quran" | "seed-morphology" | "embed-corpus";
+  label: string;
+  status: "never-run" | "running" | "success" | "failed";
+  startedAt: string | null;
+  completedAt: string | null;
+  error: string | null;
+  logTail: string | null;
+}
+
+interface JobsResponse {
+  jobs: JobStatus[];
+  embedCoverage: { embedded: number; total: number };
+}
+
+const statusTone = (s: JobStatus["status"]) =>
+  s === "running" ? "flagged" : s === "success" ? "active" : s === "failed" ? "retired" : "neutral";
+
+export function JobRunner() {
+  const api = useAdminFetch();
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const { data, error, loading, reload } = useAsync<JobsResponse>(() => api("/jobs"), "admin-jobs");
+
+  // Poll while any job is running, so status/log-tail reflects progress
+  // without a manual reload — but only while there's something to watch.
+  const anyRunning = data?.jobs.some((j) => j.status === "running") ?? false;
+  useEffect(() => {
+    if (!anyRunning) return;
+    const id = setInterval(reload, 4000);
+    return () => clearInterval(id);
+  }, [anyRunning, reload]);
+
+  const run = async (jobId: JobStatus["id"]) => {
+    setActionError(null);
+    setBusyId(jobId);
+    try {
+      await api("/jobs", { method: "POST", json: { jobId } });
+      reload();
+    } catch (e) {
+      setActionError(e instanceof AdminApiError ? e.message : "Failed to start job.");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {error && <StateNote tone="error">{error}</StateNote>}
+      {actionError && <StateNote tone="error">{actionError}</StateNote>}
+      {loading && <StateNote>Loading…</StateNote>}
+
+      {data && (
+        <Table>
+          <thead>
+            <tr>
+              <Th>Job</Th>
+              <Th>Status</Th>
+              <Th>Last run</Th>
+              <Th>Detail</Th>
+              <Th className="text-right">Actions</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.jobs.map((job) => (
+              <tr key={job.id}>
+                <Td className="text-sm text-text-primary">{job.label}</Td>
+                <Td>
+                  <Pill tone={statusTone(job.status)}>{job.status.replace("-", " ")}</Pill>
+                </Td>
+                <Td className="whitespace-nowrap text-xs text-text-muted">
+                  {job.startedAt ? new Date(job.startedAt).toLocaleString() : "—"}
+                </Td>
+                <Td className="max-w-sm">
+                  {job.id === "embed-corpus" && (
+                    <div className="text-xs text-text-secondary">
+                      {data.embedCoverage.embedded}/{data.embedCoverage.total} verses embedded
+                    </div>
+                  )}
+                  {job.error && <div className="text-xs text-error">{job.error}</div>}
+                  {job.logTail && (
+                    <pre className="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap break-all font-mono text-[10px] text-text-muted">
+                      {job.logTail}
+                    </pre>
+                  )}
+                </Td>
+                <Td>
+                  <div className="flex justify-end">
+                    <ConfirmButton
+                      variant="secondary"
+                      disabled={busyId === job.id || job.status === "running"}
+                      onConfirm={() => run(job.id)}
+                      confirmLabel="Run now?"
+                    >
+                      Run
+                    </ConfirmButton>
+                  </div>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/lib/admin/job-runner.ts
+++ b/lib/admin/job-runner.ts
@@ -1,0 +1,178 @@
+import { spawn } from "node:child_process";
+import { desc, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/infra/db";
+import { jobRuns, verses, verseEmbeddings } from "@/lib/infra/db/schema";
+
+/**
+ * Triggers and tracks the project's one-time/resumable backfill scripts
+ * (scripts/seed-quran.mjs, scripts/seed-morphology.mjs, scripts/embed-corpus.mjs)
+ * from the admin panel instead of a container shell. Deliberately simple for a
+ * single-box deployment: one job runs at a time, tracked by an in-memory child
+ * process reference in this module (the source of truth for "is a job running
+ * right now") backed by a `job_runs` DB row per invocation (the source of truth
+ * for history/last-run status, so it survives a server restart).
+ */
+
+export interface JobDefinition {
+  id: "seed-quran" | "seed-morphology" | "embed-corpus";
+  label: string;
+  script: string;
+  requiresEnv?: string[];
+}
+
+export const JOBS: readonly JobDefinition[] = [
+  { id: "seed-quran", label: "Seed Quran corpus", script: "scripts/seed-quran.mjs" },
+  {
+    id: "seed-morphology",
+    label: "Seed word morphology",
+    script: "scripts/seed-morphology.mjs",
+  },
+  {
+    id: "embed-corpus",
+    label: "Generate verse embeddings",
+    script: "scripts/embed-corpus.mjs",
+    requiresEnv: ["GEMINI_API_KEY"],
+  },
+] as const;
+
+const LOG_TAIL_LINES = 50;
+
+interface RunningJob {
+  jobId: JobDefinition["id"];
+  runId: number;
+  logTail: string[];
+}
+
+// Module-level, so it survives across requests within this `next start`
+// process but not across restarts (the DB row is what persists that).
+let running: RunningJob | null = null;
+
+export function currentlyRunningJobId(): JobDefinition["id"] | null {
+  return running?.jobId ?? null;
+}
+
+function pushLogLine(job: RunningJob, line: string) {
+  job.logTail.push(line);
+  if (job.logTail.length > LOG_TAIL_LINES) job.logTail.shift();
+}
+
+/** Starts a job if none is currently running. Throws on bad input or an
+ *  already-running job — routes should catch and translate to a 400/409. */
+export async function startJob(jobId: string, adminQfId: string): Promise<{ runId: number }> {
+  const job = JOBS.find((j) => j.id === jobId);
+  if (!job) throw new Error("Unknown job");
+  if (running) throw new Error(`Job "${running.jobId}" is already running`);
+
+  const missingEnv = (job.requiresEnv ?? []).filter((name) => !process.env[name]);
+  if (missingEnv.length > 0) {
+    throw new Error(`Missing required env var(s): ${missingEnv.join(", ")}`);
+  }
+
+  const [row] = await db
+    .insert(jobRuns)
+    .values({ jobType: job.id, status: "running", triggeredBy: adminQfId })
+    .returning({ id: jobRuns.id });
+
+  const state: RunningJob = { jobId: job.id, runId: row.id, logTail: [] };
+  running = state;
+
+  const child = spawn("bun", [job.script], { cwd: process.cwd(), env: process.env });
+
+  const onData = (chunk: Buffer) => {
+    for (const line of chunk.toString("utf8").split("\n")) {
+      if (line.trim()) pushLogLine(state, line);
+    }
+  };
+  child.stdout.on("data", onData);
+  child.stderr.on("data", onData);
+
+  child.on("close", (code) => {
+    void db
+      .update(jobRuns)
+      .set({
+        status: code === 0 ? "success" : "failed",
+        completedAt: new Date(),
+        error: code === 0 ? null : `Exited with code ${code}`,
+        logTail: state.logTail.join("\n"),
+      })
+      .where(eq(jobRuns.id, state.runId))
+      .catch((err) => console.error("job-runner: failed to record job completion", err));
+    if (running?.runId === state.runId) running = null;
+  });
+
+  child.on("error", (err) => {
+    void db
+      .update(jobRuns)
+      .set({
+        status: "failed",
+        completedAt: new Date(),
+        error: err.message,
+        logTail: state.logTail.join("\n"),
+      })
+      .where(eq(jobRuns.id, state.runId))
+      .catch((e) => console.error("job-runner: failed to record job spawn error", e));
+    if (running?.runId === state.runId) running = null;
+  });
+
+  return { runId: row.id };
+}
+
+export interface JobStatus {
+  id: JobDefinition["id"];
+  label: string;
+  status: "never-run" | "running" | "success" | "failed";
+  startedAt: string | null;
+  completedAt: string | null;
+  error: string | null;
+  logTail: string | null;
+}
+
+/** Latest run per registered job, merged with the live log tail if it's the
+ *  one currently in flight. */
+export async function getJobsStatus(): Promise<JobStatus[]> {
+  return Promise.all(
+    JOBS.map(async (job): Promise<JobStatus> => {
+      const [latest] = await db
+        .select()
+        .from(jobRuns)
+        .where(eq(jobRuns.jobType, job.id))
+        .orderBy(desc(jobRuns.startedAt))
+        .limit(1);
+
+      const live = running?.jobId === job.id ? running : null;
+
+      if (!latest) {
+        return {
+          id: job.id,
+          label: job.label,
+          status: "never-run",
+          startedAt: null,
+          completedAt: null,
+          error: null,
+          logTail: live ? live.logTail.join("\n") : null,
+        };
+      }
+
+      return {
+        id: job.id,
+        label: job.label,
+        status: latest.status as JobStatus["status"],
+        startedAt: latest.startedAt.toISOString(),
+        completedAt: latest.completedAt?.toISOString() ?? null,
+        error: latest.error,
+        logTail: live ? live.logTail.join("\n") : latest.logTail,
+      };
+    })
+  );
+}
+
+/** Live coverage check: how many verses have an embedding vs. the full corpus —
+ *  the "verify embeddings cover all 6,236 verses" check from issue #114,
+ *  surfaced directly in the panel instead of a manual DB query. */
+export async function embedCoverage(): Promise<{ embedded: number; total: number }> {
+  const [{ total }] = await db.select({ total: sql<number>`count(*)::int` }).from(verses);
+  const [{ embedded }] = await db
+    .select({ embedded: sql<number>`count(*)::int` })
+    .from(verseEmbeddings);
+  return { embedded, total };
+}

--- a/lib/infra/db/migrations/0016_milky_blindfold.sql
+++ b/lib/infra/db/migrations/0016_milky_blindfold.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "job_runs" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"job_type" text NOT NULL,
+	"status" text NOT NULL,
+	"triggered_by" text NOT NULL,
+	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"completed_at" timestamp with time zone,
+	"error" text,
+	"log_tail" text
+);
+--> statement-breakpoint
+CREATE INDEX "job_runs_type_started_idx" ON "job_runs" USING btree ("job_type","started_at");

--- a/lib/infra/db/migrations/meta/0016_snapshot.json
+++ b/lib/infra/db/migrations/meta/0016_snapshot.json
@@ -1,0 +1,2000 @@
+{
+  "id": "f702c443-f473-46d1-89c2-31cb70d674fe",
+  "prevId": "842ba325-b45b-4f62-bb03-34246448d94d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_date": {
+          "name": "activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_date_idx": {
+          "name": "activity_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_type_date_idx": {
+          "name": "activity_user_type_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_user_id_users_id_fk": {
+          "name": "activity_log_user_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_qf_id": {
+          "name": "admin_qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_created_idx": {
+          "name": "admin_audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_generations": {
+      "name": "ai_generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_generations_created_idx": {
+          "name": "ai_generations_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_idx": {
+          "name": "bookmarks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookmarks_user_ref_uniq": {
+          "name": "bookmarks_user_ref_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "verse_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_suggestions": {
+      "name": "challenge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_duration": {
+          "name": "suggested_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_suggestions_active_idx": {
+          "name": "challenge_suggestions_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenger_id": {
+          "name": "challenger_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenged_id": {
+          "name": "challenged_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_challenger_status_idx": {
+          "name": "challenges_challenger_status_idx",
+          "columns": [
+            {
+              "expression": "challenger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_challenged_status_idx": {
+          "name": "challenges_challenged_status_idx",
+          "columns": [
+            {
+              "expression": "challenged_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_ends_at_idx": {
+          "name": "challenges_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_suggestion_id_idx": {
+          "name": "challenges_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_challenger_id_users_id_fk": {
+          "name": "challenges_challenger_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_challenged_id_users_id_fk": {
+          "name": "challenges_challenged_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenged_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_suggestion_id_challenge_suggestions_id_fk": {
+          "name": "challenges_suggestion_id_challenge_suggestions_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "challenge_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "challenges_winner_id_users_id_fk": {
+          "name": "challenges_winner_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_challenge": {
+          "name": "no_self_challenge",
+          "value": "\"challenges\".\"challenger_id\" != \"challenges\".\"challenged_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_ref": {
+          "name": "to_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_from_to_kind_idx": {
+          "name": "connections_from_to_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_from_kind_idx": {
+          "name": "connections_from_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_reviewed_at_idx": {
+          "name": "connections_reviewed_at_idx",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_votd": {
+      "name": "curated_votd",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "friendships_pair_idx": {
+          "name": "friendships_pair_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_addressee_status_idx": {
+          "name": "friendships_addressee_status_idx",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_requester_status_idx": {
+          "name": "friendships_requester_status_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_requester_id_users_id_fk": {
+          "name": "friendships_requester_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_addressee_id_users_id_fk": {
+          "name": "friendships_addressee_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_friendship": {
+          "name": "no_self_friendship",
+          "value": "\"friendships\".\"requester_id\" != \"friendships\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_runs": {
+      "name": "job_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_tail": {
+          "name": "log_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_runs_type_started_idx": {
+          "name": "job_runs_type_started_idx",
+          "columns": [
+            {
+              "expression": "job_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.name_content": {
+      "name": "name_content",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "name_content_slug_kind_pk": {
+          "name": "name_content_slug_kind_pk",
+          "columns": [
+            "slug",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_versions": {
+      "name": "prompt_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "prompt_versions_key_idx": {
+          "name": "prompt_versions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_key_active_idx": {
+          "name": "prompt_versions_key_active_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_one_active_per_key_uidx": {
+          "name": "prompt_versions_one_active_per_key_uidx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_versions\".\"active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_workspaces": {
+      "name": "saved_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_workspaces_user_idx": {
+          "name": "saved_workspaces_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_workspaces_user_id_users_id_fk": {
+          "name": "saved_workspaces_user_id_users_id_fk",
+          "tableFrom": "saved_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_log": {
+      "name": "search_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zero_result": {
+          "name": "zero_result",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "search_log_created_idx": {
+          "name": "search_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_log_zero_result_idx": {
+          "name": "search_log_zero_result_idx",
+          "columns": [
+            {
+              "expression": "zero_result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_canvases": {
+      "name": "shared_canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qf_id": {
+          "name": "qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_qf_id_idx": {
+          "name": "users_qf_id_idx",
+          "columns": [
+            {
+              "expression": "qf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_active_idx": {
+          "name": "users_last_active_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_qf_id_unique": {
+          "name": "users_qf_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qf_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_embeddings": {
+      "name": "verse_embeddings",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_embeddings_hnsw_idx": {
+          "name": "verse_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_notes": {
+      "name": "verse_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_notes_user_ref_idx": {
+          "name": "verse_notes_user_ref_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_notes_user_id_users_id_fk": {
+          "name": "verse_notes_user_id_users_id_fk",
+          "tableFrom": "verse_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verses": {
+      "name": "verses",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "surah": {
+          "name": "surah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ayah": {
+          "name": "ayah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arabic_text": {
+          "name": "arabic_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transliteration": {
+          "name": "transliteration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verses_surah_ayah_idx": {
+          "name": "verses_surah_ayah_idx",
+          "columns": [
+            {
+              "expression": "surah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ayah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_morphology": {
+      "name": "word_morphology",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "word_morphology_ref_pos_idx": {
+          "name": "word_morphology_ref_pos_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_ref_idx": {
+          "name": "word_morphology_ref_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_root_idx": {
+          "name": "word_morphology_root_idx",
+          "columns": [
+            {
+              "expression": "root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/infra/db/migrations/meta/_journal.json
+++ b/lib/infra/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1783762328545,
       "tag": "0015_prompt_versions_unique_active",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1783794642875,
+      "tag": "0016_milky_blindfold",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/infra/db/schema.ts
+++ b/lib/infra/db/schema.ts
@@ -457,6 +457,31 @@ export const featureFlags = pgTable("feature_flags", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
+// ─── Job Runs ──────────────────────────────────────────────────────────────────
+// One row per admin-triggered run of a backfill script (scripts/seed-quran.mjs,
+// scripts/seed-morphology.mjs, scripts/embed-corpus.mjs), so the admin jobs panel
+// can show last-run status without tailing container logs. Written by
+// lib/admin/job-runner.ts, which is also the in-memory source of truth for
+// whether a job is *currently* running (this table only durably records the
+// outcome of runs that have started or finished).
+
+export const jobRuns = pgTable(
+  "job_runs",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    // 'seed-quran' | 'seed-morphology' | 'embed-corpus'
+    jobType: text("job_type").notNull(),
+    // 'running' | 'success' | 'failed'
+    status: text("status").notNull(),
+    triggeredBy: text("triggered_by").notNull(), // admin qfId
+    startedAt: timestamp("started_at", { withTimezone: true }).notNull().defaultNow(),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    error: text("error"),
+    logTail: text("log_tail"), // last ~50 lines of stdout/stderr, newline-joined
+  },
+  (t) => [index("job_runs_type_started_idx").on(t.jobType, t.startedAt)]
+);
+
 // ─── Exported types ───────────────────────────────────────────────────────────
 
 export type User = typeof users.$inferSelect;
@@ -498,3 +523,5 @@ export type PromptVersion = typeof promptVersions.$inferSelect;
 export type NewPromptVersion = typeof promptVersions.$inferInsert;
 export type SearchLogEntry = typeof searchLog.$inferSelect;
 export type NewSearchLogEntry = typeof searchLog.$inferInsert;
+export type JobRun = typeof jobRuns.$inferSelect;
+export type NewJobRun = typeof jobRuns.$inferInsert;


### PR DESCRIPTION
## Summary
- Closes #114: adds a `/admin/jobs` panel to trigger and monitor the corpus seed, morphology seed, and embedding backfill scripts instead of running them from a container shell.
- New `job_runs` table records status/error/log-tail per run; a module-level in-memory guard (`lib/admin/job-runner.ts`) ensures only one job runs at a time on this single-box deployment, per the issue's own reasoning against standing up a job queue.
- `GET /api/admin/jobs` returns last-run status per job plus a live "N/6236 verses embedded" coverage check; `POST /api/admin/jobs` triggers a job (rejecting with a clear 400 if it's already running or a required env var like `GEMINI_API_KEY` is missing).
- UI follows the existing admin patterns: `ConfirmButton` + busy-guard for the Run action, polling only while a job is in flight.

Branched off `fix/admin-panel-audit` (not yet merged/PR'd) since it already contains `rateLimitAdminMutation` and the confirm/busy-guard retrofit this feature reuses.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test:ci` (586 tests passing, including new `__tests__/lib/admin/job-runner.test.ts` and `__tests__/api/admin/jobs.test.ts`)
- [x] `bunx drizzle-kit generate` produced a clean `0016_milky_blindfold.sql` migration
- [ ] Manual: trigger `seed-morphology` from the admin UI against a real DB and confirm status transitions running → success with log tail populated, and a second trigger while running is rejected