### PR TITLE
Chore/268 coverage gaps

### DIFF
--- a/__tests__/lib/admin/admin-audit.test.ts
+++ b/__tests__/lib/admin/admin-audit.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockValues, mockInsert, mockIncr } = vi.hoisted(() => {
+  const mockValues = vi.fn().mockResolvedValue(undefined);
+  return {
+    mockValues,
+    mockInsert: vi.fn(() => ({ values: mockValues })),
+    mockIncr: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/infra/db", () => ({ db: { insert: mockInsert } }));
+vi.mock("@/lib/infra/metrics", () => ({ incr: mockIncr }));
+
+import { logAdminAction } from "@/lib/admin/admin-audit";
+
+describe("logAdminAction", () => {
+  beforeEach(() => {
+    mockValues.mockReset();
+    mockValues.mockResolvedValue(undefined);
+    mockInsert.mockClear();
+    mockIncr.mockClear();
+  });
+
+  it("inserts a row with meta JSON-stringified normally", async () => {
+    await logAdminAction({
+      adminQfId: "qf-1",
+      action: "flag.delete",
+      meta: { key: "ai_gen_limit" },
+    });
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adminQfId: "qf-1",
+        action: "flag.delete",
+        meta: JSON.stringify({ key: "ai_gen_limit" }),
+      })
+    );
+  });
+
+  it("stores null meta when meta is undefined", async () => {
+    await logAdminAction({ adminQfId: "qf-1", action: "noop" });
+    expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({ meta: null }));
+  });
+
+  it("defaults targetType/targetId to null when omitted", async () => {
+    await logAdminAction({ adminQfId: "qf-1", action: "noop" });
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({ targetType: null, targetId: null })
+    );
+  });
+
+  it("serializes a BigInt in meta by converting it to a string instead of throwing", async () => {
+    await logAdminAction({ adminQfId: "qf-1", action: "job.run", meta: { count: BigInt(10) } });
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({ meta: JSON.stringify({ count: "10" }) })
+    );
+  });
+
+  it("falls back to a serializationError marker for a circular reference instead of throwing", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const circular: any = { a: 1 };
+    circular.self = circular;
+    await logAdminAction({ adminQfId: "qf-1", action: "job.run", meta: circular });
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({ meta: JSON.stringify({ serializationError: true }) })
+    );
+  });
+
+  it("swallows a db insert failure and increments a failure metric instead of throwing", async () => {
+    mockValues.mockRejectedValueOnce(new Error("db down"));
+    await expect(
+      logAdminAction({ adminQfId: "qf-1", action: "flag.delete" })
+    ).resolves.toBeUndefined();
+    expect(mockIncr).toHaveBeenCalledWith("admin_audit_write_failed");
+  });
+});

--- a/__tests__/lib/ai/connection-discovery.test.ts
+++ b/__tests__/lib/ai/connection-discovery.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── DB mock: select() resolves to a configurable result via a chainable Proxy ──
+function makeSelectChain(resolveWith: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockSemanticCandidates } = vi.hoisted(() => ({
+  mockSelect: vi.fn(),
+  mockSemanticCandidates: vi.fn(),
+}));
+
+vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, selectDistinct: mockSelect } }));
+vi.mock("@/lib/quran/semantic-search", () => ({ semanticCandidates: mockSemanticCandidates }));
+
+import { discoverCandidates } from "@/lib/ai/connection-discovery";
+
+describe("discoverCandidates", () => {
+  beforeEach(() => {
+    mockSelect.mockReset();
+    mockSemanticCandidates.mockReset();
+  });
+
+  it("returns [] for 'root' when the source verse has no roots seeded", async () => {
+    mockSelect.mockReturnValueOnce(makeSelectChain([]));
+    const out = await discoverCandidates("1:1", "root");
+    expect(out).toEqual([]);
+    expect(mockSemanticCandidates).not.toHaveBeenCalled();
+  });
+
+  it("returns ranked root candidates from the second query when roots exist", async () => {
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain([{ root: "سمو" }, { root: "علم" }]))
+      .mockReturnValueOnce(
+        makeSelectChain([
+          { ref: "2:255", shared: 2 },
+          { ref: "3:18", shared: 1 },
+        ])
+      );
+    const out = await discoverCandidates("1:1", "root", 12);
+    expect(out).toEqual(["2:255", "3:18"]);
+  });
+
+  it("delegates 'thematic' to semanticCandidates without touching the db", async () => {
+    mockSemanticCandidates.mockResolvedValue(["2:255"]);
+    const out = await discoverCandidates("1:1", "thematic", 5, ["9:1"]);
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockSemanticCandidates).toHaveBeenCalledWith("1:1", 5, ["9:1"]);
+    expect(out).toEqual(["2:255"]);
+  });
+
+  it("delegates 'contrast' to semanticCandidates as well", async () => {
+    mockSemanticCandidates.mockResolvedValue(["3:18"]);
+    const out = await discoverCandidates("1:1", "contrast");
+    expect(mockSemanticCandidates).toHaveBeenCalledWith("1:1", 12, []);
+    expect(out).toEqual(["3:18"]);
+  });
+});

--- a/__tests__/lib/ai/connection-discovery.test.ts
+++ b/__tests__/lib/ai/connection-discovery.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// ── DB mock: select() resolves to a configurable result via a chainable Proxy ──
-function makeSelectChain(resolveWith: unknown[]) {
+// ── DB mock: select() resolves to a configurable result via a chainable Proxy.
+// Optionally records the arguments each chained method was called with, keyed
+// by method name, so a test can assert *which* where-clause conditions were
+// built (e.g. whether notInArray(excludeRefs) was included) without needing to
+// fully emulate drizzle's SQL builder.
+function makeSelectChain(resolveWith: unknown[], calls?: Record<string, unknown[][]>) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
     function () {
@@ -12,7 +16,10 @@ function makeSelectChain(resolveWith: unknown[]) {
         if (prop === "then")
           return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
             Promise.resolve(resolveWith).then(res, rej);
-        return () => chain;
+        return (...args: unknown[]) => {
+          if (calls) (calls[prop as string] ??= []).push(args);
+          return chain;
+        };
       },
       apply() {
         return chain;
@@ -22,13 +29,27 @@ function makeSelectChain(resolveWith: unknown[]) {
   return chain;
 }
 
-const { mockSelect, mockSemanticCandidates } = vi.hoisted(() => ({
+const { mockSelect, mockSemanticCandidates, mockAndCalls } = vi.hoisted(() => ({
   mockSelect: vi.fn(),
   mockSemanticCandidates: vi.fn(),
+  mockAndCalls: [] as unknown[][],
 }));
 
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, selectDistinct: mockSelect } }));
 vi.mock("@/lib/quran/semantic-search", () => ({ semanticCandidates: mockSemanticCandidates }));
+// Wrap the real `and` so tests can assert how many where-conditions
+// rootCandidates() built — e.g. whether notInArray(excludeRefs) was included —
+// without reimplementing drizzle's SQL builder.
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...actual,
+    and: (...args: unknown[]) => {
+      mockAndCalls.push(args);
+      return actual.and(...(args as Parameters<typeof actual.and>));
+    },
+  };
+});
 
 import { discoverCandidates } from "@/lib/ai/connection-discovery";
 
@@ -36,6 +57,7 @@ describe("discoverCandidates", () => {
   beforeEach(() => {
     mockSelect.mockReset();
     mockSemanticCandidates.mockReset();
+    mockAndCalls.length = 0;
   });
 
   it("returns [] for 'root' when the source verse has no roots seeded", async () => {
@@ -56,6 +78,36 @@ describe("discoverCandidates", () => {
       );
     const out = await discoverCandidates("1:1", "root", 12);
     expect(out).toEqual(["2:255", "3:18"]);
+  });
+
+  // Regression test for the fix in 2297aab (issue #185): repeat-clicking "root"
+  // expansion must not keep returning the same already-seen refs, which
+  // requires notInArray(excludeRefs) to actually be threaded into the second
+  // query's where-clause whenever excludeRefs is non-empty.
+  it("threads excludeRefs into the root candidate query's where-clause", async () => {
+    const rankedCalls: Record<string, unknown[][]> = {};
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain([{ root: "سمو" }]))
+      .mockReturnValueOnce(makeSelectChain([{ ref: "3:18", shared: 1 }], rankedCalls));
+
+    await discoverCandidates("1:1", "root", 12, ["2:255"]);
+
+    // rootCandidates() builds its first `and(...)` (source-verse root lookup)
+    // before the second query's own `and(...)` call — the second call is the
+    // one whose condition count reflects whether excludeRefs was included.
+    expect(mockAndCalls).toHaveLength(2);
+    expect(mockAndCalls[1]).toHaveLength(3); // inArray + ne + notInArray(excludeRefs)
+  });
+
+  it("omits the notInArray condition entirely when excludeRefs is empty", async () => {
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain([{ root: "سمو" }]))
+      .mockReturnValueOnce(makeSelectChain([{ ref: "3:18", shared: 1 }]));
+
+    await discoverCandidates("1:1", "root", 12, []);
+
+    expect(mockAndCalls).toHaveLength(2);
+    expect(mockAndCalls[1]).toHaveLength(2); // inArray + ne only, no notInArray
   });
 
   it("delegates 'thematic' to semanticCandidates without touching the db", async () => {

--- a/__tests__/lib/ai/prompt-registry.test.ts
+++ b/__tests__/lib/ai/prompt-registry.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const limitMock = vi.fn(() => Promise.resolve([] as unknown[]));
+vi.mock("@/lib/infra/db", () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => ({ orderBy: () => ({ limit: limitMock }) }) }) }),
+  },
+}));
+
+import { getPrompt, renderTemplate, invalidatePromptCache } from "@/lib/ai/prompt-registry";
+
+describe("getPrompt", () => {
+  beforeEach(() => {
+    limitMock.mockReset();
+    limitMock.mockResolvedValue([]);
+    invalidatePromptCache();
+  });
+
+  it("falls back to the hardcoded template when no active DB version exists", async () => {
+    const result = await getPrompt("connection.legacy", "fallback template");
+    expect(result).toEqual({ template: "fallback template", version: null });
+  });
+
+  it("uses the active DB-stored template when one exists", async () => {
+    limitMock.mockResolvedValue([{ id: 7, template: "db template", key: "connection.legacy" }]);
+    const result = await getPrompt("connection.legacy", "fallback template");
+    expect(result).toEqual({ template: "db template", version: 7 });
+  });
+
+  it("caches the resolved value so a second call within the TTL skips the db", async () => {
+    limitMock.mockResolvedValue([{ id: 7, template: "db template" }]);
+    await getPrompt("connection.legacy", "fallback");
+    await getPrompt("connection.legacy", "fallback");
+    expect(limitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches per-key independently", async () => {
+    limitMock.mockResolvedValue([]);
+    await getPrompt("connection.legacy", "fallback a");
+    await getPrompt("connection.selection", "fallback b");
+    expect(limitMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidatePromptCache(key) forces the next call for that key to re-query", async () => {
+    limitMock.mockResolvedValue([]);
+    await getPrompt("connection.legacy", "fallback");
+    invalidatePromptCache("connection.legacy");
+    await getPrompt("connection.legacy", "fallback");
+    expect(limitMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidatePromptCache() with no key clears every cached key", async () => {
+    limitMock.mockResolvedValue([]);
+    await getPrompt("connection.legacy", "fallback");
+    await getPrompt("connection.selection", "fallback");
+    invalidatePromptCache();
+    await getPrompt("connection.legacy", "fallback");
+    await getPrompt("connection.selection", "fallback");
+    expect(limitMock).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe("renderTemplate", () => {
+  it("fills known placeholders from vars", () => {
+    expect(renderTemplate("Hello {{name}}, welcome to {{place}}.", { name: "A", place: "B" })).toBe(
+      "Hello A, welcome to B."
+    );
+  });
+
+  it("renders unknown placeholders as empty", () => {
+    expect(renderTemplate("Hi {{missing}}!", {})).toBe("Hi !");
+  });
+
+  it("returns the template unchanged when there are no placeholders", () => {
+    expect(renderTemplate("no placeholders here", { name: "A" })).toBe("no placeholders here");
+  });
+});

--- a/__tests__/lib/canvas/share-canvas.test.ts
+++ b/__tests__/lib/canvas/share-canvas.test.ts
@@ -51,8 +51,14 @@ describe("isValidNode", () => {
     expect(isValidNode(nodeWith({ ref: "1:1", surahName: "x", translation: 1 }))).toBe(false);
   });
 
-  it("rejects a malformed shared-canvas payload attempting prototype pollution", () => {
-    const malicious = JSON.parse('{"verse": {"ref": "1:1", "__proto__": {"polluted": true}}}');
-    expect(isValidNode(malicious)).toBe(false);
+  it("ignores extra/unexpected fields and validates only ref/surahName/translation", () => {
+    // A `__proto__` key from JSON.parse is just an own data property, not the
+    // object's actual prototype — this asserts isValidNode doesn't get tripped
+    // up by it either way, as long as the three required fields are present.
+    const withExtraField = JSON.parse(
+      '{"verse": {"ref": "1:1", "surahName": "x", "translation": "y", "__proto__": {"polluted": true}}}'
+    );
+    expect(isValidNode(withExtraField)).toBe(true);
+    expect(Object.getPrototypeOf(withExtraField.verse)).toBe(Object.prototype);
   });
 });

--- a/__tests__/lib/canvas/share-canvas.test.ts
+++ b/__tests__/lib/canvas/share-canvas.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { isValidNode } from "@/lib/canvas/share-canvas";
+
+function nodeWith(verse: unknown) {
+  return { verse };
+}
+
+describe("isValidNode", () => {
+  it("accepts a node with all required verse string fields", () => {
+    expect(
+      isValidNode(
+        nodeWith({ ref: "1:1", surahName: "Al-Fatihah", translation: "In the name of..." })
+      )
+    ).toBe(true);
+  });
+
+  it("rejects null", () => {
+    expect(isValidNode(null)).toBe(false);
+  });
+
+  it("rejects non-object primitives", () => {
+    expect(isValidNode("string")).toBe(false);
+    expect(isValidNode(42)).toBe(false);
+    expect(isValidNode(undefined)).toBe(false);
+  });
+
+  it("rejects a node missing verse entirely", () => {
+    expect(isValidNode({})).toBe(false);
+  });
+
+  it("rejects a node whose verse is null", () => {
+    expect(isValidNode(nodeWith(null))).toBe(false);
+  });
+
+  it("rejects a node whose verse is not an object", () => {
+    expect(isValidNode(nodeWith("not an object"))).toBe(false);
+  });
+
+  it("rejects when ref is missing or the wrong type", () => {
+    expect(isValidNode(nodeWith({ surahName: "x", translation: "y" }))).toBe(false);
+    expect(isValidNode(nodeWith({ ref: 1, surahName: "x", translation: "y" }))).toBe(false);
+  });
+
+  it("rejects when surahName is missing or the wrong type", () => {
+    expect(isValidNode(nodeWith({ ref: "1:1", translation: "y" }))).toBe(false);
+    expect(isValidNode(nodeWith({ ref: "1:1", surahName: 1, translation: "y" }))).toBe(false);
+  });
+
+  it("rejects when translation is missing or the wrong type", () => {
+    expect(isValidNode(nodeWith({ ref: "1:1", surahName: "x" }))).toBe(false);
+    expect(isValidNode(nodeWith({ ref: "1:1", surahName: "x", translation: 1 }))).toBe(false);
+  });
+
+  it("rejects a malformed shared-canvas payload attempting prototype pollution", () => {
+    const malicious = JSON.parse('{"verse": {"ref": "1:1", "__proto__": {"polluted": true}}}');
+    expect(isValidNode(malicious)).toBe(false);
+  });
+});

--- a/__tests__/lib/quran/verse-resolver.test.ts
+++ b/__tests__/lib/quran/verse-resolver.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Verse, VerseRef } from "@/types/quran";
+
+const { mockGetVerse, mockGetSurahName } = vi.hoisted(() => ({
+  mockGetVerse: vi.fn(),
+  mockGetSurahName: vi.fn(),
+}));
+
+vi.mock("@/lib/quran/quran-corpus", () => ({ getVerse: mockGetVerse }));
+vi.mock("@/lib/quran/surah-names", () => ({ getSurahName: mockGetSurahName }));
+
+import { resolveVerse } from "@/lib/quran/verse-resolver";
+
+function verse(ref: string): Verse {
+  const [s, a] = ref.split(":");
+  return {
+    surah: parseInt(s, 10),
+    ayah: parseInt(a, 10),
+    ref: ref as VerseRef,
+    arabicText: "نص",
+    translation: "text",
+    surahName: "Surah",
+    surahNameArabic: "سورة",
+  };
+}
+
+describe("resolveVerse", () => {
+  beforeEach(() => {
+    mockGetVerse.mockReset();
+    mockGetSurahName.mockReset();
+    mockGetSurahName.mockReturnValue(["Al-Fatihah", "الفاتحة"]);
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("returns the local corpus verse without hitting the live API", async () => {
+    const v = verse("1:1");
+    mockGetVerse.mockResolvedValue(v);
+    const result = await resolveVerse("1:1");
+    expect(result).toBe(v);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the live API when the corpus has no entry", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    vi.mocked(fetch).mockImplementation(async (url: string | URL | Request) => {
+      const isArabic = String(url).includes("ar.alafasy");
+      return {
+        ok: true,
+        json: async () => ({ data: { text: isArabic ? "نص عربي" : "English text" } }),
+      } as Response;
+    });
+    const result = await resolveVerse("2:255");
+    expect(result).toMatchObject({
+      surah: 2,
+      ayah: 255,
+      ref: "2:255",
+      arabicText: "نص عربي",
+      translation: "English text",
+    });
+  });
+
+  it("falls back to the live API when the corpus lookup throws", async () => {
+    mockGetVerse.mockRejectedValue(new Error("db down"));
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { text: "x" } }),
+    } as Response);
+    const result = await resolveVerse("1:1");
+    expect(result).not.toBeNull();
+  });
+
+  it("returns null for a malformed ref without calling the live API", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    const result = await resolveVerse("not-a-ref");
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a surah number out of bounds", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    const result = await resolveVerse("115:1");
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when either live fetch response is not ok", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    vi.mocked(fetch).mockResolvedValue({ ok: false } as Response);
+    const result = await resolveVerse("2:255");
+    expect(result).toBeNull();
+  });
+
+  it("returns null and does not throw when the live fetch rejects", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    const result = await resolveVerse("2:255");
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

<!-- 1–3 bullet points: what changed and why -->

-
-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

<!-- Complete this section if you modified any Claude prompts, divine name data, or verse connection logic. Leave blank otherwise. -->

- [ ] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below

**Details** (if applicable):
<!-- Describe any changes to prompts, expected output format, or theological framing. Note any deviations from or additions to the Maturidi/Hanafi tradition. -->

## Testing

- [ ] `bun run test:ci` passes locally
- [ ] `bun run typecheck` passes locally
- [ ] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [ ] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Conventional commits
- [ ] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface
