### PR TITLE
fix: auth was completely broken — wrong userinfo endpoint + impossible aud check

### DIFF
--- a/__tests__/lib/auth/social-auth.test.ts
+++ b/__tests__/lib/auth/social-auth.test.ts
@@ -90,9 +90,19 @@ describe("requireUser — JWT signature verification", () => {
     expect("userId" in res && res.userId).toBe(7);
   });
 
-  it("rejects a token with a missing aud claim (fails closed)", async () => {
+  it("accepts a token with no aud claim at all (QF's real tokens never carry one)", async () => {
     mockLimit.mockResolvedValue([user]);
     const token = makeJwt({ sub: "qf-sub-123", exp: farFuture }, { noAud: true });
+    const res = await requireUser(reqWith(token));
+    expect("userId" in res && res.userId).toBe(7);
+  });
+
+  it("rejects a token whose aud claim is present but doesn't include our client id", async () => {
+    mockLimit.mockResolvedValue([user]);
+    const token = makeJwt(
+      { sub: "qf-sub-123", exp: farFuture, aud: "some-other-client-id" },
+      { noAud: true }
+    );
     const res = await requireUser(reqWith(token));
     expect("status" in res && (res as Response).status).toBe(401);
   });

--- a/lib/auth/social-auth.ts
+++ b/lib/auth/social-auth.ts
@@ -252,13 +252,17 @@ async function verifiedJwtSub(token: string): Promise<string | null> {
     return null;
   }
 
-  // Validate audience (aud) — reject cross-client token replay.
-  // NextAuth / QF can issue tokens for multiple clients; the middle-tier API
-  // must only accept tokens whose audience includes OUR client ID.
+  // Validate audience (aud) — reject cross-client token replay, when the token
+  // actually carries an audience claim. QF's Hydra instance does NOT populate
+  // `aud` on access tokens (confirmed: claims_supported is just ["sub"] in its
+  // OIDC discovery doc, and real production tokens arrive with no aud claim at
+  // all) — so a claim that's entirely ABSENT can't be evidence of anything and
+  // must not be treated as a rejection. A claim that IS present but doesn't
+  // include our client ID is still rejected: that's the actual cross-client
+  // replay case this check exists for.
   const qfClientId = process.env.NEXT_PUBLIC_QF_CLIENT_ID;
-  if (qfClientId) {
-    const audiences: unknown[] =
-      payload.aud === undefined ? [] : Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+  if (qfClientId && payload.aud !== undefined) {
+    const audiences: unknown[] = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
     if (!audiences.some((a) => String(a) === qfClientId)) {
       console.warn("jwt rejected: aud mismatch", { expected: qfClientId, actual: audiences });
       return null;
@@ -424,7 +428,11 @@ async function resolveQfIdFromUserinfo(accessToken: string): Promise<string | nu
     return null;
   }
 
-  const endpoints = [`${qfAuthBase}/oauth2/userinfo`, `${qfAuthBase}/auth/v1/me`];
+  // QF's real OIDC discovery doc (`${qfAuthBase}/.well-known/openid-configuration`)
+  // advertises `userinfo_endpoint` as `${qfAuthBase}/userinfo` — verified directly
+  // against production. The previously-guessed `/oauth2/userinfo` and `/auth/v1/me`
+  // paths 404 on QF's real server and never worked.
+  const endpoints = [`${qfAuthBase}/userinfo`];
 
   for (const url of endpoints) {
     try {


### PR DESCRIPTION
## Summary
Production auth has been fully broken since #246 merged — every authenticated request site-wide, not just `/admin`, was 401ing. Root-caused via the diagnostic logging from #283, plus direct verification against QF's real OIDC discovery document (`https://oauth2.quran.foundation/.well-known/openid-configuration`).

Two independent bugs, both hit on every single request:

1. **The `aud` fail-closed check (added in #246) rejects every real QF token.** QF's Hydra instance doesn't put an `aud` claim on access tokens at all — confirmed by its own discovery doc (`claims_supported: ["sub"]`) and by production logs showing `actual: []` for every token. A check meant to catch cross-client token replay was instead rejecting 100% of legitimate tokens, because it treated "claim absent" the same as "claim wrong."
2. **The userinfo fallback hits URLs that don't exist.** `${qfAuthBase}/oauth2/userinfo` and `${qfAuthBase}/auth/v1/me` both 404 on QF's real server — they were guessed, never verified against QF's docs. The real `userinfo_endpoint` (from the discovery doc) is just `${qfAuthBase}/userinfo`.

Combined effect: every JWT fails the `aud` check → falls through to the fallback → fallback 404s → `requireUser` returns 401 for everyone, including brand-new logins (same `resolveQfId` path is used in `/api/auth/exchange`).

## Fix
- `aud` check now only rejects when the claim is **present** but doesn't include our client ID. A genuinely missing claim (QF's normal case) is no longer treated as a rejection — this preserves the actual cross-client-replay protection the check exists for, without breaking every real token.
- Userinfo fallback now hits the correct, doc-verified `${qfAuthBase}/userinfo`.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `__tests__/lib/auth/social-auth.test.ts` — 22/22 passing (updated the test that encoded the old, broken "missing aud = reject" behavior; added a test confirming a *present-but-wrong* aud is still rejected)
- [x] `__tests__/api/auth`, `__tests__/api/admin/me.test.ts`, `__tests__/api/social` — 112/112 passing
- [x] Verified the real `userinfo_endpoint` URL directly against QF's production OIDC discovery doc via curl
- [ ] Deploy and confirm `/admin` (and general login) work again on openhikmah.com