### PR TITLE
fix: one failing analytics query no longer takes down the whole dashboard

### DIFF
--- a/__tests__/api/admin/analytics.test.ts
+++ b/__tests__/api/admin/analytics.test.ts
@@ -25,6 +25,27 @@ function makeDbChain(resolveWith: unknown = []) {
   return chain;
 }
 
+function makeDbErrorChain(reason: unknown) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.reject(reason).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
 const { mockSelect, mockCount } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])),
   mockCount: vi.fn(() => Promise.resolve(0)),
@@ -84,5 +105,42 @@ describe("GET /api/admin/analytics", () => {
       popular: [{ query: "mercy", count: 8 }],
       zeroResult: [{ query: "xyzzy", count: 2 }],
     });
+    expect(body.errors).toBeUndefined();
+  });
+
+  it("keeps other sections intact when only zeroResultSearches fails", async () => {
+    mockSelect
+      .mockImplementationOnce(() => makeDbChain([{ fromRef: "2:255", count: 12 }]))
+      .mockImplementationOnce(() => makeDbChain([{ kind: "thematic", count: 30 }]))
+      .mockImplementationOnce(() => makeDbChain([{ query: "mercy", count: 8 }]))
+      .mockImplementationOnce(() => makeDbErrorChain(new Error("boom")));
+    mockCount.mockImplementationOnce(() => Promise.resolve(42));
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.topVerses).toEqual([{ fromRef: "2:255", count: 12 }]);
+    expect(body.dau).toBe(42);
+    expect(body.search.popular).toEqual([{ query: "mercy", count: 8 }]);
+    expect(body.search.zeroResult).toEqual([]);
+    expect(body.errors).toEqual({ zeroResultSearches: "Failed to load" });
+  });
+
+  it("keeps other sections intact when the DAU count fails", async () => {
+    queueSelects([
+      [{ fromRef: "2:255", count: 12 }],
+      [{ kind: "thematic", count: 30 }],
+      [{ query: "mercy", count: 8 }],
+      [{ query: "xyzzy", count: 2 }],
+    ]);
+    mockCount.mockImplementationOnce(() => Promise.reject(new Error("boom")));
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.dau).toBe(0);
+    expect(body.topVerses).toEqual([{ fromRef: "2:255", count: 12 }]);
+    expect(body.search.zeroResult).toEqual([{ query: "xyzzy", count: 2 }]);
+    expect(body.errors).toEqual({ dau: "Failed to load" });
   });
 });

--- a/__tests__/api/admin/analytics.test.ts
+++ b/__tests__/api/admin/analytics.test.ts
@@ -143,4 +143,21 @@ describe("GET /api/admin/analytics", () => {
     expect(body.search.zeroResult).toEqual([{ query: "xyzzy", count: 2 }]);
     expect(body.errors).toEqual({ dau: "Failed to load" });
   });
+
+  it("returns 503 when every query fails, instead of a 200 full of empty defaults", async () => {
+    mockSelect.mockReturnValue(makeDbErrorChain(new Error("db down")));
+    mockCount.mockImplementation(() => Promise.reject(new Error("db down")));
+
+    const res = await GET(req());
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("All analytics queries failed");
+    expect(body.errors).toEqual({
+      topVerses: "Failed to load",
+      connectionsByKind: "Failed to load",
+      dau: "Failed to load",
+      popularSearches: "Failed to load",
+      zeroResultSearches: "Failed to load",
+    });
+  });
 });

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -5,6 +5,9 @@ import { StatTile, Table, Th, Td, StateNote } from "@/components/admin/primitive
 import { useAdminFetch } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 
+type AnalyticsSectionKey =
+  "topVerses" | "connectionsByKind" | "dau" | "popularSearches" | "zeroResultSearches";
+
 interface AnalyticsResponse {
   topVerses: { fromRef: string; count: number }[];
   connectionsByKind: { kind: string; count: number }[];
@@ -14,6 +17,7 @@ interface AnalyticsResponse {
     popular: { query: string; count: number }[];
     zeroResult: { query: string; count: number }[];
   };
+  errors?: Partial<Record<AnalyticsSectionKey, string>>;
 }
 
 export default function AnalyticsPage() {
@@ -35,6 +39,14 @@ export default function AnalyticsPage() {
 
         {data && (
           <>
+            {(data.errors?.dau || data.errors?.connectionsByKind) && (
+              <StateNote tone="error">
+                {[data.errors?.dau && "DAU", data.errors?.connectionsByKind && "connection counts"]
+                  .filter(Boolean)
+                  .join(" and ")}{" "}
+                failed to load.
+              </StateNote>
+            )}
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               <StatTile label="DAU" value={data.dau} hint="Active in the last 24h" />
               {data.connectionsByKind.map((k) => (
@@ -48,7 +60,9 @@ export default function AnalyticsPage() {
             </div>
 
             <Section title="Top verses explored" subtitle="By generated-connection volume">
-              {data.topVerses.length === 0 ? (
+              {data.errors?.topVerses ? (
+                <StateNote tone="error">Failed to load.</StateNote>
+              ) : data.topVerses.length === 0 ? (
                 <StateNote>No connections generated yet.</StateNote>
               ) : (
                 <Table>
@@ -71,7 +85,9 @@ export default function AnalyticsPage() {
             </Section>
 
             <Section title="Popular searches" subtitle={`Last ${data.search.lookbackDays} days`}>
-              {data.search.popular.length === 0 ? (
+              {data.errors?.popularSearches ? (
+                <StateNote tone="error">Failed to load.</StateNote>
+              ) : data.search.popular.length === 0 ? (
                 <StateNote>No searches logged yet.</StateNote>
               ) : (
                 <Table>
@@ -94,7 +110,9 @@ export default function AnalyticsPage() {
             </Section>
 
             <Section title="Zero-result searches" subtitle="Feeds directly into content & curation">
-              {data.search.zeroResult.length === 0 ? (
+              {data.errors?.zeroResultSearches ? (
+                <StateNote tone="error">Failed to load.</StateNote>
+              ) : data.search.zeroResult.length === 0 ? (
                 <StateNote>No zero-result searches in this window.</StateNote>
               ) : (
                 <Table>

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -10,6 +10,8 @@ const SEARCH_LOOKBACK_DAYS = 30;
 type SectionKey =
   "topVerses" | "connectionsByKind" | "dau" | "popularSearches" | "zeroResultSearches";
 
+const SECTION_COUNT = 5;
+
 /** Unwraps a settled query result, recording a per-section error instead of failing the whole response. */
 function settle<T>(
   result: PromiseSettledResult<T>,
@@ -85,7 +87,7 @@ export async function GET(req: NextRequest) {
     const popularSearches = settle(popularSearchesR, "popularSearches", errors, []);
     const zeroResultSearches = settle(zeroResultSearchesR, "zeroResultSearches", errors, []);
 
-    return NextResponse.json({
+    const body = {
       topVerses,
       connectionsByKind,
       dau,
@@ -95,7 +97,17 @@ export async function GET(req: NextRequest) {
         zeroResult: zeroResultSearches,
       },
       errors: Object.keys(errors).length ? errors : undefined,
-    });
+    };
+
+    // All 5 queries failing means the DB itself is unreachable/down, not a
+    // one-off issue with a single query — surface that as a real outage
+    // (so uptime/alerting keyed on status code still catches it) rather than
+    // a 200 full of empty defaults.
+    if (Object.keys(errors).length === SECTION_COUNT) {
+      return NextResponse.json({ ...body, error: "All analytics queries failed" }, { status: 503 });
+    }
+
+    return NextResponse.json(body);
   } catch (err) {
     console.error("admin analytics GET db error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -7,6 +7,22 @@ import { connections, users, searchLog } from "@/lib/infra/db/schema";
 const TOP_LIMIT = 10;
 const SEARCH_LOOKBACK_DAYS = 30;
 
+type SectionKey =
+  "topVerses" | "connectionsByKind" | "dau" | "popularSearches" | "zeroResultSearches";
+
+/** Unwraps a settled query result, recording a per-section error instead of failing the whole response. */
+function settle<T>(
+  result: PromiseSettledResult<T>,
+  key: SectionKey,
+  errors: Partial<Record<SectionKey, string>>,
+  fallback: T
+): T {
+  if (result.status === "fulfilled") return result.value;
+  console.error(`admin analytics GET db error (${key}):`, result.reason);
+  errors[key] = "Failed to load";
+  return fallback;
+}
+
 /**
  * Product-usage analytics for the admin panel: top verses explored, connection
  * volume by kind, DAU, and popular / zero-result search queries. Distinct from
@@ -28,8 +44,8 @@ export async function GET(req: NextRequest) {
     );
     const searchSince = new Date(now.getTime() - SEARCH_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
 
-    const [topVerses, connectionsByKind, dau, popularSearches, zeroResultSearches] =
-      await Promise.all([
+    const [topVersesR, connectionsByKindR, dauR, popularSearchesR, zeroResultSearchesR] =
+      await Promise.allSettled([
         // "Verses explored": the from-verse of every generated connection is the
         // verse a user expanded in the canvas (connections are only written on a
         // cache miss triggered by expansion) — the cheapest accurate proxy without
@@ -62,6 +78,13 @@ export async function GET(req: NextRequest) {
           .limit(TOP_LIMIT),
       ]);
 
+    const errors: Partial<Record<SectionKey, string>> = {};
+    const topVerses = settle(topVersesR, "topVerses", errors, []);
+    const connectionsByKind = settle(connectionsByKindR, "connectionsByKind", errors, []);
+    const dau = settle(dauR, "dau", errors, 0);
+    const popularSearches = settle(popularSearchesR, "popularSearches", errors, []);
+    const zeroResultSearches = settle(zeroResultSearchesR, "zeroResultSearches", errors, []);
+
     return NextResponse.json({
       topVerses,
       connectionsByKind,
@@ -71,6 +94,7 @@ export async function GET(req: NextRequest) {
         popular: popularSearches,
         zeroResult: zeroResultSearches,
       },
+      errors: Object.keys(errors).length ? errors : undefined,
     });
   } catch (err) {
     console.error("admin analytics GET db error:", err);


### PR DESCRIPTION
**Stacked on #281 (fix #280)** — this branch is based on `fix/280-analytics-zero-result-date-typeerror`, so this diff also contains that commit until #281 merges. Please review/merge #281 first; once it's merged this PR's diff will shrink to just the changes below.

## Problem
`GET /api/admin/analytics` ran all 5 stat queries inside a single `Promise.all`, wrapped in one generic catch-all. Any single query failing (e.g. a not-yet-migrated table in a given environment, or the #280 bug) took down the entire response with a bare "Internal server error" and no indication of which query failed.

## Fix
- Switched to `Promise.allSettled` over the same 5 queries.
- Added a `settle()` helper that unwraps each result, falling back to an empty/zero value and recording a per-section entry in an `errors` map on rejection (logged server-side with the section key for diagnosis).
- Response is now always `200` with an optional `errors: Partial<Record<SectionKey, string>>` field naming exactly which section(s) failed.
- Updated `app/admin/analytics/page.tsx` to render a "Failed to load" note for just the affected section (or stat-tile row) instead of relying on the previous all-or-nothing error state.

## Testing
Extended `__tests__/api/admin/analytics.test.ts` with two new cases: one query rejecting (other sections still populated + `errors` reflects the one failure), and the `dau` count rejecting (same guarantee).

Closes #279