### PR TITLE
fix: correct PNG export label and defer blob URL revoke

### DIFF
--- a/components/canvas/ExportMenu.tsx
+++ b/components/canvas/ExportMenu.tsx
@@ -15,7 +15,7 @@ const OPTIONS: Array<{
   description: string;
   icon: typeof ImageIcon;
 }> = [
-  { format: "png", label: "PNG", description: "Image, transparent background", icon: ImageIcon },
+  { format: "png", label: "PNG", description: "Image, current theme background", icon: ImageIcon },
   { format: "pdf", label: "PDF", description: "Single-page document", icon: FileText },
 ];
 

--- a/lib/canvas/canvas-export.ts
+++ b/lib/canvas/canvas-export.ts
@@ -76,5 +76,8 @@ export function downloadDataUrl(dataUrl: string, filename: string): void {
 export function downloadBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   downloadDataUrl(url, filename);
-  URL.revokeObjectURL(url);
+  // Defer revoke: some browsers start the download asynchronously after
+  // click(), and revoking the URL immediately can abort it before that read
+  // completes.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }


### PR DESCRIPTION
Two small follow-ups to the canvas export feature (#227, closed #115) found while poking at it further:

- `ExportMenu.tsx`: the PNG option was labeled "transparent background," but `canvas-export.ts` always fills `--color-bg` (the current theme color) behind the render, so it was never actually transparent. Label now matches reality.
- `canvas-export.ts`: `downloadBlob` revoked the object URL immediately after `.click()`. Some browsers start the download read asynchronously, so an immediate revoke can abort it mid-download — now deferred with `setTimeout(0)`.

Not tied to any open issue — just correctness fixes on already-shipped functionality.