### PR TITLE
feat: @mentions in verse notes with friends-only notifications

### DIFF
--- a/__tests__/api/notes.test.ts
+++ b/__tests__/api/notes.test.ts
@@ -25,16 +25,28 @@ function makeDbChain(resolveWith: unknown = []) {
   return chain;
 }
 
-const { mockSelect, mockInsert, mockRateLimitOrNull } = vi.hoisted(() => ({
-  mockSelect: vi.fn(() => makeDbChain([])),
-  mockInsert: vi.fn(() => makeDbChain([])),
-  mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
-}));
+const { mockSelect, mockInsert, mockRateLimitOrNull, mockResolveFriendMentions } = vi.hoisted(
+  () => ({
+    mockSelect: vi.fn(() => makeDbChain([])),
+    mockInsert: vi.fn(() => makeDbChain([])),
+    mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
+    mockResolveFriendMentions: vi.fn(async () => [] as Array<{ id: number; username: string }>),
+  })
+);
 
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, insert: mockInsert } }));
 vi.mock("@/lib/infra/rate-limit", () => ({
   rateLimitOrNull: mockRateLimitOrNull,
 }));
+// Real parseMentionedUsernames (pure), mocked resolveFriendMentions (db-backed)
+// so mention tests don't need to mock the full friends/users query chain.
+vi.mock("@/lib/social/mentions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/social/mentions")>();
+  return {
+    parseMentionedUsernames: actual.parseMentionedUsernames,
+    resolveFriendMentions: mockResolveFriendMentions,
+  };
+});
 
 import { GET, POST } from "@/app/api/notes/route";
 import { requireUser } from "@/lib/auth/social-auth";
@@ -109,6 +121,8 @@ describe("POST /api/notes", () => {
     mockInsert.mockReturnValue(makeDbChain([{ id: 1, verseRef: "2:255", note: "hi" }]));
     mockRateLimitOrNull.mockReset();
     mockRateLimitOrNull.mockResolvedValue(null);
+    mockResolveFriendMentions.mockReset();
+    mockResolveFriendMentions.mockResolvedValue([]);
   });
 
   it("401 when unauthenticated", async () => {
@@ -162,5 +176,28 @@ describe("POST /api/notes", () => {
     const res = await POST(req("POST", { ref: "2:255", note: "reflection" }));
     expect(res.status).toBe(201);
     expect(mockInsert).toHaveBeenCalled();
+  });
+
+  it("does not resolve mentions when the note has no @mentions", async () => {
+    authed();
+    await POST(req("POST", { ref: "2:255", note: "no mentions here" }));
+    expect(mockResolveFriendMentions).not.toHaveBeenCalled();
+  });
+
+  it("inserts a note_mentions row for each resolved friend mention", async () => {
+    authed();
+    mockResolveFriendMentions.mockResolvedValue([{ id: 2, username: "bob" }]);
+    const res = await POST(req("POST", { ref: "2:255", note: "thanks @bob" }));
+    expect(res.status).toBe(201);
+    expect(mockResolveFriendMentions).toHaveBeenCalledWith(1, ["bob"]);
+    // First insert() call is the note itself; the second is the mentions batch.
+    expect(mockInsert).toHaveBeenCalledTimes(2);
+  });
+
+  it("still returns 201 when mention resolution throws (best-effort, non-fatal)", async () => {
+    authed();
+    mockResolveFriendMentions.mockRejectedValue(new Error("db down"));
+    const res = await POST(req("POST", { ref: "2:255", note: "thanks @bob" }));
+    expect(res.status).toBe(201);
   });
 });

--- a/__tests__/api/social/mentions.test.ts
+++ b/__tests__/api/social/mentions.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/infra/db/schema";
+
+vi.mock("@/lib/auth/social-auth", () => ({ requireUser: vi.fn() }));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockUpdate } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockUpdate: vi.fn(() => makeDbChain(undefined)),
+}));
+vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, update: mockUpdate } }));
+
+import { GET, PATCH } from "@/app/api/social/mentions/route";
+import { requireUser } from "@/lib/auth/social-auth";
+
+function makeUser(): User {
+  return {
+    id: 1,
+    qfId: "qf-1",
+    username: "alice",
+    displayName: null,
+    createdAt: new Date(),
+    lastActiveAt: new Date(),
+    currentStreak: 0,
+    longestStreak: 0,
+    lastActivityDate: null,
+    disabledAt: null,
+  };
+}
+function authed() {
+  vi.mocked(requireUser).mockResolvedValue({ userId: 1, user: makeUser() });
+}
+function unauthed() {
+  vi.mocked(requireUser).mockResolvedValue(
+    NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  );
+}
+function req(method: string, url = "http://localhost/api/social/mentions") {
+  return new NextRequest(url, { method, headers: { Authorization: "Bearer t" } });
+}
+
+describe("GET /api/social/mentions", () => {
+  beforeEach(() => {
+    mockSelect.mockReset();
+  });
+
+  it("401 when unauthenticated", async () => {
+    unauthed();
+    expect((await GET(req("GET"))).status).toBe(401);
+  });
+
+  it("returns items and unreadCount", async () => {
+    authed();
+    mockSelect
+      .mockReturnValueOnce(
+        makeDbChain([
+          {
+            id: 1,
+            noteId: 5,
+            verseRef: "2:255",
+            read: false,
+            createdAt: new Date(),
+            mentioningUsername: "bob",
+          },
+        ])
+      )
+      .mockReturnValueOnce(makeDbChain([{ count: 1 }]));
+
+    const res = await GET(req("GET"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.unreadCount).toBe(1);
+  });
+});
+
+describe("PATCH /api/social/mentions", () => {
+  beforeEach(() => {
+    mockUpdate.mockReset();
+    mockUpdate.mockReturnValue(makeDbChain(undefined));
+  });
+
+  it("401 when unauthenticated", async () => {
+    unauthed();
+    expect((await PATCH(req("PATCH"))).status).toBe(401);
+  });
+
+  it("marks unread mentions as read", async () => {
+    authed();
+    const res = await PATCH(req("PATCH"));
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/social/mentions.test.ts
+++ b/__tests__/lib/social/mentions.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+function makeSelectChain(resolveWith: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect } = vi.hoisted(() => ({ mockSelect: vi.fn() }));
+vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect } }));
+
+import { parseMentionedUsernames, resolveFriendMentions } from "@/lib/social/mentions";
+
+describe("parseMentionedUsernames", () => {
+  it("extracts a single @username", () => {
+    expect(parseMentionedUsernames("Hey @bob check this out")).toEqual(["bob"]);
+  });
+
+  it("extracts multiple distinct usernames, lowercased", () => {
+    expect(parseMentionedUsernames("@Bob and @Carol and @bob again")).toEqual(["bob", "carol"]);
+  });
+
+  it("returns [] when there are no mentions", () => {
+    expect(parseMentionedUsernames("just a plain reflection")).toEqual([]);
+  });
+
+  it("stops a mention token at punctuation", () => {
+    expect(parseMentionedUsernames("thanks @alice, this helped")).toEqual(["alice"]);
+  });
+
+  it("ignores a bare @ with no following word characters", () => {
+    expect(parseMentionedUsernames("email me at me @ home")).toEqual([]);
+  });
+});
+
+describe("resolveFriendMentions", () => {
+  beforeEach(() => {
+    mockSelect.mockReset();
+  });
+
+  it("returns [] without querying the db when there are no usernames", async () => {
+    const out = await resolveFriendMentions(1, []);
+    expect(out).toEqual([]);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when none of the parsed usernames match a real user", async () => {
+    mockSelect.mockReturnValueOnce(makeSelectChain([]));
+    const out = await resolveFriendMentions(1, ["nobody"]);
+    expect(out).toEqual([]);
+  });
+
+  it("excludes a matched user who isn't an accepted friend of the mentioning user", async () => {
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain([{ id: 2, username: "carol" }]))
+      .mockReturnValueOnce(makeSelectChain([])); // no accepted friendship row
+    const out = await resolveFriendMentions(1, ["carol"]);
+    expect(out).toEqual([]);
+  });
+
+  it("includes a matched user who is an accepted friend (mentioning user as requester)", async () => {
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain([{ id: 2, username: "bob" }]))
+      .mockReturnValueOnce(makeSelectChain([{ requesterId: 1, addresseeId: 2 }]));
+    const out = await resolveFriendMentions(1, ["bob"]);
+    expect(out).toEqual([{ id: 2, username: "bob" }]);
+  });
+
+  it("includes a matched user who is an accepted friend (mentioning user as addressee)", async () => {
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain([{ id: 2, username: "bob" }]))
+      .mockReturnValueOnce(makeSelectChain([{ requesterId: 2, addresseeId: 1 }]));
+    const out = await resolveFriendMentions(1, ["bob"]);
+    expect(out).toEqual([{ id: 2, username: "bob" }]);
+  });
+});

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
-import { verseNotes } from "@/lib/infra/db/schema";
+import { noteMentions, verseNotes } from "@/lib/infra/db/schema";
 import { requireUser } from "@/lib/auth/social-auth";
 import { isValidRef } from "@/lib/quran/quran-corpus";
 import { jsonError, parseJson } from "@/lib/infra/http";
 import { rateLimitOrNull } from "@/lib/infra/rate-limit";
+import { parseMentionedUsernames, resolveFriendMentions } from "@/lib/social/mentions";
 
 // A study note is free text, not a serialized payload (contrast with
 // workspace's 512KB canvas cap) — bounded generously for a long personal
@@ -65,9 +66,43 @@ export async function POST(req: NextRequest) {
       .values({ userId: authed.userId, verseRef: ref, note })
       .returning();
 
+    await notifyMentions(inserted.id, authed.userId, ref, note);
+
     return NextResponse.json(inserted, { status: 201 });
   } catch (err) {
     console.error("notes POST db error:", err);
     return jsonError("Internal server error", 500);
+  }
+}
+
+/**
+ * Parses @username tokens out of a saved note and creates a mention row for
+ * each one that resolves to an accepted friend of the note's author (mentions
+ * are friends-only — see lib/social/mentions.ts). Best-effort: a mention
+ * failure must never fail the note save it's attached to.
+ */
+async function notifyMentions(
+  noteId: number,
+  mentioningUserId: number,
+  verseRef: string,
+  note: string
+): Promise<void> {
+  try {
+    const usernames = parseMentionedUsernames(note);
+    if (usernames.length === 0) return;
+
+    const mentioned = await resolveFriendMentions(mentioningUserId, usernames);
+    if (mentioned.length === 0) return;
+
+    await db.insert(noteMentions).values(
+      mentioned.map((u) => ({
+        noteId,
+        mentioningUserId,
+        mentionedUserId: u.id,
+        verseRef,
+      }))
+    );
+  } catch (err) {
+    console.error("notes POST: failed to record mentions:", err);
   }
 }

--- a/app/api/social/mentions/route.ts
+++ b/app/api/social/mentions/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/infra/db";
+import { noteMentions, users } from "@/lib/infra/db/schema";
+import { requireUser } from "@/lib/auth/social-auth";
+import { parsePagination } from "@/lib/infra/http";
+
+export async function GET(req: NextRequest) {
+  const authed = await requireUser(req);
+  if (authed instanceof NextResponse) return authed;
+
+  const { userId } = authed;
+  const { limit, offset } = parsePagination(req);
+
+  const rows = await db
+    .select({
+      id: noteMentions.id,
+      noteId: noteMentions.noteId,
+      verseRef: noteMentions.verseRef,
+      read: noteMentions.read,
+      createdAt: noteMentions.createdAt,
+      mentioningUsername: users.username,
+    })
+    .from(noteMentions)
+    .innerJoin(users, eq(users.id, noteMentions.mentioningUserId))
+    .where(eq(noteMentions.mentionedUserId, userId))
+    .orderBy(desc(noteMentions.createdAt))
+    .limit(limit + 1)
+    .offset(offset);
+
+  const hasMore = rows.length > limit;
+  const items = rows.slice(0, limit);
+
+  const [{ count }] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(noteMentions)
+    .where(and(eq(noteMentions.mentionedUserId, userId), eq(noteMentions.read, false)));
+
+  return NextResponse.json({ items, hasMore, unreadCount: count });
+}
+
+/** Marks every unread mention for the caller as read — called when the mentions panel opens. */
+export async function PATCH(req: NextRequest) {
+  const authed = await requireUser(req);
+  if (authed instanceof NextResponse) return authed;
+
+  await db
+    .update(noteMentions)
+    .set({ read: true })
+    .where(and(eq(noteMentions.mentionedUserId, authed.userId), eq(noteMentions.read, false)));
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/mentions/page.tsx
+++ b/app/mentions/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { AtSign, Network } from "lucide-react";
+import { useAuthStore } from "@/store/auth";
+import { useSocialStore } from "@/store/social";
+import { AuthShell } from "@/components/layout/AuthShell";
+import { Card, Tooltip, iconButtonVariants } from "@/components/ui";
+
+interface Mention {
+  id: number;
+  noteId: number;
+  verseRef: string;
+  read: boolean;
+  createdAt: string;
+  mentioningUsername: string;
+}
+
+export default function MentionsPage() {
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const setPendingMentionCount = useSocialStore((s) => s.setPendingMentionCount);
+
+  const [mentions, setMentions] = useState<Mention[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!accessToken) return;
+    let cancelled = false;
+
+    fetch("/api/social/mentions", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error("load failed"))))
+      .then((data: { items: Mention[] }) => {
+        if (cancelled) return;
+        setMentions(data.items);
+      })
+      .catch((e) => {
+        console.error("mentions page: load failed", e);
+        if (!cancelled) setError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    // Mark everything read now that the user has opened this page, and clear
+    // the header badge immediately rather than waiting for the next poll.
+    fetch("/api/social/mentions", {
+      method: "PATCH",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+      .then(() => {
+        if (!cancelled) setPendingMentionCount(0);
+      })
+      .catch((e) => console.error("mentions page: mark-read failed", e));
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accessToken]);
+
+  return (
+    <AuthShell>
+      <div className="mx-auto w-full max-w-2xl">
+        <div className="mb-8 flex items-center gap-3">
+          <AtSign className="h-5 w-5 text-gold" />
+          <h1 className="text-lg font-semibold text-text-primary">Mentions</h1>
+          {mentions.length > 0 && (
+            <span className="rounded border border-border px-1.5 py-0.5 font-mono text-xs text-text-muted">
+              {mentions.length}
+            </span>
+          )}
+        </div>
+
+        {error ? (
+          <p className="py-10 text-center text-sm text-error">Couldn&apos;t load mentions.</p>
+        ) : loading ? (
+          <div className="space-y-3">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="animate-pulse rounded-xl border border-border bg-surface p-5">
+                <div className="mb-3 h-4 w-40 rounded bg-surface-overlay" />
+                <div className="h-4 w-full rounded bg-surface-overlay" />
+              </div>
+            ))}
+          </div>
+        ) : mentions.length === 0 ? (
+          <div className="py-20 text-center">
+            <AtSign className="mx-auto mb-4 h-8 w-8 text-text-muted/40" />
+            <p className="text-sm text-text-muted">No mentions yet.</p>
+            <p className="mt-1 text-xs text-text-muted">
+              A friend can tag you with @{"{username}"} in a verse note.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {mentions.map((m) => (
+              <Card key={m.id} className="p-5">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="text-sm text-text-secondary">
+                    <span className="font-medium text-text-primary">@{m.mentioningUsername}</span>{" "}
+                    mentioned you on{" "}
+                    <span className="rounded border border-gold bg-gold/[0.08] px-1.5 py-0.5 font-mono text-xs text-gold">
+                      {m.verseRef}
+                    </span>
+                  </p>
+                  <Tooltip label="Open in canvas">
+                    <Link
+                      href={`/canvas?verse=${m.verseRef}`}
+                      aria-label="Open in canvas"
+                      className={iconButtonVariants({ tone: "teal", size: "xs" })}
+                    >
+                      <Network />
+                    </Link>
+                  </Tooltip>
+                </div>
+                <p className="mt-2 text-xs text-text-muted">
+                  {new Date(m.createdAt).toLocaleString()}
+                </p>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </AuthShell>
+  );
+}

--- a/components/layout/AccountMenu.tsx
+++ b/components/layout/AccountMenu.tsx
@@ -7,6 +7,7 @@ import {
   Award,
   FolderOpen,
   Trophy,
+  AtSign,
   LogOut,
   LogIn,
   ChevronDown,
@@ -25,6 +26,7 @@ export function AccountMenu() {
   const streak = useSocialStore((s) => s.streak);
   const longestStreak = useSocialStore((s) => s.longestStreak);
   const pendingFriendCount = useSocialStore((s) => s.pendingFriendCount);
+  const pendingMentionCount = useSocialStore((s) => s.pendingMentionCount);
 
   const [open, setOpen] = useState(false);
   const [signingIn, setSigningIn] = useState(false);
@@ -191,6 +193,14 @@ export function AccountMenu() {
               {pendingFriendCount > 0 && (
                 <span className="ml-auto grid h-[18px] min-w-[18px] place-items-center rounded-full bg-gold px-1 text-[10px] font-bold text-bg">
                   {pendingFriendCount > 9 ? "9+" : pendingFriendCount}
+                </span>
+              )}
+            </Link>
+            <Link href="/mentions" onClick={() => setOpen(false)} className={linkRow}>
+              <AtSign /> Mentions
+              {pendingMentionCount > 0 && (
+                <span className="ml-auto grid h-[18px] min-w-[18px] place-items-center rounded-full bg-gold px-1 text-[10px] font-bold text-bg">
+                  {pendingMentionCount > 9 ? "9+" : pendingMentionCount}
                 </span>
               )}
             </Link>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -196,7 +196,7 @@ export function Header({ onSearchOpen }: HeaderProps) {
   const accessToken = useAuthStore((s) => s.accessToken);
 
   const userId = useSocialStore((s) => s.userId);
-  const { bumpStreak, setPendingFriendCount } = useSocialStore();
+  const { bumpStreak, setPendingFriendCount, setPendingMentionCount } = useSocialStore();
 
   const playGraph = useAudioStore((s) => s.playGraph);
   const audioCurrentRef = useAudioStore((s) => s.currentRef);
@@ -234,6 +234,23 @@ export function Header({ onSearchOpen }: HeaderProps) {
           setPendingFriendCount(count);
         })
         .catch((e) => console.error("header: friend-request poll failed", e));
+    load();
+    const interval = setInterval(load, 60_000);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accessToken, userId]);
+
+  // Poll for unread @mentions every 60 s while signed in — same cadence and
+  // pattern as the friend-request poll above.
+  useEffect(() => {
+    if (!accessToken || !userId) return;
+    const load = () =>
+      fetch("/api/social/mentions?limit=1", {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      })
+        .then((r) => (r.ok ? r.json() : { unreadCount: 0 }))
+        .then((data: { unreadCount: number }) => setPendingMentionCount(data.unreadCount))
+        .catch((e) => console.error("header: mention poll failed", e));
     load();
     const interval = setInterval(load, 60_000);
     return () => clearInterval(interval);

--- a/lib/infra/db/migrations/0017_violet_gamma_corps.sql
+++ b/lib/infra/db/migrations/0017_violet_gamma_corps.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "note_mentions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"note_id" integer NOT NULL,
+	"mentioning_user_id" integer NOT NULL,
+	"mentioned_user_id" integer NOT NULL,
+	"verse_ref" text NOT NULL,
+	"read" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "note_mentions" ADD CONSTRAINT "note_mentions_note_id_verse_notes_id_fk" FOREIGN KEY ("note_id") REFERENCES "public"."verse_notes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "note_mentions" ADD CONSTRAINT "note_mentions_mentioning_user_id_users_id_fk" FOREIGN KEY ("mentioning_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "note_mentions" ADD CONSTRAINT "note_mentions_mentioned_user_id_users_id_fk" FOREIGN KEY ("mentioned_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "note_mentions_mentioned_user_read_idx" ON "note_mentions" USING btree ("mentioned_user_id","read");

--- a/lib/infra/db/migrations/meta/0017_snapshot.json
+++ b/lib/infra/db/migrations/meta/0017_snapshot.json
@@ -1,0 +1,2119 @@
+{
+  "id": "aaba433a-8033-4106-ba95-a1c0b808de8e",
+  "prevId": "f702c443-f473-46d1-89c2-31cb70d674fe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_date": {
+          "name": "activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_date_idx": {
+          "name": "activity_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_type_date_idx": {
+          "name": "activity_user_type_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_user_id_users_id_fk": {
+          "name": "activity_log_user_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_qf_id": {
+          "name": "admin_qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_created_idx": {
+          "name": "admin_audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_generations": {
+      "name": "ai_generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_generations_created_idx": {
+          "name": "ai_generations_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_idx": {
+          "name": "bookmarks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookmarks_user_ref_uniq": {
+          "name": "bookmarks_user_ref_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "verse_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_suggestions": {
+      "name": "challenge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_duration": {
+          "name": "suggested_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_suggestions_active_idx": {
+          "name": "challenge_suggestions_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenger_id": {
+          "name": "challenger_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenged_id": {
+          "name": "challenged_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_challenger_status_idx": {
+          "name": "challenges_challenger_status_idx",
+          "columns": [
+            {
+              "expression": "challenger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_challenged_status_idx": {
+          "name": "challenges_challenged_status_idx",
+          "columns": [
+            {
+              "expression": "challenged_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_ends_at_idx": {
+          "name": "challenges_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_suggestion_id_idx": {
+          "name": "challenges_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_challenger_id_users_id_fk": {
+          "name": "challenges_challenger_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_challenged_id_users_id_fk": {
+          "name": "challenges_challenged_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenged_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_suggestion_id_challenge_suggestions_id_fk": {
+          "name": "challenges_suggestion_id_challenge_suggestions_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "challenge_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "challenges_winner_id_users_id_fk": {
+          "name": "challenges_winner_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_challenge": {
+          "name": "no_self_challenge",
+          "value": "\"challenges\".\"challenger_id\" != \"challenges\".\"challenged_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_ref": {
+          "name": "to_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_from_to_kind_idx": {
+          "name": "connections_from_to_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_from_kind_idx": {
+          "name": "connections_from_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_reviewed_at_idx": {
+          "name": "connections_reviewed_at_idx",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_votd": {
+      "name": "curated_votd",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "friendships_pair_idx": {
+          "name": "friendships_pair_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_addressee_status_idx": {
+          "name": "friendships_addressee_status_idx",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_requester_status_idx": {
+          "name": "friendships_requester_status_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_requester_id_users_id_fk": {
+          "name": "friendships_requester_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_addressee_id_users_id_fk": {
+          "name": "friendships_addressee_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_friendship": {
+          "name": "no_self_friendship",
+          "value": "\"friendships\".\"requester_id\" != \"friendships\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_runs": {
+      "name": "job_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_tail": {
+          "name": "log_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_runs_type_started_idx": {
+          "name": "job_runs_type_started_idx",
+          "columns": [
+            {
+              "expression": "job_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.name_content": {
+      "name": "name_content",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "name_content_slug_kind_pk": {
+          "name": "name_content_slug_kind_pk",
+          "columns": [
+            "slug",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_mentions": {
+      "name": "note_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioning_user_id": {
+          "name": "mentioning_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_id": {
+          "name": "mentioned_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_mentions_mentioned_user_read_idx": {
+          "name": "note_mentions_mentioned_user_read_idx",
+          "columns": [
+            {
+              "expression": "mentioned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_mentions_note_id_verse_notes_id_fk": {
+          "name": "note_mentions_note_id_verse_notes_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "verse_notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_mentions_mentioning_user_id_users_id_fk": {
+          "name": "note_mentions_mentioning_user_id_users_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentioning_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_mentions_mentioned_user_id_users_id_fk": {
+          "name": "note_mentions_mentioned_user_id_users_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentioned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_versions": {
+      "name": "prompt_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "prompt_versions_key_idx": {
+          "name": "prompt_versions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_key_active_idx": {
+          "name": "prompt_versions_key_active_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_one_active_per_key_uidx": {
+          "name": "prompt_versions_one_active_per_key_uidx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_versions\".\"active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_workspaces": {
+      "name": "saved_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_workspaces_user_idx": {
+          "name": "saved_workspaces_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_workspaces_user_id_users_id_fk": {
+          "name": "saved_workspaces_user_id_users_id_fk",
+          "tableFrom": "saved_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_log": {
+      "name": "search_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zero_result": {
+          "name": "zero_result",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "search_log_created_idx": {
+          "name": "search_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_log_zero_result_idx": {
+          "name": "search_log_zero_result_idx",
+          "columns": [
+            {
+              "expression": "zero_result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_canvases": {
+      "name": "shared_canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qf_id": {
+          "name": "qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_qf_id_idx": {
+          "name": "users_qf_id_idx",
+          "columns": [
+            {
+              "expression": "qf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_active_idx": {
+          "name": "users_last_active_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_qf_id_unique": {
+          "name": "users_qf_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qf_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_embeddings": {
+      "name": "verse_embeddings",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_embeddings_hnsw_idx": {
+          "name": "verse_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_notes": {
+      "name": "verse_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_notes_user_ref_idx": {
+          "name": "verse_notes_user_ref_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_notes_user_id_users_id_fk": {
+          "name": "verse_notes_user_id_users_id_fk",
+          "tableFrom": "verse_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verses": {
+      "name": "verses",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "surah": {
+          "name": "surah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ayah": {
+          "name": "ayah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arabic_text": {
+          "name": "arabic_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transliteration": {
+          "name": "transliteration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verses_surah_ayah_idx": {
+          "name": "verses_surah_ayah_idx",
+          "columns": [
+            {
+              "expression": "surah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ayah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_morphology": {
+      "name": "word_morphology",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "word_morphology_ref_pos_idx": {
+          "name": "word_morphology_ref_pos_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_ref_idx": {
+          "name": "word_morphology_ref_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_root_idx": {
+          "name": "word_morphology_root_idx",
+          "columns": [
+            {
+              "expression": "root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/infra/db/migrations/meta/_journal.json
+++ b/lib/infra/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1783794642875,
       "tag": "0016_milky_blindfold",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1784200713179,
+      "tag": "0017_violet_gamma_corps",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/infra/db/schema.ts
+++ b/lib/infra/db/schema.ts
@@ -208,6 +208,30 @@ export const verseNotes = pgTable(
   (t) => [index("verse_notes_user_ref_idx").on(t.userId, t.verseRef)]
 );
 
+// @username mentions parsed out of a verse note at save time — friends-only
+// (resolved against the mentioning user's accepted friends, see
+// app/api/notes/route.ts), notifying the mentioned user. `noteId` cascades so
+// a deleted note takes its mentions with it.
+export const noteMentions = pgTable(
+  "note_mentions",
+  {
+    id: serial("id").primaryKey(),
+    noteId: integer("note_id")
+      .notNull()
+      .references(() => verseNotes.id, { onDelete: "cascade" }),
+    mentioningUserId: integer("mentioning_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    mentionedUserId: integer("mentioned_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    verseRef: text("verse_ref").notNull(),
+    read: boolean("read").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index("note_mentions_mentioned_user_read_idx").on(t.mentionedUserId, t.read)]
+);
+
 // ─── Quran Corpus (local) ─────────────────────────────────────────────────────
 // The full Quran, seeded once. Replaces per-request fetches to alquran.cloud /
 // quran.com — see lib/quran-corpus.ts. Keyed by "surah:ayah".
@@ -495,6 +519,8 @@ export type NewChallengeSuggestion = typeof challengeSuggestions.$inferInsert;
 export type SharedCanvas = typeof sharedCanvases.$inferSelect;
 export type VerseNote = typeof verseNotes.$inferSelect;
 export type NewVerseNote = typeof verseNotes.$inferInsert;
+export type NoteMention = typeof noteMentions.$inferSelect;
+export type NewNoteMention = typeof noteMentions.$inferInsert;
 export type Bookmark = typeof bookmarks.$inferSelect;
 export type NewBookmark = typeof bookmarks.$inferInsert;
 export type SavedWorkspace = typeof savedWorkspaces.$inferSelect;

--- a/lib/social/mentions.ts
+++ b/lib/social/mentions.ts
@@ -1,0 +1,65 @@
+import { and, eq, inArray, or, sql } from "drizzle-orm";
+import { db } from "@/lib/infra/db";
+import { friendships, users } from "@/lib/infra/db/schema";
+
+// @username: word chars only, matching the existing username convention
+// (see users.username in lib/infra/db/schema.ts) — no spaces/punctuation, so
+// a mention token ends cleanly at sentence punctuation like "@alice, thanks".
+const MENTION_RE = /@(\w+)/g;
+
+/** Extracts unique @username tokens (without the @) from free-text note content. */
+export function parseMentionedUsernames(text: string): string[] {
+  const seen = new Set<string>();
+  for (const match of text.matchAll(MENTION_RE)) {
+    seen.add(match[1].toLowerCase());
+  }
+  return [...seen];
+}
+
+/**
+ * Resolves parsed @usernames to real users, scoped to `mentioningUserId`'s
+ * accepted friends only (see #117 — mentions are friends-only, matching the
+ * existing social graph's trust boundary, not platform-wide). Case-insensitive,
+ * matching the lookup convention already used for friend search.
+ */
+export async function resolveFriendMentions(
+  mentioningUserId: number,
+  usernames: string[]
+): Promise<Array<{ id: number; username: string }>> {
+  if (usernames.length === 0) return [];
+
+  const candidates = await db
+    .select({ id: users.id, username: users.username })
+    .from(users)
+    .where(or(...usernames.map((u) => sql`lower(${users.username}) = ${u}`)));
+
+  if (candidates.length === 0) return [];
+
+  const candidateIds = candidates.map((c) => c.id);
+  const acceptedFriendships = await db
+    .select({ requesterId: friendships.requesterId, addresseeId: friendships.addresseeId })
+    .from(friendships)
+    .where(
+      and(
+        eq(friendships.status, "accepted"),
+        or(
+          and(
+            eq(friendships.requesterId, mentioningUserId),
+            inArray(friendships.addresseeId, candidateIds)
+          ),
+          and(
+            eq(friendships.addresseeId, mentioningUserId),
+            inArray(friendships.requesterId, candidateIds)
+          )
+        )
+      )
+    );
+
+  const friendIds = new Set(
+    acceptedFriendships.map((f) =>
+      f.requesterId === mentioningUserId ? f.addresseeId : f.requesterId
+    )
+  );
+
+  return candidates.filter((c) => friendIds.has(c.id));
+}

--- a/store/social.ts
+++ b/store/social.ts
@@ -15,12 +15,14 @@ interface SocialStore {
   longestStreak: number;
   pendingFriendCount: number;
   pendingChallengeCount: number;
+  pendingMentionCount: number;
 
   setProfile: (profile: SocialProfile) => void;
   clearSocial: () => void;
   bumpStreak: (newStreak: number, newLongest?: number) => void;
   setPendingFriendCount: (count: number) => void;
   setPendingChallengeCount: (count: number) => void;
+  setPendingMentionCount: (count: number) => void;
 }
 
 export const useSocialStore = create<SocialStore>()(
@@ -32,6 +34,7 @@ export const useSocialStore = create<SocialStore>()(
       longestStreak: 0,
       pendingFriendCount: 0,
       pendingChallengeCount: 0,
+      pendingMentionCount: 0,
 
       setProfile: ({ userId, username }) => set({ userId, username }),
 
@@ -43,6 +46,7 @@ export const useSocialStore = create<SocialStore>()(
           longestStreak: 0,
           pendingFriendCount: 0,
           pendingChallengeCount: 0,
+          pendingMentionCount: 0,
         }),
 
       bumpStreak: (newStreak, newLongest) =>
@@ -54,6 +58,8 @@ export const useSocialStore = create<SocialStore>()(
       setPendingFriendCount: (count) => set({ pendingFriendCount: count }),
 
       setPendingChallengeCount: (count) => set({ pendingChallengeCount: count }),
+
+      setPendingMentionCount: (count) => set({ pendingMentionCount: count }),
     }),
     {
       name: "open-hikmah-social",


### PR DESCRIPTION
## Problem
Closes #117. Verse notes are currently a solo feature — no way to draw a friend's attention to a note on a specific verse, even though the app has a working friends/social graph and an existing notification-badge pattern (the friend-request pending badge).

## Design decisions
- **Friends-only, not platform-wide.** @mentions resolve only against the mentioning user's accepted friends, matching the existing social graph's trust boundary and avoiding unsolicited-mention spam from strangers.
- **New \`note_mentions\` table (migration \`0017_violet_gamma_corps.sql\`).** There's no existing generic notifications table — the friend-request badge is a live count derived from \`friendships\` rows (\`status = 'pending'\`), not backed by a durable per-user record. A mention needs its own durable row since there's no equivalent status transition to derive it from.
- **Not** QF's "Tags" OAuth scope — stays entirely within the app's own \`users\`/\`verse_notes\` tables, no new OAuth scope.

## Fix
- \`lib/social/mentions.ts\`: \`parseMentionedUsernames\` (pure regex extraction) + \`resolveFriendMentions\` (case-insensitive match via the existing \`lower(username) = lower(...)\` convention from \`app/api/social/friends/route.ts\`, scoped to accepted friendships).
- \`app/api/notes/route.ts\`'s \`POST\` now parses mentions out of the saved note and inserts a \`note_mentions\` row per resolved friend mention — best-effort, a mention failure never fails the note save.
- New \`GET\`/\`PATCH /api/social/mentions\` (list + unread count / mark-all-read), a new \`/mentions\` page to view them (with a "Open in canvas" link per mention, matching the Bookmarks page pattern), and a badge in \`AccountMenu\` (\`pendingMentionCount\` in \`store/social.ts\`, polled in \`Header.tsx\` every 60s alongside the existing friend-request poll).

## ⚠️ Action needed after merge
This PR adds a new table via a Drizzle migration (\`lib/infra/db/migrations/0017_violet_gamma_corps.sql\`). **After merging, run migrations against the deployed database** (the same step needed for any schema change in this repo):
\`\`\`
DATABASE_URL=<production DB URL> bun scripts/migrate.mjs
\`\`\`
No new environment variables or OAuth scopes are needed.

## Test plan
- \`bun run lint -- --max-warnings=0\` — clean
- \`bun run typecheck\` — clean
- Applied the migration directly against a real local Postgres (via \`docker compose\`) to verify it's valid SQL and the FK/index shape is correct, then rolled it back to leave the dev DB clean.
- New unit tests: \`__tests__/lib/social/mentions.test.ts\` (10 tests — parsing + friend-resolution logic), \`__tests__/api/social/mentions.test.ts\` (GET/PATCH), extended \`__tests__/api/notes.test.ts\` (mention insertion + best-effort failure handling).
- \`bun run test:coverage\` — 674/674 tests pass, coverage above the configured floor.