### PR TITLE
fix: infra Reset rate limits button doesn't disclose it's global

### DIFF
--- a/app/admin/infra/page.tsx
+++ b/app/admin/infra/page.tsx
@@ -123,7 +123,7 @@ export default function InfraPage() {
                   variant="danger"
                   disabled={busy}
                   onConfirm={() => run("reset-ratelimits")}
-                  confirmLabel="Reset limits?"
+                  confirmLabel="Reset ALL rate limits for every user and IP?"
                 >
                   Reset rate limits
                 </ConfirmButton>


### PR DESCRIPTION
## Problem
Closes #278. The "Reset rate limits" action on the admin infra page (`app/api/admin/infra/route.ts:69-72`) deletes every row in the `rate_limits` table — clearing throttling for every user and IP simultaneously. The confirm copy was just "Reset limits?", giving no indication of that blast radius.

## Fix
Changed the confirm label in `app/admin/infra/page.tsx` from `"Reset limits?"` to `"Reset ALL rate limits for every user and IP?"` so an admin reaching for this as a scoped incident-response tool sees the actual scope before confirming.

A scoped (single user/IP) variant is flagged in the issue as a possible follow-up enhancement, not required here.

## Test plan
- `bun run lint -- --max-warnings=0` — clean
- `bun run typecheck` — clean
- Manually verified `ConfirmButton` swaps its label to the new copy on first click (component logic unchanged, only the label prop).