### PR TITLE
Revert "chore(deps): bump next from 16.2.10 to 16.2.11 in the npm_and_yarn group across 1 directory"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ioredis": "^5.11.1",
     "jspdf": "^4.2.1",
     "lucide-react": "^1.25.0",
-    "next": "16.2.11",
+    "next": "16.2.10",
     "postgres": "^3.4.9",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION
Reverts OpenHikmah/openhikmah-web#313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Next.js framework version to 16.2.10.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->