### PR TITLE
fix: add metrics counter for admin audit log write failures

### DIFF
--- a/lib/admin/admin-audit.ts
+++ b/lib/admin/admin-audit.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/infra/db";
 import { adminAuditLog } from "@/lib/infra/db/schema";
+import { incr } from "@/lib/infra/metrics";
 
 /**
  * Serialize `meta` defensively: a BigInt or circular reference must not throw and
@@ -40,5 +41,6 @@ export async function logAdminAction(entry: {
     });
   } catch (err) {
     console.error("Failed to write admin audit log:", entry.action, err);
+    incr("admin_audit_write_failed");
   }
 }


### PR DESCRIPTION
## Description

Adds an `incr("admin_audit_write_failed")` metric counter to the `catch` block in `logAdminAction` so that failures in admin audit log writes are visible on `/api/metrics`, matching the existing pattern used in `lib/infra/rate-limit.ts` (e.g. `ratelimit_fail_open`, `ratelimit_redis_fallback`).

With this change, operators can detect gaps via metrics even when no console monitoring is in place.

Fixes #101