### PR TITLE
fix(names): rate-limit AI content generation per client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ hosting.md
 /local/
 test-results/
 playwright-report/
+/strix_runs

--- a/__tests__/api/auth-exchange.test.ts
+++ b/__tests__/api/auth-exchange.test.ts
@@ -103,6 +103,91 @@ describe("POST /api/auth/exchange", () => {
     expect(capturedBody!.get("code_verifier")).toBe("my-verifier");
   });
 
+  describe("OIDC nonce verification", () => {
+    function fakeIdToken(payload: object) {
+      const b64url = (s: string) =>
+        Buffer.from(s).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+      return `${b64url(JSON.stringify({ alg: "RS256" }))}.${b64url(JSON.stringify(payload))}.sig`;
+    }
+
+    it("accepts a matching nonce", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "access-123",
+          refresh_token: "refresh-456",
+          id_token: fakeIdToken({ nonce: "expected-nonce" }),
+        }),
+      });
+
+      const res = await POST(
+        makeReq({ code: "auth-code", codeVerifier: "verifier", nonce: "expected-nonce" })
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).accessToken).toBe("access-123");
+    });
+
+    it("rejects a nonce mismatch with 400 and sets no session cookie", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "access-123",
+          refresh_token: "refresh-456",
+          id_token: fakeIdToken({ nonce: "attacker-nonce" }),
+        }),
+      });
+
+      const res = await POST(
+        makeReq({ code: "auth-code", codeVerifier: "verifier", nonce: "expected-nonce" })
+      );
+      expect(res.status).toBe(400);
+      expect(res.headers.get("set-cookie")).toBeNull();
+    });
+
+    it("rejects an undecodable id_token with 400 when a nonce was provided", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "access-123",
+          id_token: "not-a-jwt",
+        }),
+      });
+
+      const res = await POST(
+        makeReq({ code: "auth-code", codeVerifier: "verifier", nonce: "expected-nonce" })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("fails soft (200 + warning) when the token response has no id_token", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "access-123", refresh_token: "refresh-456" }),
+      });
+
+      const res = await POST(
+        makeReq({ code: "auth-code", codeVerifier: "verifier", nonce: "expected-nonce" })
+      );
+      expect(res.status).toBe(200);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("no id_token"));
+      warn.mockRestore();
+    });
+
+    it("skips the check when the client sends no nonce (legacy in-flight sign-ins)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "access-123",
+          id_token: fakeIdToken({ nonce: "whatever" }),
+        }),
+      });
+
+      const res = await POST(makeReq({ code: "auth-code", codeVerifier: "verifier" }));
+      expect(res.status).toBe(200);
+    });
+  });
+
   it("returns 400 when token endpoint returns non-ok", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,

--- a/__tests__/api/auth-exchange.test.ts
+++ b/__tests__/api/auth-exchange.test.ts
@@ -159,8 +159,7 @@ describe("POST /api/auth/exchange", () => {
       expect(res.status).toBe(400);
     });
 
-    it("fails soft (200 + warning) when the token response has no id_token", async () => {
-      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    it("fails closed (400, no cookie) when the token response has no id_token", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ access_token: "access-123", refresh_token: "refresh-456" }),
@@ -169,9 +168,25 @@ describe("POST /api/auth/exchange", () => {
       const res = await POST(
         makeReq({ code: "auth-code", codeVerifier: "verifier", nonce: "expected-nonce" })
       );
-      expect(res.status).toBe(200);
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining("no id_token"));
-      warn.mockRestore();
+      expect(res.status).toBe(400);
+      expect(res.headers.get("set-cookie")).toBeNull();
+    });
+
+    it("fails closed on a non-string id_token", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "access-123",
+          refresh_token: "refresh-456",
+          id_token: 12345,
+        }),
+      });
+
+      const res = await POST(
+        makeReq({ code: "auth-code", codeVerifier: "verifier", nonce: "expected-nonce" })
+      );
+      expect(res.status).toBe(400);
+      expect(res.headers.get("set-cookie")).toBeNull();
     });
 
     it("skips the check when the client sends no nonce (legacy in-flight sign-ins)", async () => {

--- a/__tests__/api/name-content-rate-limit.test.ts
+++ b/__tests__/api/name-content-rate-limit.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Chainable + thenable DB proxy (mirrors __tests__/lib/names/name-content.test.ts) ──
+function makeSelectChain(resolveWith: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockConsume, mockCallAI } = vi.hoisted(() => ({
+  mockSelect: vi.fn(),
+  mockConsume: vi.fn(),
+  mockCallAI: vi.fn(),
+}));
+
+vi.mock("@/lib/infra/db", () => ({
+  db: {
+    select: mockSelect,
+    insert: () => ({ values: () => ({ onConflictDoUpdate: async () => undefined }) }),
+  },
+}));
+
+vi.mock("@/lib/infra/rate-limit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/infra/rate-limit")>();
+  return { ...actual, consume: mockConsume };
+});
+
+vi.mock("@/lib/ai/ai", () => ({ callAI: mockCallAI }));
+
+import { GET as getReflection } from "@/app/api/names/[slug]/reflection/route";
+import { GET as getPairings } from "@/app/api/names/[slug]/pairings/route";
+import { GET as getVerses } from "@/app/api/names/[slug]/verses/route";
+
+// Stub fetch AFTER static imports so vi.stubGlobal wins over any fetch patch
+// applied during next/server module initialization.
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function req(slug: string, path: string) {
+  return new NextRequest(`http://localhost/api/names/${slug}/${path}`);
+}
+function params(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+const ROUTES: Array<{
+  label: string;
+  call: (slug: string) => Promise<Response>;
+}> = [
+  { label: "reflection", call: (slug) => getReflection(req(slug, "reflection"), params(slug)) },
+  { label: "pairings", call: (slug) => getPairings(req(slug, "pairings"), params(slug)) },
+  { label: "verses", call: (slug) => getVerses(req(slug, "verses"), params(slug)) },
+];
+
+describe("names AI routes — per-client rate limiting", () => {
+  beforeEach(() => {
+    mockSelect.mockReset();
+    mockConsume.mockReset();
+    mockCallAI.mockReset();
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: false });
+  });
+
+  for (const { label, call } of ROUTES) {
+    it(`${label}: returns 429 on a cache miss when the limiter denies, without calling the AI`, async () => {
+      mockSelect.mockReturnValue(makeSelectChain([])); // durable-cache miss
+      mockConsume.mockResolvedValue(false);
+
+      const res = await call("ar-rahman");
+
+      expect(res.status).toBe(429);
+      expect(mockConsume).toHaveBeenCalledTimes(1);
+      expect(mockCallAI).not.toHaveBeenCalled();
+    });
+
+    it(`${label}: serves a cache hit without consuming rate-limit budget`, async () => {
+      const cached =
+        label === "reflection" ? JSON.stringify("a cached reflection") : JSON.stringify([]);
+      // version must match each route's current VERSION const (reflection/pairings: 1, verses: 2)
+      const version = label === "verses" ? 2 : 1;
+      mockSelect.mockReturnValue(makeSelectChain([{ data: cached, version }]));
+      mockConsume.mockResolvedValue(false); // would deny — must never be asked
+
+      const res = await call("ar-rahman");
+
+      expect(res.status).toBe(200);
+      expect(mockConsume).not.toHaveBeenCalled();
+      expect(mockCallAI).not.toHaveBeenCalled();
+    });
+  }
+
+  it("reflection: generates normally when the limiter allows", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([]));
+    mockConsume.mockResolvedValue(true);
+    mockCallAI.mockResolvedValue("A grounded reflection.");
+
+    const res = await getReflection(req("ar-rahman", "reflection"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ reflection: "A grounded reflection." });
+    expect(mockConsume).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/api/name-content-rate-limit.test.ts
+++ b/__tests__/api/name-content-rate-limit.test.ts
@@ -86,6 +86,8 @@ describe("names AI routes — per-client rate limiting", () => {
 
       expect(res.status).toBe(429);
       expect(mockConsume).toHaveBeenCalledTimes(1);
+      // The budget must be keyed per client — the core guarantee of this gate.
+      expect(mockConsume).toHaveBeenCalledWith(expect.stringMatching(/^names-gen:.+/));
       expect(mockCallAI).not.toHaveBeenCalled();
     });
 
@@ -115,5 +117,48 @@ describe("names AI routes — per-client rate limiting", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ reflection: "A grounded reflection." });
     expect(mockConsume).toHaveBeenCalledTimes(1);
+  });
+
+  it("pairings: generates normally when the limiter allows", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([]));
+    mockConsume.mockResolvedValue(true);
+    mockCallAI.mockResolvedValue(
+      JSON.stringify([
+        {
+          transliteration: "Ar-Rahim",
+          arabic: "الرَّحِيم",
+          explanation: "Mercy paired with mercy.",
+        },
+      ])
+    );
+
+    const res = await getPairings(req("ar-rahman", "pairings"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(mockConsume).toHaveBeenCalledTimes(1);
+    expect(mockCallAI).toHaveBeenCalledTimes(1);
+  });
+
+  it("verses: generates normally when the limiter allows", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([]));
+    mockConsume.mockResolvedValue(true);
+    // quran.com search stays ok:false → AI fallback path; alquran.cloud hydrates.
+    mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "Ayat al-Kursi." }]));
+    mockFetch.mockImplementation(async (url: unknown) => {
+      if (typeof url !== "string") return { ok: false };
+      if (url.includes("api.alquran.cloud"))
+        return { ok: true, json: async () => ({ data: { text: "نص" } }) };
+      return { ok: false };
+    });
+
+    const res = await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(mockConsume).toHaveBeenCalledTimes(1);
+    expect(mockCallAI).toHaveBeenCalled();
   });
 });

--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Chainable + thenable DB proxy (mirrors __tests__/lib/names/name-content.test.ts) ──
+function makeSelectChain(resolveWith: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockConsume, mockCallAI } = vi.hoisted(() => ({
+  mockConsume: vi.fn(),
+  mockCallAI: vi.fn(),
+}));
+
+vi.mock("@/lib/infra/db", () => ({
+  db: {
+    select: () => makeSelectChain([]), // durable cache always misses
+    insert: () => ({ values: () => ({ onConflictDoUpdate: async () => undefined }) }),
+  },
+}));
+
+vi.mock("@/lib/infra/rate-limit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/infra/rate-limit")>();
+  return { ...actual, consume: mockConsume };
+});
+
+vi.mock("@/lib/ai/ai", () => ({ callAI: mockCallAI }));
+
+import { GET as getPairings } from "@/app/api/names/[slug]/pairings/route";
+import { GET as getVerses } from "@/app/api/names/[slug]/verses/route";
+
+// Stub fetch AFTER static imports so vi.stubGlobal wins over any fetch patch
+// applied during next/server module initialization.
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function req(slug: string, path: string) {
+  return new NextRequest(`http://localhost/api/names/${slug}/${path}`);
+}
+function params(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+describe("names AI routes — model output validation", () => {
+  beforeEach(() => {
+    mockConsume.mockReset().mockResolvedValue(true);
+    mockCallAI.mockReset();
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: false }); // quran.com search yields no refs
+  });
+
+  it("pairings: parseable-but-wrong-shaped JSON (string array) returns empty, not a 500", async () => {
+    mockCallAI.mockResolvedValue(JSON.stringify(["Ar-Rahim", "Al-Malik"]));
+
+    const res = await getPairings(req("ar-rahman", "pairings"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("pairings: entries missing string fields are dropped, valid ones kept", async () => {
+    mockCallAI.mockResolvedValue(
+      JSON.stringify([
+        {
+          transliteration: "Ar-Rahim",
+          arabic: "الرَّحِيم",
+          explanation: "Balances majesty with mercy.",
+        },
+        { transliteration: 42, arabic: null },
+        "junk",
+      ])
+    );
+
+    const res = await getPairings(req("ar-rahman", "pairings"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].transliteration).toBe("Ar-Rahim");
+  });
+
+  it("verses: AI fallback refs outside real Quran bounds are dropped (no 500)", async () => {
+    mockCallAI.mockResolvedValue(
+      JSON.stringify([
+        { ref: "2:300", reason: "out-of-range ayah" },
+        { ref: "999:1", reason: "out-of-range surah" },
+        { ref: "2:255", reason: 42 },
+        "junk",
+      ])
+    );
+
+    const res = await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("verses: a valid AI-fallback entry survives among malformed ones", async () => {
+    mockCallAI.mockResolvedValue(
+      JSON.stringify([{ ref: "2:255", reason: "Ayat al-Kursi." }, { ref: "0:0" }, null])
+    );
+    mockFetch.mockImplementation(async (url: unknown) => {
+      if (typeof url !== "string") return { ok: false };
+      if (url.includes("api.alquran.cloud"))
+        return {
+          ok: true,
+          json: async () => ({ data: { text: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ" } }),
+        };
+      return { ok: false };
+    });
+
+    const res = await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].ref).toBe("2:255");
+    expect(body[0].reason).toBe("Ayat al-Kursi.");
+  });
+});

--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -100,6 +100,8 @@ describe("names AI routes — model output validation", () => {
       JSON.stringify([
         { ref: "2:300", reason: "out-of-range ayah" },
         { ref: "999:1", reason: "out-of-range surah" },
+        { ref: "1:8", reason: "past Al-Fatihah's 7 ayahs (per-surah bound)" },
+        { ref: "50:46", reason: "past Qaf's 45 ayahs (per-surah bound)" },
         { ref: "2:255", reason: 42 },
         "junk",
       ])
@@ -115,13 +117,15 @@ describe("names AI routes — model output validation", () => {
     mockCallAI.mockResolvedValue(
       JSON.stringify([{ ref: "2:255", reason: "Ayat al-Kursi." }, { ref: "0:0" }, null])
     );
+    const ARABIC = "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ";
+    const ENGLISH = "Allah - there is no deity except Him, the Ever-Living.";
     mockFetch.mockImplementation(async (url: unknown) => {
       if (typeof url !== "string") return { ok: false };
-      if (url.includes("api.alquran.cloud"))
-        return {
-          ok: true,
-          json: async () => ({ data: { text: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ" } }),
-        };
+      // Distinct per-edition payloads so a swapped translation source is caught.
+      if (url.includes("ar.alafasy"))
+        return { ok: true, json: async () => ({ data: { text: ARABIC } }) };
+      if (url.includes("en.sahih"))
+        return { ok: true, json: async () => ({ data: { text: ENGLISH } }) };
       return { ok: false };
     });
 
@@ -132,5 +136,7 @@ describe("names AI routes — model output validation", () => {
     expect(body).toHaveLength(1);
     expect(body[0].ref).toBe("2:255");
     expect(body[0].reason).toBe("Ayat al-Kursi.");
+    expect(body[0].arabicText).toBe(ARABIC);
+    expect(body[0].translation).toBe(ENGLISH);
   });
 });

--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -148,6 +148,72 @@ describe("getOrGenerateNameContent", () => {
     expect(c).toBe(a);
   });
 
+  it("calls onBeforeGenerate on a miss, before generate", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const order: string[] = [];
+    const onBeforeGenerate = vi.fn(async () => {
+      order.push("gate");
+    });
+    const generate = vi.fn(async () => {
+      order.push("generate");
+      return ["x"];
+    });
+
+    const out = await getOrGenerateNameContent(
+      "al-malik",
+      "verses",
+      1,
+      generate,
+      isEmptyArr,
+      onBeforeGenerate
+    );
+
+    expect(out).toEqual(["x"]);
+    expect(onBeforeGenerate).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["gate", "generate"]);
+  });
+
+  it("does NOT call onBeforeGenerate on a cache hit", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([{ data: JSON.stringify(["cached"]), version: 1 }]));
+    const onBeforeGenerate = vi.fn();
+    const generate = vi.fn();
+
+    const out = await getOrGenerateNameContent(
+      "as-salam",
+      "verses",
+      1,
+      generate,
+      isEmptyArr,
+      onBeforeGenerate
+    );
+
+    expect(out).toEqual(["cached"]);
+    expect(onBeforeGenerate).not.toHaveBeenCalled();
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("a throwing onBeforeGenerate propagates, skips generation, and caches nothing", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const onBeforeGenerate = vi.fn().mockRejectedValue(new Error("rate limited"));
+    const generate = vi.fn();
+
+    await expect(
+      getOrGenerateNameContent("al-malik", "verses", 1, generate, isEmptyArr, onBeforeGenerate)
+    ).rejects.toThrow("rate limited");
+    expect(generate).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+
+    // A later allowed call still generates (no stuck lock).
+    const out = await getOrGenerateNameContent(
+      "al-malik",
+      "verses",
+      1,
+      vi.fn().mockResolvedValue(["ok"]),
+      isEmptyArr
+    );
+    expect(out).toEqual(["ok"]);
+  });
+
   it("surfaces a generate() rejection and clears the lock so the next call retries", async () => {
     mockSelect.mockReturnValue(makeSelectChain([])); // miss
     const generate = vi.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValue(["ok"]);

--- a/__tests__/lib/quran/quran-corpus.test.ts
+++ b/__tests__/lib/quran/quran-corpus.test.ts
@@ -64,6 +64,14 @@ describe("quran-corpus", () => {
     it("rejects an absurdly large ayah number regardless of surah", () => {
       expect(isValidRef("114:99999")).toBe(false); // An-Nas has only 6 ayahs
     });
+    it("enforces each surah's real ayah count, not just a global ceiling", () => {
+      expect(isValidRef("1:7")).toBe(true); // Al-Fatihah's last ayah
+      expect(isValidRef("1:8")).toBe(false); // Al-Fatihah has only 7
+      expect(isValidRef("114:6")).toBe(true); // An-Nas's last ayah
+      expect(isValidRef("114:7")).toBe(false);
+      expect(isValidRef("50:45")).toBe(true); // Qaf's last ayah
+      expect(isValidRef("50:46")).toBe(false);
+    });
   });
 
   describe("getVerse", () => {

--- a/app/api/auth/exchange/route.ts
+++ b/app/api/auth/exchange/route.ts
@@ -12,6 +12,26 @@ import { clientKey } from "@/lib/infra/http";
 const EXCHANGE_LIMIT = 20;
 const EXCHANGE_WINDOW_SECONDS = 10 * 60;
 
+// Minimal payload decode for the id_token nonce check. Signature verification
+// is deliberately not done here: the token arrives directly from the QF token
+// endpoint over TLS with HTTP Basic client auth (OIDC Core §3.1.3.7 permits
+// skipping signature validation for tokens received on that direct channel).
+// Do NOT reuse this for tokens that arrive from the browser — those must go
+// through the JWKS-verified path in lib/auth/social-auth.ts.
+function decodeJwtPayload(jwt: string): Record<string, unknown> | null {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const parsed: unknown = JSON.parse(Buffer.from(b64, "base64").toString("utf8"));
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function generateUsername(): string {
   const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
   const bytes = new Uint8Array(8);
@@ -29,7 +49,7 @@ export async function POST(req: NextRequest) {
   );
   if (limited) return limited;
 
-  let body: { code?: string; codeVerifier?: string };
+  let body: { code?: string; codeVerifier?: string; nonce?: string };
   try {
     body = await req.json();
   } catch {
@@ -37,6 +57,7 @@ export async function POST(req: NextRequest) {
   }
 
   const { code, codeVerifier } = body;
+  const nonce = typeof body.nonce === "string" ? body.nonce : undefined;
   if (!code || !codeVerifier) {
     return NextResponse.json({ error: "Missing code or codeVerifier" }, { status: 400 });
   }
@@ -77,7 +98,28 @@ export async function POST(req: NextRequest) {
     const data = (await res.json()) as {
       access_token: string;
       refresh_token?: string;
+      id_token?: string;
     };
+
+    // Verify the OIDC nonce round-trip: the value minted at sign-in start must
+    // come back inside the id_token, binding this token response to the
+    // authorize request that initiated it. A mismatch means the code/token was
+    // not produced by our sign-in attempt — reject and set no session cookie.
+    if (nonce) {
+      if (data.id_token) {
+        const claims = decodeJwtPayload(data.id_token);
+        if (!claims || claims.nonce !== nonce) {
+          console.error("Auth exchange: id_token nonce mismatch — rejecting sign-in.");
+          return NextResponse.json({ error: "Nonce mismatch" }, { status: 400 });
+        }
+      } else {
+        // Fail-soft like the missing-refresh-token case below: a QF-side change
+        // that stops returning id_tokens must degrade to a warning, not brick
+        // sign-in (PKCE + state remain enforced regardless).
+        console.warn("Auth exchange: no id_token in token response — nonce not verifiable.");
+      }
+    }
+
     const accessToken = data.access_token;
     const refreshToken = data.refresh_token ?? null;
     const COOKIE_NAME = "qf_refresh_token";

--- a/app/api/auth/exchange/route.ts
+++ b/app/api/auth/exchange/route.ts
@@ -103,20 +103,15 @@ export async function POST(req: NextRequest) {
 
     // Verify the OIDC nonce round-trip: the value minted at sign-in start must
     // come back inside the id_token, binding this token response to the
-    // authorize request that initiated it. A mismatch means the code/token was
-    // not produced by our sign-in attempt — reject and set no session cookie.
+    // authorize request that initiated it. Fail closed — we always request the
+    // `openid` scope, so a compliant server always returns an id_token; a
+    // missing or undecodable one is as anomalous as a mismatched nonce, and
+    // continuing would silently skip the check entirely.
     if (nonce) {
-      if (data.id_token) {
-        const claims = decodeJwtPayload(data.id_token);
-        if (!claims || claims.nonce !== nonce) {
-          console.error("Auth exchange: id_token nonce mismatch — rejecting sign-in.");
-          return NextResponse.json({ error: "Nonce mismatch" }, { status: 400 });
-        }
-      } else {
-        // Fail-soft like the missing-refresh-token case below: a QF-side change
-        // that stops returning id_tokens must degrade to a warning, not brick
-        // sign-in (PKCE + state remain enforced regardless).
-        console.warn("Auth exchange: no id_token in token response — nonce not verifiable.");
+      const claims = typeof data.id_token === "string" ? decodeJwtPayload(data.id_token) : null;
+      if (!claims || claims.nonce !== nonce) {
+        console.error("Auth exchange: id_token nonce verification failed — rejecting sign-in.");
+        return NextResponse.json({ error: "Nonce verification failed" }, { status: 400 });
       }
     }
 

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -48,7 +48,7 @@ async function getPairings(
     async () => {
       const text = await callAI(buildPrompt(name.transliteration, name.arabic, name.meaning));
 
-      let raw: Array<{ transliteration: string; arabic: string; explanation: string }>;
+      let raw: unknown;
       try {
         const match = text.match(/\[[\s\S]*\]/);
         if (!match) {
@@ -63,7 +63,23 @@ async function getPairings(
         return [];
       }
 
-      return raw.slice(0, 3).map((p) => {
+      // Parsing successfully does not mean the shape is right — a valid-JSON
+      // response with the wrong structure must degrade to empty, not throw a 500
+      // at the property accesses below.
+      const items = (Array.isArray(raw) ? raw : []).filter(
+        (p): p is { transliteration: string; arabic: string; explanation: string } =>
+          typeof p === "object" &&
+          p !== null &&
+          typeof (p as Record<string, unknown>).transliteration === "string" &&
+          typeof (p as Record<string, unknown>).arabic === "string" &&
+          typeof (p as Record<string, unknown>).explanation === "string"
+      );
+      if (items.length === 0) {
+        console.error(`Pairings: AI response for ${slug} had no validly-shaped entries`);
+        return [];
+      }
+
+      return items.slice(0, 3).map((p) => {
         const match = DIVINE_NAMES.find(
           (n) =>
             n.transliteration.toLowerCase() === p.transliteration.toLowerCase() ||

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { callAI } from "@/lib/ai/ai";
 import { getNameBySlug, DIVINE_NAMES } from "@/lib/names/divine-names";
 import { getOrGenerateNameContent } from "@/lib/names/name-content";
+import { consume, RateLimitError } from "@/lib/infra/rate-limit";
+import { clientKey } from "@/lib/infra/http";
 
 // Bump to force regeneration after a prompt change.
 const PAIRINGS_VERSION = 1;
@@ -32,7 +34,10 @@ Return ONLY a JSON array:
 ]`;
 }
 
-async function getPairings(slug: string): Promise<Pairing[]> {
+async function getPairings(
+  slug: string,
+  onBeforeGenerate: () => Promise<void>
+): Promise<Pairing[]> {
   const name = getNameBySlug(slug);
   if (!name) return [];
 
@@ -72,11 +77,12 @@ async function getPairings(slug: string): Promise<Pairing[]> {
         };
       });
     },
-    (v) => v.length === 0
+    (v) => v.length === 0,
+    onBeforeGenerate
   );
 }
 
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const name = getNameBySlug(slug);
   if (!name) {
@@ -84,9 +90,14 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ slu
   }
 
   try {
-    const pairings = await getPairings(slug);
+    const pairings = await getPairings(slug, async () => {
+      if (!(await consume(`names-gen:${clientKey(req)}`))) throw new RateLimitError();
+    });
     return NextResponse.json(pairings);
   } catch (err) {
+    if (err instanceof RateLimitError) {
+      return NextResponse.json({ error: "Too many requests — please slow down." }, { status: 429 });
+    }
     console.error("Pairings error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/app/api/names/[slug]/reflection/route.ts
+++ b/app/api/names/[slug]/reflection/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { callAI } from "@/lib/ai/ai";
 import { getNameBySlug } from "@/lib/names/divine-names";
 import { getOrGenerateNameContent } from "@/lib/names/name-content";
+import { consume, RateLimitError } from "@/lib/infra/rate-limit";
+import { clientKey } from "@/lib/infra/http";
 
 // Bump to force regeneration after a prompt change.
 const REFLECTION_VERSION = 1;
@@ -30,7 +32,7 @@ Critical rules:
 Example for Al-Razzaq: "The believer's realisation of Al-Razzaq is not to claim any power over provision, but to strive with full effort in lawful means while maintaining absolute certainty in the heart that the outcome belongs solely to Allah. The servant plants, waters, and labours — yet knows that it is Allah who causes the grain to grow."`;
 }
 
-async function getReflection(slug: string): Promise<string> {
+async function getReflection(slug: string, onBeforeGenerate: () => Promise<void>): Promise<string> {
   const name = getNameBySlug(slug);
   if (!name) return "";
   return getOrGenerateNameContent(
@@ -38,11 +40,12 @@ async function getReflection(slug: string): Promise<string> {
     "reflection",
     REFLECTION_VERSION,
     () => callAI(buildPrompt(name.arabic, name.transliteration, name.meaning, name.description)),
-    (s) => s.trim() === ""
+    (s) => s.trim() === "",
+    onBeforeGenerate
   );
 }
 
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const name = getNameBySlug(slug);
   if (!name) {
@@ -50,9 +53,14 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ slu
   }
 
   try {
-    const reflection = await getReflection(slug);
+    const reflection = await getReflection(slug, async () => {
+      if (!(await consume(`names-gen:${clientKey(req)}`))) throw new RateLimitError();
+    });
     return NextResponse.json({ reflection });
   } catch (err) {
+    if (err instanceof RateLimitError) {
+      return NextResponse.json({ error: "Too many requests — please slow down." }, { status: 429 });
+    }
     console.error("Reflection error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { callAI } from "@/lib/ai/ai";
 import { getNameBySlug } from "@/lib/names/divine-names";
 import { getSurahName } from "@/lib/quran/surah-names";
+import { isValidRef } from "@/lib/quran/quran-corpus";
 import { getOrGenerateNameContent } from "@/lib/names/name-content";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
@@ -24,10 +25,10 @@ interface NameVerse {
 }
 
 async function fetchVerseData(ref: string): Promise<Omit<NameVerse, "reason"> | null> {
+  if (!isValidRef(ref)) return null;
   const [surahStr, ayahStr] = ref.split(":");
   const surahNum = parseInt(surahStr, 10);
   const ayahNum = parseInt(ayahStr, 10);
-  if (!surahNum || !ayahNum || surahNum < 1 || surahNum > 114 || ayahNum < 1) return null;
 
   try {
     const [arabicRes, translationRes] = await Promise.all([
@@ -105,8 +106,11 @@ Output format:
     const text = await callAI(prompt);
     const match = text.match(/\{[\s\S]*\}/);
     if (!match) return new Map();
-    const obj = JSON.parse(match[0]) as Record<string, string>;
-    return new Map(Object.entries(obj));
+    const obj: unknown = JSON.parse(match[0]);
+    if (typeof obj !== "object" || obj === null || Array.isArray(obj)) return new Map();
+    return new Map(
+      Object.entries(obj).filter((e): e is [string, string] => typeof e[1] === "string")
+    );
   } catch (err) {
     // Reasons are best-effort (a default reason is used per verse if missing) —
     // log so a persistently malformed AI response is visible, not silent.
@@ -135,7 +139,17 @@ Return ONLY a JSON array:
     const text = await callAI(prompt);
     const match = text.match(/\[[\s\S]*\]/);
     if (!match) return [];
-    return JSON.parse(match[0]) as Array<{ ref: string; reason: string }>;
+    const raw: unknown = JSON.parse(match[0]);
+    // The model proposes refs from memory here — validate shape AND that each
+    // ref is a real Quran reference before anything downstream touches it.
+    return (Array.isArray(raw) ? raw : []).filter(
+      (item): item is { ref: string; reason: string } =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as Record<string, unknown>).ref === "string" &&
+        isValidRef((item as Record<string, unknown>).ref as string) &&
+        typeof (item as Record<string, unknown>).reason === "string"
+    );
   } catch (err) {
     // Empty result is not cached (it retries), but log the parse failure so a
     // broken prompt surfaces instead of silently re-invoking the AI forever.

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -3,6 +3,8 @@ import { callAI } from "@/lib/ai/ai";
 import { getNameBySlug } from "@/lib/names/divine-names";
 import { getSurahName } from "@/lib/quran/surah-names";
 import { getOrGenerateNameContent } from "@/lib/names/name-content";
+import { consume, RateLimitError } from "@/lib/infra/rate-limit";
+import { clientKey } from "@/lib/infra/http";
 import { incr } from "@/lib/infra/metrics";
 import sanitizeHtml from "sanitize-html";
 import type { VerseRef } from "@/types/quran";
@@ -146,7 +148,10 @@ function stripHtml(text: string): string {
   return sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });
 }
 
-async function getVersesBySlug(slug: string): Promise<NameVerse[]> {
+async function getVersesBySlug(
+  slug: string,
+  onBeforeGenerate: () => Promise<void>
+): Promise<NameVerse[]> {
   const name = getNameBySlug(slug);
   if (!name) return [];
 
@@ -201,11 +206,12 @@ async function getVersesBySlug(slug: string): Promise<NameVerse[]> {
         })
         .filter((v): v is NameVerse => v !== null);
     },
-    (v) => v.length === 0
+    (v) => v.length === 0,
+    onBeforeGenerate
   );
 }
 
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const name = getNameBySlug(slug);
   if (!name) {
@@ -213,9 +219,14 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ slu
   }
 
   try {
-    const verses = await getVersesBySlug(slug);
+    const verses = await getVersesBySlug(slug, async () => {
+      if (!(await consume(`names-gen:${clientKey(req)}`))) throw new RateLimitError();
+    });
     return NextResponse.json(verses);
   } catch (err) {
+    if (err instanceof RateLimitError) {
+      return NextResponse.json({ error: "Too many requests — please slow down." }, { status: 429 });
+    }
     console.error("Name verses error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/app/callback/CallbackClient.tsx
+++ b/app/callback/CallbackClient.tsx
@@ -32,6 +32,7 @@ export function CallbackClient({ code, state, error }: Props) {
 
     const codeVerifier = sessionStorage.getItem("pkce_code_verifier");
     const expectedState = sessionStorage.getItem("pkce_state");
+    const nonce = sessionStorage.getItem("pkce_nonce");
 
     if (!codeVerifier || !expectedState) {
       setFailReason("Session expired — please try signing in again.");
@@ -56,7 +57,7 @@ export function CallbackClient({ code, state, error }: Props) {
     fetch("/api/auth/exchange", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ code, codeVerifier }),
+      body: JSON.stringify({ code, codeVerifier, nonce: nonce ?? undefined }),
     })
       .then(async (res) => {
         if (!res.ok) {

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -30,13 +30,20 @@ const inFlight = new Map<string, Promise<unknown>>();
  * persist, leaving the next request free to retry (mirrors how the connection
  * graph only stores non-empty generations). Bumping `version` for a kind forces
  * regeneration after a prompt change.
+ *
+ * `onBeforeGenerate` runs only on a durable-cache miss, before joining or
+ * starting a generation — the seam where routes enforce their per-client
+ * rate limit (cache hits stay unlimited, matching the limiter's contract in
+ * lib/infra/rate-limit.ts). A throw here (RateLimitError) propagates to the
+ * caller and nothing is generated or cached.
  */
 export async function getOrGenerateNameContent<T>(
   slug: string,
   kind: NameContentKind,
   version: number,
   generate: () => Promise<T>,
-  isEmpty: (value: T) => boolean
+  isEmpty: (value: T) => boolean,
+  onBeforeGenerate?: () => Promise<void>
 ): Promise<T> {
   // 1. Durable cache hit (only when the stored version matches the current one).
   const [row] = await db
@@ -55,6 +62,8 @@ export async function getOrGenerateNameContent<T>(
       console.error(`Corrupt name_content row for ${slug}/${kind}, regenerating:`, err);
     }
   }
+
+  if (onBeforeGenerate) await onBeforeGenerate();
 
   // 2. Single-flight: the get→set stays synchronous so two concurrent callers
   // can't both become the leader. `version` is part of the key so a follower can

--- a/lib/quran/audio.ts
+++ b/lib/quran/audio.ts
@@ -1,5 +1,6 @@
-// Hafs/Uthmani standard ayah counts per surah (114 surahs, 6236 total)
-const SURAH_LENGTHS: number[] = [
+// Hafs/Uthmani standard ayah counts per surah (114 surahs, 6236 total).
+// Exported for per-surah ref validation in lib/quran/quran-corpus.ts.
+export const SURAH_LENGTHS: number[] = [
   7, 286, 200, 176, 120, 165, 206, 75, 129, 109, 123, 111, 43, 52, 99, 128, 111, 110, 98, 135, 112,
   78, 118, 64, 77, 227, 93, 88, 69, 60, 34, 30, 73, 54, 45, 83, 182, 88, 75, 85, 54, 53, 89, 59, 37,
   35, 38, 29, 18, 45, 60, 49, 62, 55, 78, 96, 29, 22, 24, 13, 14, 11, 11, 18, 12, 12, 30, 52, 52,

--- a/lib/quran/quran-corpus.ts
+++ b/lib/quran/quran-corpus.ts
@@ -2,6 +2,7 @@ import { eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { verses, type VerseRow } from "@/lib/infra/db/schema";
 import { getSurahName } from "@/lib/quran/surah-names";
+import { SURAH_LENGTHS } from "@/lib/quran/audio";
 import type { Verse, VerseRef } from "@/types/quran";
 
 /**
@@ -23,21 +24,17 @@ function rowToVerse(row: VerseRow): Verse {
   };
 }
 
-// The longest surah (2, Al-Baqarah) has 286 ayahs — no surah exceeds this, so
-// it's a safe generous upper bound without needing a full per-surah table.
-// isValidRef intentionally doesn't validate the exact per-surah count; refs
-// that pass this but don't exist (e.g. "114:200") simply fail to resolve
-// downstream (getVerse/getVerses return null/absent), same as any other
-// not-found ref.
-const MAX_AYAH = 286;
-
-/** A syntactically valid verse reference within Quran bounds (surah 1–114). */
+/**
+ * A syntactically valid verse reference within real Quran bounds: surah 1–114
+ * and ayah within that surah's actual Hafs/Uthmani ayah count (so "1:8" is
+ * rejected — Al-Fatihah has 7 ayahs — not just refs beyond a global ceiling).
+ */
 export function isValidRef(ref: string): boolean {
   const match = /^(\d+):(\d+)$/.exec(ref);
   if (!match) return false;
   const surah = parseInt(match[1], 10);
   const ayah = parseInt(match[2], 10);
-  return surah >= 1 && surah <= 114 && ayah >= 1 && ayah <= MAX_AYAH;
+  return surah >= 1 && surah <= 114 && ayah >= 1 && ayah <= SURAH_LENGTHS[surah - 1];
 }
 
 /** Returns the verse for a `"surah:ayah"` ref, or null if not in the corpus. */


### PR DESCRIPTION
The reflection/pairings/verses routes were the only callers of callAI() with no rate limit — and because empty generations are deliberately not cached, a persistently-empty generation re-invoked the AI on every anonymous request. Gate generation (cache misses only, matching the limiter's documented contract) with the same per-client budget as /api/connections via a new onBeforeGenerate seam on getOrGenerateNameContent; cache hits stay unlimited.


## Summary

<!-- 1–3 bullet points: what changed and why -->

-
-

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

<!-- Complete this section if you modified any Claude prompts, divine name data, or verse connection logic. Leave blank otherwise. -->

- [ ] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below
- [ ] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)

**Details** (if applicable):
<!-- Describe any changes to prompts, expected output format, or theological framing. Note any deviations from or additions to the Maturidi/Hanafi tradition. -->

## Testing

- [ ] `bun run test:ci` passes locally
- [ ] `bun run typecheck` passes locally
- [ ] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [ ] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-client rate limiting to name reflection, pairing, and verse generation endpoints (HTTP 429 when throttled).
  * Improved auth code exchange by supporting nonce verification for enhanced security.
* **Bug Fixes**
  * Hardened AI response handling for pairings and verses to safely return empty/filtered results on malformed output.
  * Ensured failed pre-generation checks don’t start or persist generation work.
* **Tests**
  * Expanded automated coverage for rate limiting, cache behavior, generation ordering, nonce exchange scenarios, and invalid AI-output validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->