### PR TITLE
fix: reduce self-heal queries and batch score computation on challenges GET (#176, #103)

### DIFF
--- a/__tests__/api/social/challenges.test.ts
+++ b/__tests__/api/social/challenges.test.ts
@@ -299,15 +299,13 @@ describe("GET /api/social/challenges", () => {
   });
 
   it("bounds the challenges query with orderBy + limit(200)", async () => {
-    // NOTE: the route issues the unbounded active-resolution select, then the
-    // unbounded pending-expiry select, then the capped display select. The
-    // recording chain is wired to that third select. If the route is
-    // reordered, update which Once() carries the recording chain.
+    // NOTE: the route issues the unbounded combined resolution select (active or
+    // pending that has ended), then the capped display select. The recording
+    // chain is wired to the second select.
     authedAs(makeUser({ id: 1 }));
     const calls: Record<string, unknown[][]> = {};
     mockSelect
-      .mockReturnValueOnce(makeDbChain([])) // resolution query (no ended-active)
-      .mockReturnValueOnce(makeDbChain([])) // pending-expiry query (none expired)
+      .mockReturnValueOnce(makeDbChain([])) // combined resolution (none expired)
       .mockReturnValueOnce(makeRecordingChain([], calls)); // capped display query
     const res = await GET(makeGetReq());
     expect(res.status).toBe(200);
@@ -326,8 +324,7 @@ describe("GET /api/social/challenges", () => {
     authedAs(makeUser({ id: 1 }));
     const challenge = makeChallenge({ status: "pending" });
     mockSelect
-      .mockReturnValueOnce(makeDbChain([])) // resolution query (none ended-active)
-      .mockReturnValueOnce(makeDbChain([])) // pending-expiry query (none expired)
+      .mockReturnValueOnce(makeDbChain([])) // combined resolution (none expired)
       .mockReturnValueOnce(makeDbChain([challenge])) // capped display query
       .mockReturnValueOnce(
         makeDbChain([
@@ -352,10 +349,9 @@ describe("GET /api/social/challenges", () => {
       endsAt: new Date(Date.now() - 1000), // already ended
     });
     mockSelect
-      .mockReturnValueOnce(makeDbChain([expired])) // resolution query (the ended-active row)
+      .mockReturnValueOnce(makeDbChain([expired])) // combined resolution (includes the ended-active row)
       .mockReturnValueOnce(makeDbChain([{ score: 3 }])) // challengerScore (resolution)
       .mockReturnValueOnce(makeDbChain([{ score: 1 }])) // challengedScore (resolution)
-      .mockReturnValueOnce(makeDbChain([])) // pending-expiry query (none expired)
       .mockReturnValueOnce(
         makeDbChain([
           // capped display query — re-reads the
@@ -390,8 +386,7 @@ describe("GET /api/social/challenges", () => {
       endsAt: new Date(Date.now() + 3_600_000), // 1 hour from now
     });
     mockSelect
-      .mockReturnValueOnce(makeDbChain([])) // resolution query (not ended → none)
-      .mockReturnValueOnce(makeDbChain([])) // pending-expiry query (none expired)
+      .mockReturnValueOnce(makeDbChain([])) // combined resolution (not ended → none)
       .mockReturnValueOnce(makeDbChain([active])) // capped display query
       .mockReturnValueOnce(
         makeDbChain([
@@ -414,8 +409,7 @@ describe("GET /api/social/challenges", () => {
     authedAs(makeUser({ id: 1 }));
     const pending = makeChallenge({ status: "pending" });
     mockSelect
-      .mockReturnValueOnce(makeDbChain([])) // resolution query (none ended-active)
-      .mockReturnValueOnce(makeDbChain([])) // pending-expiry query (none expired)
+      .mockReturnValueOnce(makeDbChain([])) // combined resolution (none expired)
       .mockReturnValueOnce(makeDbChain([pending])) // capped display query
       .mockReturnValueOnce(
         makeDbChain([

--- a/app/api/social/challenges/route.ts
+++ b/app/api/social/challenges/route.ts
@@ -68,13 +68,9 @@ export async function GET(req: NextRequest) {
     // (e.g. a challenge still in progress). Using mapWithConcurrency keeps the
     // round trips bounded instead of N*2 concurrent queries.
     const needsScoring = rows.filter(
-      (c) =>
-        (c.status === "active" || c.status === "completed") && !resolvedScores.has(c.id),
+      (c) => (c.status === "active" || c.status === "completed") && !resolvedScores.has(c.id)
     );
-    const computedScores = new Map<
-      number,
-      { challengerScore: number; challengedScore: number }
-    >();
+    const computedScores = new Map<number, { challengerScore: number; challengedScore: number }>();
     if (needsScoring.length > 0) {
       await mapWithConcurrency(needsScoring, RESOLVE_CONCURRENCY, async (c) => {
         const [challengerScore, challengedScore] = await Promise.all([

--- a/app/api/social/challenges/route.ts
+++ b/app/api/social/challenges/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { and, desc, eq, gte, lt, or } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lt, or } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { challenges, challengeSuggestions, friendships, users } from "@/lib/infra/db/schema";
 import { requireUser } from "@/lib/auth/social-auth";
 import {
   DURATIONS,
+  RESOLVE_CONCURRENCY,
+  mapWithConcurrency,
   scoreChallenge,
   resolveEndedChallenges,
   resolveExpiredPending,
@@ -19,35 +21,27 @@ export async function GET(req: NextRequest) {
   try {
     const now = new Date();
 
-    // Resolve EVERY ended-but-still-active challenge for this user first, unbounded
-    // by the display cap below — otherwise a stale one sitting beyond the newest 200
-    // rows would never be finalized. This self-heals on read, like the admin
-    // "finalize ended" route. Returns the scores it computed so we can reuse them.
-    const endedActive = await db
+    // Single query for all expired challenges (active or pending) instead of two
+    // separate SELECTs — halves the self-heal query overhead on every GET.
+    const expired = await db
       .select()
       .from(challenges)
       .where(
         and(
           or(eq(challenges.challengerId, userId), eq(challenges.challengedId, userId)),
-          eq(challenges.status, "active"),
+          inArray(challenges.status, ["active", "pending"]),
           lt(challenges.endsAt, now)
         )
       );
-    const resolvedScores = await resolveEndedChallenges(endedActive, now);
 
-    // Same self-heal for `pending` invites nobody acted on — otherwise an
-    // ignored invite permanently blocks the pair from a new challenge.
-    const expiredPending = await db
-      .select()
-      .from(challenges)
-      .where(
-        and(
-          or(eq(challenges.challengerId, userId), eq(challenges.challengedId, userId)),
-          eq(challenges.status, "pending"),
-          lt(challenges.endsAt, now)
-        )
-      );
-    await resolveExpiredPending(expiredPending, now);
+    const resolvedScores = await resolveEndedChallenges(
+      expired.filter((c) => c.status === "active"),
+      now
+    );
+    await resolveExpiredPending(
+      expired.filter((c) => c.status === "pending"),
+      now
+    );
 
     // Bound the per-user challenge list for the response (newest first). 200 is far
     // above any real user's volume; statuses are current after the resolution above.
@@ -69,28 +63,39 @@ export async function GET(req: NextRequest) {
         : [];
     const userMap = new Map(userRows.map((u) => [u.id, u.username]));
 
-    // Enrich with scores for active + completed challenges; reuse cached scores where available.
-    const enriched = await Promise.all(
-      rows.map(async (c) => {
-        const needsScores = c.status === "active" || c.status === "completed";
-        const cached = resolvedScores.get(c.id);
-        const [challengerScore, challengedScore] = cached
-          ? [cached.challengerScore, cached.challengedScore]
-          : needsScores
-            ? await Promise.all([
-                scoreChallenge(c.challengerId, c),
-                scoreChallenge(c.challengedId, c),
-              ])
-            : [0, 0];
-        return {
-          ...c,
-          challengerUsername: userMap.get(c.challengerId) ?? null,
-          challengedUsername: userMap.get(c.challengedId) ?? null,
-          challengerScore,
-          challengedScore,
-        };
-      })
+    // Build a complete scores map: cached from the self-heal above, plus freshly
+    // computed for any active/completed challenge the self-heal didn't touch
+    // (e.g. a challenge still in progress). Using mapWithConcurrency keeps the
+    // round trips bounded instead of N*2 concurrent queries.
+    const needsScoring = rows.filter(
+      (c) =>
+        (c.status === "active" || c.status === "completed") && !resolvedScores.has(c.id),
     );
+    const computedScores = new Map<
+      number,
+      { challengerScore: number; challengedScore: number }
+    >();
+    if (needsScoring.length > 0) {
+      await mapWithConcurrency(needsScoring, RESOLVE_CONCURRENCY, async (c) => {
+        const [challengerScore, challengedScore] = await Promise.all([
+          scoreChallenge(c.challengerId, c),
+          scoreChallenge(c.challengedId, c),
+        ]);
+        computedScores.set(c.id, { challengerScore, challengedScore });
+      });
+    }
+    const allScores = new Map([...resolvedScores, ...computedScores]);
+
+    const enriched = rows.map((c) => {
+      const s = allScores.get(c.id) ?? { challengerScore: 0, challengedScore: 0 };
+      return {
+        ...c,
+        challengerUsername: userMap.get(c.challengerId) ?? null,
+        challengedUsername: userMap.get(c.challengedId) ?? null,
+        challengerScore: s.challengerScore,
+        challengedScore: s.challengedScore,
+      };
+    });
 
     return NextResponse.json(enriched);
   } catch (err) {

--- a/lib/social/challenges.ts
+++ b/lib/social/challenges.ts
@@ -79,7 +79,7 @@ export async function mapWithConcurrency<T>(
   await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
 }
 
-const RESOLVE_CONCURRENCY = 8;
+export const RESOLVE_CONCURRENCY = 8;
 
 /**
  * Finalize any `active` challenges in `rows` whose window has ended: compute both


### PR DESCRIPTION
Closes #176
Closes #103

Two changes to the challenges GET handler:

1. **#176**: Combined two separate self-heal SELECT queries into one using
   `inArray(['active', 'pending'])`, then dispatches to the appropriate
   resolver based on status. Halves the self-heal query overhead per request.

2. **#103**: Replaced the `rows.map` with unbounded `Promise.all`
   (fire N×2 concurrent score queries) with `mapWithConcurrency` at 8-wide
   concurrency, after filtering out already-cached scores from the self-heal
   step. Eliminates the N+1 query storm for users with many challenges.