### PR TITLE
fix: add loading/error boundaries to onboarding, callback, and names routes

### DIFF
--- a/app/callback/error.tsx
+++ b/app/callback/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+export default function CallbackError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/callback/loading.tsx
+++ b/app/callback/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/names/error.tsx
+++ b/app/names/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+export default function NamesError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/names/loading.tsx
+++ b/app/names/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/onboarding/error.tsx
+++ b/app/onboarding/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+export default function OnboardingError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/onboarding/loading.tsx
+++ b/app/onboarding/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}


### PR DESCRIPTION
## Description
Adds missing `loading.tsx` and `error.tsx` sibling files to the onboarding, callback, and names routes, following the existing pattern from `app/bookmarks`/ `app/canvas`.

These routes were the only ones without loading/error boundaries, even `names/[slug]` already had them. This ensures that stalled network requests or thrown errors show recovery UI instead of leaving users on a blank/broken screen.

### Routes affected:
- `/onboarding`: critical first-user flow where a blank screen causes the highest bounce rate
- `/callback`: OAuth callback where a stalled request blocks sign
- `/names`: content-heavy data-fetching route similar to bookmarks/canvas

Fixes #178