### PR TITLE
fix: remove redundant decodeURIComponent on already-decoded Next.js params

### DIFF
--- a/app/api/bookmarks/[ref]/route.ts
+++ b/app/api/bookmarks/[ref]/route.ts
@@ -9,7 +9,7 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ r
   if (authed instanceof NextResponse) return authed;
 
   const { ref } = await params;
-  const verseRef = decodeURIComponent(ref);
+  const verseRef = ref;
 
   try {
     await db

--- a/app/api/root/[root]/route.ts
+++ b/app/api/root/[root]/route.ts
@@ -14,7 +14,7 @@ const MAX_VERSES = 24;
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ root: string }> }) {
   const { root: rawRoot } = await params;
-  const root = decodeURIComponent(rawRoot ?? "").trim();
+  const root = (rawRoot ?? "").trim();
 
   if (!root) {
     return NextResponse.json({ error: "Missing root" }, { status: 400 });


### PR DESCRIPTION
## Description

Removes redundant `decodeURIComponent` calls in two route handlers where Next.js has already URL-decoded the dynamic param value.

Next.js App Router decodes URL-encoded path segments before passing them to `params`. A second `decodeURIComponent` call throws `URIError: URI malformed` on bare `%` sequences (e.g. `GET /api/root/%25` where Next.js decodes `%25` → `%`, then the route crashes on `decodeURIComponent("%")`).

### Routes affected:

- `app/api/root/[root]/route.ts`: concordance endpoint that doc-comments promise "Returns an empty list (200) on any failure", but the decode sits before the `try/catch`, bypassing that graceful degradation.
- `app/api/bookmarks/[ref]/route.ts`: the decode sits before the `try` block, so a malformed ref crashes with an unhandled 500 instead of the intended error response.

Fixes #104