### PR TITLE
chore: extract DB migrations to a one-shot deploy step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ COPY --from=deps /app/node_modules/@google/generative-ai ./node_modules/@google/
 
 USER nextjs
 EXPOSE 3000
-# Run pending migrations (idempotent) then start the server.
-# This ensures new tables are always created on deploy without a manual step.
-CMD ["sh", "-c", "bun scripts/migrate.mjs && bun scripts/ensure-tables.mjs && bun server.js"]
+# Migrations run as a one-shot step in scripts/deploy.sh before this container
+# starts, not here — running migrate.mjs from every replica's CMD would race
+# multiple `drizzle-orm/postgres-js/migrator` runs against the same DB once
+# there's ever more than one app replica.
+CMD ["bun", "server.js"]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,10 @@ echo "==> Ensuring database and redis are running..."
 $COMPOSE up -d db redis
 
 echo "==> Running database migrations (one-shot, before the app starts)..."
-$COMPOSE run --rm app sh -c "bun scripts/migrate.mjs && bun scripts/ensure-tables.mjs"
+# --name avoids colliding with the still-running `open-hikmah-app` container
+# (fixed container_name in docker-compose.yml) — the old app container isn't
+# stopped until `up -d app` below replaces it.
+$COMPOSE run --rm --name open-hikmah-migrate app sh -c "bun scripts/migrate.mjs && bun scripts/ensure-tables.mjs"
 
 echo "==> Starting app container..."
 $COMPOSE up -d app

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,8 +14,17 @@ git pull origin main
 echo "==> Tagging current image as :previous (for rollback)..."
 docker tag open-hikmah-app:latest open-hikmah-app:previous 2>/dev/null || true
 
-echo "==> Building new image and starting containers..."
-$COMPOSE up -d --build
+echo "==> Building new app image..."
+$COMPOSE build app
+
+echo "==> Ensuring database and redis are running..."
+$COMPOSE up -d db redis
+
+echo "==> Running database migrations (one-shot, before the app starts)..."
+$COMPOSE run --rm app sh -c "bun scripts/migrate.mjs && bun scripts/ensure-tables.mjs"
+
+echo "==> Starting app container..."
+$COMPOSE up -d app
 
 echo "==> Waiting for health check (up to 60s)..."
 HEALTHY=false


### PR DESCRIPTION
## Summary
Closes #154.

The Docker `CMD` ran `bun scripts/migrate.mjs && bun scripts/ensure-tables.mjs && bun server.js` in every container. This is safe today because the app runs as a single container/replica, but it's a pre-diagnosed race condition waiting to reappear the moment a second app replica is ever started: multiple containers would run `drizzle-orm/postgres-js/migrator` concurrently against the same database on boot.

## Changes
- **Dockerfile**: `CMD` now only starts the server (`bun server.js`). Migrations are no longer run per-container.
- **scripts/deploy.sh**: migrations now run as an explicit one-shot step — `docker compose run --rm app sh -c "bun scripts/migrate.mjs && bun scripts/ensure-tables.mjs"` — after building the new image and ensuring `db`/`redis` are up, but before the `app` container is started. `docker compose run` respects the existing `depends_on: condition: service_healthy` for `db`/`redis`, so no extra wait-loop was needed.
- This also makes migration failures more visible: they now fail the deploy script directly (`set -euo pipefail`) with a scoped log message, instead of being buried inside the app container's boot sequence.

## Why this is safe
- `migrate.mjs` and `ensure-tables.mjs` are both idempotent (Drizzle's migration tracking table + `CREATE ... IF NOT EXISTS` DDL respectively), so running them once per deploy, before the app starts, is equivalent to the old behavior for the current single-replica setup — just no longer racy if replicas are ever added.
- `docker-compose.yml` is unchanged; no schema/runtime behavior changes, no new dependencies.

## Test plan
- [x] `bun run typecheck` (no source changes, included for completeness)
- [x] Traced `deploy.sh` step-by-step against `docker-compose.yml`'s `depends_on`/healthcheck config to confirm `docker compose run --rm app` waits for `db`/`redis` health the same way `up -d --build` did
- [ ] Infra-only change (Dockerfile + deploy shell script) with no existing automated coverage for deploy.sh; recommend a dry run against a staging-like compose stack before the next production deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deployment**
  * Updated container startup to run only the application server, without performing database migrations or table checks on boot.
  * Adjusted the deployment flow to run migrations and table-ensuring as a one-shot step before starting the application container.
  * Lowered the chance of migration conflicts across multiple running instances.
  * Kept existing health checks and rollback behavior for safer releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->