### PR TITLE
fix: cap notes content field at 10,000 characters

### DIFF
--- a/__tests__/api/notes.test.ts
+++ b/__tests__/api/notes.test.ts
@@ -144,6 +144,19 @@ describe("POST /api/notes", () => {
     expect((await POST(req("POST", { ref: "2:255" }))).status).toBe(400);
   });
 
+  it("400 when note exceeds the max length", async () => {
+    authed();
+    const res = await POST(req("POST", { ref: "2:255", note: "x".repeat(10_001) }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/too long/i);
+  });
+
+  it("201 when note is exactly at the max length", async () => {
+    authed();
+    const res = await POST(req("POST", { ref: "2:255", note: "x".repeat(10_000) }));
+    expect(res.status).toBe(201);
+  });
+
   it("201 when note is created", async () => {
     authed();
     const res = await POST(req("POST", { ref: "2:255", note: "reflection" }));

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -7,6 +7,11 @@ import { isValidRef } from "@/lib/quran/quran-corpus";
 import { jsonError, parseJson } from "@/lib/infra/http";
 import { rateLimitOrNull } from "@/lib/infra/rate-limit";
 
+// A study note is free text, not a serialized payload (contrast with
+// workspace's 512KB canvas cap) — bounded generously for a long personal
+// reflection while still closing the unbounded-text DB bloat gap.
+const MAX_NOTE_LENGTH = 10_000;
+
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
@@ -49,6 +54,9 @@ export async function POST(req: NextRequest) {
   }
   if (!note) {
     return jsonError("Missing note", 400);
+  }
+  if (note.length > MAX_NOTE_LENGTH) {
+    return jsonError(`Note too long (max ${MAX_NOTE_LENGTH} characters)`, 400);
   }
 
   try {


### PR DESCRIPTION
## Problem
\`app/api/notes/route.ts\` POST only checked that \`note\` is present (\`if (!note) return jsonError(...)\`), with no max-length validation — and the underlying DB column is an unbounded \`text\`.

Closes #171

## Fix
Added an explicit \`MAX_NOTE_LENGTH = 10_000\` cap (sized for a long personal study reflection, not a serialized payload — contrast with \`workspace\`'s 512KB canvas cap, which is a different kind of field). Returns 400 with a clear error when exceeded, checked right after the existing \`!note\` guard.

## Testing
- Added cases to \`__tests__/api/notes.test.ts\`: 400 when the note exceeds 10,000 chars, 201 when it's exactly at the limit.
- \`bun run typecheck\`, \`bun run lint\`, and the full \`bun run test\` suite pass.