### PR TITLE
fix: reject JWTs with missing or non-numeric exp claim

### DIFF
--- a/__tests__/lib/auth/social-auth.test.ts
+++ b/__tests__/lib/auth/social-auth.test.ts
@@ -98,6 +98,20 @@ describe("requireUser — JWT signature verification", () => {
     expect("status" in res && (res as Response).status).toBe(401);
   });
 
+  it("rejects a validly-signed token whose payload omits exp entirely (fails closed)", async () => {
+    mockLimit.mockResolvedValue([user]); // even if a row existed, we must not reach it
+    const token = makeJwt({ sub: "qf-sub-123" });
+    const res = await requireUser(reqWith(token));
+    expect("status" in res && (res as Response).status).toBe(401);
+  });
+
+  it("rejects a validly-signed token whose exp is non-numeric (fails closed)", async () => {
+    mockLimit.mockResolvedValue([user]);
+    const token = makeJwt({ sub: "qf-sub-123", exp: "not-a-number" });
+    const res = await requireUser(reqWith(token));
+    expect("status" in res && (res as Response).status).toBe(401);
+  });
+
   it("rejects the alg=none bypass", async () => {
     mockLimit.mockResolvedValue([user]);
     const token = makeJwt({ sub: "qf-sub-123", exp: farFuture }, { alg: "none", sign: false });

--- a/lib/auth/social-auth.ts
+++ b/lib/auth/social-auth.ts
@@ -245,8 +245,10 @@ async function verifiedJwtSub(token: string): Promise<string | null> {
   // are the classic JWT signature-bypass vectors.
   if (header.alg !== "RS256") return null;
 
-  // Reject expired tokens.
-  if (typeof payload.exp === "number" && payload.exp * 1000 <= Date.now()) return null;
+  // Reject expired tokens. Fail closed like every other check in this
+  // function: a missing or non-numeric exp is treated as invalid, not as
+  // "no expiry."
+  if (typeof payload.exp !== "number" || payload.exp * 1000 <= Date.now()) return null;
 
   const keys = await fetchJwks();
   if (keys.length === 0) return null; // can't verify → caller uses userinfo


### PR DESCRIPTION
## Problem
\`verifiedJwtSub()\` in \`lib/auth/social-auth.ts\` only rejected a token as expired when the \`exp\` claim was present **and** numeric:

\`\`\`ts
if (typeof payload.exp === "number" && payload.exp * 1000 <= Date.now()) return null;
\`\`\`

If \`exp\` is absent or non-numeric, this condition is simply \`false\` and the function proceeds as if the token has no expiry — the only place in this function that treats "can't determine" as "assume valid" instead of "assume invalid" (unparseable header/payload, unrecognized \`alg\`, and unverifiable signature all fail closed already).

Closes #107

## Fix
One-line fail-closed fix, exactly as the issue specifies:
\`\`\`ts
if (typeof payload.exp !== "number" || payload.exp * 1000 <= Date.now()) return null;
\`\`\`

## Testing
- Added two cases to \`__tests__/lib/auth/social-auth.test.ts\`: a validly-signed JWT with \`exp\` omitted entirely is rejected (401), and one with a non-numeric \`exp\` is rejected (401) — both previously would have proceeded to signature verification and succeeded.
- \`bun run typecheck\`, \`bun run lint\`, and the full \`bun run test\` suite pass.