### PR TITLE
fix: add rate limiting to endpoints missing it vs sibling routes

### DIFF
--- a/__tests__/api/auth-exchange.test.ts
+++ b/__tests__/api/auth-exchange.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+
+const { mockRateLimitOrNull } = vi.hoisted(() => ({
+  mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
+}));
+vi.mock("@/lib/infra/rate-limit", () => ({ rateLimitOrNull: mockRateLimitOrNull }));
+
 import { POST } from "@/app/api/auth/exchange/route";
 
 const mockFetch = vi.fn();
@@ -14,7 +20,19 @@ function makeReq(body: object) {
 }
 
 describe("POST /api/auth/exchange", () => {
-  beforeEach(() => mockFetch.mockReset());
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockRateLimitOrNull.mockReset().mockResolvedValue(null);
+  });
+
+  it("returns 429 when the rate limiter reports over-limit, without calling the token endpoint", async () => {
+    mockRateLimitOrNull.mockResolvedValue(
+      NextResponse.json({ error: "Too many requests" }, { status: 429 })
+    );
+    const res = await POST(makeReq({ code: "auth-code", codeVerifier: "verifier" }));
+    expect(res.status).toBe(429);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 
   it("returns 400 for malformed JSON body", async () => {
     const req = new NextRequest("http://localhost/api/auth/exchange", {

--- a/__tests__/api/bookmarks.test.ts
+++ b/__tests__/api/bookmarks.test.ts
@@ -8,6 +8,11 @@ vi.mock("@/lib/auth/social-auth", () => ({
   requireUser: vi.fn(),
 }));
 
+const { mockRateLimitOrNull } = vi.hoisted(() => ({
+  mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
+}));
+vi.mock("@/lib/infra/rate-limit", () => ({ rateLimitOrNull: mockRateLimitOrNull }));
+
 function makeDbChain(resolveWith: unknown = []) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
@@ -215,6 +220,19 @@ describe("DELETE /api/bookmarks/[ref]", () => {
   beforeEach(() => {
     mockDelete.mockReset();
     mockDelete.mockReturnValue(makeDbChain([]));
+    mockRateLimitOrNull.mockReset().mockResolvedValue(null);
+  });
+
+  it("returns 429 when the rate limiter reports over-limit, without deleting", async () => {
+    authedUser();
+    mockRateLimitOrNull.mockResolvedValue(
+      NextResponse.json({ error: "Too many bookmarks" }, { status: 429 })
+    );
+    const res = await DELETE(deleteReq(), {
+      params: Promise.resolve({ ref: "2%3A255" }),
+    });
+    expect(res.status).toBe(429);
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   function deleteReq(withToken = true) {

--- a/__tests__/api/share.test.ts
+++ b/__tests__/api/share.test.ts
@@ -46,6 +46,7 @@ vi.mock("@/lib/infra/rate-limit", () => ({
 }));
 
 import { POST } from "@/app/api/share/route";
+import { GET } from "@/app/api/share/[id]/route";
 import Image from "@/app/api/share/[id]/opengraph-image";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -105,6 +106,39 @@ describe("POST /api/share", () => {
     const res = await POST(postReq({ v: 1, nodes: [{ verse: validVerse }] }));
     expect(res.status).toBe(429);
     expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/share/[id]", () => {
+  function getReq(id: string) {
+    return GET(new Request(`http://localhost/api/share/${id}`), {
+      params: Promise.resolve({ id }),
+    });
+  }
+
+  it("returns 429 when the rate limiter reports over-limit", async () => {
+    mockRateLimitOrNull.mockResolvedValue(
+      NextResponse.json({ error: "Too many requests" }, { status: 429 })
+    );
+    const res = await getReq(VALID_ID);
+    expect(res.status).toBe(429);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns the stored canvas for a valid id", async () => {
+    mockSelect.mockReturnValue(
+      makeDbChain([
+        { id: VALID_ID, data: JSON.stringify({ v: 1, nodes: [{ verse: validVerse }] }) },
+      ])
+    );
+    const res = await getReq(VALID_ID);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 404 for a malformed id without querying the db", async () => {
+    const res = await getReq("not-a-uuid");
+    expect(res.status).toBe(404);
+    expect(mockSelect).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/api/social/users.test.ts
+++ b/__tests__/api/social/users.test.ts
@@ -4,6 +4,11 @@ import type { User } from "@/lib/infra/db/schema";
 
 vi.mock("@/lib/auth/social-auth", () => ({ requireUser: vi.fn() }));
 
+const { mockRateLimitOrNull } = vi.hoisted(() => ({
+  mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
+}));
+vi.mock("@/lib/infra/rate-limit", () => ({ rateLimitOrNull: mockRateLimitOrNull }));
+
 function makeDbChain(resolveWith: unknown = []) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
@@ -61,6 +66,17 @@ describe("GET /api/social/users", () => {
   beforeEach(() => {
     vi.mocked(requireUser).mockReset();
     mockSelect.mockReturnValue(makeDbChain([]));
+    mockRateLimitOrNull.mockReset().mockResolvedValue(null);
+  });
+
+  it("returns 429 when the rate limiter reports over-limit", async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 1, user: makeUser() });
+    mockRateLimitOrNull.mockResolvedValue(
+      NextResponse.json({ error: "Too many search requests" }, { status: 429 })
+    );
+    const res = await GET(req("ali"));
+    expect(res.status).toBe(429);
+    expect(mockSelect).not.toHaveBeenCalled();
   });
 
   it("returns 401 when unauthorized", async () => {
@@ -74,6 +90,13 @@ describe("GET /api/social/users", () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 1, user: makeUser() });
     const body = await (await GET(req())).json();
     expect(body).toEqual([]);
+  });
+
+  it("rejects a query over the max length with 400", async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 1, user: makeUser() });
+    const res = await GET(req("a".repeat(51)));
+    expect(res.status).toBe(400);
+    expect(mockSelect).not.toHaveBeenCalled();
   });
 
   it("derives the relationship status for each match", async () => {

--- a/__tests__/api/verse-tafsir.test.ts
+++ b/__tests__/api/verse-tafsir.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { mockRateLimitOrNull } = vi.hoisted(() => ({
+  mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
+}));
+vi.mock("@/lib/infra/rate-limit", () => ({ rateLimitOrNull: mockRateLimitOrNull }));
+
+import { GET } from "@/app/api/verse/[surah]/[ayah]/tafsir/route";
+
+function call(surah: string, ayah: string) {
+  return GET(new NextRequest("http://localhost/api/verse/x/tafsir"), {
+    params: Promise.resolve({ surah, ayah }),
+  });
+}
+
+describe("GET /api/verse/[surah]/[ayah]/tafsir", () => {
+  beforeEach(() => {
+    mockRateLimitOrNull.mockReset().mockResolvedValue(null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ tafsir: { text: "<p>Some tafsir</p>" } }),
+      })
+    );
+  });
+
+  it("returns 429 when the rate limiter reports over-limit, without calling the upstream API", async () => {
+    mockRateLimitOrNull.mockResolvedValue(
+      NextResponse.json({ error: "Too many requests" }, { status: 429 })
+    );
+    const res = await call("1", "1");
+    expect(res.status).toBe(429);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an out-of-bounds reference without calling the upstream API", async () => {
+    const res = await call("999", "1");
+    expect(res.status).toBe(400);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns tafsir blocks for a valid ref", async () => {
+    const res = await call("1", "1");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.blocks.length).toBeGreaterThan(0);
+    expect(body.source).toBe("Ibn Kathir (Abridged)");
+  });
+});

--- a/app/api/auth/exchange/route.ts
+++ b/app/api/auth/exchange/route.ts
@@ -3,6 +3,14 @@ import { eq } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { users } from "@/lib/infra/db/schema";
 import { resolveQfId } from "@/lib/auth/social-auth";
+import { rateLimitOrNull } from "@/lib/infra/rate-limit";
+import { clientKey } from "@/lib/infra/http";
+
+// Unauthenticated (pre-login) route — each request triggers an outbound
+// Basic-auth call to the QF token endpoint, so it's keyed per-IP rather than
+// per-user like the mutation routes.
+const EXCHANGE_LIMIT = 20;
+const EXCHANGE_WINDOW_SECONDS = 10 * 60;
 
 function generateUsername(): string {
   const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -13,6 +21,14 @@ function generateUsername(): string {
 }
 
 export async function POST(req: NextRequest) {
+  const limited = await rateLimitOrNull(
+    `auth-exchange:${clientKey(req)}`,
+    "Too many requests",
+    EXCHANGE_LIMIT,
+    EXCHANGE_WINDOW_SECONDS
+  );
+  if (limited) return limited;
+
   let body: { code?: string; codeVerifier?: string };
   try {
     body = await req.json();

--- a/app/api/bookmarks/[ref]/route.ts
+++ b/app/api/bookmarks/[ref]/route.ts
@@ -3,10 +3,14 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { bookmarks } from "@/lib/infra/db/schema";
 import { requireUser } from "@/lib/auth/social-auth";
+import { rateLimitOrNull } from "@/lib/infra/rate-limit";
 
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ ref: string }> }) {
   const authed = await requireUser(req);
   if (authed instanceof NextResponse) return authed;
+
+  const limited = await rateLimitOrNull("bookmark:" + authed.userId, "Too many bookmarks");
+  if (limited) return limited;
 
   const { ref } = await params;
   const verseRef = ref;

--- a/app/api/share/[id]/route.ts
+++ b/app/api/share/[id]/route.ts
@@ -2,8 +2,23 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/infra/db";
 import { sharedCanvases } from "@/lib/infra/db/schema";
 import { eq } from "drizzle-orm";
+import { clientKey } from "@/lib/infra/http";
+import { rateLimitOrNull } from "@/lib/infra/rate-limit";
 
-export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+// Public, unauthenticated route over a UUID keyspace — rate limit per-IP to
+// bound both DB load and brute-force ID guessing, matching POST /api/share.
+const SHARE_GET_LIMIT = 60;
+const SHARE_GET_WINDOW_SECONDS = 60 * 60;
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const limited = await rateLimitOrNull(
+    `share-get:${clientKey(req)}`,
+    "Too many requests",
+    SHARE_GET_LIMIT,
+    SHARE_GET_WINDOW_SECONDS
+  );
+  if (limited) return limited;
+
   const { id } = await params;
 
   if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(id)) {

--- a/app/api/social/users/route.ts
+++ b/app/api/social/users/route.ts
@@ -7,6 +7,11 @@ import { rateLimitOrNull } from "@/lib/infra/rate-limit";
 
 const MAX_QUERY_LENGTH = 50;
 
+// Read-only typeahead search, not a mutation — given its own budget rather
+// than the shared MUTATION_LIMIT (scoped to writes like friend requests/notes).
+const USER_SEARCH_LIMIT = 30;
+const USER_SEARCH_WINDOW_SECONDS = 60;
+
 /**
  * User search for the add-friend flow: case-insensitive partial username match,
  * excluding self, capped at 10. Each result carries the viewer's relationship
@@ -18,14 +23,19 @@ export async function GET(req: NextRequest) {
 
   const { userId } = authed;
 
-  const limited = await rateLimitOrNull(`user-search:${userId}`, "Too many search requests");
-  if (limited) return limited;
-
   const q = req.nextUrl.searchParams.get("q")?.trim();
   if (!q) return NextResponse.json([]);
   if (q.length > MAX_QUERY_LENGTH) {
     return NextResponse.json({ error: "Query too long" }, { status: 400 });
   }
+
+  const limited = await rateLimitOrNull(
+    `user-search:${userId}`,
+    "Too many search requests",
+    USER_SEARCH_LIMIT,
+    USER_SEARCH_WINDOW_SECONDS
+  );
+  if (limited) return limited;
 
   const matches = await db
     .select({ id: users.id, username: users.username, displayName: users.displayName })

--- a/app/api/social/users/route.ts
+++ b/app/api/social/users/route.ts
@@ -3,6 +3,9 @@ import { and, eq, ne, or, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { friendships, users } from "@/lib/infra/db/schema";
 import { requireUser } from "@/lib/auth/social-auth";
+import { rateLimitOrNull } from "@/lib/infra/rate-limit";
+
+const MAX_QUERY_LENGTH = 50;
 
 /**
  * User search for the add-friend flow: case-insensitive partial username match,
@@ -14,8 +17,15 @@ export async function GET(req: NextRequest) {
   if (authed instanceof NextResponse) return authed;
 
   const { userId } = authed;
+
+  const limited = await rateLimitOrNull(`user-search:${userId}`, "Too many search requests");
+  if (limited) return limited;
+
   const q = req.nextUrl.searchParams.get("q")?.trim();
   if (!q) return NextResponse.json([]);
+  if (q.length > MAX_QUERY_LENGTH) {
+    return NextResponse.json({ error: "Query too long" }, { status: 400 });
+  }
 
   const matches = await db
     .select({ id: users.id, username: users.username, displayName: users.displayName })

--- a/app/api/verse/[surah]/[ayah]/tafsir/route.ts
+++ b/app/api/verse/[surah]/[ayah]/tafsir/route.ts
@@ -1,11 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isValidRef } from "@/lib/quran/quran-corpus";
 import { htmlToTafsirBlocks } from "@/lib/quran/tafsir";
+import { clientKey } from "@/lib/infra/http";
+import { rateLimitOrNull } from "@/lib/infra/rate-limit";
 
 // English "Ibn Kathir (Abridged)" on the quran.com API. The previous source
 // (alquran.cloud en.ibn-kathir) doesn't exist there and silently fell back to
 // the plain Arabic Qur'an text, so the panel showed the verse, not tafsir (#54).
 const IBN_KATHIR_EN = 169;
+
+// Public, unauthenticated route that hits a third-party API on cache misses —
+// rate limit per-IP so one caller can't amplify load onto api.quran.com.
+const TAFSIR_LIMIT = 60;
+const TAFSIR_WINDOW_SECONDS = 60;
 
 /**
  * English Ibn Kathir tafsir for a verse, sourced from quran.com and returned as
@@ -14,9 +21,17 @@ const IBN_KATHIR_EN = 169;
  * unavailable" rather than erroring.
  */
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ surah: string; ayah: string }> }
 ) {
+  const limited = await rateLimitOrNull(
+    `tafsir:${clientKey(req)}`,
+    "Too many requests",
+    TAFSIR_LIMIT,
+    TAFSIR_WINDOW_SECONDS
+  );
+  if (limited) return limited;
+
   const { surah, ayah } = await params;
   const ref = `${parseInt(surah, 10)}:${parseInt(ayah, 10)}`;
 


### PR DESCRIPTION
## Summary
Closes #256.

Same class of gap already closed in #170 (bookmarks POST), #172 (connections), and #173 (keyword search): these five sites had no request budget while sibling routes doing similar work already did.

## Changes
1. **`app/api/social/users/route.ts`** — `rateLimitOrNull` keyed per-user (default mutation budget), plus a 50-char cap on the `q` param before it hits an `ILIKE '%q%'` scan + follow-up relationship query.
2. **`app/api/auth/exchange/route.ts`** — `rateLimitOrNull` keyed per-IP (`clientKey`), 20 requests / 10 min. Unauthenticated pre-login route; each request triggers an outbound Basic-auth call to the QF token endpoint.
3. **`app/api/bookmarks/[ref]/route.ts` `DELETE`** — same key/budget (`bookmark:<userId>`, default mutation budget) as sibling `POST /api/bookmarks`.
4. **`app/api/share/[id]/route.ts` `GET`** — `rateLimitOrNull` per-IP, 60/hour, matching `POST /api/share`'s per-IP protection. Bounds both DB load and UUID brute-force enumeration.
5. **`app/api/verse/[surah]/[ayah]/tafsir/route.ts`** — `rateLimitOrNull` per-IP, 60/min, to bound one caller amplifying load onto `api.quran.com` on cache-cold refs.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] Added/extended tests for each route's new 429 path (`__tests__/api/social/users.test.ts`, `__tests__/api/auth-exchange.test.ts`, `__tests__/api/bookmarks.test.ts`, `__tests__/api/share.test.ts`, new `__tests__/api/verse-tafsir.test.ts`)
- [x] `bun run test:ci` — full suite, 693/693 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to authentication, bookmark deletion, sharing, social user search, and tafsir requests.
  * Added validation for overly long social user search queries.
  * Invalid or excessive requests now receive appropriate error responses without unnecessary database or external service calls.

* **Tests**
  * Expanded API coverage for rate limits, validation, valid responses, and error handling across affected endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->