### PR TITLE
fix: draw edge instead of silently dropping expansion to an existing node

### DIFF
--- a/__tests__/lib/canvas/canvas-layout.test.ts
+++ b/__tests__/lib/canvas/canvas-layout.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   findFreeSlot,
   viewportCenter,
-  buildExistingNodeEdge,
+  buildConnectionEdge,
   NODE_WIDTH,
   NODE_HEIGHT,
   NODE_GAP,
@@ -86,11 +86,11 @@ describe("viewportCenter", () => {
   });
 });
 
-describe("buildExistingNodeEdge", () => {
+describe("buildConnectionEdge", () => {
   const conn = { kind: "thematic" as const, reason: "Both describe divine mercy." };
 
   it("builds an edge from the source node to the existing node", () => {
-    const edge = buildExistingNodeEdge("node-a", "node-b", conn);
+    const edge = buildConnectionEdge("node-a", "node-b", conn);
     expect(edge).toEqual({
       id: "edge-node-a-node-b",
       source: "node-a",
@@ -102,12 +102,12 @@ describe("buildExistingNodeEdge", () => {
 
   it("truncates the label to 60 characters but keeps the full reason", () => {
     const longReason = "x".repeat(100);
-    const edge = buildExistingNodeEdge("node-a", "node-b", { kind: "root", reason: longReason });
+    const edge = buildConnectionEdge("node-a", "node-b", { kind: "root", reason: longReason });
     expect(edge!.data.label).toHaveLength(60);
     expect(edge!.data.reason).toBe(longReason);
   });
 
   it("returns null for a self-loop (existing node is the source itself)", () => {
-    expect(buildExistingNodeEdge("node-a", "node-a", conn)).toBeNull();
+    expect(buildConnectionEdge("node-a", "node-a", conn)).toBeNull();
   });
 });

--- a/__tests__/lib/canvas/canvas-layout.test.ts
+++ b/__tests__/lib/canvas/canvas-layout.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   findFreeSlot,
   viewportCenter,
+  buildExistingNodeEdge,
   NODE_WIDTH,
   NODE_HEIGHT,
   NODE_GAP,
@@ -82,5 +83,31 @@ describe("viewportCenter", () => {
     const c = viewportCenter({ x: 0, y: 0, zoom: 0 }, 800, 400);
     expect(Number.isFinite(c.x)).toBe(true);
     expect(c).toEqual({ x: 400, y: 200 });
+  });
+});
+
+describe("buildExistingNodeEdge", () => {
+  const conn = { kind: "thematic" as const, reason: "Both describe divine mercy." };
+
+  it("builds an edge from the source node to the existing node", () => {
+    const edge = buildExistingNodeEdge("node-a", "node-b", conn);
+    expect(edge).toEqual({
+      id: "edge-node-a-node-b",
+      source: "node-a",
+      target: "node-b",
+      type: "hikmah",
+      data: { kind: "thematic", label: "Both describe divine mercy.", reason: conn.reason },
+    });
+  });
+
+  it("truncates the label to 60 characters but keeps the full reason", () => {
+    const longReason = "x".repeat(100);
+    const edge = buildExistingNodeEdge("node-a", "node-b", { kind: "root", reason: longReason });
+    expect(edge!.data.label).toHaveLength(60);
+    expect(edge!.data.reason).toBe(longReason);
+  });
+
+  it("returns null for a self-loop (existing node is the source itself)", () => {
+    expect(buildExistingNodeEdge("node-a", "node-a", conn)).toBeNull();
   });
 });

--- a/components/canvas/HikmahCanvas.tsx
+++ b/components/canvas/HikmahCanvas.tsx
@@ -21,7 +21,12 @@ import { CanvasToolbar } from "./CanvasToolbar";
 import { useCanvasStore } from "@/store/canvas";
 import { useActivityTracker } from "@/hooks/useActivityTracker";
 import { useCanvasPersistence } from "@/hooks/useCanvasPersistence";
-import { findFreeSlot, NODE_WIDTH, NODE_HEIGHT } from "@/lib/canvas/canvas-layout";
+import {
+  findFreeSlot,
+  NODE_WIDTH,
+  NODE_HEIGHT,
+  buildExistingNodeEdge,
+} from "@/lib/canvas/canvas-layout";
 import { cn } from "@/lib/utils";
 import type { ConnectionResult, Verse } from "@/types/quran";
 
@@ -96,6 +101,7 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
   const setSidebarContent = useCanvasStore((s) => s.setSidebarContent);
   const setViewport = useCanvasStore((s) => s.setViewport);
   const getNodeById = useCanvasStore((s) => s.getNodeById);
+  const getNodeByRef = useCanvasStore((s) => s.getNodeByRef);
   const hasNode = useCanvasStore((s) => s.hasNode);
   const getExpansionRefs = useCanvasStore((s) => s.getExpansionRefs);
 
@@ -135,7 +141,16 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
           if (!mountedRef.current) break;
 
           const conn = connections[i];
-          if (hasNode(conn.ref)) continue;
+          if (hasNode(conn.ref)) {
+            // Verse is already on the canvas elsewhere — draw the edge the AI
+            // identified instead of silently dropping the connection, but
+            // don't add a duplicate node. addConnectionEdge itself dedupes
+            // repeat source/target pairs, so re-expanding is a safe no-op.
+            const existing = getNodeByRef(conn.ref);
+            const edge = existing && buildExistingNodeEdge(nodeId, existing.id, conn);
+            if (edge) addConnectionEdge(edge);
+            continue;
+          }
 
           // Fan out radially, then nudge off any collision with the live graph
           // (including siblings added moments ago in this same expansion).
@@ -197,7 +212,15 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
         expandingRef.current = false;
       }
     },
-    [addVerseNode, addConnectionEdge, setExpandingNode, hasNode, getExpansionRefs, reactFlow]
+    [
+      addVerseNode,
+      addConnectionEdge,
+      setExpandingNode,
+      hasNode,
+      getNodeByRef,
+      getExpansionRefs,
+      reactFlow,
+    ]
   );
 
   useEffect(() => {

--- a/components/canvas/HikmahCanvas.tsx
+++ b/components/canvas/HikmahCanvas.tsx
@@ -25,7 +25,7 @@ import {
   findFreeSlot,
   NODE_WIDTH,
   NODE_HEIGHT,
-  buildExistingNodeEdge,
+  buildConnectionEdge,
 } from "@/lib/canvas/canvas-layout";
 import { cn } from "@/lib/utils";
 import type { ConnectionResult, Verse } from "@/types/quran";
@@ -147,7 +147,7 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
             // don't add a duplicate node. addConnectionEdge itself dedupes
             // repeat source/target pairs, so re-expanding is a safe no-op.
             const existing = getNodeByRef(conn.ref);
-            const edge = existing && buildExistingNodeEdge(nodeId, existing.id, conn);
+            const edge = existing && buildConnectionEdge(nodeId, existing.id, conn);
             if (edge) addConnectionEdge(edge);
             continue;
           }
@@ -178,17 +178,8 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
           const pos = findFreeSlot(existing, target, { labelObstacles });
           const newId = addVerseNode(conn as unknown as Verse, pos);
 
-          addConnectionEdge({
-            id: `edge-${nodeId}-${newId}`,
-            source: nodeId,
-            target: newId,
-            type: "hikmah",
-            data: {
-              kind: conn.kind,
-              label: conn.reason.slice(0, 60),
-              reason: conn.reason,
-            },
-          });
+          const newEdge = buildConnectionEdge(nodeId, newId, conn);
+          if (newEdge) addConnectionEdge(newEdge);
         }
 
         if (mountedRef.current) {

--- a/lib/canvas/canvas-layout.ts
+++ b/lib/canvas/canvas-layout.ts
@@ -1,5 +1,6 @@
 /**
- * Collision-aware node placement for the canvas.
+ * Layout and edge-construction helpers for the canvas, extracted out of
+ * HikmahCanvas.tsx for unit testability.
  *
  * Verse nodes are a fixed width (`w-72` = 288px) and roughly fixed height. When a
  * new node is added — whether by searching a verse onto a populated canvas or by
@@ -110,22 +111,22 @@ export function viewportCenter(
 }
 
 /**
- * Builds the edge to draw when an expansion's connection target already
- * exists as a node elsewhere on the canvas, instead of silently dropping the
- * connection (the AI still identified a real relationship, it's just not a
- * new node). Returns null for a self-loop — a source node's own ref showing
- * up as a "connection" to itself, which should draw nothing.
+ * Builds the edge for an expansion connection, whether its target is a
+ * freshly-added node or one that already existed elsewhere on the canvas (the
+ * AI still identified a real relationship even when no new node is created).
+ * Returns null for a self-loop — a source node's own ref showing up as a
+ * "connection" to itself, which should draw nothing.
  */
-export function buildExistingNodeEdge(
+export function buildConnectionEdge(
   sourceNodeId: string,
-  existingNodeId: string,
+  targetNodeId: string,
   conn: { kind: EdgeKind; reason: string }
 ): CanvasEdge | null {
-  if (existingNodeId === sourceNodeId) return null;
+  if (targetNodeId === sourceNodeId) return null;
   return {
-    id: `edge-${sourceNodeId}-${existingNodeId}`,
+    id: `edge-${sourceNodeId}-${targetNodeId}`,
     source: sourceNodeId,
-    target: existingNodeId,
+    target: targetNodeId,
     type: "hikmah",
     data: {
       kind: conn.kind,

--- a/lib/canvas/canvas-layout.ts
+++ b/lib/canvas/canvas-layout.ts
@@ -8,6 +8,8 @@
  * node-sized steps and returns the nearest grid slot that overlaps nothing.
  */
 
+import type { CanvasEdge, EdgeKind } from "@/types/quran";
+
 export interface XY {
   x: number;
   y: number;
@@ -104,5 +106,31 @@ export function viewportCenter(
   return {
     x: (screenW / 2 - viewport.x) / zoom,
     y: (screenH / 2 - viewport.y) / zoom,
+  };
+}
+
+/**
+ * Builds the edge to draw when an expansion's connection target already
+ * exists as a node elsewhere on the canvas, instead of silently dropping the
+ * connection (the AI still identified a real relationship, it's just not a
+ * new node). Returns null for a self-loop — a source node's own ref showing
+ * up as a "connection" to itself, which should draw nothing.
+ */
+export function buildExistingNodeEdge(
+  sourceNodeId: string,
+  existingNodeId: string,
+  conn: { kind: EdgeKind; reason: string }
+): CanvasEdge | null {
+  if (existingNodeId === sourceNodeId) return null;
+  return {
+    id: `edge-${sourceNodeId}-${existingNodeId}`,
+    source: sourceNodeId,
+    target: existingNodeId,
+    type: "hikmah",
+    data: {
+      kind: conn.kind,
+      label: conn.reason.slice(0, 60),
+      reason: conn.reason,
+    },
   };
 }


### PR DESCRIPTION
## Summary
Closes #260.

When `runExpansion` walked AI-returned connections for a node, any connection whose target verse ref was already present as a node anywhere on the canvas was simply skipped (`continue`) — no edge drawn, no message explaining the discrepancy. Because `connections.length > 0` in this case, the `ExhaustedExpansionError` path never fired either, so the outcome looked incomplete/broken without being flagged as an error.

## Changes
- `lib/canvas/canvas-layout.ts`: added `buildExistingNodeEdge(sourceNodeId, existingNodeId, conn)`, a small pure helper (alongside the existing `findFreeSlot`/`viewportCenter` extractions from this same component) that builds the edge to draw when a connection's target already exists as a node — returning `null` for a self-loop (the AI returning the source's own ref).
- `components/canvas/HikmahCanvas.tsx`: when `hasNode(conn.ref)` is true, looks up the existing node via `getNodeByRef` and draws the edge via `addConnectionEdge` instead of dropping the connection. `addConnectionEdge` already dedupes repeat source/target pairs (either direction), so re-expanding the same node is a safe no-op — no new duplicate-edge logic was needed there.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bunx vitest run __tests__/lib/canvas/canvas-layout.test.ts __tests__/store/canvas.test.ts` (42/42 passing) — added tests for `buildExistingNodeEdge`: builds the correct edge, truncates the label to 60 chars while keeping the full reason, and returns `null` for a self-loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canvas expansion now preserves suggested connections to nodes that already exist, avoiding duplicate nodes.
  * Existing-node connections use the correct connection type and show a shortened label while keeping the full explanation available.
  * Self-referential connections are excluded to prevent invalid canvas links.
* **Tests**
  * Added unit coverage for existing-node edge construction, label truncation behavior, connection field correctness, and self-loop handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->