### PR TITLE
feat: guest access — explore, bookmark, and canvas without sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ query.
 - **Audio** — Play all canvas verses in Qur'an order with a single button.
 - **99 Divine Names** — Full Asma'ul Husna with Arabic script, root morphology, taxonomy, verse
   feed, and contemplative reflections.
-- **Bookmarks** — Save verses to your account; syncs across devices via the Quran Foundation API.
+- **Bookmarks** — Save verses locally without signing in, or to your account for cross-device sync.
 - **Social** — Daily engagement streaks, a friends leaderboard, and head-to-head challenges
   (24h / 48h / 7d).
 

--- a/__tests__/hooks/useCanvasPersistence.test.ts
+++ b/__tests__/hooks/useCanvasPersistence.test.ts
@@ -115,8 +115,7 @@ describe("mergeGuestWorkspace", () => {
     await mergeGuestWorkspace("tok_abc");
 
     const body = JSON.parse(
-      (globalThis.fetch as ReturnType<typeof vi.spyOn>).mock.calls[0][1]!
-        .body as string,
+      (globalThis.fetch as ReturnType<typeof vi.spyOn>).mock.calls[0][1]!.body as string
     );
     expect(body.name).toMatch(/1 verse\b/);
     expect(body.nodeCount).toBe(1);

--- a/__tests__/hooks/useCanvasPersistence.test.ts
+++ b/__tests__/hooks/useCanvasPersistence.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mergeGuestWorkspace, CANVAS_STORAGE_KEY } from "@/hooks/useCanvasPersistence";
+
+const MERGE_FLAG_KEY = "open-hikmah-guest-merged";
+
+function setCanvas(data: unknown) {
+  localStorage.setItem(CANVAS_STORAGE_KEY, JSON.stringify(data));
+}
+
+describe("mergeGuestWorkspace", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("skips when merge flag already exists", async () => {
+    localStorage.setItem(MERGE_FLAG_KEY, "1");
+    setCanvas({ v: 1, nodes: [{ id: "1" }] });
+
+    const spy = vi.spyOn(globalThis, "fetch");
+
+    await mergeGuestWorkspace("tok_abc");
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("skips when no canvas in localStorage", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+
+    await mergeGuestWorkspace("tok_abc");
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("skips when canvas has no nodes", async () => {
+    setCanvas({ v: 1, nodes: [] });
+    const spy = vi.spyOn(globalThis, "fetch");
+
+    await mergeGuestWorkspace("tok_abc");
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("skips when canvas version is not 1", async () => {
+    setCanvas({ v: 2, nodes: [{ id: "1" }] });
+    const spy = vi.spyOn(globalThis, "fetch");
+
+    await mergeGuestWorkspace("tok_abc");
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("skips when canvas data is malformed JSON", async () => {
+    localStorage.setItem(CANVAS_STORAGE_KEY, "not-json");
+    const spy = vi.spyOn(globalThis, "fetch");
+
+    await mergeGuestWorkspace("tok_abc");
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("posts to /api/workspace and sets merge flag on success", async () => {
+    setCanvas({ v: 1, nodes: [{ id: "1" }, { id: "2" }] });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+    } as Response);
+
+    await mergeGuestWorkspace("tok_xyz");
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/workspace");
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: expect.objectContaining({
+        Authorization: "Bearer tok_xyz",
+      }),
+    });
+
+    const body = JSON.parse(init!.body as string);
+    expect(body.name).toMatch(/2 verses/);
+    expect(body.nodeCount).toBe(2);
+    expect(body.data.v).toBe(1);
+
+    expect(localStorage.getItem(MERGE_FLAG_KEY)).toBe("1");
+  });
+
+  it("does not set merge flag when response is not ok", async () => {
+    setCanvas({ v: 1, nodes: [{ id: "1" }] });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as Response);
+
+    await mergeGuestWorkspace("tok_xyz");
+
+    expect(localStorage.getItem(MERGE_FLAG_KEY)).toBeNull();
+  });
+
+  it("does not throw when fetch fails", async () => {
+    setCanvas({ v: 1, nodes: [{ id: "1" }] });
+
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+
+    await expect(mergeGuestWorkspace("tok_xyz")).resolves.toBeUndefined();
+  });
+
+  it("sends singular name for single node", async () => {
+    setCanvas({ v: 1, nodes: [{ id: "1" }] });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as Response);
+
+    await mergeGuestWorkspace("tok_abc");
+
+    const body = JSON.parse(
+      (globalThis.fetch as ReturnType<typeof vi.spyOn>).mock.calls[0][1]!
+        .body as string,
+    );
+    expect(body.name).toMatch(/1 verse\b/);
+    expect(body.nodeCount).toBe(1);
+  });
+});

--- a/app/bookmarks/page.tsx
+++ b/app/bookmarks/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Heart, Trash2, Network } from "lucide-react";
 import { useAuthStore } from "@/store/auth";
-import { AuthShell } from "@/components/layout/AuthShell";
+import { LandingHeader } from "@/components/layout/LandingHeader";
 import { Card, IconButton, Tooltip, iconButtonVariants } from "@/components/ui";
 import type { Verse } from "@/types/quran";
 
@@ -46,8 +46,9 @@ export default function BookmarksPage() {
   }, [bookmarks.join(",")]);
 
   return (
-    <AuthShell>
-      <div className="mx-auto w-full max-w-2xl">
+    <div className="flex min-h-dvh flex-col bg-bg">
+      <LandingHeader />
+      <div className="mx-auto w-full max-w-2xl flex-1">
         {/* Page header */}
         <div className="mb-8 flex items-center gap-3">
           <Heart className="h-5 w-5 text-gold" />
@@ -144,6 +145,6 @@ export default function BookmarksPage() {
           </div>
         )}
       </div>
-    </AuthShell>
+    </div>
   );
 }

--- a/app/callback/CallbackClient.tsx
+++ b/app/callback/CallbackClient.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
+import { mergeGuestWorkspace } from "@/hooks/useCanvasPersistence";
 import { Loader2 } from "lucide-react";
 
 interface Props {
@@ -73,6 +74,7 @@ export function CallbackClient({ code, state, error }: Props) {
         }
 
         await loadRemoteBookmarks();
+        await mergeGuestWorkspace(accessToken);
 
         router.replace(isNewUser ? "/onboarding" : "/");
       })

--- a/components/home/HomeView.tsx
+++ b/components/home/HomeView.tsx
@@ -1,14 +1,37 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import { useAuthStore } from "@/store/auth";
 import { MarketingHero } from "./MarketingHero";
 import { PersonalHome } from "./PersonalHome";
 import { AuthLoadingSkeleton } from "./AuthLoadingSkeleton";
+import { CANVAS_STORAGE_KEY } from "@/hooks/useCanvasPersistence";
 import type { Verse } from "@/types/quran";
+
+function detectLocalCanvas(): boolean {
+  try {
+    const raw = localStorage.getItem(CANVAS_STORAGE_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as { v?: number; nodes?: unknown[] };
+    return parsed?.v === 1 && Array.isArray(parsed.nodes) && parsed.nodes.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function subscribeToStorage() {
+  return () => {};
+}
 
 export function HomeView({ verse }: { verse: Verse | null }) {
   const accessToken = useAuthStore((s) => s.accessToken);
   const isSessionLoading = useAuthStore((s) => s.isSessionLoading);
+
+  // Detect guests who have an in-progress canvas in localStorage — they should
+  // see the PersonalHome dashboard (with bookmarks & continue-canvas) rather
+  // than the marketing landing. Uses useSyncExternalStore to avoid the
+  // react-hooks/set-state-in-effect lint violation.
+  const hasLocalCanvas = useSyncExternalStore(subscribeToStorage, detectLocalCanvas, () => false);
 
   // While the session is restoring, show a skeleton that matches PersonalHome's
   // layout. Without this, signed-in users briefly see the MarketingHero on every
@@ -17,5 +40,9 @@ export function HomeView({ verse }: { verse: Verse | null }) {
     return <AuthLoadingSkeleton />;
   }
 
-  return accessToken ? <PersonalHome verse={verse} /> : <MarketingHero verse={verse} />;
+  return accessToken || hasLocalCanvas ? (
+    <PersonalHome verse={verse} />
+  ) : (
+    <MarketingHero verse={verse} />
+  );
 }

--- a/components/home/PersonalHome.tsx
+++ b/components/home/PersonalHome.tsx
@@ -116,18 +116,20 @@ export function PersonalHome({ verse }: { verse: Verse | null }) {
                 : "Search a verse and map its connections"
             }
           />
-          <QuickLink
-            href="/workspaces"
-            icon={FolderOpen}
-            title="Saved canvases"
-            subtitle={
-              savedCount !== null
-                ? `${savedCount} saved canvas${savedCount === 1 ? "" : "es"}`
-                : savedCountError
-                  ? "Couldn't load your saved canvases"
-                  : "Your saved graphs"
-            }
-          />
+          {accessToken && (
+            <QuickLink
+              href="/workspaces"
+              icon={FolderOpen}
+              title="Saved canvases"
+              subtitle={
+                savedCount !== null
+                  ? `${savedCount} saved canvas${savedCount === 1 ? "" : "es"}`
+                  : savedCountError
+                    ? "Couldn't load your saved canvases"
+                    : "Your saved graphs"
+              }
+            />
+          )}
           <QuickLink
             href="/bookmarks"
             icon={Heart}

--- a/components/layout/HeaderNavLinks.tsx
+++ b/components/layout/HeaderNavLinks.tsx
@@ -3,25 +3,24 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { useAuthStore } from "@/store/auth";
 
 // The single source of primary section navigation, rendered inline in the
-// global header row. Bookmarks only appears here once signed in — it isn't
-// duplicated in the AccountMenu dropdown, so there's exactly one home for it.
+// global header row. Bookmarks is always visible — guests can bookmark
+// verses in localStorage and sync them on sign-in.
 const ITEMS = [
   { href: "/canvas", label: "Canvas" },
   { href: "/search", label: "Search" },
-  { href: "/names", label: "Asma’ul Husna" },
+  { href: "/names", label: "Asma'ul Husna" },
+  { href: "/bookmarks", label: "Bookmarks" },
 ] as const;
 
 export function HeaderNavLinks() {
   const pathname = usePathname();
-  const accessToken = useAuthStore((s) => s.accessToken);
 
   const isActive = (href: string) =>
     href === "/canvas" ? pathname === "/canvas" : pathname.startsWith(href);
 
-  const items = accessToken ? [...ITEMS, { href: "/bookmarks", label: "Bookmarks" }] : ITEMS;
+  const items = ITEMS;
 
   return (
     <nav className="hidden md:flex h-full items-center gap-0.5">

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -5,6 +5,7 @@ import { MiniPlayer } from "@/components/audio/MiniPlayer";
 import { TooltipProvider } from "@/components/ui";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
+import { mergeGuestWorkspace } from "@/hooks/useCanvasPersistence";
 
 function SessionRestorer() {
   const setTokens = useAuthStore((s) => s.setTokens);
@@ -81,6 +82,7 @@ function SessionRestorer() {
         const [profileRes] = await Promise.all([
           fetch("/api/social/me", { headers: { Authorization: `Bearer ${accessToken}` } }),
           loadRemoteBookmarks(),
+          mergeGuestWorkspace(accessToken),
         ]);
 
         if (profileRes.ok) {

--- a/hooks/useCanvasPersistence.ts
+++ b/hooks/useCanvasPersistence.ts
@@ -6,6 +6,10 @@ import { useCanvasStore, serializeCanvas, type SavedCanvas } from "@/store/canva
 /** localStorage key for the in-progress canvas. Exported so the home screen can
  *  surface a "continue where you left off" entry without re-deriving the key. */
 export const CANVAS_STORAGE_KEY = "open-hikmah-canvas";
+
+/** localStorage flag set after a guest's canvas has been merged into the user's
+ *  cloud workspaces, preventing duplicate merges on re-login. */
+const MERGE_FLAG_KEY = "open-hikmah-guest-merged";
 const LS_KEY = CANVAS_STORAGE_KEY;
 
 export async function buildShareUrl(canvas: SavedCanvas): Promise<string> {
@@ -24,6 +28,41 @@ export async function buildShareUrl(canvas: SavedCanvas): Promise<string> {
   url.hash = "";
   url.searchParams.set("share", id);
   return url.toString();
+}
+
+/**
+ * Merges a guest's local canvas into the authenticated user's cloud workspaces.
+ * Called once after OAuth sign-in or session restore. Idempotent — skips if the
+ * merge has already completed (tracked via localStorage flag) or if there is no
+ * local canvas data.
+ */
+export async function mergeGuestWorkspace(accessToken: string): Promise<void> {
+  try {
+    if (localStorage.getItem(MERGE_FLAG_KEY)) return;
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return;
+    const saved: SavedCanvas = JSON.parse(raw);
+    if (saved?.v !== 1 || !saved.nodes || saved.nodes.length === 0) return;
+
+    const count = saved.nodes.length;
+    const date = new Date().toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    const name = `${count} verse${count === 1 ? "" : "s"} — ${date}`;
+
+    const res = await fetch("/api/workspace", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ name, data: saved, nodeCount: count }),
+    });
+
+    if (res.ok) {
+      localStorage.setItem(MERGE_FLAG_KEY, "1");
+    }
+  } catch {
+    // Non-fatal — guest canvas survives in localStorage for next attempt.
+  }
 }
 
 export function useCanvasPersistence() {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,32 @@
 import "@testing-library/jest-dom/vitest";
 
+// Node ≥22 requires --localstorage-file for jsdom to expose localStorage.
+// Provide a minimal in-memory polyfill so tests that call localStorage.clear()
+// (e.g. the auth store and CanvasTour tests) don't crash.
+if (typeof globalThis.localStorage === "undefined" || globalThis.localStorage === null) {
+  const store = new Map<string, string>();
+  globalThis.localStorage = {
+    get length() {
+      return store.size;
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    clear() {
+      store.clear();
+    },
+    key(index: number) {
+      return [...store.keys()][index] ?? null;
+    },
+  } as Storage;
+}
+
 // Provide dummy env vars so API route modules load without throwing
 process.env.NEXT_PUBLIC_QF_CLIENT_ID = "test-client-id";
 process.env.QF_API_BASE = "https://api.test.qf.com";


### PR DESCRIPTION
## Summary

- Allow visitors to use the canvas, search, Asma'ul Husna, and bookmark verses without signing in — guest data is stored in localStorage
- Add merge-on-login: when a guest signs in, their local canvas is automatically saved as a cloud workspace (idempotent via `open-hikmah-guest-merged` flag)
- Fix two pre-existing test failures caused by `localStorage` being unavailable in Node >=22 test environments

fix #108 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [x] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below

**Details** (if applicable):

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [x] `README.md` updated if the feature changes the public interface