### PR TITLE
test: fix misleading proto-pollution test + excludeRefs regression coverage

### DIFF
--- a/__tests__/lib/ai/connection-discovery.test.ts
+++ b/__tests__/lib/ai/connection-discovery.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// ── DB mock: select() resolves to a configurable result via a chainable Proxy ──
-function makeSelectChain(resolveWith: unknown[]) {
+// ── DB mock: select() resolves to a configurable result via a chainable Proxy.
+// Optionally records the arguments each chained method was called with, keyed
+// by method name, so a test can assert *which* where-clause conditions were
+// built (e.g. whether notInArray(excludeRefs) was included) without needing to
+// fully emulate drizzle's SQL builder.
+function makeSelectChain(resolveWith: unknown[], calls?: Record<string, unknown[][]>) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
     function () {
@@ -12,7 +16,10 @@ function makeSelectChain(resolveWith: unknown[]) {
         if (prop === "then")
           return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
             Promise.resolve(resolveWith).then(res, rej);
-        return () => chain;
+        return (...args: unknown[]) => {
+          if (calls) (calls[prop as string] ??= []).push(args);
+          return chain;
+        };
       },
       apply() {
         return chain;
@@ -22,13 +29,27 @@ function makeSelectChain(resolveWith: unknown[]) {
   return chain;
 }
 
-const { mockSelect, mockSemanticCandidates } = vi.hoisted(() => ({
+const { mockSelect, mockSemanticCandidates, mockAndCalls } = vi.hoisted(() => ({
   mockSelect: vi.fn(),
   mockSemanticCandidates: vi.fn(),
+  mockAndCalls: [] as unknown[][],
 }));
 
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, selectDistinct: mockSelect } }));
 vi.mock("@/lib/quran/semantic-search", () => ({ semanticCandidates: mockSemanticCandidates }));
+// Wrap the real `and` so tests can assert how many where-conditions
+// rootCandidates() built — e.g. whether notInArray(excludeRefs) was included —
+// without reimplementing drizzle's SQL builder.
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...actual,
+    and: (...args: unknown[]) => {
+      mockAndCalls.push(args);
+      return actual.and(...(args as Parameters<typeof actual.and>));
+    },
+  };
+});
 
 import { discoverCandidates } from "@/lib/ai/connection-discovery";
 
@@ -36,6 +57,7 @@ describe("discoverCandidates", () => {
   beforeEach(() => {
     mockSelect.mockReset();
     mockSemanticCandidates.mockReset();
+    mockAndCalls.length = 0;
   });
 
   it("returns [] for 'root' when the source verse has no roots seeded", async () => {
@@ -56,6 +78,36 @@ describe("discoverCandidates", () => {
       );
     const out = await discoverCandidates("1:1", "root", 12);
     expect(out).toEqual(["2:255", "3:18"]);
+  });
+
+  // Regression test for the fix in 2297aab (issue #185): repeat-clicking "root"
+  // expansion must not keep returning the same already-seen refs, which
+  // requires notInArray(excludeRefs) to actually be threaded into the second
+  // query's where-clause whenever excludeRefs is non-empty.
+  it("threads excludeRefs into the root candidate query's where-clause", async () => {
+    const rankedCalls: Record<string, unknown[][]> = {};
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain([{ root: "سمو" }]))
+      .mockReturnValueOnce(makeSelectChain([{ ref: "3:18", shared: 1 }], rankedCalls));
+
+    await discoverCandidates("1:1", "root", 12, ["2:255"]);
+
+    // rootCandidates() builds its first `and(...)` (source-verse root lookup)
+    // before the second query's own `and(...)` call — the second call is the
+    // one whose condition count reflects whether excludeRefs was included.
+    expect(mockAndCalls).toHaveLength(2);
+    expect(mockAndCalls[1]).toHaveLength(3); // inArray + ne + notInArray(excludeRefs)
+  });
+
+  it("omits the notInArray condition entirely when excludeRefs is empty", async () => {
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain([{ root: "سمو" }]))
+      .mockReturnValueOnce(makeSelectChain([{ ref: "3:18", shared: 1 }]));
+
+    await discoverCandidates("1:1", "root", 12, []);
+
+    expect(mockAndCalls).toHaveLength(2);
+    expect(mockAndCalls[1]).toHaveLength(2); // inArray + ne only, no notInArray
   });
 
   it("delegates 'thematic' to semanticCandidates without touching the db", async () => {

--- a/__tests__/lib/canvas/share-canvas.test.ts
+++ b/__tests__/lib/canvas/share-canvas.test.ts
@@ -51,8 +51,14 @@ describe("isValidNode", () => {
     expect(isValidNode(nodeWith({ ref: "1:1", surahName: "x", translation: 1 }))).toBe(false);
   });
 
-  it("rejects a malformed shared-canvas payload attempting prototype pollution", () => {
-    const malicious = JSON.parse('{"verse": {"ref": "1:1", "__proto__": {"polluted": true}}}');
-    expect(isValidNode(malicious)).toBe(false);
+  it("ignores extra/unexpected fields and validates only ref/surahName/translation", () => {
+    // A `__proto__` key from JSON.parse is just an own data property, not the
+    // object's actual prototype — this asserts isValidNode doesn't get tripped
+    // up by it either way, as long as the three required fields are present.
+    const withExtraField = JSON.parse(
+      '{"verse": {"ref": "1:1", "surahName": "x", "translation": "y", "__proto__": {"polluted": true}}}'
+    );
+    expect(isValidNode(withExtraField)).toBe(true);
+    expect(Object.getPrototypeOf(withExtraField.verse)).toBe(Object.prototype);
   });
 });


### PR DESCRIPTION
## Context
Follow-up to #287 (already merged). #287's own \`/code-review:code-review\` pass surfaced two real issues after the PR had already been merged — this PR lands the fixes on top of \`main\`.

## Problem
1. \`__tests__/lib/canvas/share-canvas.test.ts\`'s "prototype pollution" test passed for the wrong reason: \`JSON.parse\` sets \`__proto__\` as a plain own data property, not the object's actual prototype, so the test passed only because the required \`surahName\`/\`translation\` fields were absent — the same reason an adjacent test already passes. It gave false confidence that a security property was covered.
2. \`__tests__/lib/ai/connection-discovery.test.ts\` had no coverage for the \`excludeRefs\` → \`notInArray\` wiring in \`rootCandidates()\` (added in 2297aab to fix #185 — repeat-click expansion returning stale refs). The one "root" test never passed \`excludeRefs\`, so a regression there would go undetected.

## Fix
- Replaced the misleading test with one that verifies what \`isValidNode\` actually does with an extra \`__proto__\`-named field (ignores it, doesn't touch the real prototype).
- Added two tests that inspect the actual \`and(...)\` where-clause call shape drizzle builds, to assert \`notInArray(excludeRefs)\` is included when \`excludeRefs\` is non-empty and omitted when it's empty. Verified these fail by temporarily reverting the source wiring locally, then restored it.

## Test plan
- \`bun run lint -- --max-warnings=0\` — clean
- \`bun run typecheck\` — clean
- \`bun run vitest run __tests__/lib/ai/connection-discovery.test.ts __tests__/lib/canvas/share-canvas.test.ts\` — 16/16 pass