### PR TITLE
fix: cache OG image responses instead of regenerating on every request

### DIFF
--- a/app/api/share/[id]/opengraph-image.tsx
+++ b/app/api/share/[id]/opengraph-image.tsx
@@ -11,6 +11,12 @@ export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 export const dynamic = "force-dynamic";
 
+// A canvas's shared data never changes once inserted, so a hit can be cached
+// forever; a miss/error is cached briefly in case the row appears shortly
+// after (e.g. replication lag) rather than being stuck for a year.
+const HIT_CACHE = { "Cache-Control": "public, immutable, no-transform, max-age=31536000" };
+const MISS_CACHE = { "Cache-Control": "public, max-age=300" };
+
 export default async function Image({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
 
@@ -20,7 +26,7 @@ export default async function Image({ params }: { params: Promise<{ id: string }
         eyebrow: "Open Hikmah",
         body: "Explore the Qur'an as a connected graph.",
       }),
-      { ...OG_SIZE }
+      { ...OG_SIZE, headers: MISS_CACHE }
     );
 
   if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(id)) {
@@ -56,6 +62,6 @@ export default async function Image({ params }: { params: Promise<{ id: string }
       title: first.verse.surahName,
       body: clampBody(first.verse.translation),
     }),
-    { ...OG_SIZE }
+    { ...OG_SIZE, headers: HIT_CACHE }
   );
 }

--- a/app/today/opengraph-image.tsx
+++ b/app/today/opengraph-image.tsx
@@ -11,6 +11,12 @@ export const contentType = OG_CONTENT_TYPE;
 export const dynamic = "force-dynamic";
 
 // Runs in the Node runtime (default) so the verse DB read works.
+//
+// The verse only changes once per UTC day, so the response is cached at the
+// edge for an hour (and served stale for up to a day while revalidating)
+// instead of hitting the DB on every crawler/browser fetch.
+const CACHE_HEADERS = { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" };
+
 export default async function Image() {
   const verse = await getVerseOfDay().catch(() => null);
 
@@ -21,7 +27,7 @@ export default async function Image() {
         body: "Explore the Qur'an as a connected graph.",
         footer: "openhikmah.com",
       }),
-      { ...size }
+      { ...size, headers: CACHE_HEADERS }
     );
   }
 
@@ -32,6 +38,6 @@ export default async function Image() {
       title: verse.surahName,
       body: clampBody(verse.translation),
     }),
-    { ...size }
+    { ...size, headers: CACHE_HEADERS }
   );
 }


### PR DESCRIPTION
## Summary
- Fixes #223 — shared canvas and verse-of-day Open Graph images were `force-dynamic` with no `Cache-Control` header, so every crawler fetch (X, Slack, Discord, etc.) re-ran a Postgres query and Satori render from scratch, causing slow or intermittently broken previews on X.
- Adds explicit `Cache-Control` headers via `ImageResponse`'s `headers` option:
  - `/api/share/[id]/opengraph-image`: `public, immutable, no-transform, max-age=31536000` on a hit (share data never changes once created), `public, max-age=300` on a miss/fallback.
  - `/today/opengraph-image`: `public, s-maxage=3600, stale-while-revalidate=86400` (verse of the day only changes once per UTC day).
- No runtime/driver changes — `lib/infra/db.ts` uses the TCP `postgres-js` driver, which isn't Edge-compatible, so moving these routes to `runtime = "edge"` is out of scope here.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npx eslint` on both changed files passes clean
- [ ] Manually verify `Cache-Control` header is present via `curl -I` on both hit and miss paths for `/api/share/[id]/opengraph-image` and `/today/opengraph-image`
- [ ] Re-share a canvas link on X and confirm the preview image loads