### PR TITLE
fix: paginate leaderboard/friends endpoints instead of hardcoded limit(500)

### DIFF
--- a/__tests__/api/social/friends.test.ts
+++ b/__tests__/api/social/friends.test.ts
@@ -108,14 +108,53 @@ describe("GET /api/social/friends", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns empty array when user has no friends", async () => {
+  it("returns { items: [], hasMore: false } when user has no friends", async () => {
     authedAs(makeUser());
     mockSelect.mockReturnValue(makeDbChain([]));
     const res = await GET(makeGetReq());
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(Array.isArray(body)).toBe(true);
-    expect(body).toHaveLength(0);
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.items).toHaveLength(0);
+    expect(body.hasMore).toBe(false);
+  });
+
+  it("paginates via limit/offset and reports hasMore", async () => {
+    authedAs(makeUser({ id: 1 }));
+    // Route asks for limit+1 rows to detect hasMore; give it limit+1 = 2 for limit=1.
+    mockSelect
+      .mockReturnValueOnce(
+        makeDbChain([
+          { id: 1, requesterId: 1, addresseeId: 2, status: "accepted", createdAt: new Date() },
+          { id: 2, requesterId: 1, addresseeId: 3, status: "accepted", createdAt: new Date() },
+        ])
+      )
+      .mockReturnValueOnce(makeDbChain([{ id: 2, username: "friend2", currentStreak: 1 }]));
+    const req = new NextRequest("http://localhost/api/social/friends?limit=1&offset=0", {
+      headers: { Authorization: "Bearer valid-token" },
+    });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.hasMore).toBe(true);
+  });
+
+  it("hasMore is false on the last page", async () => {
+    authedAs(makeUser({ id: 1 }));
+    mockSelect
+      .mockReturnValueOnce(
+        makeDbChain([
+          { id: 1, requesterId: 1, addresseeId: 2, status: "accepted", createdAt: new Date() },
+        ])
+      )
+      .mockReturnValueOnce(makeDbChain([{ id: 2, username: "friend2", currentStreak: 1 }]));
+    const req = new NextRequest("http://localhost/api/social/friends?limit=1&offset=0", {
+      headers: { Authorization: "Bearer valid-token" },
+    });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.hasMore).toBe(false);
   });
 });
 

--- a/__tests__/api/social/leaderboard.test.ts
+++ b/__tests__/api/social/leaderboard.test.ts
@@ -93,7 +93,7 @@ describe("GET /api/social/leaderboard", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns an array", async () => {
+  it("returns { items, hasMore }", async () => {
     authedAs(makeUser({ id: 1 }));
     mockSelect
       .mockReturnValueOnce(makeDbChain([]))
@@ -105,7 +105,8 @@ describe("GET /api/social/leaderboard", () => {
     const res = await GET(makeReq());
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(Array.isArray(body)).toBe(true);
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.hasMore).toBe(false);
   });
 
   it("self is included on leaderboard with isYou: true", async () => {
@@ -119,7 +120,7 @@ describe("GET /api/social/leaderboard", () => {
       );
     const res = await GET(makeReq());
     const body = await res.json();
-    const selfRow = body.find((r: { id: number }) => r.id === 1);
+    const selfRow = body.items.find((r: { id: number }) => r.id === 1);
     expect(selfRow).toBeDefined();
     expect(selfRow.isYou).toBe(true);
   });
@@ -140,7 +141,7 @@ describe("GET /api/social/leaderboard", () => {
     );
     const res = await GET(makeReq());
     const body = await res.json();
-    expect(body[0]).toMatchObject({
+    expect(body.items[0]).toMatchObject({
       rank: 1,
       streak: 7,
       longestStreak: 12,
@@ -176,8 +177,8 @@ describe("GET /api/social/leaderboard", () => {
       );
     const res = await GET(makeReq());
     const body = await res.json();
-    expect(body[0]).toMatchObject({ id: 1, rank: 1, streak: 3 });
-    expect(body[1]).toMatchObject({ id: 2, rank: 2, streak: 0 });
+    expect(body.items[0]).toMatchObject({ id: 1, rank: 1, streak: 3 });
+    expect(body.items[1]).toMatchObject({ id: 2, rank: 2, streak: 0 });
   });
 
   it("breaks ties deterministically by longest streak then username", async () => {
@@ -207,8 +208,8 @@ describe("GET /api/social/leaderboard", () => {
     const res = await GET(makeReq());
     const body = await res.json();
     // Equal current streak → higher longest streak wins.
-    expect(body[0]).toMatchObject({ id: 2, rank: 1 });
-    expect(body[1]).toMatchObject({ id: 1, rank: 2 });
+    expect(body.items[0]).toMatchObject({ id: 2, rank: 1 });
+    expect(body.items[1]).toMatchObject({ id: 1, rank: 2 });
   });
 
   it("friends are included alongside self", async () => {
@@ -223,10 +224,55 @@ describe("GET /api/social/leaderboard", () => {
       );
     const res = await GET(makeReq());
     const body = await res.json();
-    expect(body).toHaveLength(2);
-    const friendRow = body.find((r: { id: number }) => r.id === 2);
+    expect(body.items).toHaveLength(2);
+    const friendRow = body.items.find((r: { id: number }) => r.id === 2);
     expect(friendRow).toBeDefined();
     expect(friendRow.isYou).toBe(false);
     expect(friendRow.username).toBe("friend99");
+  });
+
+  it("paginates via limit/offset and reports hasMore", async () => {
+    authedAs(makeUser({ id: 1 }));
+    const rows = Array.from({ length: 3 }, (_, i) => ({
+      id: i + 1,
+      username: `user${i + 1}`,
+      displayName: null,
+      currentStreak: 10 - i,
+      longestStreak: 10 - i,
+      lastActivityDate: today,
+    }));
+    mockSelect.mockReturnValueOnce(makeDbChain([])).mockReturnValueOnce(makeDbChain(rows));
+
+    const req = new NextRequest("http://localhost/api/social/leaderboard?limit=2&offset=0", {
+      headers: { Authorization: "Bearer valid-token" },
+    });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.items).toHaveLength(2);
+    expect(body.hasMore).toBe(true);
+    expect(body.items[0].rank).toBe(1);
+    expect(body.items[1].rank).toBe(2);
+  });
+
+  it("hasMore is false on the last page", async () => {
+    authedAs(makeUser({ id: 1 }));
+    const rows = Array.from({ length: 3 }, (_, i) => ({
+      id: i + 1,
+      username: `user${i + 1}`,
+      displayName: null,
+      currentStreak: 10 - i,
+      longestStreak: 10 - i,
+      lastActivityDate: today,
+    }));
+    mockSelect.mockReturnValueOnce(makeDbChain([])).mockReturnValueOnce(makeDbChain(rows));
+
+    const req = new NextRequest("http://localhost/api/social/leaderboard?limit=2&offset=2", {
+      headers: { Authorization: "Bearer valid-token" },
+    });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.hasMore).toBe(false);
+    expect(body.items[0].rank).toBe(3);
   });
 });

--- a/app/api/social/friends/route.ts
+++ b/app/api/social/friends/route.ts
@@ -1,17 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
-import { and, eq, or, sql } from "drizzle-orm";
+import { and, desc, eq, or, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { friendships, users } from "@/lib/infra/db/schema";
 import { requireUser } from "@/lib/auth/social-auth";
 import { rateLimitOrNull } from "@/lib/infra/rate-limit";
-import { isUniqueViolation } from "@/lib/infra/http";
+import { isUniqueViolation, parsePagination } from "@/lib/infra/http";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
 
   const { userId } = authed;
+  const { limit, offset } = parsePagination(req);
 
+  // Fetch one extra row to detect `hasMore` without a separate count query.
   const rows = await db
     .select({
       id: friendships.id,
@@ -24,10 +26,15 @@ export async function GET(req: NextRequest) {
     .from(friendships)
     .innerJoin(users, eq(users.id, friendships.requesterId))
     .where(or(eq(friendships.requesterId, userId), eq(friendships.addresseeId, userId)))
-    .limit(500);
+    .orderBy(desc(friendships.createdAt))
+    .limit(limit + 1)
+    .offset(offset);
+
+  const hasMore = rows.length > limit;
+  const page = rows.slice(0, limit);
 
   // Enrich with the friend's username (the other side)
-  const friendIds = rows.map((r) => (r.requesterId === userId ? r.addresseeId : r.requesterId));
+  const friendIds = page.map((r) => (r.requesterId === userId ? r.addresseeId : r.requesterId));
 
   const friendUsers =
     friendIds.length > 0
@@ -43,7 +50,7 @@ export async function GET(req: NextRequest) {
 
   const friendMap = new Map(friendUsers.map((u) => [u.id, u]));
 
-  const result = rows.map((r) => {
+  const items = page.map((r) => {
     const friendId = r.requesterId === userId ? r.addresseeId : r.requesterId;
     const friend = friendMap.get(friendId);
     return {
@@ -57,7 +64,7 @@ export async function GET(req: NextRequest) {
     };
   });
 
-  return NextResponse.json(result);
+  return NextResponse.json({ items, hasMore });
 }
 
 export async function POST(req: NextRequest) {

--- a/app/api/social/leaderboard/route.ts
+++ b/app/api/social/leaderboard/route.ts
@@ -4,12 +4,14 @@ import { db } from "@/lib/infra/db";
 import { friendships, users } from "@/lib/infra/db/schema";
 import { requireUser } from "@/lib/auth/social-auth";
 import { effectiveStreak } from "@/lib/social/streak";
+import { parsePagination } from "@/lib/infra/http";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
 
   const { userId } = authed;
+  const { limit, offset } = parsePagination(req);
 
   // Get all accepted friend IDs
   const friendRows = await db
@@ -31,8 +33,11 @@ export async function GET(req: NextRequest) {
 
   // Include self on leaderboard
   const allIds = [userId, ...friendIds];
-  if (allIds.length === 0) return NextResponse.json([]);
+  if (allIds.length === 0) return NextResponse.json({ items: [], hasMore: false });
 
+  // Bounded by allIds.length (a WHERE...IN over a fixed id list can't return
+  // more rows than ids given) — no arbitrary row cap needed here, unlike a
+  // plain unbounded table scan.
   const rows = await db
     .select({
       id: users.id,
@@ -43,11 +48,12 @@ export async function GET(req: NextRequest) {
       lastActivityDate: users.lastActivityDate,
     })
     .from(users)
-    .where(or(...allIds.map((id) => eq(users.id, id))))
-    .limit(500);
+    .where(or(...allIds.map((id) => eq(users.id, id))));
 
   // Rank by the *effective* (decayed) streak so broken streaks don't sit at the
   // top stale, with deterministic tie-breakers: longest streak, then username.
+  // Ranking requires the full set (rank depends on every row's position), so
+  // pagination is applied to the already-ranked list, not the DB query.
   const ranked = rows
     .map((u) => ({ ...u, streak: effectiveStreak(u.currentStreak, u.lastActivityDate) }))
     .sort(
@@ -57,15 +63,18 @@ export async function GET(req: NextRequest) {
         a.username.localeCompare(b.username)
     );
 
-  return NextResponse.json(
-    ranked.map((u, i) => ({
-      rank: i + 1,
+  const page = ranked.slice(offset, offset + limit);
+
+  return NextResponse.json({
+    items: page.map((u, i) => ({
+      rank: offset + i + 1,
       id: u.id,
       username: u.username,
       displayName: u.displayName,
       streak: u.streak,
       longestStreak: u.longestStreak,
       isYou: u.id === userId,
-    }))
-  );
+    })),
+    hasMore: offset + limit < ranked.length,
+  });
 }

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -41,7 +41,11 @@ export default function SocialPage() {
 
   const [tab, setTab] = useState<Tab>("leaderboard");
   const [friends, setFriends] = useState<unknown[]>([]);
+  const [friendsHasMore, setFriendsHasMore] = useState(false);
+  const [loadingMoreFriends, setLoadingMoreFriends] = useState(false);
   const [leaderboard, setLeaderboard] = useState<unknown[]>([]);
+  const [leaderboardHasMore, setLeaderboardHasMore] = useState(false);
+  const [loadingMoreLeaderboard, setLoadingMoreLeaderboard] = useState(false);
   const [challengesList, setChallengesList] = useState<EnrichedChallenge[]>([]);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [prefill, setPrefill] = useState<ChallengePrefill | null>(null);
@@ -86,10 +90,11 @@ export default function SocialPage() {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
       if (res.ok) {
-        const data = await res.json();
-        setFriends(data);
+        const data: { items: unknown[]; hasMore: boolean } = await res.json();
+        setFriends(data.items);
+        setFriendsHasMore(data.hasMore);
         // Keep the header badge in sync immediately after any friend action.
-        setPendingFriendCount(countPendingReceived(data));
+        setPendingFriendCount(countPendingReceived(data.items));
         setFriendsError(false);
       } else {
         setFriendsError(true);
@@ -101,6 +106,23 @@ export default function SocialPage() {
     }
   }, [accessToken, setPendingFriendCount]);
 
+  const loadMoreFriends = useCallback(async () => {
+    if (!accessToken || loadingMoreFriends) return;
+    setLoadingMoreFriends(true);
+    try {
+      const res = await fetch(`/api/social/friends?offset=${friends.length}`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (res.ok) {
+        const data: { items: unknown[]; hasMore: boolean } = await res.json();
+        setFriends((prev) => [...prev, ...data.items]);
+        setFriendsHasMore(data.hasMore);
+      }
+    } finally {
+      setLoadingMoreFriends(false);
+    }
+  }, [accessToken, friends.length, loadingMoreFriends]);
+
   const fetchLeaderboard = useCallback(async () => {
     if (!accessToken) return;
     setLoadingLeaderboard(true);
@@ -109,7 +131,9 @@ export default function SocialPage() {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
       if (res.ok) {
-        setLeaderboard(await res.json());
+        const data: { items: unknown[]; hasMore: boolean } = await res.json();
+        setLeaderboard(data.items);
+        setLeaderboardHasMore(data.hasMore);
         setLeaderboardError(false);
       } else {
         setLeaderboardError(true);
@@ -120,6 +144,23 @@ export default function SocialPage() {
       setLoadingLeaderboard(false);
     }
   }, [accessToken]);
+
+  const loadMoreLeaderboard = useCallback(async () => {
+    if (!accessToken || loadingMoreLeaderboard) return;
+    setLoadingMoreLeaderboard(true);
+    try {
+      const res = await fetch(`/api/social/leaderboard?offset=${leaderboard.length}`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (res.ok) {
+        const data: { items: unknown[]; hasMore: boolean } = await res.json();
+        setLeaderboard((prev) => [...prev, ...data.items]);
+        setLeaderboardHasMore(data.hasMore);
+      }
+    } finally {
+      setLoadingMoreLeaderboard(false);
+    }
+  }, [accessToken, leaderboard.length, loadingMoreLeaderboard]);
 
   const fetchChallenges = useCallback(async () => {
     if (!accessToken) return;
@@ -174,10 +215,11 @@ export default function SocialPage() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoadingFriends(true);
     fetch("/api/social/friends", { headers: { Authorization: `Bearer ${accessToken}` }, signal })
-      .then((r) => (r.ok ? r.json() : []))
-      .then((data) => {
-        setFriends(data);
-        setPendingFriendCount(countPendingReceived(data));
+      .then((r) => (r.ok ? r.json() : { items: [], hasMore: false }))
+      .then((data: { items: unknown[]; hasMore: boolean }) => {
+        setFriends(data.items);
+        setFriendsHasMore(data.hasMore);
+        setPendingFriendCount(countPendingReceived(data.items));
       })
       .catch(() => {})
       .finally(() => setLoadingFriends(false));
@@ -187,8 +229,11 @@ export default function SocialPage() {
       headers: { Authorization: `Bearer ${accessToken}` },
       signal,
     })
-      .then((r) => (r.ok ? r.json() : []))
-      .then((data) => setLeaderboard(data))
+      .then((r) => (r.ok ? r.json() : { items: [], hasMore: false }))
+      .then((data: { items: unknown[]; hasMore: boolean }) => {
+        setLeaderboard(data.items);
+        setLeaderboardHasMore(data.hasMore);
+      })
       .catch(() => {})
       .finally(() => setLoadingLeaderboard(false));
 
@@ -297,13 +342,26 @@ export default function SocialPage() {
                     <Loader2 className="h-4 w-4 animate-spin text-teal" />
                   </div>
                 ) : (
-                  <FriendList
-                    friends={friends as Parameters<typeof FriendList>[0]["friends"]}
-                    onUpdate={() => {
-                      fetchFriends();
-                      fetchLeaderboard();
-                    }}
-                  />
+                  <>
+                    <FriendList
+                      friends={friends as Parameters<typeof FriendList>[0]["friends"]}
+                      onUpdate={() => {
+                        fetchFriends();
+                        fetchLeaderboard();
+                      }}
+                    />
+                    {friendsHasMore && (
+                      <div className="flex justify-center pt-2">
+                        <button
+                          onClick={loadMoreFriends}
+                          disabled={loadingMoreFriends}
+                          className="cursor-pointer text-xs text-teal underline disabled:cursor-wait disabled:opacity-50"
+                        >
+                          {loadingMoreFriends ? "Loading…" : "Load more"}
+                        </button>
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
             )}
@@ -353,6 +411,17 @@ export default function SocialPage() {
                   <LeaderboardTable
                     entries={leaderboard as Parameters<typeof LeaderboardTable>[0]["entries"]}
                   />
+                )}
+                {!loadingLeaderboard && leaderboardHasMore && (
+                  <div className="flex justify-center pt-2">
+                    <button
+                      onClick={loadMoreLeaderboard}
+                      disabled={loadingMoreLeaderboard}
+                      className="cursor-pointer text-xs text-teal underline disabled:cursor-wait disabled:opacity-50"
+                    >
+                      {loadingMoreLeaderboard ? "Loading…" : "Load more"}
+                    </button>
+                  </div>
                 )}
                 {!loadingLeaderboard && leaderboard.length <= 1 && (
                   <p className="text-center text-xs text-text-muted">

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -87,13 +87,16 @@ export function Header({ onSearchOpen }: HeaderProps) {
   // Poll for incoming friend requests every 60 s while signed in
   useEffect(() => {
     if (!accessToken || !userId) return;
+    // limit=200 (the pagination max) rather than the default page size: this
+    // poll only needs an accurate pending-request count, and defaulting to a
+    // small page could undercount for a user with many friends.
     const load = () =>
-      fetch("/api/social/friends", {
+      fetch("/api/social/friends?limit=200", {
         headers: { Authorization: `Bearer ${accessToken}` },
       })
-        .then((r) => (r.ok ? r.json() : []))
-        .then((data: { status: string; direction: string }[]) => {
-          const count = data.filter(
+        .then((r) => (r.ok ? r.json() : { items: [] }))
+        .then((data: { items: { status: string; direction: string }[] }) => {
+          const count = data.items.filter(
             (f) => f.status === "pending" && f.direction === "received"
           ).length;
           setPendingFriendCount(count);

--- a/lib/infra/http.ts
+++ b/lib/infra/http.ts
@@ -55,6 +55,32 @@ export function clientKey(req: Request): string {
   return IP_PATTERN.test(candidate) ? candidate : "unknown";
 }
 
+export interface Pagination {
+  limit: number;
+  offset: number;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+/**
+ * Parses and clamps `limit`/`offset` query params for list endpoints.
+ * Invalid, missing, or out-of-range input is clamped to a sane value rather
+ * than rejected — pagination controls a response shape, not a validity
+ * boundary that should 400 the request.
+ */
+export function parsePagination(req: NextRequest): Pagination {
+  const params = req.nextUrl.searchParams;
+  const rawLimit = Number(params.get("limit"));
+  const rawOffset = Number(params.get("offset"));
+  const limit =
+    Number.isFinite(rawLimit) && rawLimit > 0
+      ? Math.min(Math.floor(rawLimit), MAX_LIMIT)
+      : DEFAULT_LIMIT;
+  const offset = Number.isFinite(rawOffset) && rawOffset > 0 ? Math.floor(rawOffset) : 0;
+  return { limit, offset };
+}
+
 /** Postgres unique-violation, possibly wrapped by the driver under `cause`. */
 export function isUniqueViolation(err: unknown): boolean {
   const code =


### PR DESCRIPTION
## Problem
`app/api/social/leaderboard/route.ts` and `app/api/social/friends/route.ts` both hardcoded `.limit(500)` on their main query with no offset/cursor pagination contract — results were silently truncated with no indication to the client.

Closes #177

## Fix
- Added a shared `parsePagination(req)` helper (`lib/infra/http.ts`) that parses/clamps `limit` (default 50, max 200) and `offset` (default 0) query params.
- **`/api/social/leaderboard`**: removed the arbitrary `.limit(500)` on the DB query (naturally bounded by the friend-id `IN` list, so no cap was needed there in the first place — that's what caused rows to be silently dropped by unspecified DB order before ranking). Ranking still happens over the full set (rank depends on every row's relative position); pagination is applied to the already-ranked list. Response is now `{ items, hasMore }` instead of a bare array.
- **`/api/social/friends`**: applies `limit`/`offset` at the DB level (ordered by `createdAt desc` for determinism), fetching `limit + 1` rows to detect `hasMore` without a separate count query. Response is now `{ items, hasMore }`.
- Updated frontend consumers (`app/social/page.tsx`, `components/layout/Header.tsx`) for the new response shape, and added a "Load more" control on both the friends list and leaderboard tabs on the social page.

## Testing
- Extended `__tests__/api/social/leaderboard.test.ts` and `__tests__/api/social/friends.test.ts` for the new response shape plus new pagination cases (second page returns the next slice, `hasMore` is `true`/`false` correctly across page boundaries).
- `bun run typecheck`, `bun run lint`, and the full `bun run test` suite (592 tests) pass.