### PR TITLE
fix: validate data shape per kind in admin PATCH /api/admin/names

### DIFF
--- a/__tests__/api/admin/names.test.ts
+++ b/__tests__/api/admin/names.test.ts
@@ -66,7 +66,7 @@ function del(query?: string) {
 beforeEach(() => {
   vi.mocked(requireAdmin).mockResolvedValue(admin);
   mockSelect.mockReturnValue(makeDbChain([]));
-  mockUpdate.mockReturnValue(makeDbChain([]));
+  mockUpdate.mockClear().mockReturnValue(makeDbChain([]));
   mockDelete.mockReturnValue(makeDbChain([]));
   vi.mocked(logAdminAction).mockClear();
 });
@@ -130,19 +130,104 @@ describe("PATCH /api/admin/names", () => {
 
   it("returns 404 when there's no cached row for that slug/kind", async () => {
     mockUpdate.mockReturnValue(makeDbChain([]));
-    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses", data: { a: 1 } }));
+    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses", data: [] }));
     expect(res.status).toBe(404);
   });
 
   it("updates the cached content and logs the action", async () => {
     mockUpdate.mockReturnValue(makeDbChain([{ slug: "ar-rahman", kind: "verses" }]));
-    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses", data: { a: 1 } }));
+    const validVerse = [
+      {
+        ref: "2:255",
+        surah: 2,
+        ayah: 255,
+        arabicText: "arabic",
+        translation: "translation",
+        surahName: "Al-Baqarah",
+        surahNameArabic: "البقرة",
+        reason: "reason",
+      },
+    ];
+    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses", data: validVerse }));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data).toEqual({ a: 1 });
+    expect(body.data).toEqual(validVerse);
     expect(logAdminAction).toHaveBeenCalledWith(
       expect.objectContaining({ action: "name.edit", targetId: "ar-rahman/verses" })
     );
+  });
+
+  it("rejects verses data that isn't an array of the expected shape", async () => {
+    const res = await PATCH(patch({ slug: "ar-rahman", kind: "verses", data: { a: 1 } }));
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rejects verses data with a wrong field type (surah as string)", async () => {
+    const res = await PATCH(
+      patch({
+        slug: "ar-rahman",
+        kind: "verses",
+        data: [
+          {
+            ref: "2:255",
+            surah: "2",
+            ayah: 255,
+            arabicText: "a",
+            translation: "t",
+            surahName: "s",
+            surahNameArabic: "s",
+            reason: "r",
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts a valid reflection (plain string)", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([{ slug: "ar-rahman", kind: "reflection" }]));
+    const res = await PATCH(
+      patch({ slug: "ar-rahman", kind: "reflection", data: "A believer's reflection." })
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a reflection that isn't a string", async () => {
+    const res = await PATCH(patch({ slug: "ar-rahman", kind: "reflection", data: { text: "x" } }));
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid pairings", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([{ slug: "ar-rahman", kind: "pairings" }]));
+    const res = await PATCH(
+      patch({
+        slug: "ar-rahman",
+        kind: "pairings",
+        data: [
+          {
+            name: "ar-rahim",
+            transliteration: "Ar-Rahim",
+            arabic: "الرَّحِيم",
+            explanation: "Balances mercy in general and specific senses.",
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects pairings missing a required field", async () => {
+    const res = await PATCH(
+      patch({
+        slug: "ar-rahman",
+        kind: "pairings",
+        data: [{ transliteration: "Ar-Rahim", arabic: "الرَّحِيم" }],
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/api/admin/names.test.ts
+++ b/__tests__/api/admin/names.test.ts
@@ -229,6 +229,25 @@ describe("PATCH /api/admin/names", () => {
     expect(res.status).toBe(400);
     expect(mockUpdate).not.toHaveBeenCalled();
   });
+
+  it("rejects a pairing with an empty name (unresolved slug reference, see PR #89)", async () => {
+    const res = await PATCH(
+      patch({
+        slug: "ar-rahman",
+        kind: "pairings",
+        data: [
+          {
+            name: "",
+            transliteration: "Ar-Rahim",
+            arabic: "الرَّحِيم",
+            explanation: "Balances mercy in general and specific senses.",
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
 });
 
 describe("DELETE /api/admin/names", () => {

--- a/app/api/admin/names/route.ts
+++ b/app/api/admin/names/route.ts
@@ -7,6 +7,57 @@ import { nameContent } from "@/lib/infra/db/schema";
 import { safeParse } from "@/lib/infra/http";
 
 const KINDS = ["verses", "reflection", "pairings"] as const;
+type Kind = (typeof KINDS)[number];
+
+function isStringField(v: unknown): v is string {
+  return typeof v === "string";
+}
+
+/** `reflection` is a single AI-generated paragraph (see app/api/names/[slug]/reflection/route.ts). */
+function isValidReflection(data: unknown): boolean {
+  return typeof data === "string";
+}
+
+/** `pairings` shape from app/api/names/[slug]/pairings/route.ts's Pairing type. */
+function isValidPairings(data: unknown): boolean {
+  if (!Array.isArray(data)) return false;
+  return data.every((p) => {
+    if (typeof p !== "object" || p === null) return false;
+    const { name, transliteration, arabic, explanation } = p as Record<string, unknown>;
+    return (
+      isStringField(name) &&
+      isStringField(transliteration) &&
+      isStringField(arabic) &&
+      isStringField(explanation)
+    );
+  });
+}
+
+/** `verses` shape from app/api/names/[slug]/verses/route.ts's NameVerse type. */
+function isValidVerses(data: unknown): boolean {
+  if (!Array.isArray(data)) return false;
+  return data.every((v) => {
+    if (typeof v !== "object" || v === null) return false;
+    const { ref, surah, ayah, arabicText, translation, surahName, surahNameArabic, reason } =
+      v as Record<string, unknown>;
+    return (
+      isStringField(ref) &&
+      typeof surah === "number" &&
+      typeof ayah === "number" &&
+      isStringField(arabicText) &&
+      isStringField(translation) &&
+      isStringField(surahName) &&
+      isStringField(surahNameArabic) &&
+      isStringField(reason)
+    );
+  });
+}
+
+const VALIDATORS: Record<Kind, (data: unknown) => boolean> = {
+  reflection: isValidReflection,
+  pairings: isValidPairings,
+  verses: isValidVerses,
+};
 
 /** All cached 99-Names AI content rows (slug + kind), for review/override. */
 export async function GET(req: NextRequest) {
@@ -56,6 +107,9 @@ export async function PATCH(req: NextRequest) {
   }
   if (body.data === undefined) {
     return NextResponse.json({ error: "Missing data" }, { status: 400 });
+  }
+  if (!VALIDATORS[kind as Kind](body.data)) {
+    return NextResponse.json({ error: `Invalid data shape for kind "${kind}"` }, { status: 400 });
   }
 
   try {

--- a/app/api/admin/names/route.ts
+++ b/app/api/admin/names/route.ts
@@ -9,13 +9,16 @@ import { safeParse } from "@/lib/infra/http";
 const KINDS = ["verses", "reflection", "pairings"] as const;
 type Kind = (typeof KINDS)[number];
 
-function isStringField(v: unknown): v is string {
-  return typeof v === "string";
+// Non-empty (not just typeof) — PR #89's review on the pairings AI-generation
+// route flagged that an empty `name` (unresolved slug reference) still got
+// cached and served; admin edits must be held to the same bar.
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.trim() !== "";
 }
 
 /** `reflection` is a single AI-generated paragraph (see app/api/names/[slug]/reflection/route.ts). */
 function isValidReflection(data: unknown): boolean {
-  return typeof data === "string";
+  return isNonEmptyString(data);
 }
 
 /** `pairings` shape from app/api/names/[slug]/pairings/route.ts's Pairing type. */
@@ -25,10 +28,10 @@ function isValidPairings(data: unknown): boolean {
     if (typeof p !== "object" || p === null) return false;
     const { name, transliteration, arabic, explanation } = p as Record<string, unknown>;
     return (
-      isStringField(name) &&
-      isStringField(transliteration) &&
-      isStringField(arabic) &&
-      isStringField(explanation)
+      isNonEmptyString(name) &&
+      isNonEmptyString(transliteration) &&
+      isNonEmptyString(arabic) &&
+      isNonEmptyString(explanation)
     );
   });
 }
@@ -41,14 +44,14 @@ function isValidVerses(data: unknown): boolean {
     const { ref, surah, ayah, arabicText, translation, surahName, surahNameArabic, reason } =
       v as Record<string, unknown>;
     return (
-      isStringField(ref) &&
+      isNonEmptyString(ref) &&
       typeof surah === "number" &&
       typeof ayah === "number" &&
-      isStringField(arabicText) &&
-      isStringField(translation) &&
-      isStringField(surahName) &&
-      isStringField(surahNameArabic) &&
-      isStringField(reason)
+      isNonEmptyString(arabicText) &&
+      isNonEmptyString(translation) &&
+      isNonEmptyString(surahName) &&
+      isNonEmptyString(surahNameArabic) &&
+      isNonEmptyString(reason)
     );
   });
 }


### PR DESCRIPTION
## Summary
Closes #257.

`PATCH /api/admin/names` persisted admin-submitted `data` for a given `(slug, kind)` without validating its shape matched what the public-facing routes expect for that `kind`. A malformed edit (typo, wrong type, wrong field name) would silently break the public name page's rendering for all visitors.

## Changes
`app/api/admin/names/route.ts`: added a per-kind type guard, matching the shapes each public route actually produces/consumes:
- `reflection` → plain string (`app/api/names/[slug]/reflection/route.ts`)
- `pairings` → array of `{ name, transliteration, arabic, explanation }` (`app/api/names/[slug]/pairings/route.ts`'s `Pairing` type)
- `verses` → array of `{ ref, surah, ayah, arabicText, translation, surahName, surahNameArabic, reason }` (`app/api/names/[slug]/verses/route.ts`'s `NameVerse` type)

`PATCH` now returns 400 with a clear message when `data` doesn't match the expected shape for `kind`, before writing. No new dependency — matches the existing manual-type-guard pattern already used in `lib/canvas/share-canvas.ts` (`isValidNode`) rather than introducing Zod for one route.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bunx vitest run __tests__/api/admin/names.test.ts` (16/16 passing) — added tests for valid/invalid data per kind (reflection non-string, verses non-array and wrong-field-type, pairings missing a required field), and updated the pre-existing "no cached row" / "updates the cached content" tests to use shape-valid fixtures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for admin content updates, ensuring reflections, pairings, and verses use supported data formats.
  * Invalid update requests now receive a clear 400 error without modifying stored content.

* **Bug Fixes**
  * Improved handling of cached verse updates and ensured valid content is returned correctly.
  * Strengthened test coverage for accepted and rejected update payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->