### PR TITLE
chore: gate /api/metrics behind requireAdmin

### DIFF
--- a/__tests__/api/metrics.test.ts
+++ b/__tests__/api/metrics.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/infra/db/schema";
+
+vi.mock("@/lib/admin/admin-auth", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+const { mockExecute } = vi.hoisted(() => ({
+  mockExecute: vi.fn(() => Promise.resolve(undefined)),
+}));
+vi.mock("@/lib/infra/db", () => ({ db: { execute: mockExecute } }));
+
+const { mockRedisEnabled, mockGetRedis } = vi.hoisted(() => ({
+  mockRedisEnabled: vi.fn(() => false),
+  mockGetRedis: vi.fn<() => { ping: () => Promise<string> } | null>(() => null),
+}));
+vi.mock("@/lib/infra/redis", () => ({
+  redisEnabled: mockRedisEnabled,
+  getRedis: mockGetRedis,
+}));
+
+const { mockCounterSnapshot, mockUptimeSeconds } = vi.hoisted(() => ({
+  mockCounterSnapshot: vi.fn(() => ({ "csp.violation": 3 })),
+  mockUptimeSeconds: vi.fn(() => 123),
+}));
+vi.mock("@/lib/infra/metrics", () => ({
+  counterSnapshot: mockCounterSnapshot,
+  uptimeSeconds: mockUptimeSeconds,
+}));
+
+import { GET } from "@/app/api/metrics/route";
+import { requireAdmin } from "@/lib/admin/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function req() {
+  return new NextRequest("http://localhost/api/metrics", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockExecute.mockReset();
+  mockExecute.mockImplementation(() => Promise.resolve(undefined));
+  mockRedisEnabled.mockReturnValue(false);
+  mockGetRedis.mockReturnValue(null);
+});
+
+describe("GET /api/metrics", () => {
+  it("returns the guard's own response for a non-admin/unauthenticated caller", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(404);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("returns the metrics snapshot for an admin caller", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.uptimeSeconds).toBe(123);
+    expect(body.counters).toEqual({ "csp.violation": 3 });
+    expect(body.db.ok).toBe(true);
+  });
+
+  it("reports db as unreachable when the probe query throws", async () => {
+    mockExecute.mockRejectedValue(new Error("connection refused"));
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.db.ok).toBe(false);
+  });
+});

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,8 +1,9 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { getRedis, redisEnabled } from "@/lib/infra/redis";
 import { counterSnapshot, uptimeSeconds } from "@/lib/infra/metrics";
+import { requireAdmin } from "@/lib/admin/admin-auth";
 
 // Live probes must not be cached.
 export const dynamic = "force-dynamic";
@@ -34,10 +35,14 @@ async function probeDb(): Promise<{ ok: boolean; latencyMs?: number }> {
 
 /**
  * Lightweight observability surface: process uptime, Redis/DB reachability, and
- * the in-process counters (cache hit rates, rate-limit blocks, AI calls). Returns
- * JSON; intended to be scraped or eyeballed. Exposes no secrets or user data.
+ * the in-process counters (cache hit rates, rate-limit blocks, AI calls). Gated
+ * behind requireAdmin — like /api/admin/infra — since rate-limit and AI-call
+ * counters are operational signals, not something anonymous callers should see.
  */
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+
   const [redis, database] = await Promise.all([probeRedis(), probeDb()]);
   return NextResponse.json({
     uptimeSeconds: uptimeSeconds(),


### PR DESCRIPTION
## Summary
Closes #255.

`GET /api/metrics` returned process uptime, Redis/DB reachability + latency, and in-process counters (including `ratelimit_fail_open`, `ratelimit_block`, AI call counts) to any anonymous caller. `/api/admin/infra` already gates materially overlapping data behind `requireAdmin`; this route had no access control at all.

## Changes
- `app/api/metrics/route.ts`: gated `GET` behind `requireAdmin`, matching the `/api/admin/infra` pattern.
- Added `__tests__/api/metrics.test.ts`: verifies non-admin/unauthenticated callers get the guard's own response, admin callers get the full snapshot, and the db-unreachable branch is exercised.

No public/anonymous consumer of this route was found in the codebase (checked for fetch/curl references beyond code comments), so this isn't expected to break an external health-check integration — `docker-compose.yml`'s healthcheck uses `/api/health`, a separate route.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bunx vitest run __tests__/api/metrics.test.ts` (3/3 passing)