### PR TITLE
fix: eliminate modulo bias in PKCE randomString

### DIFF
--- a/__tests__/lib/auth/pkce.test.ts
+++ b/__tests__/lib/auth/pkce.test.ts
@@ -1,5 +1,39 @@
-import { describe, it, expect } from "vitest";
-import { buildAuthUrl } from "@/lib/auth/pkce";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { buildAuthUrl, randomString } from "@/lib/auth/pkce";
+
+const PKCE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+
+describe("randomString", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns a string of the requested length using only the PKCE alphabet", () => {
+    const s = randomString(64);
+    expect(s).toHaveLength(64);
+    expect([...s].every((c) => PKCE_CHARS.includes(c))).toBe(true);
+  });
+
+  it("rejects and redraws out-of-range bytes instead of using them (modulo bias fix)", () => {
+    // 198 = MAX_UNBIASED_BYTE (largest multiple of 66 <= 256). Each draw pulls a
+    // 2-byte batch (length=2): batch 1 has one out-of-range byte (255) and one
+    // in-range byte (0 -> 'A'); batch 2 has one out-of-range byte (200) and one
+    // in-range byte (1 -> 'B'). The out-of-range bytes must never appear, and a
+    // second draw must happen since the first only yields one accepted char.
+    const batches = [
+      [255, 0],
+      [200, 1],
+    ];
+    let call = 0;
+    vi.spyOn(crypto, "getRandomValues").mockImplementation(((arr: Uint8Array) => {
+      arr.set(batches[call]);
+      call++;
+      return arr;
+    }) as typeof crypto.getRandomValues);
+
+    const s = randomString(2);
+    expect(s).toBe("AB");
+    expect(call).toBe(2); // had to redraw a second batch to get the 2nd character
+  });
+});
 
 describe("buildAuthUrl", () => {
   it("returns an object with url, codeVerifier, and state", async () => {

--- a/lib/auth/pkce.ts
+++ b/lib/auth/pkce.ts
@@ -1,8 +1,22 @@
-function randomString(length: number): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
-  const bytes = new Uint8Array(length);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes, (b) => chars[b % chars.length]).join("");
+const PKCE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+// Largest multiple of chars.length that fits in a byte (198 for 66 chars) —
+// bytes >= this are rejected and redrawn so every character is drawn with
+// exactly equal probability, instead of `b % chars.length` biasing the first
+// `256 % chars.length` characters toward a slightly higher probability.
+const MAX_UNBIASED_BYTE = Math.floor(256 / PKCE_CHARS.length) * PKCE_CHARS.length;
+
+/** Exported for unit testing the rejection-sampling logic directly. */
+export function randomString(length: number): string {
+  const result: string[] = [];
+  const batch = new Uint8Array(length);
+  while (result.length < length) {
+    crypto.getRandomValues(batch);
+    for (const b of batch) {
+      if (result.length >= length) break;
+      if (b < MAX_UNBIASED_BYTE) result.push(PKCE_CHARS[b % PKCE_CHARS.length]);
+    }
+  }
+  return result.join("");
 }
 
 // OAuth scopes the QF client is approved for — hardcoded (the scope is public; it


### PR DESCRIPTION
## Summary
Closes #258.

**Auth/security surface change** (per AGENTS.md guardrails — `lib/auth/` is high-risk): `randomString` in `lib/auth/pkce.ts` generates the PKCE `code_verifier`, OAuth `state`, and OIDC `nonce` used by `buildAuthUrl`. It mapped each random byte onto a 66-character alphabet via `chars[b % chars.length]`. Since `256 % 66 = 58`, the first 58 characters were drawn with probability 4/256 and the remaining 8 with probability 3/256 — a small but real non-uniform bias in security-sensitive random values.

## Changes
`lib/auth/pkce.ts`: replaced the modulo-biased selection with rejection sampling — bytes `>= 198` (the largest multiple of 66 that fits in a byte) are discarded and redrawn, so every character in the alphabet has exactly equal probability. Same alphabet, same output length, same call sites (`buildAuthUrl`'s `code_verifier`/`state`/`nonce` generation) — only the sampling method changed. `randomString` is now exported so its rejection-sampling behavior can be unit tested directly.

No change to the OAuth flow itself, scopes, or the PKCE challenge/verifier relationship (`sha256Base64url` is untouched).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bunx vitest run __tests__/lib/auth/pkce.test.ts` (11/11 passing) — added a test asserting output stays within the PKCE alphabet at the requested length, and a test that mocks `crypto.getRandomValues` to return out-of-range bytes (255, 200) interleaved with in-range ones, asserting the out-of-range bytes are never used and a second draw happens to complete the string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PKCE string generation to provide unbiased, consistently distributed characters.
  * Ensured invalid random values are rejected and replaced, improving authentication reliability.

* **Tests**
  * Added coverage for requested string lengths, valid character sets, and rejection-sampling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->