### PR TITLE
fix: replace silent catch blocks with console.error across client call sites

### DIFF
--- a/app/api/social/challenges/route.ts
+++ b/app/api/social/challenges/route.ts
@@ -235,7 +235,7 @@ export async function POST(req: NextRequest) {
           lt(challenges.createdAt, cutoff)
         )
       )
-      .catch(() => {});
+      .catch((e) => console.error("challenges: cleanup prune failed", e));
   }
 
   return NextResponse.json(inserted, { status: 201 });

--- a/app/callback/error.tsx
+++ b/app/callback/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+export default function CallbackError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/callback/loading.tsx
+++ b/app/callback/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/canvas/CanvasPageClient.tsx
+++ b/app/canvas/CanvasPageClient.tsx
@@ -63,7 +63,7 @@ function VerseLoader() {
         url.searchParams.delete("verse");
         window.history.replaceState(null, "", url.toString());
       })
-      .catch(() => {});
+      .catch((e) => console.error("canvas: incoming verse fetch failed", e));
   }, [searchParams, addVerseNode, setPendingAutoExpand]);
 
   return null;

--- a/app/names/error.tsx
+++ b/app/names/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+export default function NamesError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/names/loading.tsx
+++ b/app/names/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/onboarding/error.tsx
+++ b/app/onboarding/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/layout/RouteError";
+
+export default function OnboardingError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return <RouteError error={error} retry={unstable_retry} />;
+}

--- a/app/onboarding/loading.tsx
+++ b/app/onboarding/loading.tsx
@@ -1,0 +1,5 @@
+import { RouteLoading } from "@/components/layout/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -221,7 +221,7 @@ export default function SocialPage() {
         setFriendsHasMore(data.hasMore);
         setPendingFriendCount(countPendingReceived(data.items));
       })
-      .catch(() => {})
+      .catch((e) => console.error("social: friends fetch failed", e))
       .finally(() => setLoadingFriends(false));
 
     setLoadingLeaderboard(true);
@@ -234,7 +234,7 @@ export default function SocialPage() {
         setLeaderboard(data.items);
         setLeaderboardHasMore(data.hasMore);
       })
-      .catch(() => {})
+      .catch((e) => console.error("social: leaderboard fetch failed", e))
       .finally(() => setLoadingLeaderboard(false));
 
     setLoadingChallenges(true);
@@ -244,7 +244,7 @@ export default function SocialPage() {
         setChallengesList(data);
         setPendingChallengeCount(countIncomingChallenges(data, userId));
       })
-      .catch(() => {})
+      .catch((e) => console.error("social: challenges fetch failed", e))
       .finally(() => setLoadingChallenges(false));
 
     fetch("/api/social/challenge-suggestions", {
@@ -253,7 +253,7 @@ export default function SocialPage() {
     })
       .then((r) => (r.ok ? r.json() : { suggestions: [] }))
       .then((data: { suggestions: Suggestion[] }) => setSuggestions(data.suggestions))
-      .catch(() => {});
+      .catch((e) => console.error("social: challenge-suggestions fetch failed", e));
 
     return () => ctrl.abort();
   }, [accessToken, userId, setPendingFriendCount, setPendingChallengeCount]);

--- a/components/layout/AccountMenu.tsx
+++ b/components/layout/AccountMenu.tsx
@@ -69,7 +69,7 @@ export function AccountMenu() {
     await fetch("/api/auth/signout", {
       method: "POST",
       headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
-    }).catch(() => {});
+    }).catch((e) => console.error("signout: POST failed", e));
     clearAuth();
   };
 

--- a/components/layout/ContextSidebar.tsx
+++ b/components/layout/ContextSidebar.tsx
@@ -93,7 +93,7 @@ function NotesSection({ verseRef }: { verseRef: string }) {
         setNotes(data);
         setLoaded(true);
       })
-      .catch(() => {});
+      .catch((e) => console.error("sidebar: notes fetch failed", e));
   }, [open, verseRef, accessToken, loaded]);
 
   const save = async () => {
@@ -127,7 +127,7 @@ function NotesSection({ verseRef }: { verseRef: string }) {
     await fetch(`/api/notes/${id}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${accessToken}` },
-    }).catch(() => {});
+    }).catch((e) => console.error("sidebar: note delete failed", e));
     setNotes((prev) => prev.filter((n) => n.id !== id));
   };
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -80,7 +80,7 @@ export function Header({ onSearchOpen }: HeaderProps) {
       .then((data) => {
         if (data?.streak !== undefined) bumpStreak(data.streak, data.longestStreak);
       })
-      .catch(() => {});
+      .catch((e) => console.error("header: streak hydration failed", e));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accessToken, userId]);
 
@@ -101,7 +101,7 @@ export function Header({ onSearchOpen }: HeaderProps) {
           ).length;
           setPendingFriendCount(count);
         })
-        .catch(() => {});
+        .catch((e) => console.error("header: friend-request poll failed", e));
     load();
     const interval = setInterval(load, 60_000);
     return () => clearInterval(interval);

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -28,7 +28,9 @@ function SessionRestorer() {
       if (!res.ok) {
         try {
           sessionStorage.removeItem("__devToken");
-        } catch (e) { console.error("dev: failed to clear __devToken", e); }
+        } catch (e) {
+          console.error("dev: failed to clear __devToken", e);
+        }
         console.warn("dev login failed — token rejected");
         return;
       }
@@ -37,7 +39,9 @@ function SessionRestorer() {
       // access token is in-memory only by design).
       try {
         sessionStorage.setItem("__devToken", token);
-      } catch (e) { console.error("dev: failed to persist __devToken", e); }
+      } catch (e) {
+        console.error("dev: failed to persist __devToken", e);
+      }
       const p = (await res.json()) as { id?: number; username?: string };
       if (p.id && p.username) setProfile({ userId: p.id, username: p.username });
       console.warn("dev login set — navigate to /admin");
@@ -46,7 +50,9 @@ function SessionRestorer() {
     let saved: string | null = null;
     try {
       saved = sessionStorage.getItem("__devToken");
-    } catch (e) { console.error("dev: failed to read __devToken", e); }
+    } catch (e) {
+      console.error("dev: failed to read __devToken", e);
+    }
     if (saved) void w.__devLogin(saved);
   }, [setTokens, setProfile]);
 

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -28,7 +28,7 @@ function SessionRestorer() {
       if (!res.ok) {
         try {
           sessionStorage.removeItem("__devToken");
-        } catch {}
+        } catch (e) { console.error("dev: failed to clear __devToken", e); }
         console.warn("dev login failed — token rejected");
         return;
       }
@@ -37,7 +37,7 @@ function SessionRestorer() {
       // access token is in-memory only by design).
       try {
         sessionStorage.setItem("__devToken", token);
-      } catch {}
+      } catch (e) { console.error("dev: failed to persist __devToken", e); }
       const p = (await res.json()) as { id?: number; username?: string };
       if (p.id && p.username) setProfile({ userId: p.id, username: p.username });
       console.warn("dev login set — navigate to /admin");
@@ -46,7 +46,7 @@ function SessionRestorer() {
     let saved: string | null = null;
     try {
       saved = sessionStorage.getItem("__devToken");
-    } catch {}
+    } catch (e) { console.error("dev: failed to read __devToken", e); }
     if (saved) void w.__devLogin(saved);
   }, [setTokens, setProfile]);
 

--- a/components/social/AddFriendForm.tsx
+++ b/components/social/AddFriendForm.tsx
@@ -43,7 +43,7 @@ export function AddFriendForm({ onAdded }: Props) {
       })
         .then((r) => (r.ok ? r.json() : []))
         .then((data: SearchResult[]) => setResults(data))
-        .catch(() => {})
+        .catch((e) => console.error("user-search: fetch failed", e))
         .finally(() => setSearching(false));
     }, 300);
     return () => {

--- a/components/social/StreakBadge.tsx
+++ b/components/social/StreakBadge.tsx
@@ -24,7 +24,7 @@ export function StreakBadge() {
           bumpStreak(data.streak, data.longestStreak);
         }
       })
-      .catch(() => {});
+      .catch((e) => console.error("streak: failed to fetch streak", e));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accessToken, userId]);
 


### PR DESCRIPTION
## Description

Replaces bare `.catch(() => {})` and empty `catch {}` blocks with `console.error` calls that include contextual messages, making failures visible in production.

### Files changed:

| File | Context |
|---|---|
| `components/providers.tsx` | Dev-only sessionStorage ops (remove/persist/restore dev token) |
| `components/social/StreakBadge.tsx` | Streak hydration fetch |
| `components/social/AddFriendForm.tsx` | User search fetch |
| `components/layout/AccountMenu.tsx` | Signout POST |
| `components/layout/Header.tsx` | Streak hydration + friend-request polling |
| `components/layout/ContextSidebar.tsx` | Notes fetch + note delete |
| `app/canvas/CanvasPageClient.tsx` | Incoming verse via query param |
| `app/social/page.tsx` | Friends, leaderboard, challenges, suggestions fetches |
| `app/api/social/challenges/route.ts` | Cleanup prune |

Fixes #175