### PR TITLE
refactor: extract duplicated safeParse and redisStatus helpers

### DIFF
--- a/__tests__/api/admin/infra.test.ts
+++ b/__tests__/api/admin/infra.test.ts
@@ -35,11 +35,26 @@ const { mockCount, mockDelete } = vi.hoisted(() => ({
 }));
 vi.mock("@/lib/infra/db", () => ({ db: { $count: mockCount, delete: mockDelete } }));
 
-const { mockRedisEnabled, mockGetRedis } = vi.hoisted(() => ({
-  mockRedisEnabled: vi.fn(() => false),
-  mockGetRedis: vi.fn(() => null),
-}));
-vi.mock("@/lib/infra/redis", () => ({ redisEnabled: mockRedisEnabled, getRedis: mockGetRedis }));
+const { mockRedisEnabled, mockGetRedis, mockRedisStatus } = vi.hoisted(() => {
+  const enabled = vi.fn(() => false);
+  const get = vi.fn(() => null);
+  return {
+    mockRedisEnabled: enabled,
+    mockGetRedis: get,
+    mockRedisStatus: vi.fn(async () => {
+      if (!enabled()) return "disabled";
+      const client = get();
+      if (!client) return "disabled";
+      try {
+        const pong = await client.ping();
+        return pong === "PONG" ? "up" : "down";
+      } catch {
+        return "down";
+      }
+    }),
+  };
+});
+vi.mock("@/lib/infra/redis", () => ({ redisEnabled: mockRedisEnabled, getRedis: mockGetRedis, redisStatus: mockRedisStatus }));
 
 const { mockCounterSnapshot, mockUptimeSeconds } = vi.hoisted(() => ({
   mockCounterSnapshot: vi.fn(() => ({})),

--- a/__tests__/api/admin/infra.test.ts
+++ b/__tests__/api/admin/infra.test.ts
@@ -37,7 +37,7 @@ vi.mock("@/lib/infra/db", () => ({ db: { $count: mockCount, delete: mockDelete }
 
 const { mockRedisEnabled, mockGetRedis, mockRedisStatus } = vi.hoisted(() => {
   const enabled = vi.fn(() => false);
-  const get = vi.fn(() => null);
+  const get = vi.fn<() => { ping: () => Promise<string> } | null>(() => null);
   return {
     mockRedisEnabled: enabled,
     mockGetRedis: get,

--- a/__tests__/api/admin/infra.test.ts
+++ b/__tests__/api/admin/infra.test.ts
@@ -54,7 +54,11 @@ const { mockRedisEnabled, mockGetRedis, mockRedisStatus } = vi.hoisted(() => {
     }),
   };
 });
-vi.mock("@/lib/infra/redis", () => ({ redisEnabled: mockRedisEnabled, getRedis: mockGetRedis, redisStatus: mockRedisStatus }));
+vi.mock("@/lib/infra/redis", () => ({
+  redisEnabled: mockRedisEnabled,
+  getRedis: mockGetRedis,
+  redisStatus: mockRedisStatus,
+}));
 
 const { mockCounterSnapshot, mockUptimeSeconds } = vi.hoisted(() => ({
   mockCounterSnapshot: vi.fn(() => ({})),

--- a/__tests__/api/admin/overview.test.ts
+++ b/__tests__/api/admin/overview.test.ts
@@ -33,7 +33,7 @@ vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, $count: mockCount }
 
 const { mockRedisEnabled, mockGetRedis, mockRedisStatus } = vi.hoisted(() => {
   const enabled = vi.fn(() => false);
-  const get = vi.fn(() => null);
+  const get = vi.fn<() => { ping: () => Promise<string> } | null>(() => null);
   return {
     mockRedisEnabled: enabled,
     mockGetRedis: get,

--- a/__tests__/api/admin/overview.test.ts
+++ b/__tests__/api/admin/overview.test.ts
@@ -31,13 +31,29 @@ const { mockSelect, mockCount } = vi.hoisted(() => ({
 }));
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, $count: mockCount } }));
 
-const { mockRedisEnabled, mockGetRedis } = vi.hoisted(() => ({
-  mockRedisEnabled: vi.fn(() => false),
-  mockGetRedis: vi.fn(() => null),
-}));
+const { mockRedisEnabled, mockGetRedis, mockRedisStatus } = vi.hoisted(() => {
+  const enabled = vi.fn(() => false);
+  const get = vi.fn(() => null);
+  return {
+    mockRedisEnabled: enabled,
+    mockGetRedis: get,
+    mockRedisStatus: vi.fn(async () => {
+      if (!enabled()) return "disabled";
+      const client = get();
+      if (!client) return "disabled";
+      try {
+        const pong = await client.ping();
+        return pong === "PONG" ? "up" : "down";
+      } catch {
+        return "down";
+      }
+    }),
+  };
+});
 vi.mock("@/lib/infra/redis", () => ({
   redisEnabled: mockRedisEnabled,
   getRedis: mockGetRedis,
+  redisStatus: mockRedisStatus,
 }));
 
 import { GET } from "@/app/api/admin/overview/route";

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -3,6 +3,7 @@ import { desc } from "drizzle-orm";
 import { requireAdmin } from "@/lib/admin/admin-auth";
 import { db } from "@/lib/infra/db";
 import { adminAuditLog } from "@/lib/infra/db/schema";
+import { safeParse } from "@/lib/infra/http";
 
 /** Most-recent admin actions (newest first). `?limit=` caps the page (default 100). */
 export async function GET(req: NextRequest) {
@@ -33,13 +34,5 @@ export async function GET(req: NextRequest) {
   } catch (err) {
     console.error("admin audit GET db error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
-
-function safeParse(s: string): unknown {
-  try {
-    return JSON.parse(s);
-  } catch {
-    return s;
   }
 }

--- a/app/api/admin/flags/route.ts
+++ b/app/api/admin/flags/route.ts
@@ -5,6 +5,7 @@ import { logAdminAction } from "@/lib/admin/admin-audit";
 import { db } from "@/lib/infra/db";
 import { featureFlags } from "@/lib/infra/db/schema";
 import { invalidateFlagCache, validateFlagType } from "@/lib/admin/feature-flags";
+import { safeParse } from "@/lib/infra/http";
 
 const KEY_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
 
@@ -107,13 +108,5 @@ export async function DELETE(req: NextRequest) {
   } catch (err) {
     console.error("admin flags DELETE db error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
-
-function safeParse(s: string): unknown {
-  try {
-    return JSON.parse(s);
-  } catch {
-    return s;
   }
 }

--- a/app/api/admin/infra/route.ts
+++ b/app/api/admin/infra/route.ts
@@ -3,19 +3,9 @@ import { requireAdmin, rateLimitAdminMutation } from "@/lib/admin/admin-auth";
 import { logAdminAction } from "@/lib/admin/admin-audit";
 import { db } from "@/lib/infra/db";
 import { rateLimits } from "@/lib/infra/db/schema";
-import { redisEnabled, getRedis } from "@/lib/infra/redis";
+import { redisStatus } from "@/lib/infra/redis";
 import { counterSnapshot, uptimeSeconds } from "@/lib/infra/metrics";
 import { tokenCache, broadcastFlushTokenCache, clearJwksCache } from "@/lib/auth/social-auth";
-
-async function redisStatus(): Promise<"disabled" | "up" | "down"> {
-  if (!redisEnabled()) return "disabled";
-  try {
-    const pong = await getRedis()?.ping();
-    return pong === "PONG" ? "up" : "down";
-  } catch {
-    return "down";
-  }
-}
 
 /** Infrastructure snapshot: process metrics, cache sizes, Redis + rate-limit state. */
 export async function GET(req: NextRequest) {

--- a/app/api/admin/names/route.ts
+++ b/app/api/admin/names/route.ts
@@ -4,6 +4,7 @@ import { requireAdmin, rateLimitAdminMutation } from "@/lib/admin/admin-auth";
 import { logAdminAction } from "@/lib/admin/admin-audit";
 import { db } from "@/lib/infra/db";
 import { nameContent } from "@/lib/infra/db/schema";
+import { safeParse } from "@/lib/infra/http";
 
 const KINDS = ["verses", "reflection", "pairings"] as const;
 
@@ -111,13 +112,5 @@ export async function DELETE(req: NextRequest) {
   } catch (err) {
     console.error("admin names DELETE db error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
-
-function safeParse(s: string): unknown {
-  try {
-    return JSON.parse(s);
-  } catch {
-    return s;
   }
 }

--- a/app/api/admin/overview/route.ts
+++ b/app/api/admin/overview/route.ts
@@ -3,20 +3,8 @@ import { sql, gte, eq, isNotNull } from "drizzle-orm";
 import { requireAdmin } from "@/lib/admin/admin-auth";
 import { db } from "@/lib/infra/db";
 import { users, connections, curatedVotd, aiGenerations } from "@/lib/infra/db/schema";
-import { redisEnabled, getRedis } from "@/lib/infra/redis";
+import { redisStatus } from "@/lib/infra/redis";
 import { votdDateKey } from "@/lib/quran/verse-of-day";
-
-async function redisStatus(): Promise<"disabled" | "up" | "down"> {
-  if (!redisEnabled()) return "disabled";
-  try {
-    const client = getRedis();
-    if (!client) return "disabled";
-    const pong = await client.ping();
-    return pong === "PONG" ? "up" : "down";
-  } catch {
-    return "down";
-  }
-}
 
 /** Dashboard snapshot for the Overview page. */
 export async function GET(req: NextRequest) {

--- a/lib/infra/http.ts
+++ b/lib/infra/http.ts
@@ -81,6 +81,18 @@ export function parsePagination(req: NextRequest): Pagination {
   return { limit, offset };
 }
 
+/**
+ * Parse a JSON string, returning the raw string on failure. Useful for
+ * admin list endpoints where DB columns store JSON-encoded values.
+ */
+export function safeParse(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}
+
 /** Postgres unique-violation, possibly wrapped by the driver under `cause`. */
 export function isUniqueViolation(err: unknown): boolean {
   const code =

--- a/lib/infra/redis.ts
+++ b/lib/infra/redis.ts
@@ -143,6 +143,20 @@ export function redisSubscribe(channel: string, onMessage: (message: string) => 
   });
 }
 
+/** Health-check the Redis connection. Returns "disabled" when Redis is
+ *  unconfigured or unreachable, "up" when PONG responds, or "down" on error. */
+export async function redisStatus(): Promise<"disabled" | "up" | "down"> {
+  if (!redisEnabled()) return "disabled";
+  try {
+    const client = getRedis();
+    if (!client) return "disabled";
+    const pong = await client.ping();
+    return pong === "PONG" ? "up" : "down";
+  } catch {
+    return "down";
+  }
+}
+
 /**
  * Atomically increments `key` and ensures it expires after `ttlSeconds`,
  * returning the new count. Returns null when Redis is disabled or errors, so


### PR DESCRIPTION
## Summary

- Extracts `safeParse()` (parses JSON, returns raw string on failure) from 3 admin routes into `lib/infra/http.ts`
- Extracts `redisStatus()` (Redis health check) from 2 admin routes into `lib/infra/redis.ts`
- Updates all 5 routes to import the shared helper instead of defining their own

Net: −48 lines of duplicated code across the routes, +31 lines of shared helpers.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [X] No AI or theological changes in this PR

## Testing

- [X] `bun run test:ci` passes locally
- [ ] `bun run typecheck` passes locally
- [X] `bun run lint` passes locally
- [X] `bun run format:check` passes locally
- [ ] New tests added for new functionality

## Checklist

- [X] Branch is up to date with `main`
- [X] Conventional commits
- [X] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface