### PR TITLE
fix: cap arabicText/translation length in /api/connections

### DIFF
--- a/__tests__/api/connections.test.ts
+++ b/__tests__/api/connections.test.ts
@@ -154,6 +154,29 @@ describe("POST /api/connections", () => {
     expect(mockConsume).not.toHaveBeenCalled();
   });
 
+  it("returns 400 when arabicText exceeds the max length, without calling the AI path", async () => {
+    const req = makeRequest({
+      fromRef: "1:1",
+      kind: "thematic",
+      arabicText: "x".repeat(5001),
+      translation: "trans",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(mockConsume).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when translation exceeds the max length", async () => {
+    const req = makeRequest({
+      fromRef: "1:1",
+      kind: "thematic",
+      arabicText: "text",
+      translation: "x".repeat(5001),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
   it("returns 400 for a malformed fromRef", async () => {
     const req = makeRequest({
       fromRef: "garbage",

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -6,6 +6,11 @@ import { clientKey } from "@/lib/infra/http";
 import type { EdgeKind } from "@/types/quran";
 
 const MAX_EXCLUDE_REFS = 100;
+// A single verse's Arabic text and translation are at most a few hundred
+// characters even for the longest ayahs — this is a generous but bounded cap
+// to close the unbounded-prompt-into-AI-call gap without risking false
+// rejections on legitimate verses.
+const MAX_TEXT_LENGTH = 5000;
 
 export async function POST(req: NextRequest) {
   let body: {
@@ -33,6 +38,10 @@ export async function POST(req: NextRequest) {
 
   if (!isValidRef(fromRef)) {
     return NextResponse.json({ error: "Invalid fromRef" }, { status: 400 });
+  }
+
+  if (arabicText.length > MAX_TEXT_LENGTH || translation.length > MAX_TEXT_LENGTH) {
+    return NextResponse.json({ error: "arabicText/translation too long" }, { status: 400 });
   }
 
   let excludeRefs: string[] = [];


### PR DESCRIPTION
## Problem
\`app/api/connections/route.ts\` POST forwards \`arabicText\`/\`translation\` body fields directly into \`getConnections\` (AI generation) with no length cap or sanitization before the AI call — an unbounded-prompt cost-abuse and prompt-injection surface, distinct from the AI-expansion rate-limiting gap tracked separately in #126.

Closes #172

## Fix
Added a \`MAX_TEXT_LENGTH = 5000\` cap on both \`arabicText\` and \`translation\`, checked right after the existing \`fromRef\` validation and before the AI call. 5,000 chars is generous for even the longest verses (real verse text/translations are at most a few hundred characters) while closing the unbounded-payload gap. Mirrors the size-cap pattern this file already uses for \`excludeRefs\` (\`MAX_EXCLUDE_REFS\`).

## Testing
- Added two cases to \`__tests__/api/connections.test.ts\`: 400 when \`arabicText\` exceeds the cap (and confirms the rate-limit/AI path is never reached), 400 when \`translation\` exceeds the cap.
- \`bun run typecheck\`, \`bun run lint\`, and the full \`bun run test\` suite pass.