### PR TITLE
fix: offset MiniPlayer above MobileNavBar instead of overlapping it

### DIFF
--- a/__tests__/components/audio/MiniPlayer.test.tsx
+++ b/__tests__/components/audio/MiniPlayer.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MiniPlayer } from "@/components/audio/MiniPlayer";
+import { useAudioStore } from "@/store/audio";
+
+const { mockMobileNavVisible } = vi.hoisted(() => ({ mockMobileNavVisible: vi.fn() }));
+vi.mock("@/hooks/useMobileNavVisible", () => ({
+  useMobileNavVisible: mockMobileNavVisible,
+}));
+
+function seedPlaying() {
+  useAudioStore.setState({
+    currentRef: "2:255",
+    currentSurahName: "Al-Baqarah",
+    isPlaying: true,
+    isLoading: false,
+    queue: [{ ref: "2:255" }] as never,
+    queueIndex: 0,
+  });
+}
+
+describe("MiniPlayer", () => {
+  beforeEach(() => {
+    mockMobileNavVisible.mockReset();
+  });
+
+  it("renders nothing when nothing is playing", () => {
+    useAudioStore.setState({ currentRef: null });
+    mockMobileNavVisible.mockReturnValue(false);
+    const { container } = render(<MiniPlayer />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("offsets above the mobile nav bar when it's visible", () => {
+    seedPlaying();
+    mockMobileNavVisible.mockReturnValue(true);
+    render(<MiniPlayer />);
+    expect(screen.getByText("2:255").closest("div.fixed")).toHaveClass(
+      "max-md:bottom-[calc(58px+env(safe-area-inset-bottom)+16px)]"
+    );
+  });
+
+  it("uses the default offset when the mobile nav bar is hidden", () => {
+    seedPlaying();
+    mockMobileNavVisible.mockReturnValue(false);
+    render(<MiniPlayer />);
+    const el = screen.getByText("2:255").closest("div.fixed");
+    expect(el).toHaveClass("bottom-4");
+    expect(el).not.toHaveClass("max-md:bottom-[calc(58px+env(safe-area-inset-bottom)+16px)]");
+  });
+});

--- a/__tests__/components/audio/MiniPlayer.test.tsx
+++ b/__tests__/components/audio/MiniPlayer.test.tsx
@@ -1,20 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MiniPlayer } from "@/components/audio/MiniPlayer";
-import { useAudioStore } from "@/store/audio";
+import { useAudioStore, type AudioVerse } from "@/store/audio";
 
 const { mockMobileNavVisible } = vi.hoisted(() => ({ mockMobileNavVisible: vi.fn() }));
 vi.mock("@/hooks/useMobileNavVisible", () => ({
   useMobileNavVisible: mockMobileNavVisible,
 }));
 
+const verse: AudioVerse = { ref: "2:255", surah: 2, ayah: 255, surahName: "Al-Baqarah" };
+
 function seedPlaying() {
   useAudioStore.setState({
-    currentRef: "2:255",
-    currentSurahName: "Al-Baqarah",
+    currentRef: verse.ref,
+    currentSurahName: verse.surahName,
     isPlaying: true,
     isLoading: false,
-    queue: [{ ref: "2:255" }] as never,
+    queue: [verse],
     queueIndex: 0,
   });
 }

--- a/__tests__/components/layout/MobileNavBar.test.tsx
+++ b/__tests__/components/layout/MobileNavBar.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MobileNavBar } from "@/components/layout/MobileNavBar";
+
+const { mockUsePathname } = vi.hoisted(() => ({ mockUsePathname: vi.fn() }));
+vi.mock("next/navigation", () => ({ usePathname: mockUsePathname }));
+
+const { mockMobileNavVisible } = vi.hoisted(() => ({ mockMobileNavVisible: vi.fn() }));
+vi.mock("@/hooks/useMobileNavVisible", () => ({
+  useMobileNavVisible: mockMobileNavVisible,
+}));
+
+describe("MobileNavBar", () => {
+  it("renders the tab bar when the shared hook reports visible", () => {
+    mockUsePathname.mockReturnValue("/search");
+    mockMobileNavVisible.mockReturnValue(true);
+    render(<MobileNavBar />);
+    expect(screen.getByRole("link", { name: /Search/i })).toBeInTheDocument();
+  });
+
+  it("renders nothing when the shared hook reports hidden", () => {
+    mockUsePathname.mockReturnValue("/canvas");
+    mockMobileNavVisible.mockReturnValue(false);
+    const { container } = render(<MobileNavBar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/__tests__/hooks/useMobileNavVisible.test.ts
+++ b/__tests__/hooks/useMobileNavVisible.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useMobileNavVisible } from "@/hooks/useMobileNavVisible";
+
+const { mockUsePathname } = vi.hoisted(() => ({ mockUsePathname: vi.fn() }));
+vi.mock("next/navigation", () => ({ usePathname: mockUsePathname }));
+
+const { mockNodeCount } = vi.hoisted(() => ({ mockNodeCount: vi.fn() }));
+vi.mock("@/store/canvas", () => ({
+  useCanvasStore: (selector: (s: { nodes: unknown[] }) => unknown) =>
+    selector({ nodes: new Array(mockNodeCount()) }),
+}));
+
+describe("useMobileNavVisible", () => {
+  it("is visible on non-canvas routes regardless of node count", () => {
+    mockUsePathname.mockReturnValue("/search");
+    mockNodeCount.mockReturnValue(0);
+    expect(renderHook(() => useMobileNavVisible()).result.current).toBe(true);
+  });
+
+  it("is visible on an empty canvas", () => {
+    mockUsePathname.mockReturnValue("/canvas");
+    mockNodeCount.mockReturnValue(0);
+    expect(renderHook(() => useMobileNavVisible()).result.current).toBe(true);
+  });
+
+  it("is hidden on a populated canvas", () => {
+    mockUsePathname.mockReturnValue("/canvas");
+    mockNodeCount.mockReturnValue(3);
+    expect(renderHook(() => useMobileNavVisible()).result.current).toBe(false);
+  });
+});

--- a/components/audio/MiniPlayer.tsx
+++ b/components/audio/MiniPlayer.tsx
@@ -3,6 +3,8 @@
 import { useAudioStore } from "@/store/audio";
 import { Play, Pause, SkipBack, SkipForward, X, Loader2, Volume2 } from "lucide-react";
 import { IconButton } from "@/components/ui";
+import { useMobileNavVisible } from "@/hooks/useMobileNavVisible";
+import { cn } from "@/lib/utils";
 
 export function MiniPlayer() {
   const {
@@ -18,6 +20,7 @@ export function MiniPlayer() {
     next,
     prev,
   } = useAudioStore();
+  const mobileNavVisible = useMobileNavVisible();
 
   if (!currentRef) return null;
 
@@ -26,7 +29,14 @@ export function MiniPlayer() {
   const queueLabel = queue.length > 1 ? ` (${queueIndex + 1}/${queue.length})` : "";
 
   return (
-    <div className="fixed bottom-4 left-1/2 z-50 flex min-w-[280px] -translate-x-1/2 items-center gap-3 rounded-xl border border-border bg-surface-raised px-4 py-2.5 shadow-floating">
+    <div
+      className={cn(
+        "fixed bottom-4 left-1/2 z-50 flex min-w-[280px] -translate-x-1/2 items-center gap-3 rounded-xl border border-border bg-surface-raised px-4 py-2.5 shadow-floating",
+        // MobileNavBar (md:hidden, min-h-[58px] + safe-area inset) sits on the
+        // bottom edge below md — offset above it instead of overlapping.
+        mobileNavVisible && "max-md:bottom-[calc(58px+env(safe-area-inset-bottom)+16px)]"
+      )}
+    >
       {/* Icon */}
       <Volume2 className="h-3.5 w-3.5 shrink-0 text-teal" />
 

--- a/components/layout/MobileNavBar.tsx
+++ b/components/layout/MobileNavBar.tsx
@@ -24,10 +24,7 @@ export function MobileNavBar() {
   const isActive = (href: string) =>
     href === "/canvas" ? pathname === "/canvas" : pathname.startsWith(href);
 
-  // On the canvas, hide the mobile tabs only once it has nodes — that's when the
-  // Header's mobile action bar takes over the bottom edge (and the two fixed bars
-  // would otherwise collide). On an empty canvas the tabs stay, so mobile users
-  // can still navigate away (the EmptyState is centred and isn't obscured).
+  // See useMobileNavVisible for the hide condition (populated /canvas only).
   if (!visible) return null;
 
   return (

--- a/components/layout/MobileNavBar.tsx
+++ b/components/layout/MobileNavBar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LayoutTemplate, Search, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useCanvasStore } from "@/store/canvas";
+import { useMobileNavVisible } from "@/hooks/useMobileNavVisible";
 
 // The mobile bottom tab bar for primary section navigation. Its desktop
 // counterpart lives inline in the header row (see HeaderNavLinks) — the two
@@ -17,7 +17,7 @@ const ITEMS = [
 
 export function MobileNavBar() {
   const pathname = usePathname();
-  const nodeCount = useCanvasStore((s) => s.nodes.length);
+  const visible = useMobileNavVisible();
 
   const items = ITEMS;
 
@@ -28,9 +28,7 @@ export function MobileNavBar() {
   // Header's mobile action bar takes over the bottom edge (and the two fixed bars
   // would otherwise collide). On an empty canvas the tabs stay, so mobile users
   // can still navigate away (the EmptyState is centred and isn't obscured).
-  const hideMobileTabs = pathname === "/canvas" && nodeCount > 0;
-
-  if (hideMobileTabs) return null;
+  if (!visible) return null;
 
   return (
     <nav className="fixed inset-x-0 bottom-0 z-30 flex md:hidden border-t border-border bg-surface/95 backdrop-blur pb-[env(safe-area-inset-bottom)]">

--- a/hooks/useMobileNavVisible.ts
+++ b/hooks/useMobileNavVisible.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useCanvasStore } from "@/store/canvas";
+
+/**
+ * Whether MobileNavBar is currently rendering its fixed bottom tab bar (on
+ * viewports below `md`). Shared with MiniPlayer, which needs to offset itself
+ * above the bar instead of overlapping it — kept in one place so the two
+ * components' visibility can't drift out of sync.
+ */
+export function useMobileNavVisible(): boolean {
+  const pathname = usePathname();
+  const nodeCount = useCanvasStore((s) => s.nodes.length);
+
+  // Mirrors MobileNavBar's own hideMobileTabs condition: hidden only on a
+  // populated canvas, where the Header's mobile action bar takes over instead.
+  const hideMobileTabs = pathname === "/canvas" && nodeCount > 0;
+  return !hideMobileTabs;
+}

--- a/hooks/useMobileNavVisible.ts
+++ b/hooks/useMobileNavVisible.ts
@@ -13,8 +13,10 @@ export function useMobileNavVisible(): boolean {
   const pathname = usePathname();
   const nodeCount = useCanvasStore((s) => s.nodes.length);
 
-  // Mirrors MobileNavBar's own hideMobileTabs condition: hidden only on a
-  // populated canvas, where the Header's mobile action bar takes over instead.
+  // Hidden only once the canvas has nodes — that's when the Header's mobile
+  // action bar takes over the bottom edge (and the two fixed bars would
+  // otherwise collide). On an empty canvas the tabs stay, so mobile users can
+  // still navigate away (the EmptyState is centred and isn't obscured).
   const hideMobileTabs = pathname === "/canvas" && nodeCount > 0;
   return !hideMobileTabs;
 }


### PR DESCRIPTION
## Summary
Closes #261.

`MiniPlayer` is a fixed `bottom-4` element rendered globally (`components/providers.tsx`). `MobileNavBar` is a fixed `bottom-0` mobile tab bar (`min-h-[58px]` + safe-area inset) that only hides itself on a populated `/canvas`. On every other route — home, `/search`, `/names`, or an empty canvas — playing audio put the floating mini-player directly on top of the nav bar on mobile, obscuring labels and shrinking tap targets.

## Changes
- Added `hooks/useMobileNavVisible.ts`: extracts `MobileNavBar`'s own visibility condition (hidden only on a populated `/canvas`) into a shared hook, so `MiniPlayer` can read the same state instead of duplicating (and risking drift from) that logic.
- `components/layout/MobileNavBar.tsx`: now uses the shared hook instead of computing `hideMobileTabs` itself.
- `components/audio/MiniPlayer.tsx`: offsets above the nav bar (`max-md:bottom-[calc(58px+env(safe-area-inset-bottom)+16px)]`, since the bar itself is `md:hidden`) only when the hook reports it visible; otherwise keeps the existing `bottom-4`.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bunx vitest run __tests__/hooks/useMobileNavVisible.test.ts __tests__/components/audio/MiniPlayer.test.tsx __tests__/components/layout/MobileNavBar.test.tsx` (8/8 passing) — covers the hook's three states (non-canvas route, empty canvas, populated canvas), `MiniPlayer` applying/omitting the offset class accordingly, and `MobileNavBar` rendering/hiding based on the shared hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent mobile bottom navigation visibility behavior across the app.
  - Introduced shared logic to show/hide the mobile navigation based on the current route and whether the canvas has content.
  - Mini player now adjusts its fixed bottom spacing when the mobile navigation is visible to avoid overlap.

- **Bug Fixes**
  - Improved mobile layout spacing between the mini player and the navigation bar.

- **Tests**
  - Added tests covering mobile navigation visibility, canvas states, and mini player positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->