### PR TITLE
fix: canvas Export menu has no click-outside-to-close handling

### DIFF
--- a/__tests__/components/canvas/CanvasToolbar.test.tsx
+++ b/__tests__/components/canvas/CanvasToolbar.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useCanvasStore } from "@/store/canvas";
+import type { Verse, VerseRef } from "@/types/quran";
+
+vi.mock("@xyflow/react", () => ({
+  Panel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useReactFlow: () => ({ fitView: vi.fn() }),
+}));
+
+import { CanvasToolbar } from "@/components/canvas/CanvasToolbar";
+
+function verseNode() {
+  const verse: Verse = {
+    surah: 1,
+    ayah: 1,
+    ref: "1:1" as VerseRef,
+    arabicText: "نص",
+    translation: "text",
+    surahName: "Al-Fatihah",
+    surahNameArabic: "الفاتحة",
+  };
+  return { id: "n1", type: "verse", position: { x: 0, y: 0 }, data: verse };
+}
+
+describe("CanvasToolbar export menu", () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useCanvasStore.setState({ nodes: [verseNode() as any], edges: [] });
+  });
+
+  it("opens the export menu on click", () => {
+    render(<CanvasToolbar onSearchOpen={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    expect(screen.getByRole("button", { name: /PNG/ })).toBeInTheDocument();
+  });
+
+  it("closes the export menu on an outside click", () => {
+    render(
+      <div>
+        <div data-testid="outside">outside</div>
+        <CanvasToolbar onSearchOpen={vi.fn()} />
+      </div>
+    );
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    expect(screen.getByRole("button", { name: /PNG/ })).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    expect(screen.queryByRole("button", { name: /PNG/ })).not.toBeInTheDocument();
+  });
+
+  it("stays open on a click inside the menu itself", () => {
+    render(<CanvasToolbar onSearchOpen={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    fireEvent.mouseDown(screen.getByRole("button", { name: /PNG/ }));
+    expect(screen.getByRole("button", { name: /PNG/ })).toBeInTheDocument();
+  });
+
+  it("re-clicking the export toggle button still closes the menu", () => {
+    render(<CanvasToolbar onSearchOpen={vi.fn()} />);
+    const toggle = screen.getByRole("button", { name: /export/i });
+    fireEvent.click(toggle);
+    expect(screen.getByRole("button", { name: /PNG/ })).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.queryByRole("button", { name: /PNG/ })).not.toBeInTheDocument();
+  });
+});

--- a/components/canvas/CanvasToolbar.tsx
+++ b/components/canvas/CanvasToolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Search,
   Share2,
@@ -79,6 +79,22 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState(false);
+  const exportContainerRef = useRef<HTMLDivElement>(null);
+
+  // Close on any click outside the export button/menu — panning the canvas,
+  // clicking a node, or clicking the minimap would otherwise leave it open
+  // (ReactFlow's onPaneClick only resets node-expansion state, not this).
+  // Mirrors the outside-click handling in components/layout/AccountMenu.tsx.
+  useEffect(() => {
+    if (!exportMenuOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (exportContainerRef.current && !exportContainerRef.current.contains(e.target as Node)) {
+        setExportMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [exportMenuOpen]);
 
   const nodes = useCanvasStore((s) => s.nodes);
   const edges = useCanvasStore((s) => s.edges);
@@ -244,7 +260,7 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
           </ToolbarBtn>
         )}
 
-        <div className="relative">
+        <div className="relative" ref={exportContainerRef}>
           <ToolbarBtn
             onClick={() => setExportMenuOpen((v) => !v)}
             disabled={exporting || nodes.length === 0}


### PR DESCRIPTION
## Problem
Closes #263. \`exportMenuOpen\` was only closed by selecting an export option or pressing Escape (handled inside \`ExportMenu\`). ReactFlow's \`onPaneClick\` only resets \`openExpandNodeId\`, not \`exportMenuOpen\`, and there was no outside-pointerdown listener — so clicking anywhere else on the canvas (panning, a node, the minimap) left the export dropdown visually stuck open until re-clicking Export or hitting Escape. Inconsistent with \`AccountMenu\`, which already closes on outside click.

## Fix
Added a \`mousedown\` document listener in \`components/canvas/CanvasToolbar.tsx\`, scoped to a ref wrapping the export toggle button + \`ExportMenu\` together (mirroring \`components/layout/AccountMenu.tsx:33-47\`, which wraps its own toggle button + dropdown in one ref for the same reason — this avoids a toggle/re-open race that would happen if the ref only wrapped the menu and not the button that opens it).

## Test plan
- \`bun run lint -- --max-warnings=0\` — clean
- \`bun run typecheck\` — clean
- Added \`__tests__/components/canvas/CanvasToolbar.test.tsx\` (4 tests): menu opens on click, closes on outside click, stays open on a click inside the menu, and the toggle button itself still correctly opens/closes without a re-open race.
- \`bun run vitest run __tests__/components/canvas/\` — 14/14 pass (all canvas component tests, including pre-existing \`ExportMenu.test.tsx\`)