### PR TITLE
fix: prevent audio player state desync on rapid track switches

### DIFF
--- a/store/audio.ts
+++ b/store/audio.ts
@@ -71,8 +71,12 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
       queueIndex: 0,
     });
     loadAndPlay(verse, () => get()._onEnded())
-      .then(() => { if (token === playGen) set({ isLoading: false }); })
-      .catch(() => { if (token === playGen) set({ isPlaying: false, isLoading: false }); });
+      .then(() => {
+        if (token === playGen) set({ isLoading: false });
+      })
+      .catch(() => {
+        if (token === playGen) set({ isPlaying: false, isLoading: false });
+      });
   },
 
   playGraph: (verses) => {
@@ -88,8 +92,12 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
       queueIndex: 0,
     });
     loadAndPlay(first, () => get()._onEnded())
-      .then(() => { if (token === playGen) set({ isLoading: false }); })
-      .catch(() => { if (token === playGen) set({ isPlaying: false, isLoading: false }); });
+      .then(() => {
+        if (token === playGen) set({ isLoading: false });
+      })
+      .catch(() => {
+        if (token === playGen) set({ isPlaying: false, isLoading: false });
+      });
   },
 
   pause: () => {
@@ -136,8 +144,12 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
       isLoading: true,
     });
     loadAndPlay(verse, () => get()._onEnded())
-      .then(() => { if (token === playGen) set({ isLoading: false }); })
-      .catch(() => { if (token === playGen) set({ isPlaying: false, isLoading: false }); });
+      .then(() => {
+        if (token === playGen) set({ isLoading: false });
+      })
+      .catch(() => {
+        if (token === playGen) set({ isPlaying: false, isLoading: false });
+      });
   },
 
   prev: () => {
@@ -153,8 +165,12 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
       isLoading: true,
     });
     loadAndPlay(verse, () => get()._onEnded())
-      .then(() => { if (token === playGen) set({ isLoading: false }); })
-      .catch(() => { if (token === playGen) set({ isPlaying: false, isLoading: false }); });
+      .then(() => {
+        if (token === playGen) set({ isLoading: false });
+      })
+      .catch(() => {
+        if (token === playGen) set({ isPlaying: false, isLoading: false });
+      });
   },
 
   _onEnded: () => {

--- a/store/audio.ts
+++ b/store/audio.ts
@@ -38,6 +38,12 @@ function getAudio(): HTMLAudioElement {
   return _audio!;
 }
 
+// Monotonically increasing generation counter. Each play call captures the
+// current token; stale .then/.catch callbacks from superseded requests
+// check the token and skip their state updates, preventing race conditions
+// when the user switches tracks faster than a play() promise settles.
+let playGen = 0;
+
 function loadAndPlay(verse: AudioVerse, onEnded: () => void) {
   const a = getAudio();
   a.onended = onEnded;
@@ -55,6 +61,7 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
   queueIndex: 0,
 
   playVerse: (verse) => {
+    const token = ++playGen;
     set({
       currentRef: verse.ref,
       currentSurahName: verse.surahName,
@@ -64,13 +71,14 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
       queueIndex: 0,
     });
     loadAndPlay(verse, () => get()._onEnded())
-      .then(() => set({ isLoading: false }))
-      .catch(() => set({ isPlaying: false, isLoading: false }));
+      .then(() => { if (token === playGen) set({ isLoading: false }); })
+      .catch(() => { if (token === playGen) set({ isPlaying: false, isLoading: false }); });
   },
 
   playGraph: (verses) => {
     if (verses.length === 0) return;
     const first = verses[0];
+    const token = ++playGen;
     set({
       currentRef: first.ref,
       currentSurahName: first.surahName,
@@ -80,8 +88,8 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
       queueIndex: 0,
     });
     loadAndPlay(first, () => get()._onEnded())
-      .then(() => set({ isLoading: false }))
-      .catch(() => set({ isPlaying: false, isLoading: false }));
+      .then(() => { if (token === playGen) set({ isLoading: false }); })
+      .catch(() => { if (token === playGen) set({ isPlaying: false, isLoading: false }); });
   },
 
   pause: () => {
@@ -120,6 +128,7 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
       return;
     }
     const verse = queue[nextIdx];
+    const token = ++playGen;
     set({
       currentRef: verse.ref,
       currentSurahName: verse.surahName,
@@ -127,8 +136,8 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
       isLoading: true,
     });
     loadAndPlay(verse, () => get()._onEnded())
-      .then(() => set({ isLoading: false }))
-      .catch(() => set({ isPlaying: false, isLoading: false }));
+      .then(() => { if (token === playGen) set({ isLoading: false }); })
+      .catch(() => { if (token === playGen) set({ isPlaying: false, isLoading: false }); });
   },
 
   prev: () => {
@@ -136,6 +145,7 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
     const prevIdx = queueIndex - 1;
     if (prevIdx < 0) return;
     const verse = queue[prevIdx];
+    const token = ++playGen;
     set({
       currentRef: verse.ref,
       currentSurahName: verse.surahName,
@@ -143,8 +153,8 @@ export const useAudioStore = create<AudioStore>((set, get) => ({
       isLoading: true,
     });
     loadAndPlay(verse, () => get()._onEnded())
-      .then(() => set({ isLoading: false }))
-      .catch(() => set({ isPlaying: false, isLoading: false }));
+      .then(() => { if (token === playGen) set({ isLoading: false }); })
+      .catch(() => { if (token === playGen) set({ isPlaying: false, isLoading: false }); });
   },
 
   _onEnded: () => {


### PR DESCRIPTION
## Description

Adds a monotonically increasing `playGen` counter to the audio store. Each play call captures the current token. Stale `.then`/`.catch` callbacks from superseded requests check `token === playGen` before applying state updates.

### The bug

`store/audio.ts` uses a single module-level `HTMLAudioElement` and reassigns `src` + calls `.load()` on every track change. If the user triggers two play calls in quick succession (e.g. double-tapping Next, or tapping a verse while another is loading), the browser rejects the \*first\* `play()` promise with `AbortError`. That stale rejection's `.catch()` then unconditionally sets `isPlaying: false`, even though the second track's `play()` has since resolved and audio is audibly playing.

### The fix

Every play entry point now increments `playGen` and captures the new value as `token`. The `.then`/`.catch` handlers only call `set(...)` when their captured token matches the current `playGen`, making stale callbacks a no-op.

### Affected call sites

- `playVerse`
- `playGraph`
- `next`
- `prev`

Fixes #102