### PR TITLE
docs: consolidate AI agent guidance into AGENTS.md, wire other tools

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,11 @@
+# Aider config
+#
+# Read AGENTS.md at the repo root first — it is the single source of truth for
+# this repo's coding agent guidance. The read-only file below is a condensed
+# mirror of its highest-stakes rules for tools that don't reliably follow
+# cross-file references; if it drifts from AGENTS.md, AGENTS.md wins.
+# (Condensed copies of the same summary also live in .github/copilot-instructions.md,
+# .cursor/rules/agents.mdc, .windsurfrules, .clinerules — update all of them together.)
+
+read:
+  - AGENTS.md

--- a/.clinerules
+++ b/.clinerules
@@ -1,0 +1,14 @@
+# Cline rules
+
+Read `AGENTS.md` at the repo root first — it is the single source of truth for this repo's coding agent guidance. This file is a condensed mirror of its highest-stakes rules for tools that don't reliably follow cross-file references; if it drifts from `AGENTS.md`, `AGENTS.md` wins. (Condensed copies of this block also live in `.github/copilot-instructions.md`, `.cursor/rules/agents.mdc`, `.windsurfrules`, `.aider.conf.yml` — update all of them together.)
+
+## Critical rules
+
+- **No `Co-Authored-By` trailers in commits.** For large AI-generated contributions (a whole new file, or ~30+ lines with minimal human review), add a `Generated-By: <tool-name>` trailer instead.
+- **TypeScript strict mode** — no `any`, no `ts-ignore` without a comment explaining why.
+- **No comments** unless the *why* is non-obvious.
+- **No feature flags or backwards-compatibility shims** — change the code directly.
+- **No error handling for impossible scenarios** — only validate at system boundaries.
+- **Theological standards** (binding on any prompt, divine-name, or verse-connection change): stay within the Maturidi/Hanafi tradition; maintain strict Tanzih (never imply physical form or spatial location for divine attributes — see `app/api/connections/route.ts`); never fabricate a Quran verse reference; treat Quranic text as sacred data even in test fixtures (no "lorem ipsum" for Arabic fields); attribute translations correctly (`en.sahih` / Saheeh International from alquran.cloud).
+
+Full detail, rationale, and setup/testing commands: see `AGENTS.md`.

--- a/.clinerules
+++ b/.clinerules
@@ -10,5 +10,8 @@ Read `AGENTS.md` at the repo root first — it is the single source of truth for
 - **No feature flags or backwards-compatibility shims** — change the code directly.
 - **No error handling for impossible scenarios** — only validate at system boundaries.
 - **Theological standards** (binding on any prompt, divine-name, or verse-connection change): stay within the Maturidi/Hanafi tradition; maintain strict Tanzih (never imply physical form or spatial location for divine attributes — see `app/api/connections/route.ts`); never fabricate a Quran verse reference; treat Quranic text as sacred data even in test fixtures (no "lorem ipsum" for Arabic fields); attribute translations correctly (`en.sahih` / Saheeh International from alquran.cloud).
+- **No silent `catch` blocks** — failures must surface loudly, not fall back silently.
+- **Auth/security surface** (`lib/auth/`, `app/callback/`, `app/api/admin/`) and DB migrations are high-risk — call out explicitly in the PR, never skip git hooks without explicit instruction.
+- **Never loosen theological/verse-reference validation** to make a failing test pass — fix the underlying data or prompt instead.
 
 Full detail, rationale, and setup/testing commands: see `AGENTS.md`.

--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -1,0 +1,17 @@
+---
+description: Repo-wide agent guidance — read AGENTS.md first
+alwaysApply: true
+---
+
+Read `AGENTS.md` at the repo root first — it is the single source of truth for this repo's coding agent guidance. This file is a condensed mirror of its highest-stakes rules for tools that don't reliably follow cross-file references; if it drifts from `AGENTS.md`, `AGENTS.md` wins. (Condensed copies of this block also live in `.github/copilot-instructions.md`, `.windsurfrules`, `.clinerules`, `.aider.conf.yml` — update all of them together.)
+
+## Critical rules
+
+- **No `Co-Authored-By` trailers in commits.** For large AI-generated contributions (a whole new file, or ~30+ lines with minimal human review), add a `Generated-By: <tool-name>` trailer instead.
+- **TypeScript strict mode** — no `any`, no `ts-ignore` without a comment explaining why.
+- **No comments** unless the *why* is non-obvious.
+- **No feature flags or backwards-compatibility shims** — change the code directly.
+- **No error handling for impossible scenarios** — only validate at system boundaries.
+- **Theological standards** (binding on any prompt, divine-name, or verse-connection change): stay within the Maturidi/Hanafi tradition; maintain strict Tanzih (never imply physical form or spatial location for divine attributes — see `app/api/connections/route.ts`); never fabricate a Quran verse reference; treat Quranic text as sacred data even in test fixtures (no "lorem ipsum" for Arabic fields); attribute translations correctly (`en.sahih` / Saheeh International from alquran.cloud).
+
+Full detail, rationale, and setup/testing commands: see `AGENTS.md`.

--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -13,5 +13,8 @@ Read `AGENTS.md` at the repo root first — it is the single source of truth for
 - **No feature flags or backwards-compatibility shims** — change the code directly.
 - **No error handling for impossible scenarios** — only validate at system boundaries.
 - **Theological standards** (binding on any prompt, divine-name, or verse-connection change): stay within the Maturidi/Hanafi tradition; maintain strict Tanzih (never imply physical form or spatial location for divine attributes — see `app/api/connections/route.ts`); never fabricate a Quran verse reference; treat Quranic text as sacred data even in test fixtures (no "lorem ipsum" for Arabic fields); attribute translations correctly (`en.sahih` / Saheeh International from alquran.cloud).
+- **No silent `catch` blocks** — failures must surface loudly, not fall back silently.
+- **Auth/security surface** (`lib/auth/`, `app/callback/`, `app/api/admin/`) and DB migrations are high-risk — call out explicitly in the PR, never skip git hooks without explicit instruction.
+- **Never loosen theological/verse-reference validation** to make a failing test pass — fix the underlying data or prompt instead.
 
 Full detail, rationale, and setup/testing commands: see `AGENTS.md`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,7 @@
 - [ ] Claude prompt modified — described below
 - [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
 - [ ] Changes to theological framing — described below
+- [ ] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)
 
 **Details** (if applicable):
 <!-- Describe any changes to prompts, expected output format, or theological framing. Note any deviations from or additions to the Maturidi/Hanafi tradition. -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,14 @@
+# Copilot instructions
+
+Read `AGENTS.md` at the repo root first — it is the single source of truth for this repo's coding agent guidance. This file is a condensed mirror of its highest-stakes rules for tools that don't reliably follow cross-file references; if it drifts from `AGENTS.md`, `AGENTS.md` wins. (Condensed copies of this block also live in `.cursor/rules/agents.mdc`, `.windsurfrules`, `.clinerules`, `.aider.conf.yml` — update all of them together.)
+
+## Critical rules
+
+- **No `Co-Authored-By` trailers in commits.** For large AI-generated contributions (a whole new file, or ~30+ lines with minimal human review), add a `Generated-By: <tool-name>` trailer instead.
+- **TypeScript strict mode** — no `any`, no `ts-ignore` without a comment explaining why.
+- **No comments** unless the _why_ is non-obvious.
+- **No feature flags or backwards-compatibility shims** — change the code directly.
+- **No error handling for impossible scenarios** — only validate at system boundaries.
+- **Theological standards** (binding on any prompt, divine-name, or verse-connection change): stay within the Maturidi/Hanafi tradition; maintain strict Tanzih (never imply physical form or spatial location for divine attributes — see `app/api/connections/route.ts`); never fabricate a Quran verse reference; treat Quranic text as sacred data even in test fixtures (no "lorem ipsum" for Arabic fields); attribute translations correctly (`en.sahih` / Saheeh International from alquran.cloud).
+
+Full detail, rationale, and setup/testing commands: see `AGENTS.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,5 +10,8 @@ Read `AGENTS.md` at the repo root first — it is the single source of truth for
 - **No feature flags or backwards-compatibility shims** — change the code directly.
 - **No error handling for impossible scenarios** — only validate at system boundaries.
 - **Theological standards** (binding on any prompt, divine-name, or verse-connection change): stay within the Maturidi/Hanafi tradition; maintain strict Tanzih (never imply physical form or spatial location for divine attributes — see `app/api/connections/route.ts`); never fabricate a Quran verse reference; treat Quranic text as sacred data even in test fixtures (no "lorem ipsum" for Arabic fields); attribute translations correctly (`en.sahih` / Saheeh International from alquran.cloud).
+- **No silent `catch` blocks** — failures must surface loudly, not fall back silently.
+- **Auth/security surface** (`lib/auth/`, `app/callback/`, `app/api/admin/`) and DB migrations are high-risk — call out explicitly in the PR, never skip git hooks without explicit instruction.
+- **Never loosen theological/verse-reference validation** to make a failing test pass — fix the underlying data or prompt instead.
 
 Full detail, rationale, and setup/testing commands: see `AGENTS.md`.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -10,5 +10,8 @@ Read `AGENTS.md` at the repo root first — it is the single source of truth for
 - **No feature flags or backwards-compatibility shims** — change the code directly.
 - **No error handling for impossible scenarios** — only validate at system boundaries.
 - **Theological standards** (binding on any prompt, divine-name, or verse-connection change): stay within the Maturidi/Hanafi tradition; maintain strict Tanzih (never imply physical form or spatial location for divine attributes — see `app/api/connections/route.ts`); never fabricate a Quran verse reference; treat Quranic text as sacred data even in test fixtures (no "lorem ipsum" for Arabic fields); attribute translations correctly (`en.sahih` / Saheeh International from alquran.cloud).
+- **No silent `catch` blocks** — failures must surface loudly, not fall back silently.
+- **Auth/security surface** (`lib/auth/`, `app/callback/`, `app/api/admin/`) and DB migrations are high-risk — call out explicitly in the PR, never skip git hooks without explicit instruction.
+- **Never loosen theological/verse-reference validation** to make a failing test pass — fix the underlying data or prompt instead.
 
 Full detail, rationale, and setup/testing commands: see `AGENTS.md`.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,14 @@
+# Windsurf rules
+
+Read `AGENTS.md` at the repo root first — it is the single source of truth for this repo's coding agent guidance. This file is a condensed mirror of its highest-stakes rules for tools that don't reliably follow cross-file references; if it drifts from `AGENTS.md`, `AGENTS.md` wins. (Condensed copies of this block also live in `.github/copilot-instructions.md`, `.cursor/rules/agents.mdc`, `.clinerules`, `.aider.conf.yml` — update all of them together.)
+
+## Critical rules
+
+- **No `Co-Authored-By` trailers in commits.** For large AI-generated contributions (a whole new file, or ~30+ lines with minimal human review), add a `Generated-By: <tool-name>` trailer instead.
+- **TypeScript strict mode** — no `any`, no `ts-ignore` without a comment explaining why.
+- **No comments** unless the *why* is non-obvious.
+- **No feature flags or backwards-compatibility shims** — change the code directly.
+- **No error handling for impossible scenarios** — only validate at system boundaries.
+- **Theological standards** (binding on any prompt, divine-name, or verse-connection change): stay within the Maturidi/Hanafi tradition; maintain strict Tanzih (never imply physical form or spatial location for divine attributes — see `app/api/connections/route.ts`); never fabricate a Quran verse reference; treat Quranic text as sacred data even in test fixtures (no "lorem ipsum" for Arabic fields); attribute translations correctly (`en.sahih` / Saheeh International from alquran.cloud).
+
+Full detail, rationale, and setup/testing commands: see `AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,15 @@ Describe the theological implications of any AI prompt change in the PR (see the
 - **Code-level disclosure for large AI-generated contributions.** When an agent generates a whole new file, or a block of roughly 30+ lines, with minimal human review or editing, the commit message must carry a `Generated-By: <tool-name>` trailer (e.g. `Generated-By: Claude Code`). This is a plain-text disclosure trailer, distinct from `Co-Authored-By` — it does not trigger GitHub's co-author UI. Don't add inline "AI-generated" comments in source files; that conflicts with the no-unnecessary-comments code style rule above. The commit trailer is the disclosure mechanism.
 - **Condensed copies exist** in the tool-specific pointer files (`.github/copilot-instructions.md`, `.cursor/rules/agents.mdc`, `.windsurfrules`, `.clinerules`, `.aider.conf.yml`) for tools that can't import this file directly. If you change this policy, update those too — see the note in each file.
 
+## Guardrails
+
+- **Scope discipline** — no dependency additions/upgrades without flagging them in the PR description; no new abstractions or config layers for one-off use, reuse existing patterns in `lib/`; never skip git hooks (`--no-verify`, `--force`, etc.) without explicit user instruction.
+- **Database / migrations** — schema changes must be reversible and exercised via `bun run test:integration` (Testcontainers), not just unit tests.
+- **Auth / security surface** — treat `lib/auth/`, `app/callback/`, the PKCE flow, and `app/api/admin/` as high-risk (matches existing `CODEOWNERS` gating). Changes there must be called out explicitly in the PR description, not just left to pass CI silently. No new secrets/env vars committed; no loosening of CSP or auth checks without justification in the PR.
+- **Error handling** — no silent `catch` blocks. A failure should surface loudly, especially around parsing AI responses, where silently falling back could produce wrong theological content instead of a visible error.
+- **Testing bar** — new logic requires new tests in the same PR, not left for CI to catch after the fact.
+- **AI-specific correctness** — never "fix" a failing theological/verse-reference test by loosening the validation; only by fixing the underlying data or prompt. This is the failure mode most specific to this repo: an agent under test pressure weakening a real guardrail.
+
 ## Available tooling
 
 MCP servers configured for this repo (`.mcp.json`, `.claude.json`): `codegraph` (tree-sitter-parsed knowledge graph of every symbol/edge/file) and `sequential-thinking`. If your agent supports MCP, prefer these over grep/read for structural questions. Claude Code-specific usage rules for CodeGraph live in `CLAUDE.md` — read that file if you're Claude Code; other MCP-capable agents should discover the same tools via their own MCP client.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,79 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+# AGENTS.md
+
+This is the single, tool-agnostic source of truth for any AI coding agent (or human) working in this repo. Tool-specific config files (`CLAUDE.md`, `GEMINI.md`, `.cursor/rules/agents.mdc`, `.github/copilot-instructions.md`, `.windsurfrules`, `.clinerules`, `.aider.conf.yml`) all point back here — read those only for the extra, tool-specific bits they add.
+
+## Project overview
+
+Open Hikmah is a theological sensemaking tool for the Quran. Contributions touch both code and sacred content, so code-quality standards and theological standards both apply, and both are binding.
+
+## Setup / commands
+
+```bash
+bun install
+cp .env.example .env.local   # fill in values, see .env.example
+bun run dev                  # http://localhost:3000
+```
+
+At minimum you need `ANTHROPIC_API_KEY` set to test AI connections. Quran Foundation OAuth variables are only needed to test bookmarks.
+
+```bash
+bun run test              # unit tests, interactive watch mode
+bun run test:ci           # unit tests, single run (used in CI)
+bun run test:integration  # integration tests against real Postgres (Testcontainers, needs Docker)
+bun run test:e2e          # end-to-end tests (Playwright), including accessibility checks
+bun run lint
+bun run format:check
+bun run typecheck
+```
+
+**Docker is required to push.** `.husky/pre-push` runs integration tests via Testcontainers, which spin up a real Postgres instance in Docker. Make sure `docker ps` succeeds before running `git push`, or the hook fails with an unclear error.
+
+Unit tests live in `__tests__/` and mirror the source structure (`lib/`, `api/`, `store/`). End-to-end tests live in `e2e/`. All CI checks (lint, typecheck, unit, integration, build, e2e) must pass before merge.
+
+## Branch & commit conventions
+
+Branch names: `feat/`, `fix/`, `chore/`, or `docs/` followed by a short kebab-case description (e.g. `feat/audio-recitation`).
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix(search): prevent focus loss when query is in-flight`).
+
+**Do not add `Co-Authored-By` trailers to commits.** See the AI Attribution Policy below for what to use instead when disclosure is required.
+
+## Code style
+
+- **TypeScript strict mode** — no `any`, no `ts-ignore` without a comment explaining why.
+- **No comments** unless the _why_ is non-obvious (a hidden constraint, a Quran API quirk, a security invariant).
+- **No feature flags or backwards-compatibility shims** — change the code directly.
+- **No error handling for impossible scenarios** — trust Next.js and TypeScript guarantees; only validate at system boundaries.
+- File structure follows Next.js App Router conventions: API routes under `app/api/`, pages under `app/`, shared logic under `lib/`, Zustand stores under `store/`.
+- Run `bun run lint` and `bun run format:check` before pushing; CI rejects lint/format failures.
+
+## Theological standards
+
+All AI prompts, divine name descriptions, and verse connections must:
+
+1. **Stay within the Maturidi/Hanafi tradition** — this is the theological framework of the project. Don't introduce Ash'ari-only positions without noting the difference, and don't conflate schools.
+2. **Maintain strict Tanzih (transcendence)** — never describe divine attributes in ways that imply physical form, spatial location, or resemblance to created things (Tashbih). The prompts in `app/api/connections/route.ts` include this constraint explicitly.
+3. **Use verified verse references** — never fabricate a Quran verse reference. If a model returns a reference that cannot be verified via the alquran.cloud API, the system rejects it. In tests, use known valid refs (e.g. `2:255`, `1:1`, `112:1`).
+4. **Handle Quranic text as sacred data** — even in test fixtures and mock data, use real or plausible Arabic text. Don't use placeholder strings like `"lorem ipsum"` for Arabic fields.
+5. **Attribute translations correctly** — the project uses `en.sahih` (Saheeh International) from alquran.cloud. If you add a new translation source, document it clearly.
+
+Describe the theological implications of any AI prompt change in the PR (see the "AI / Theological changes" section of the PR template).
+
+## AI Attribution Policy
+
+- **No `Co-Authored-By` trailers.** This repo does not use GitHub's co-author attribution for AI-assisted commits — it implies joint human authorship that doesn't apply here.
+- **PR-level disclosure is required** for any change to Claude prompts, divine-name data, or theological framing — check the relevant box(es) in the PR template's "AI / Theological changes" section and describe the change.
+- **Code-level disclosure for large AI-generated contributions.** When an agent generates a whole new file, or a block of roughly 30+ lines, with minimal human review or editing, the commit message must carry a `Generated-By: <tool-name>` trailer (e.g. `Generated-By: Claude Code`). This is a plain-text disclosure trailer, distinct from `Co-Authored-By` — it does not trigger GitHub's co-author UI. Don't add inline "AI-generated" comments in source files; that conflicts with the no-unnecessary-comments code style rule above. The commit trailer is the disclosure mechanism.
+- **Condensed copies exist** in the tool-specific pointer files (`.github/copilot-instructions.md`, `.cursor/rules/agents.mdc`, `.windsurfrules`, `.clinerules`, `.aider.conf.yml`) for tools that can't import this file directly. If you change this policy, update those too — see the note in each file.
+
+## Available tooling
+
+MCP servers configured for this repo (`.mcp.json`, `.claude.json`): `codegraph` (tree-sitter-parsed knowledge graph of every symbol/edge/file) and `sequential-thinking`. If your agent supports MCP, prefer these over grep/read for structural questions. Claude Code-specific usage rules for CodeGraph live in `CLAUDE.md` — read that file if you're Claude Code; other MCP-capable agents should discover the same tools via their own MCP client.
+
+## Reporting bugs / feature requests
+
+Use the issue templates in `.github/ISSUE_TEMPLATE/`. For security vulnerabilities, email security@openhikmah.com instead of opening an issue — see `SECURITY.md`. Feature requests affecting how the Quran is presented or connected should include theological rationale.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,7 @@ Thank you for your interest in contributing. Open Hikmah is a theological sensem
 - [Getting Started](#getting-started)
 - [Branch and Commit Conventions](#branch-and-commit-conventions)
 - [Running Tests](#running-tests)
-- [Code Style](#code-style)
-- [Theological Standards](#theological-standards)
+- [Code Style and Theological Standards](#code-style-and-theological-standards)
 - [Submitting a Pull Request](#submitting-a-pull-request)
 - [Reporting Bugs](#reporting-bugs)
 - [Feature Requests](#feature-requests)
@@ -54,7 +53,7 @@ chore(deps): bump @anthropic-ai/sdk to 0.97.0
 docs(names): add theological notes for Sifat al-Af'al
 ```
 
-**Do not add `Co-Authored-By` lines** to commits.
+**Do not add `Co-Authored-By` lines** to commits. See [`AGENTS.md`](AGENTS.md#ai-attribution-policy) for the full AI attribution policy, including when a `Generated-By` trailer is required.
 
 ---
 
@@ -89,32 +88,9 @@ CI runs automatically on every push via GitHub Actions (`.github/workflows/ci.ym
 
 ---
 
-## Code Style
+## Code Style and Theological Standards
 
-- **TypeScript strict mode** — no `any`, no `ts-ignore` without a comment explaining why
-- **No comments** unless the _why_ is non-obvious (a hidden constraint, a Quran API quirk, a security invariant)
-- **No feature flags or backwards-compatibility shims** — change the code directly
-- **No error handling for impossible scenarios** — trust Next.js and TypeScript guarantees; only validate at system boundaries
-
-* Run `bun run lint` and `bun run format:check` before pushing; the CI will reject lint/format failures
-
-File structure follows Next.js App Router conventions. New API routes go under `app/api/`, new pages under `app/`, shared logic under `lib/`, Zustand stores under `store/`.
-
----
-
-## Theological Standards
-
-All AI prompts, divine name descriptions, and verse connections must:
-
-1. **Stay within the Maturidi/Hanafi tradition** — This is the theological framework of the project. Don't introduce Ash'ari-only positions without noting the difference, and don't conflate schools.
-
-2. **Maintain strict Tanzih (transcendence)** — Never describe divine attributes in ways that imply physical form, spatial location, or resemblance to created things (Tashbih). The prompts in `app/api/connections/route.ts` include this constraint explicitly.
-
-3. **Use verified verse references** — Never fabricate a Quran verse reference. If Claude returns a reference that cannot be verified via the alquran.cloud API, the system will reject it. In tests, use known valid refs (e.g. `2:255`, `1:1`, `112:1`).
-
-4. **Handle Quranic text as sacred data** — Even in test fixtures and mock data, use real or plausible Arabic text. Don't use placeholder strings like `"lorem ipsum"` for Arabic fields.
-
-5. **Attribute translations correctly** — The project uses `en.sahih` (Saheeh International) from alquran.cloud. If you add a new translation source, document it clearly.
+These are now defined canonically in [`AGENTS.md`](AGENTS.md) at the repo root (the shared guide for both AI coding agents and human contributors) — see its "Code Style" and "Theological Standards" sections. Read it before opening a PR that touches source code, AI prompts, divine-name data, or verse connections.
 
 ---
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary
- AGENTS.md was a 4-line Next.js-breaking-changes stub; the real agent rules (code style, theological standards, commit conventions) were buried in CONTRIBUTING.md and only reachable by Claude via CLAUDE.md's import. AGENTS.md is now the canonical, tool-agnostic guide for any AI coding agent (and humans).
- Wired pointer configs for the other major AI coding tools so they all read the same source of truth: `GEMINI.md`, `.github/copilot-instructions.md`, `.cursor/rules/agents.mdc`, `.windsurfrules`, `.clinerules`, `.aider.conf.yml`.
- Formalized and expanded the AI attribution policy: no `Co-Authored-By` trailers (existing rule, now documented with rationale), plus a new `Generated-By: <tool-name>` commit trailer requirement for large AI-generated contributions (whole file or ~30+ line block with minimal human review). Added a matching checkbox to the PR template.
- `CONTRIBUTING.md`'s Code Style and Theological Standards sections now defer to AGENTS.md instead of duplicating it, to avoid drift.

## Type of change
- [x] Documentation

## Test plan
- [x] Read back all new/edited files to confirm no content was lost from CONTRIBUTING.md
- [x] Grepped for `Co-Authored-By`/`Generated-By` across the repo for consistency
- [x] Verified all markdown anchor links (`AGENTS.md#ai-attribution-policy`, CONTRIBUTING.md TOC) resolve to the actual headings
- [x] `bun run test:ci`, `typecheck`, `lint`, `format:check` all pass locally (docs-only change, no runtime surface)