### PR TITLE
fix: validate JWT aud/iss to prevent cross-client token replay (#106)

### DIFF
--- a/__tests__/lib/auth/social-auth.test.ts
+++ b/__tests__/lib/auth/social-auth.test.ts
@@ -42,10 +42,15 @@ function b64url(obj: unknown): string {
 
 function makeJwt(
   payload: object,
-  opts: { kid?: string; alg?: string; sign?: boolean } = {}
+  opts: { kid?: string; alg?: string; sign?: boolean; noAud?: boolean } = {}
 ): string {
+  const merged = { ...payload };
+  // The vitest setup sets NEXT_PUBLIC_QF_CLIENT_ID, so every JWT that goes
+  // through verifiedJwtSub must include a matching aud claim. Tests that
+  // deliberately test missing-aud rejection pass noAud:true.
+  if (!opts.noAud) (merged as Record<string, unknown>).aud = "test-client-id";
   const header = { alg: opts.alg ?? "RS256", typ: "JWT", kid: opts.kid ?? KID };
-  const body = `${b64url(header)}.${b64url(payload)}`;
+  const body = `${b64url(header)}.${b64url(merged)}`;
   if (opts.sign === false) return `${body}.not-a-real-signature`;
   const sig = cryptoSign("RSA-SHA256", Buffer.from(body), privateKey).toString("base64url");
   return `${body}.${sig}`;
@@ -82,6 +87,13 @@ describe("requireUser — JWT signature verification", () => {
     const token = makeJwt({ sub: "qf-sub-123", exp: farFuture });
     const res = await requireUser(reqWith(token));
     expect("userId" in res && res.userId).toBe(7);
+  });
+
+  it("rejects a token with a missing aud claim (fails closed)", async () => {
+    mockLimit.mockResolvedValue([user]);
+    const token = makeJwt({ sub: "qf-sub-123", exp: farFuture }, { noAud: true });
+    const res = await requireUser(reqWith(token));
+    expect("status" in res && (res as Response).status).toBe(401);
   });
 
   it("rejects a token whose signature does not verify (tampered)", async () => {

--- a/__tests__/lib/auth/social-auth.test.ts
+++ b/__tests__/lib/auth/social-auth.test.ts
@@ -42,13 +42,14 @@ function b64url(obj: unknown): string {
 
 function makeJwt(
   payload: object,
-  opts: { kid?: string; alg?: string; sign?: boolean; noAud?: boolean } = {}
+  opts: { kid?: string; alg?: string; sign?: boolean; noAud?: boolean; noIss?: boolean } = {}
 ): string {
   const merged = { ...payload };
-  // The vitest setup sets NEXT_PUBLIC_QF_CLIENT_ID, so every JWT that goes
-  // through verifiedJwtSub must include a matching aud claim. Tests that
-  // deliberately test missing-aud rejection pass noAud:true.
+  // The vitest setup sets NEXT_PUBLIC_QF_CLIENT_ID and QF_AUTH_BASE, so every
+  // JWT that goes through verifiedJwtSub must include matching aud/iss claims.
+  // Tests that deliberately test missing-claim rejection pass noAud/noIss.
   if (!opts.noAud) (merged as Record<string, unknown>).aud = "test-client-id";
+  if (!opts.noIss) (merged as Record<string, unknown>).iss = "https://auth.example.test";
   const header = { alg: opts.alg ?? "RS256", typ: "JWT", kid: opts.kid ?? KID };
   const body = `${b64url(header)}.${b64url(merged)}`;
   if (opts.sign === false) return `${body}.not-a-real-signature`;
@@ -98,14 +99,14 @@ describe("requireUser — JWT signature verification", () => {
 
   it("rejects a token with a missing iss claim (fails closed)", async () => {
     mockLimit.mockResolvedValue([user]);
-    const token = makeJwt({ sub: "qf-sub-123", exp: farFuture });
+    const token = makeJwt({ sub: "qf-sub-123", exp: farFuture }, { noIss: true });
     const res = await requireUser(reqWith(token));
     expect("status" in res && (res as Response).status).toBe(401);
   });
 
   it("rejects a token with a mismatched iss claim", async () => {
     mockLimit.mockResolvedValue([user]);
-    const token = makeJwt({ sub: "qf-sub-123", exp: farFuture, iss: "https://wrong-issuer.test" });
+    const token = makeJwt({ sub: "qf-sub-123", exp: farFuture, iss: "https://wrong-issuer.test" }, { noIss: true });
     const res = await requireUser(reqWith(token));
     expect("status" in res && (res as Response).status).toBe(401);
   });

--- a/__tests__/lib/auth/social-auth.test.ts
+++ b/__tests__/lib/auth/social-auth.test.ts
@@ -96,6 +96,20 @@ describe("requireUser — JWT signature verification", () => {
     expect("status" in res && (res as Response).status).toBe(401);
   });
 
+  it("rejects a token with a missing iss claim (fails closed)", async () => {
+    mockLimit.mockResolvedValue([user]);
+    const token = makeJwt({ sub: "qf-sub-123", exp: farFuture });
+    const res = await requireUser(reqWith(token));
+    expect("status" in res && (res as Response).status).toBe(401);
+  });
+
+  it("rejects a token with a mismatched iss claim", async () => {
+    mockLimit.mockResolvedValue([user]);
+    const token = makeJwt({ sub: "qf-sub-123", exp: farFuture, iss: "https://wrong-issuer.test" });
+    const res = await requireUser(reqWith(token));
+    expect("status" in res && (res as Response).status).toBe(401);
+  });
+
   it("rejects a token whose signature does not verify (tampered)", async () => {
     mockLimit.mockResolvedValue([user]); // even if a row existed, we must not reach it
     const token = makeJwt({ sub: "qf-sub-123", exp: farFuture }, { sign: false });

--- a/__tests__/lib/auth/social-auth.test.ts
+++ b/__tests__/lib/auth/social-auth.test.ts
@@ -106,7 +106,10 @@ describe("requireUser — JWT signature verification", () => {
 
   it("rejects a token with a mismatched iss claim", async () => {
     mockLimit.mockResolvedValue([user]);
-    const token = makeJwt({ sub: "qf-sub-123", exp: farFuture, iss: "https://wrong-issuer.test" }, { noIss: true });
+    const token = makeJwt(
+      { sub: "qf-sub-123", exp: farFuture, iss: "https://wrong-issuer.test" },
+      { noIss: true }
+    );
     const res = await requireUser(reqWith(token));
     expect("status" in res && (res as Response).status).toBe(401);
   });

--- a/lib/auth/social-auth.ts
+++ b/lib/auth/social-auth.ts
@@ -263,7 +263,7 @@ async function verifiedJwtSub(token: string): Promise<string | null> {
   // QF uses the auth base URL (e.g. "https://oauth2.quran.foundation") as the
   // issuer claim. If the token was issued by a different auth provider, refuse it.
   const qfAuthBase = process.env.QF_AUTH_BASE;
-  if (qfAuthBase && typeof payload.iss === "string" && payload.iss !== qfAuthBase) return null;
+  if (qfAuthBase && (typeof payload.iss !== "string" || payload.iss !== qfAuthBase)) return null;
 
   const keys = await fetchJwks();
   if (keys.length === 0) return null; // can't verify → caller uses userinfo

--- a/lib/auth/social-auth.ts
+++ b/lib/auth/social-auth.ts
@@ -245,10 +245,24 @@ async function verifiedJwtSub(token: string): Promise<string | null> {
   // are the classic JWT signature-bypass vectors.
   if (header.alg !== "RS256") return null;
 
-  // Reject expired tokens. Fail closed like every other check in this
-  // function: a missing or non-numeric exp is treated as invalid, not as
-  // "no expiry."
+  // Reject expired tokens. Fail closed like every other check — a missing or
+  // non-numeric exp is treated as invalid, not as "no expiry."
   if (typeof payload.exp !== "number" || payload.exp * 1000 <= Date.now()) return null;
+
+  // Validate audience (aud) — reject cross-client token replay.
+  // NextAuth / QF can issue tokens for multiple clients; the middle-tier API
+  // must only accept tokens whose audience includes OUR client ID.
+  const qfClientId = process.env.NEXT_PUBLIC_QF_CLIENT_ID;
+  if (qfClientId && payload.aud !== undefined) {
+    const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+    if (!audiences.some((a) => String(a) === qfClientId)) return null;
+  }
+
+  // Validate issuer (iss) — reject tokens minted by a different auth domain.
+  // QF uses the auth base URL (e.g. "https://oauth2.quran.foundation") as the
+  // issuer claim. If the token was issued by a different auth provider, refuse it.
+  const qfAuthBase = process.env.QF_AUTH_BASE;
+  if (qfAuthBase && typeof payload.iss === "string" && payload.iss !== qfAuthBase) return null;
 
   const keys = await fetchJwks();
   if (keys.length === 0) return null; // can't verify → caller uses userinfo

--- a/lib/auth/social-auth.ts
+++ b/lib/auth/social-auth.ts
@@ -253,8 +253,9 @@ async function verifiedJwtSub(token: string): Promise<string | null> {
   // NextAuth / QF can issue tokens for multiple clients; the middle-tier API
   // must only accept tokens whose audience includes OUR client ID.
   const qfClientId = process.env.NEXT_PUBLIC_QF_CLIENT_ID;
-  if (qfClientId && payload.aud !== undefined) {
-    const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+  if (qfClientId) {
+    const audiences: unknown[] =
+      payload.aud === undefined ? [] : Array.isArray(payload.aud) ? payload.aud : [payload.aud];
     if (!audiences.some((a) => String(a) === qfClientId)) return null;
   }
 


### PR DESCRIPTION
Closes #106

Adds audience (`aud`) and issuer (`iss`) validation to the verified-JWT fast path in `verifiedJwtSub`. Without this, a QF access token issued for one client could authenticate against a different clients API, which is an audience mismatch allowing cross-client token replay.

- **aud**: must contain `NEXT_PUBLIC_QF_CLIENT_ID` (handles single string or array-of-strings claims). Skipped when the env var is unset (local dev, CI).
- **iss**: must equal `QF_AUTH_BASE`. Skipped when the env var is unset.
- Both checks fail closed: a missing or mismatched claim returns `null`, forcing fallback to the authoritative QF userinfo endpoint.