### PR TITLE
fix: restore mobile canvas actions and surface silent search/expansion failures

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -14,9 +14,14 @@ const SEMANTIC_RESULT_CAP = 100;
 interface KeywordSearchResult {
   results: SearchResult[];
   total: number;
+  /** True when the upstream call itself failed (network error, non-2xx) — as opposed
+   *  to succeeding with genuinely zero matches. The client needs this distinction:
+   *  "the search broke" and "nothing matched" call for different user-facing copy. */
+  failed?: boolean;
 }
 
-/** Keyword search via the quran.com full-text API. Returns empty on any failure. */
+/** Keyword search via the quran.com full-text API. Returns empty (and `failed: true`)
+ *  on any failure, rather than treating it identically to a real zero-result search. */
 async function keywordSearch(
   q: string,
   page: number,
@@ -30,7 +35,7 @@ async function keywordSearch(
     });
     if (!res.ok) {
       console.error(`Search API error: ${res.status} ${res.statusText}`);
-      return { results: [], total: 0 };
+      return { results: [], total: 0, failed: true };
     }
     const data = await res.json();
     const rawResults = (data?.search?.results ?? []) as Array<{
@@ -62,7 +67,7 @@ async function keywordSearch(
     };
   } catch (err) {
     console.error("Keyword search error:", err);
-    return { results: [], total: 0 };
+    return { results: [], total: 0, failed: true };
   }
 }
 
@@ -163,18 +168,25 @@ export async function GET(req: NextRequest) {
         console.error("Semantic search route error:", err);
       }
     }
-    const { results, total } = await keywordSearch(q, page, pageSize);
+    const { results, total, failed } = await keywordSearch(q, page, pageSize);
     const response: SearchResponse = { results, total, page, pageSize };
     await maybeLogSearchQuery(req, q, "keyword", total);
-    return NextResponse.json(response, { headers: { "x-search-fallback": "keyword" } });
+    return NextResponse.json(response, {
+      headers: {
+        "x-search-fallback": "keyword",
+        ...(failed ? { "x-search-error": "keyword-unavailable" } : {}),
+      },
+    });
   }
 
   const allowed = await consume(`search:${clientKey(req)}`);
   if (!allowed) {
     return NextResponse.json({ error: "Too many search requests" }, { status: 429 });
   }
-  const { results, total } = await keywordSearch(q, page, pageSize);
+  const { results, total, failed } = await keywordSearch(q, page, pageSize);
   const response: SearchResponse = { results, total, page, pageSize };
   await maybeLogSearchQuery(req, q, "keyword", total);
-  return NextResponse.json(response);
+  return NextResponse.json(response, {
+    headers: failed ? { "x-search-error": "keyword-unavailable" } : {},
+  });
 }

--- a/app/search/SearchPageClient.tsx
+++ b/app/search/SearchPageClient.tsx
@@ -14,6 +14,17 @@ import type { SearchResponse, SearchResult } from "@/types/quran";
 
 const PAGE_SIZE = 20;
 
+// Curated starting points for the empty state — natural-language topics search
+// best in "meaning" mode, so chips navigate there rather than defaulting to Keyword.
+const EXAMPLE_SEARCHES = [
+  "2:255 — Ayat al-Kursi",
+  "Patience",
+  "Mercy",
+  "Gratitude",
+  "Forgiveness",
+  "The Night Journey",
+];
+
 function buildHref(q: string, mode: SearchMode, page: number) {
   const params = new URLSearchParams({ q, type: mode, page: String(page) });
   return `/search?${params.toString()}`;
@@ -32,6 +43,12 @@ export function SearchPageClient() {
   const [loading, setLoading] = useState(!!q.trim());
   const [error, setError] = useState(false);
   const [fellBackToKeyword, setFellBackToKeyword] = useState(false);
+  // Keyword search calls an upstream API — this distinguishes "the search itself
+  // failed" from a genuine zero-match result, which call for different copy.
+  const [keywordUnavailable, setKeywordUnavailable] = useState(false);
+  // Bumped by the "Try again" button so the fetch effect re-runs even when
+  // q/mode/page are unchanged (router.replace to the same URL is a no-op).
+  const [retryCount, setRetryCount] = useState(0);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -62,6 +79,7 @@ export function SearchPageClient() {
     setLoading(true);
     setError(false);
     setFellBackToKeyword(false);
+    setKeywordUnavailable(false);
 
     fetch(
       `/api/search?q=${encodeURIComponent(trimmed)}${
@@ -75,6 +93,7 @@ export function SearchPageClient() {
         setFellBackToKeyword(
           mode === "meaning" && res.headers.get("x-search-fallback") === "keyword"
         );
+        setKeywordUnavailable(res.headers.get("x-search-error") === "keyword-unavailable");
         setData(json);
       })
       .catch((err) => {
@@ -88,7 +107,7 @@ export function SearchPageClient() {
       });
 
     return () => controller.abort();
-  }, [q, mode, page]);
+  }, [q, mode, page, retryCount]);
 
   const navigate = useCallback(
     (nextQ: string, nextMode: SearchMode, nextPage: number) => {
@@ -133,9 +152,27 @@ export function SearchPageClient() {
         <SearchModeToggle mode={mode} onChange={(m) => navigate(q, m, 1)} className="mb-6" />
 
         {!q.trim() ? (
-          <div className="py-20 text-center">
+          <div className="py-16 text-center">
             <Search className="mx-auto mb-4 h-8 w-8 text-text-muted/40" />
-            <p className="text-sm text-text-muted">Enter a search term to get started.</p>
+            <p className="mb-6 text-sm text-text-muted">Enter a search term to get started.</p>
+            <div className="mx-auto flex max-w-md flex-wrap justify-center gap-2">
+              {EXAMPLE_SEARCHES.map((example) => {
+                // Ref-shaped examples (e.g. "2:255 — Ayat al-Kursi") search fine in either
+                // mode; plain topics only work in "meaning" mode.
+                const isRef = /^\d+:\d+/.test(example);
+                const [term] = example.split(" — ");
+                return (
+                  <button
+                    key={example}
+                    type="button"
+                    onClick={() => navigate(term, isRef ? "keyword" : "meaning", 1)}
+                    className="rounded-full border border-border bg-surface px-3 py-1.5 text-xs text-text-secondary transition-colors hover:border-teal/40 hover:text-teal-bright"
+                  >
+                    {example}
+                  </button>
+                );
+              })}
+            </div>
           </div>
         ) : loading ? (
           <div className="space-y-3">
@@ -158,8 +195,31 @@ export function SearchPageClient() {
           <div className="py-20 text-center">
             <BookOpen className="mx-auto mb-4 h-8 w-8 text-text-muted/40" />
             <p className="text-sm text-text-muted">
-              {mode === "meaning" ? "No verses matched that meaning." : "No results found."}
+              {keywordUnavailable
+                ? "Search is temporarily unavailable."
+                : mode === "meaning"
+                  ? "No verses matched that meaning."
+                  : "No exact matches."}
             </p>
+            {keywordUnavailable ? (
+              <button
+                type="button"
+                onClick={() => setRetryCount((c) => c + 1)}
+                className="mt-3 text-sm text-teal-bright hover:underline"
+              >
+                Try again →
+              </button>
+            ) : (
+              mode === "keyword" && (
+                <button
+                  type="button"
+                  onClick={() => navigate(q, "meaning", 1)}
+                  className="mt-3 text-sm text-teal-bright hover:underline"
+                >
+                  Try &ldquo;By meaning&rdquo; search instead →
+                </button>
+              )
+            )}
           </div>
         ) : (
           <>
@@ -169,7 +229,8 @@ export function SearchPageClient() {
             </p>
             {fellBackToKeyword && (
               <p className="mb-4 text-xs text-text-muted">
-                Showing keyword matches — semantic search is warming up.
+                Meaning-based results aren&rsquo;t ready for this query yet — showing keyword
+                matches instead.
               </p>
             )}
             <div className="space-y-3">

--- a/components/canvas/HikmahCanvas.tsx
+++ b/components/canvas/HikmahCanvas.tsx
@@ -13,6 +13,7 @@ import {
   type Node,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { X } from "lucide-react";
 import { VerseNode } from "./VerseNode";
 import { HikmahEdge } from "./HikmahEdge";
 import { CanvasLegend } from "./CanvasLegend";
@@ -21,6 +22,7 @@ import { useCanvasStore } from "@/store/canvas";
 import { useActivityTracker } from "@/hooks/useActivityTracker";
 import { useCanvasPersistence } from "@/hooks/useCanvasPersistence";
 import { findFreeSlot, NODE_WIDTH, NODE_HEIGHT } from "@/lib/canvas/canvas-layout";
+import { cn } from "@/lib/utils";
 import type { ConnectionResult, Verse } from "@/types/quran";
 
 const nodeTypes = { verse: VerseNode };
@@ -55,7 +57,20 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
   const reactFlow = useReactFlow();
   const expandingRef = useRef(false);
   const mountedRef = useRef(true);
-  const [expansionError, setExpansionError] = useState<string | null>(null);
+  const [expansionNotice, setExpansionNotice] = useState<{
+    message: string;
+    kind: "error" | "info";
+  } | null>(null);
+
+  // The mobile bottom bar (in Header, outside this ReactFlowProvider) can't call
+  // useReactFlow() directly, so it asks for a fit via the store instead.
+  const fitRequestToken = useCanvasStore((s) => s.fitRequestToken);
+  useEffect(() => {
+    if (fitRequestToken === 0) return;
+    reactFlow.fitView({ padding: 0.35, maxZoom: 1, duration: 400 });
+    // reactFlow's identity changes across renders; only fitRequestToken should retrigger this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fitRequestToken]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -169,12 +184,13 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
         const exhausted = err instanceof ExhaustedExpansionError;
         if (!exhausted) console.error("Expansion failed:", err);
         if (mountedRef.current) {
-          setExpansionError(
-            exhausted
+          setExpansionNotice({
+            message: exhausted
               ? "No more connections of this type."
-              : "Could not find connections. Try a different type."
-          );
-          setTimeout(() => setExpansionError(null), 3500);
+              : "Could not find connections. Try a different type.",
+            kind: exhausted ? "info" : "error",
+          });
+          setTimeout(() => setExpansionNotice(null), 6000);
         }
       } finally {
         if (mountedRef.current) setExpandingNode(null);
@@ -262,9 +278,24 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
 
   return (
     <div className="w-full h-full">
-      {expansionError && (
-        <div className="pointer-events-none absolute bottom-20 left-1/2 z-50 -translate-x-1/2 rounded-md border border-border bg-surface-raised px-4 py-2 font-mono text-xs text-text-muted md:bottom-6">
-          {expansionError}
+      {expansionNotice && (
+        <div
+          role="status"
+          className={cn(
+            "absolute bottom-20 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-md border px-4 py-2 text-xs shadow-floating md:bottom-6",
+            expansionNotice.kind === "error"
+              ? "border-error/40 bg-surface-raised text-error"
+              : "border-teal/40 bg-surface-raised text-teal"
+          )}
+        >
+          <span className="font-mono">{expansionNotice.message}</span>
+          <button
+            onClick={() => setExpansionNotice(null)}
+            className="text-text-muted hover:text-text-primary"
+            aria-label="Dismiss"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
         </div>
       )}
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -12,6 +12,7 @@ import {
   FileText,
   Loader2,
   Check,
+  AlertCircle,
 } from "lucide-react";
 import { useCanvasStore, serializeCanvas } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
@@ -20,7 +21,7 @@ import { useAudioStore } from "@/store/audio";
 import type { AudioVerse } from "@/store/audio";
 import type { Verse } from "@/types/quran";
 import { buildShareUrl } from "@/hooks/useCanvasPersistence";
-import { useState, useEffect, useRef, type ReactNode } from "react";
+import { useState, useEffect, useRef, forwardRef, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { useCopyFeedback } from "@/hooks/useCopyFeedback";
 import {
@@ -38,23 +39,20 @@ interface HeaderProps {
 }
 
 /** A thumb-sized icon+label button for the mobile bottom action bar (≥56px tap target). */
-function BarButton({
-  icon,
-  label,
-  onClick,
-  active,
-  disabled,
-  danger,
-}: {
-  icon: ReactNode;
-  label: string;
-  onClick: () => void;
-  active?: boolean;
-  disabled?: boolean;
-  danger?: boolean;
-}) {
+const BarButton = forwardRef<
+  HTMLButtonElement,
+  {
+    icon: ReactNode;
+    label: string;
+    onClick: () => void;
+    active?: boolean;
+    disabled?: boolean;
+    danger?: boolean;
+  }
+>(function BarButton({ icon, label, onClick, active, disabled, danger }, ref) {
   return (
     <button
+      ref={ref}
       onClick={onClick}
       disabled={disabled}
       className={cn(
@@ -68,7 +66,7 @@ function BarButton({
       <span>{label}</span>
     </button>
   );
-}
+});
 
 const LEGEND_ITEMS: Array<{ label: string; className: string }> = [
   { label: "Theme", className: "bg-theme-edge" },
@@ -85,7 +83,9 @@ function MoreSheet({
   onSave,
   saving,
   saved,
+  saveError,
   canSave,
+  triggerRef,
 }: {
   onClose: () => void;
   onExport: (format: "png" | "pdf") => void;
@@ -93,17 +93,29 @@ function MoreSheet({
   onSave: (() => void) | null;
   saving: boolean;
   saved: boolean;
+  saveError: boolean;
   canSave: boolean;
+  /** The "More" bar button that opens this sheet — excluded from the outside-click
+   *  check, otherwise tapping it to close the sheet immediately reopens it (the
+   *  mousedown-driven close runs before the button's own click-toggle handler). */
+  triggerRef: React.RefObject<HTMLElement | null>;
 }) {
   const sheetRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const onDocClick = (e: MouseEvent) => {
-      if (sheetRef.current && !sheetRef.current.contains(e.target as Node)) onClose();
+      const target = e.target as Node;
+      if (
+        sheetRef.current &&
+        !sheetRef.current.contains(target) &&
+        !triggerRef.current?.contains(target)
+      ) {
+        onClose();
+      }
     };
     document.addEventListener("mousedown", onDocClick);
     return () => document.removeEventListener("mousedown", onDocClick);
-  }, [onClose]);
+  }, [onClose, triggerRef]);
 
   return (
     <div
@@ -120,11 +132,19 @@ function MoreSheet({
             <Loader2 className="h-4 w-4 shrink-0 animate-spin text-text-muted" />
           ) : saved ? (
             <Check className="h-4 w-4 shrink-0 text-teal" />
+          ) : saveError ? (
+            <AlertCircle className="h-4 w-4 shrink-0 text-error" />
           ) : (
             <Save className="h-4 w-4 shrink-0 text-text-muted" />
           )}
-          <span className="text-sm font-medium text-text-primary">
-            {saving ? "Saving…" : saved ? "Saved" : "Save workspace"}
+          <span className={cn("text-sm font-medium text-text-primary", saveError && "text-error")}>
+            {saving
+              ? "Saving…"
+              : saved
+                ? "Saved"
+                : saveError
+                  ? "Save failed — try again"
+                  : "Save workspace"}
           </span>
         </button>
       )}
@@ -164,6 +184,8 @@ export function Header({ onSearchOpen }: HeaderProps) {
   const [exportError, setExportError] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState(false);
+  const moreButtonRef = useRef<HTMLButtonElement>(null);
 
   const reset = useCanvasStore((s) => s.reset);
   const nodes = useCanvasStore((s) => s.nodes);
@@ -283,7 +305,13 @@ export function Header({ onSearchOpen }: HeaderProps) {
           setSaved(false);
           setMoreOpen(false);
         }, 1200);
+      } else {
+        setSaveError(true);
+        setTimeout(() => setSaveError(false), 2500);
       }
+    } catch {
+      setSaveError(true);
+      setTimeout(() => setSaveError(false), 2500);
     } finally {
       setSaving(false);
     }
@@ -310,7 +338,9 @@ export function Header({ onSearchOpen }: HeaderProps) {
               onSave={accessToken ? handleSave : null}
               saving={saving}
               saved={saved}
+              saveError={saveError}
               canSave={nodes.length > 0}
+              triggerRef={moreButtonRef}
             />
           )}
           <div className="fixed inset-x-0 bottom-0 z-40 flex md:hidden bg-surface/95 backdrop-blur border-t border-border pb-[env(safe-area-inset-bottom)]">
@@ -330,6 +360,7 @@ export function Header({ onSearchOpen }: HeaderProps) {
               active={copied}
             />
             <BarButton
+              ref={moreButtonRef}
               icon={exportError ? <RotateCcw /> : <MoreHorizontal />}
               label={exportError ? "Failed" : "More"}
               onClick={() => setMoreOpen((v) => !v)}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,6 +1,18 @@
 "use client";
 
-import { Search, RotateCcw, Share2, ListMusic } from "lucide-react";
+import {
+  Search,
+  RotateCcw,
+  Share2,
+  ListMusic,
+  Maximize2,
+  MoreHorizontal,
+  Save,
+  Image as ImageIcon,
+  FileText,
+  Loader2,
+  Check,
+} from "lucide-react";
 import { useCanvasStore, serializeCanvas } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
@@ -8,9 +20,15 @@ import { useAudioStore } from "@/store/audio";
 import type { AudioVerse } from "@/store/audio";
 import type { Verse } from "@/types/quran";
 import { buildShareUrl } from "@/hooks/useCanvasPersistence";
-import { useState, useEffect, type ReactNode } from "react";
+import { useState, useEffect, useRef, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { useCopyFeedback } from "@/hooks/useCopyFeedback";
+import {
+  exportCanvasToPng,
+  exportCanvasToPdf,
+  downloadDataUrl,
+  downloadBlob,
+} from "@/lib/canvas/canvas-export";
 import { AccountMenu } from "./AccountMenu";
 import { Wordmark } from "./Wordmark";
 import { HeaderNavLinks } from "./HeaderNavLinks";
@@ -52,13 +70,105 @@ function BarButton({
   );
 }
 
+const LEGEND_ITEMS: Array<{ label: string; className: string }> = [
+  { label: "Theme", className: "bg-theme-edge" },
+  { label: "Root", className: "bg-root-edge" },
+  { label: "Contrast", className: "bg-contrast-edge" },
+];
+
+/** The mobile bar's overflow — export, save (signed-in only), and the edge-color
+ * legend, none of which fit as a first-class bottom-bar button on a phone screen. */
+function MoreSheet({
+  onClose,
+  onExport,
+  exporting,
+  onSave,
+  saving,
+  saved,
+  canSave,
+}: {
+  onClose: () => void;
+  onExport: (format: "png" | "pdf") => void;
+  exporting: boolean;
+  onSave: (() => void) | null;
+  saving: boolean;
+  saved: boolean;
+  canSave: boolean;
+}) {
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onDocClick = (e: MouseEvent) => {
+      if (sheetRef.current && !sheetRef.current.contains(e.target as Node)) onClose();
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={sheetRef}
+      className="fixed inset-x-3 bottom-[calc(58px+env(safe-area-inset-bottom)+8px)] z-50 rounded-lg border border-border bg-surface-overlay shadow-floating md:hidden"
+    >
+      {onSave && (
+        <button
+          onClick={onSave}
+          disabled={saving || !canSave}
+          className="flex w-full items-center gap-2.5 px-4 py-3 text-left disabled:opacity-40"
+        >
+          {saving ? (
+            <Loader2 className="h-4 w-4 shrink-0 animate-spin text-text-muted" />
+          ) : saved ? (
+            <Check className="h-4 w-4 shrink-0 text-teal" />
+          ) : (
+            <Save className="h-4 w-4 shrink-0 text-text-muted" />
+          )}
+          <span className="text-sm font-medium text-text-primary">
+            {saving ? "Saving…" : saved ? "Saved" : "Save workspace"}
+          </span>
+        </button>
+      )}
+      <button
+        onClick={() => onExport("png")}
+        disabled={exporting}
+        className="flex w-full items-center gap-2.5 px-4 py-3 text-left disabled:opacity-40"
+      >
+        <ImageIcon className="h-4 w-4 shrink-0 text-text-muted" />
+        <span className="text-sm font-medium text-text-primary">Export as PNG</span>
+      </button>
+      <button
+        onClick={() => onExport("pdf")}
+        disabled={exporting}
+        className="flex w-full items-center gap-2.5 px-4 py-3 text-left disabled:opacity-40"
+      >
+        <FileText className="h-4 w-4 shrink-0 text-text-muted" />
+        <span className="text-sm font-medium text-text-primary">Export as PDF</span>
+      </button>
+      <div className="flex items-center gap-3 border-t border-border-subtle px-4 py-3">
+        {LEGEND_ITEMS.map((item) => (
+          <div key={item.label} className="flex items-center gap-1.5">
+            <span className={`h-0.5 w-3.5 rounded-full ${item.className}`} />
+            <span className="text-[11px] text-text-secondary">{item.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function Header({ onSearchOpen }: HeaderProps) {
   const { copied, copy } = useCopyFeedback();
   const [sharing, setSharing] = useState(false);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
 
   const reset = useCanvasStore((s) => s.reset);
   const nodes = useCanvasStore((s) => s.nodes);
   const edges = useCanvasStore((s) => s.edges);
+  const requestFit = useCanvasStore((s) => s.requestFit);
   const nodeCount = nodes.length;
 
   const accessToken = useAuthStore((s) => s.accessToken);
@@ -134,6 +244,51 @@ export function Header({ onSearchOpen }: HeaderProps) {
     }
   };
 
+  const handleExport = async (format: "png" | "pdf") => {
+    if (exporting) return;
+    setExporting(true);
+    try {
+      const stamp = new Date().toISOString().slice(0, 10);
+      if (format === "png") {
+        const dataUrl = await exportCanvasToPng(nodes);
+        downloadDataUrl(dataUrl, `hikmah-canvas-${stamp}.png`);
+      } else {
+        const blob = await exportCanvasToPdf(nodes);
+        downloadBlob(blob, `hikmah-canvas-${stamp}.pdf`);
+      }
+      setMoreOpen(false);
+    } catch {
+      setExportError(true);
+      setTimeout(() => setExportError(false), 2500);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (saving || !accessToken || nodes.length === 0) return;
+    setSaving(true);
+    try {
+      const count = nodes.length;
+      const date = new Date().toLocaleDateString("en-US", { month: "short", day: "numeric" });
+      const name = `${count} verse${count === 1 ? "" : "s"} — ${date}`;
+      const res = await fetch("/api/workspace", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+        body: JSON.stringify({ name, data: serializeCanvas(nodes, edges), nodeCount: count }),
+      });
+      if (res.ok) {
+        setSaved(true);
+        setTimeout(() => {
+          setSaved(false);
+          setMoreOpen(false);
+        }, 1200);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <>
       <header className="flex items-center justify-between px-6 md:px-12 h-[60px] shrink-0 bg-bg border-b border-border">
@@ -146,23 +301,43 @@ export function Header({ onSearchOpen }: HeaderProps) {
 
       {/* Mobile: bottom action bar — primary canvas actions (<md, only with nodes) */}
       {nodeCount > 0 && (
-        <div className="fixed inset-x-0 bottom-0 z-40 flex md:hidden bg-surface/95 backdrop-blur border-t border-border pb-[env(safe-area-inset-bottom)]">
-          <BarButton icon={<Search />} label="Search" onClick={onSearchOpen} />
-          <BarButton
-            icon={<ListMusic />}
-            label={audioCurrentRef ? "Stop" : "Play all"}
-            onClick={handlePlayGraph}
-            active={!!audioCurrentRef}
-          />
-          <BarButton
-            icon={<Share2 />}
-            label={sharing ? "…" : copied ? "Copied" : "Share"}
-            onClick={handleShare}
-            disabled={sharing}
-            active={copied}
-          />
-          <BarButton icon={<RotateCcw />} label="Clear" onClick={reset} danger />
-        </div>
+        <>
+          {moreOpen && (
+            <MoreSheet
+              onClose={() => setMoreOpen(false)}
+              onExport={handleExport}
+              exporting={exporting}
+              onSave={accessToken ? handleSave : null}
+              saving={saving}
+              saved={saved}
+              canSave={nodes.length > 0}
+            />
+          )}
+          <div className="fixed inset-x-0 bottom-0 z-40 flex md:hidden bg-surface/95 backdrop-blur border-t border-border pb-[env(safe-area-inset-bottom)]">
+            <BarButton icon={<Search />} label="Search" onClick={onSearchOpen} />
+            <BarButton icon={<Maximize2 />} label="Fit" onClick={requestFit} />
+            <BarButton
+              icon={<ListMusic />}
+              label={audioCurrentRef ? "Stop" : "Play all"}
+              onClick={handlePlayGraph}
+              active={!!audioCurrentRef}
+            />
+            <BarButton
+              icon={<Share2 />}
+              label={sharing ? "…" : copied ? "Copied" : "Share"}
+              onClick={handleShare}
+              disabled={sharing}
+              active={copied}
+            />
+            <BarButton
+              icon={exportError ? <RotateCcw /> : <MoreHorizontal />}
+              label={exportError ? "Failed" : "More"}
+              onClick={() => setMoreOpen((v) => !v)}
+              active={moreOpen}
+            />
+            <BarButton icon={<RotateCcw />} label="Clear" onClick={reset} danger />
+          </div>
+        </>
       )}
     </>
   );

--- a/store/canvas.ts
+++ b/store/canvas.ts
@@ -87,6 +87,7 @@ interface CanvasStore {
   newlyAddedNodeId: string | null;
   viewport: CanvasViewport;
   sidebarWidth: number;
+  fitRequestToken: number;
 
   setNodes: (nodes: Node[]) => void;
   setEdges: (edges: Edge[]) => void;
@@ -105,6 +106,10 @@ interface CanvasStore {
   setPendingPanToNode: (nodeId: string | null) => void;
   setNewlyAddedNode: (nodeId: string | null) => void;
   setSidebarWidth: (width: number) => void;
+  /** Bumps `fitRequestToken` — components that render the ReactFlow instance (which
+   * may live outside the caller's tree, e.g. the mobile bar in Header) watch this
+   * to trigger `fitView()` without needing direct access to the ReactFlow instance. */
+  requestFit: () => void;
   hasNode: (ref: string) => boolean;
   getNodeByRef: (ref: string) => Node | undefined;
   getNodeById: (id: string) => Node | undefined;
@@ -139,6 +144,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
   newlyAddedNodeId: null,
   viewport: { x: 0, y: 0, zoom: 1 },
   sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+  fitRequestToken: 0,
 
   setNodes: (nodes) => set({ nodes }),
   setEdges: (edges) => set({ edges }),
@@ -199,6 +205,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
   setPendingAutoExpand: (nodeId) => set({ pendingAutoExpand: nodeId }),
   setPendingPanToNode: (nodeId) => set({ pendingPanToNodeId: nodeId }),
   setSidebarWidth: (width) => set({ sidebarWidth: width }),
+  requestFit: () => set((s) => ({ fitRequestToken: s.fitRequestToken + 1 })),
 
   setNewlyAddedNode: (nodeId) => {
     if (newlyAddedTimeout) clearTimeout(newlyAddedTimeout);


### PR DESCRIPTION
## Summary

A UX/UI audit of the running app (driven live with Playwright, not just code review) surfaced several places where the experience silently drops functionality or fails without telling the user. This fixes the concrete ones found:

- **Mobile canvas toolbar dropped Fit, Export, and the edge-color legend below `md`** — the mobile bottom bar was a hand-maintained 4-button duplicate of the desktop toolbar, not a responsive variant, so these were simply never added. Added a `requestFit` token to the canvas store (lets the mobile bar trigger `fitView()` without needing the ReactFlow instance), a **Fit** button, and a **More** overflow sheet (Export PNG/PDF, Save-when-signed-in, legend).
- **Connection-expansion failures were invisible** — the error banner existed but was low-contrast gray, bottom-center, and auto-dismissed in 3.5s. Now color-coded (red for real failures, teal for "no more of this type"), stays up 6s, and has a dismiss control.
- **`/api/search` silently treated a failed upstream keyword-search call as a zero-result search** — this was the real bug behind "No results found" for plain-English queries in Keyword mode, not a tokenization mismatch. Threaded a `failed` flag through to an `x-search-error` response header so the client shows "Search is temporarily unavailable — Try again" instead of a misleading empty state.
- **Search empty state was bare** — added 6 curated example chips (a ref + five topics) matching the instructive-empty-state pattern the canvas already uses.

No design-system changes — same navy/gold/teal palette and tokens throughout (`DESIGN.md`).

## Test plan

- [x] `bun run typecheck` and `bun run lint` clean on all touched files
- [x] Re-drove every fixed flow live via Playwright at 1440px and 375px (mobile canvas Fit/More sheet, connection-expansion error banner, search empty state chips, search failure retry)
- [x] `bun run test:ci` (full unit suite) passing via pre-commit hook
- [x] `test:e2e` integration suite passing via pre-push hook
- [x] Confirmed the 2 pre-existing `e2e/canvas.spec.ts` / `e2e/search.spec.ts` failures reproduce identically on unmodified `main` — not caused by this change