### PR TITLE
chore: cache bun install cache across CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Cache bun install cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -80,6 +88,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Cache bun install cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -113,6 +129,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Cache bun install cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -224,6 +248,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Cache bun install cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Problem
Closes #269. Every job in the CI workflow (\`lint-typecheck-test\`, \`integration\`, \`build\`, \`e2e\`) ran \`bun install --frozen-lockfile\` with no \`actions/cache\` step for Bun's global install cache, so every run re-downloaded the full dependency set across 4 separate jobs — avoidable CI minutes and unnecessary load/flake risk against the registry.

## Fix
Added an \`actions/cache@v6\` step for \`~/.bun/install/cache\`, keyed on \`bun.lock\`'s hash (with an OS-scoped \`restore-keys\` fallback), to all 4 jobs right after \`oven-sh/setup-bun\`. Modeled on the already-working Playwright browser cache in the \`e2e\` job.

Did not touch the one-off \`Install base dependencies\` step in the \`build\` job (bundle-size comparison against the PR's base branch, run in a separate \`base/\` checkout) — that install doesn't have its own \`setup-bun\` step and is a single comparison build, not worth caching separately.

## Test plan
- \`bun run lint -- --max-warnings=0\` — clean (YAML isn't linted by eslint, but visually verified all 4 cache blocks are structurally identical and correctly placed before each \`Install dependencies\` step)
- This will be exercised for real on the next CI run for this PR — first run seeds the cache (cache miss), subsequent runs should show faster \`bun install\` steps.