### PR TITLE
feat(i18n): multi-edition Quran translation storage (Phase 1 of #331)

### DIFF
--- a/__tests__/integration/verse-translations.integration.test.ts
+++ b/__tests__/integration/verse-translations.integration.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { sql, eq } from "drizzle-orm";
+
+// Real Postgres (Testcontainers). No live fetch should ever be needed once the
+// corpus + translation rows are seeded.
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => ({ ok: false }))
+);
+
+import { db } from "@/lib/infra/db";
+import { verses, verseTranslations } from "@/lib/infra/db/schema";
+import { getVerse, getVerses } from "@/lib/quran/quran-corpus";
+import { resolveVerse } from "@/lib/quran/verse-resolver";
+
+async function reset() {
+  await db.execute(sql`TRUNCATE verses, verse_translations RESTART IDENTITY CASCADE`);
+}
+
+async function seedVerse(ref: string, translation = `en-${ref}`) {
+  const [s, a] = ref.split(":");
+  await db.insert(verses).values({
+    ref,
+    surah: Number(s),
+    ayah: Number(a),
+    arabicText: `arabic-${ref}`,
+    translation,
+  });
+}
+
+beforeEach(async () => {
+  await reset();
+  await seedVerse("1:1", "en.sahih text");
+  await seedVerse("2:255", "en.sahih ayat al-kursi");
+});
+
+describe("verse_translations (integration, real Postgres)", () => {
+  it("getVerse falls back to the base en.sahih column when no edition is requested", async () => {
+    const v = await getVerse("1:1");
+    expect(v?.translation).toBe("en.sahih text");
+  });
+
+  it("getVerse returns the edition-specific row when one exists", async () => {
+    await db.insert(verseTranslations).values({
+      ref: "1:1",
+      edition: "tr.diyanet",
+      language: "tr",
+      text: "Türkçe metin",
+    });
+    const v = await getVerse("1:1", "tr.diyanet");
+    expect(v?.translation).toBe("Türkçe metin");
+  });
+
+  it("getVerse COALESCEs back to en.sahih when the requested edition has no row for this verse", async () => {
+    // No verse_translations row for 2:255/tr.diyanet at all.
+    const v = await getVerse("2:255", "tr.diyanet");
+    expect(v?.translation).toBe("en.sahih ayat al-kursi");
+  });
+
+  it("getVerses batch-resolves a mix of translated and untranslated refs for the same edition", async () => {
+    await db.insert(verseTranslations).values({
+      ref: "1:1",
+      edition: "ru.kuliev",
+      language: "ru",
+      text: "Русский текст",
+    });
+    const map = await getVerses(["1:1", "2:255"], "ru.kuliev");
+    expect(map.get("1:1")?.translation).toBe("Русский текст");
+    expect(map.get("2:255")?.translation).toBe("en.sahih ayat al-kursi");
+  });
+
+  it("resolveVerse resolves the requested edition from the local corpus without a live fetch", async () => {
+    await db.insert(verseTranslations).values({
+      ref: "1:1",
+      edition: "az.mammadaliyev",
+      language: "az",
+      text: "Azərbaycan mətni",
+    });
+    const v = await resolveVerse("1:1", "az.mammadaliyev");
+    expect(v?.translation).toBe("Azərbaycan mətni");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("deleting a verse cascades to its translation rows", async () => {
+    await db.insert(verseTranslations).values({
+      ref: "1:1",
+      edition: "tr.diyanet",
+      language: "tr",
+      text: "Türkçe metin",
+    });
+    await db.execute(sql`DELETE FROM verses WHERE ref = '1:1'`);
+    const rows = await db.select().from(verseTranslations).where(eq(verseTranslations.ref, "1:1"));
+    expect(rows.length).toBe(0);
+  });
+});

--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -110,8 +110,13 @@ describe("startJob", () => {
 });
 
 describe("JOBS", () => {
-  it("registers exactly the three backfill scripts from issue #114", () => {
-    expect(JOBS.map((j) => j.id)).toEqual(["seed-quran", "seed-morphology", "embed-corpus"]);
+  it("registers the backfill scripts from issue #114 plus seed-translations (#331)", () => {
+    expect(JOBS.map((j) => j.id)).toEqual([
+      "seed-quran",
+      "seed-morphology",
+      "embed-corpus",
+      "seed-translations",
+    ]);
   });
 });
 

--- a/__tests__/lib/i18n/config.test.ts
+++ b/__tests__/lib/i18n/config.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidLocale,
+  isValidEdition,
+  DEFAULT_EDITION_BY_LOCALE,
+  LOCALES,
+} from "@/lib/i18n/config";
+
+describe("i18n config", () => {
+  describe("isValidLocale", () => {
+    it("accepts every declared locale", () => {
+      for (const locale of LOCALES) expect(isValidLocale(locale)).toBe(true);
+    });
+
+    it("rejects unknown values", () => {
+      expect(isValidLocale("fr")).toBe(false);
+      expect(isValidLocale("")).toBe(false);
+    });
+  });
+
+  describe("isValidEdition", () => {
+    it("accepts every default edition", () => {
+      for (const edition of Object.values(DEFAULT_EDITION_BY_LOCALE)) {
+        expect(isValidEdition(edition)).toBe(true);
+      }
+    });
+
+    it("rejects an unrecognized or attacker-controlled value", () => {
+      expect(isValidEdition("en.sahih; DROP TABLE verses;")).toBe(false);
+      expect(isValidEdition("../../etc/passwd")).toBe(false);
+    });
+  });
+});

--- a/__tests__/lib/i18n/request-prefs.test.ts
+++ b/__tests__/lib/i18n/request-prefs.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockCookies } = vi.hoisted(() => ({ mockCookies: vi.fn() }));
+vi.mock("next/headers", () => ({ cookies: mockCookies }));
+
+import { getUiLocale, getQuranEdition } from "@/lib/i18n/request-prefs";
+
+function cookieJar(values: Record<string, string>) {
+  return { get: (name: string) => (values[name] ? { value: values[name] } : undefined) };
+}
+
+describe("request-prefs", () => {
+  beforeEach(() => mockCookies.mockReset());
+
+  describe("getUiLocale", () => {
+    it("returns the cookie value when valid", async () => {
+      mockCookies.mockResolvedValue(cookieJar({ oh_locale: "tr" }));
+      expect(await getUiLocale()).toBe("tr");
+    });
+
+    it("falls back to en when the cookie is missing", async () => {
+      mockCookies.mockResolvedValue(cookieJar({}));
+      expect(await getUiLocale()).toBe("en");
+    });
+
+    it("falls back to en when the cookie holds an unrecognized value", async () => {
+      mockCookies.mockResolvedValue(cookieJar({ oh_locale: "fr" }));
+      expect(await getUiLocale()).toBe("en");
+    });
+  });
+
+  describe("getQuranEdition", () => {
+    it("returns the cookie value when whitelisted", async () => {
+      mockCookies.mockResolvedValue(cookieJar({ oh_edition: "tr.diyanet" }));
+      expect(await getQuranEdition()).toBe("tr.diyanet");
+    });
+
+    it("falls back to the default edition for the resolved locale when the cookie is invalid", async () => {
+      mockCookies.mockResolvedValue(cookieJar({ oh_locale: "ru", oh_edition: "not-real" }));
+      expect(await getQuranEdition()).toBe("ru.kuliev");
+    });
+
+    it("falls back to en.sahih when neither cookie is set", async () => {
+      mockCookies.mockResolvedValue(cookieJar({}));
+      expect(await getQuranEdition()).toBe("en.sahih");
+    });
+  });
+});

--- a/__tests__/lib/quran/quran-corpus.test.ts
+++ b/__tests__/lib/quran/quran-corpus.test.ts
@@ -112,6 +112,38 @@ describe("quran-corpus", () => {
     });
   });
 
+  describe("getVerse with edition", () => {
+    it("uses the joined translation text when an edition row exists", async () => {
+      mockSelect.mockReturnValue(
+        makeDbChain([{ verse: row("2:255", 2, 255), translationText: "Türkçe metin" }])
+      );
+      const verse = await getVerse("2:255", "tr.diyanet");
+      expect(verse?.translation).toBe("Türkçe metin");
+    });
+
+    it("falls back to the base English translation when no edition row exists", async () => {
+      mockSelect.mockReturnValue(
+        makeDbChain([{ verse: row("2:255", 2, 255), translationText: null }])
+      );
+      const verse = await getVerse("2:255", "tr.diyanet");
+      expect(verse?.translation).toBe("text"); // row()'s default translation
+    });
+  });
+
+  describe("getVerses with edition", () => {
+    it("returns a map keyed by ref with per-row translation overrides", async () => {
+      mockSelect.mockReturnValue(
+        makeDbChain([
+          { verse: row("1:1", 1, 1), translationText: "Türkçe 1" },
+          { verse: row("2:255", 2, 255), translationText: null },
+        ])
+      );
+      const map = await getVerses(["1:1", "2:255"], "tr.diyanet");
+      expect(map.get("1:1")?.translation).toBe("Türkçe 1");
+      expect(map.get("2:255")?.translation).toBe("text");
+    });
+  });
+
   describe("existingRefs", () => {
     it("returns the set of refs present in the corpus", async () => {
       mockSelect.mockReturnValue(makeDbChain([{ ref: "1:1" }, { ref: "2:255" }]));

--- a/__tests__/lib/quran/verse-resolver.test.ts
+++ b/__tests__/lib/quran/verse-resolver.test.ts
@@ -96,4 +96,48 @@ describe("resolveVerse", () => {
     const result = await resolveVerse("2:255");
     expect(result).toBeNull();
   });
+
+  it("passes an unrecognized edition through as undefined (falls back to en.sahih)", async () => {
+    const v = verse("1:1");
+    mockGetVerse.mockResolvedValue(v);
+    await resolveVerse("1:1", "not-a-real-edition");
+    expect(mockGetVerse).toHaveBeenCalledWith("1:1", undefined);
+  });
+
+  it("passes a whitelisted non-default edition through to getVerse", async () => {
+    const v = verse("1:1");
+    mockGetVerse.mockResolvedValue(v);
+    await resolveVerse("1:1", "tr.diyanet");
+    expect(mockGetVerse).toHaveBeenCalledWith("1:1", "tr.diyanet");
+  });
+
+  it("live fallback fetches the requested edition's endpoint", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    vi.mocked(fetch).mockImplementation(async (url: string | URL | Request) => {
+      const isArabic = String(url).includes("ar.alafasy");
+      return {
+        ok: true,
+        json: async () => ({ data: { text: isArabic ? "نص عربي" : "Türkçe metin" } }),
+      } as Response;
+    });
+    const result = await resolveVerse("2:255", "tr.diyanet");
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/tr.diyanet"), expect.anything());
+    expect(result?.translation).toBe("Türkçe metin");
+  });
+
+  it("live fallback falls back to en.sahih when the requested edition 404s upstream", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    vi.mocked(fetch).mockImplementation(async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("ar.alafasy")) {
+        return { ok: true, json: async () => ({ data: { text: "نص عربي" } }) } as Response;
+      }
+      if (u.includes("tr.diyanet")) {
+        return { ok: false } as Response;
+      }
+      return { ok: true, json: async () => ({ data: { text: "English fallback" } }) } as Response;
+    });
+    const result = await resolveVerse("2:255", "tr.diyanet");
+    expect(result?.translation).toBe("English fallback");
+  });
 });

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { callAI } from "@/lib/ai/ai";
 import { getNameBySlug } from "@/lib/names/divine-names";
-import { getSurahName } from "@/lib/quran/surah-names";
 import { isValidRef } from "@/lib/quran/quran-corpus";
+import { resolveVerse } from "@/lib/quran/verse-resolver";
 import { getOrGenerateNameContent } from "@/lib/names/name-content";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
@@ -26,37 +26,15 @@ interface NameVerse {
 
 async function fetchVerseData(ref: string): Promise<Omit<NameVerse, "reason"> | null> {
   if (!isValidRef(ref)) return null;
-  const [surahStr, ayahStr] = ref.split(":");
-  const surahNum = parseInt(surahStr, 10);
-  const ayahNum = parseInt(ayahStr, 10);
-
-  try {
-    const [arabicRes, translationRes] = await Promise.all([
-      fetch(`https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/ar.alafasy`),
-      fetch(`https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/en.sahih`),
-    ]);
-    if (!arabicRes.ok || !translationRes.ok) return null;
-    const [arabicData, translationData] = await Promise.all([
-      arabicRes.json(),
-      translationRes.json(),
-    ]);
-    const [surahName, surahNameArabic] = getSurahName(surahNum);
-    return {
-      ref: ref as VerseRef,
-      surah: surahNum,
-      ayah: ayahNum,
-      arabicText: arabicData.data.text,
-      translation: translationData.data.text,
-      surahName,
-      surahNameArabic,
-    };
-  } catch (err) {
-    // An upstream outage must not look identical to "no verse data" —
-    // log and count it so it's visible on /api/metrics, not silent.
-    console.error(`Name verses: alquran.cloud fetch failed for ${ref}:`, err);
+  const verse = await resolveVerse(ref);
+  if (!verse) {
+    // resolveVerse already logs the underlying corpus/live-fetch failure —
+    // this just keeps the metric so an upstream outage stays visible on
+    // /api/metrics, not silent.
     incr("quran_api_fetch_error");
     return null;
   }
+  return verse;
 }
 
 // Search quran.com for verses containing this name's Arabic text

--- a/lib/admin/job-runner.ts
+++ b/lib/admin/job-runner.ts
@@ -5,7 +5,8 @@ import { jobRuns, verses, verseEmbeddings } from "@/lib/infra/db/schema";
 
 /**
  * Triggers and tracks the project's one-time/resumable backfill scripts
- * (scripts/seed-quran.mjs, scripts/seed-morphology.mjs, scripts/embed-corpus.mjs)
+ * (scripts/seed-quran.mjs, scripts/seed-morphology.mjs, scripts/embed-corpus.mjs,
+ * scripts/seed-translations.mjs)
  * from the admin panel instead of a container shell. Deliberately simple for a
  * single-box deployment: one job runs at a time, tracked by an in-memory child
  * process reference in this module (the source of truth for "is a job running
@@ -14,7 +15,7 @@ import { jobRuns, verses, verseEmbeddings } from "@/lib/infra/db/schema";
  */
 
 export interface JobDefinition {
-  id: "seed-quran" | "seed-morphology" | "embed-corpus";
+  id: "seed-quran" | "seed-morphology" | "embed-corpus" | "seed-translations";
   label: string;
   script: string;
   requiresEnv?: string[];
@@ -32,6 +33,11 @@ export const JOBS: readonly JobDefinition[] = [
     label: "Generate verse embeddings",
     script: "scripts/embed-corpus.mjs",
     requiresEnv: ["GEMINI_API_KEY"],
+  },
+  {
+    id: "seed-translations",
+    label: "Seed verse translations (TR/RU/AZ)",
+    script: "scripts/seed-translations.mjs",
   },
 ] as const;
 

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -1,0 +1,36 @@
+// Framework-free locale config, shared by server helpers (lib/i18n/request-prefs.ts)
+// and the client preferences store (store/preferences.ts). No next-intl or Next.js
+// imports here — this module must be safe to import from anywhere.
+
+export const LOCALES = ["en", "tr", "ru", "az"] as const;
+export type Locale = (typeof LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = "en";
+
+export const DEFAULT_EDITION_BY_LOCALE: Record<Locale, string> = {
+  en: "en.sahih",
+  tr: "tr.diyanet",
+  ru: "ru.kuliev",
+  az: "az.mammadaliyev",
+};
+
+// Alternate editions available per locale (default is always index 0 of the
+// combined list — DEFAULT_EDITION_BY_LOCALE — plus these). Kept as a flat
+// whitelist so any cookie/query value can be validated in one place.
+export const VALID_EDITIONS: readonly string[] = [
+  "en.sahih",
+  "tr.diyanet",
+  "ru.kuliev",
+  "az.mammadaliyev",
+];
+
+export const LOCALE_COOKIE = "oh_locale";
+export const EDITION_COOKIE = "oh_edition";
+
+export function isValidLocale(value: string): value is Locale {
+  return (LOCALES as readonly string[]).includes(value);
+}
+
+export function isValidEdition(value: string): boolean {
+  return VALID_EDITIONS.includes(value);
+}

--- a/lib/i18n/request-prefs.ts
+++ b/lib/i18n/request-prefs.ts
@@ -1,0 +1,31 @@
+import { cookies } from "next/headers";
+import {
+  DEFAULT_LOCALE,
+  DEFAULT_EDITION_BY_LOCALE,
+  LOCALE_COOKIE,
+  EDITION_COOKIE,
+  isValidLocale,
+  isValidEdition,
+  type Locale,
+} from "@/lib/i18n/config";
+
+/**
+ * Server-only cookie readers for the locale/translation-edition preference.
+ * Both values are whitelist-validated before use — a cookie is client-writable,
+ * so an invalid or tampered value must fail closed to the default rather than
+ * ever being interpolated into a URL or SQL query.
+ */
+
+export async function getUiLocale(): Promise<Locale> {
+  const store = await cookies();
+  const raw = store.get(LOCALE_COOKIE)?.value;
+  return raw && isValidLocale(raw) ? raw : DEFAULT_LOCALE;
+}
+
+export async function getQuranEdition(): Promise<string> {
+  const store = await cookies();
+  const raw = store.get(EDITION_COOKIE)?.value;
+  if (raw && isValidEdition(raw)) return raw;
+  const locale = await getUiLocale();
+  return DEFAULT_EDITION_BY_LOCALE[locale];
+}

--- a/lib/infra/db/migrations/0018_verse_translations.sql
+++ b/lib/infra/db/migrations/0018_verse_translations.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "verse_translations" (
+	"ref" text NOT NULL,
+	"edition" text NOT NULL,
+	"language" text NOT NULL,
+	"text" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "verse_translations_ref_edition_pk" PRIMARY KEY("ref","edition")
+);
+--> statement-breakpoint
+ALTER TABLE "verse_translations" ADD CONSTRAINT "verse_translations_ref_verses_ref_fk" FOREIGN KEY ("ref") REFERENCES "public"."verses"("ref") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "verse_translations_edition_idx" ON "verse_translations" USING btree ("edition");

--- a/lib/infra/db/migrations/meta/0018_snapshot.json
+++ b/lib/infra/db/migrations/meta/0018_snapshot.json
@@ -1,0 +1,2201 @@
+{
+  "id": "6b309de0-818d-4201-afe5-d185dbdb51b0",
+  "prevId": "aaba433a-8033-4106-ba95-a1c0b808de8e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_date": {
+          "name": "activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_date_idx": {
+          "name": "activity_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_type_date_idx": {
+          "name": "activity_user_type_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_user_id_users_id_fk": {
+          "name": "activity_log_user_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_qf_id": {
+          "name": "admin_qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_created_idx": {
+          "name": "admin_audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_generations": {
+      "name": "ai_generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_generations_created_idx": {
+          "name": "ai_generations_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_idx": {
+          "name": "bookmarks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookmarks_user_ref_uniq": {
+          "name": "bookmarks_user_ref_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "verse_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_suggestions": {
+      "name": "challenge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_duration": {
+          "name": "suggested_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_suggestions_active_idx": {
+          "name": "challenge_suggestions_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenger_id": {
+          "name": "challenger_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenged_id": {
+          "name": "challenged_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_challenger_status_idx": {
+          "name": "challenges_challenger_status_idx",
+          "columns": [
+            {
+              "expression": "challenger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_challenged_status_idx": {
+          "name": "challenges_challenged_status_idx",
+          "columns": [
+            {
+              "expression": "challenged_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_ends_at_idx": {
+          "name": "challenges_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_suggestion_id_idx": {
+          "name": "challenges_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_challenger_id_users_id_fk": {
+          "name": "challenges_challenger_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_challenged_id_users_id_fk": {
+          "name": "challenges_challenged_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenged_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_suggestion_id_challenge_suggestions_id_fk": {
+          "name": "challenges_suggestion_id_challenge_suggestions_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "challenge_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "challenges_winner_id_users_id_fk": {
+          "name": "challenges_winner_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_challenge": {
+          "name": "no_self_challenge",
+          "value": "\"challenges\".\"challenger_id\" != \"challenges\".\"challenged_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_ref": {
+          "name": "to_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_from_to_kind_idx": {
+          "name": "connections_from_to_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_from_kind_idx": {
+          "name": "connections_from_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_reviewed_at_idx": {
+          "name": "connections_reviewed_at_idx",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_votd": {
+      "name": "curated_votd",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "friendships_pair_idx": {
+          "name": "friendships_pair_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_addressee_status_idx": {
+          "name": "friendships_addressee_status_idx",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_requester_status_idx": {
+          "name": "friendships_requester_status_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_requester_id_users_id_fk": {
+          "name": "friendships_requester_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_addressee_id_users_id_fk": {
+          "name": "friendships_addressee_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_friendship": {
+          "name": "no_self_friendship",
+          "value": "\"friendships\".\"requester_id\" != \"friendships\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_runs": {
+      "name": "job_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_tail": {
+          "name": "log_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_runs_type_started_idx": {
+          "name": "job_runs_type_started_idx",
+          "columns": [
+            {
+              "expression": "job_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.name_content": {
+      "name": "name_content",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "name_content_slug_kind_pk": {
+          "name": "name_content_slug_kind_pk",
+          "columns": [
+            "slug",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_mentions": {
+      "name": "note_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioning_user_id": {
+          "name": "mentioning_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_id": {
+          "name": "mentioned_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_mentions_mentioned_user_read_idx": {
+          "name": "note_mentions_mentioned_user_read_idx",
+          "columns": [
+            {
+              "expression": "mentioned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_mentions_note_id_verse_notes_id_fk": {
+          "name": "note_mentions_note_id_verse_notes_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "verse_notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_mentions_mentioning_user_id_users_id_fk": {
+          "name": "note_mentions_mentioning_user_id_users_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentioning_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_mentions_mentioned_user_id_users_id_fk": {
+          "name": "note_mentions_mentioned_user_id_users_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentioned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_versions": {
+      "name": "prompt_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "prompt_versions_key_idx": {
+          "name": "prompt_versions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_key_active_idx": {
+          "name": "prompt_versions_key_active_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_one_active_per_key_uidx": {
+          "name": "prompt_versions_one_active_per_key_uidx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_versions\".\"active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_workspaces": {
+      "name": "saved_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_workspaces_user_idx": {
+          "name": "saved_workspaces_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_workspaces_user_id_users_id_fk": {
+          "name": "saved_workspaces_user_id_users_id_fk",
+          "tableFrom": "saved_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_log": {
+      "name": "search_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zero_result": {
+          "name": "zero_result",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "search_log_created_idx": {
+          "name": "search_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_log_zero_result_idx": {
+          "name": "search_log_zero_result_idx",
+          "columns": [
+            {
+              "expression": "zero_result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_canvases": {
+      "name": "shared_canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qf_id": {
+          "name": "qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_qf_id_idx": {
+          "name": "users_qf_id_idx",
+          "columns": [
+            {
+              "expression": "qf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_active_idx": {
+          "name": "users_last_active_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_qf_id_unique": {
+          "name": "users_qf_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qf_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_embeddings": {
+      "name": "verse_embeddings",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_embeddings_hnsw_idx": {
+          "name": "verse_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_notes": {
+      "name": "verse_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_notes_user_ref_idx": {
+          "name": "verse_notes_user_ref_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_notes_user_id_users_id_fk": {
+          "name": "verse_notes_user_id_users_id_fk",
+          "tableFrom": "verse_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_translations": {
+      "name": "verse_translations",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edition": {
+          "name": "edition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_translations_edition_idx": {
+          "name": "verse_translations_edition_idx",
+          "columns": [
+            {
+              "expression": "edition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_translations_ref_verses_ref_fk": {
+          "name": "verse_translations_ref_verses_ref_fk",
+          "tableFrom": "verse_translations",
+          "tableTo": "verses",
+          "columnsFrom": [
+            "ref"
+          ],
+          "columnsTo": [
+            "ref"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "verse_translations_ref_edition_pk": {
+          "name": "verse_translations_ref_edition_pk",
+          "columns": [
+            "ref",
+            "edition"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verses": {
+      "name": "verses",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "surah": {
+          "name": "surah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ayah": {
+          "name": "ayah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arabic_text": {
+          "name": "arabic_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transliteration": {
+          "name": "transliteration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verses_surah_ayah_idx": {
+          "name": "verses_surah_ayah_idx",
+          "columns": [
+            {
+              "expression": "surah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ayah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_morphology": {
+      "name": "word_morphology",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "word_morphology_ref_pos_idx": {
+          "name": "word_morphology_ref_pos_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_ref_idx": {
+          "name": "word_morphology_ref_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_root_idx": {
+          "name": "word_morphology_root_idx",
+          "columns": [
+            {
+              "expression": "root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/infra/db/migrations/meta/_journal.json
+++ b/lib/infra/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1784200713179,
       "tag": "0017_violet_gamma_corps",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1785337523680,
+      "tag": "0018_verse_translations",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/infra/db/schema.ts
+++ b/lib/infra/db/schema.ts
@@ -252,6 +252,26 @@ export const verses = pgTable(
   (t) => [uniqueIndex("verses_surah_ayah_idx").on(t.surah, t.ayah)]
 );
 
+// ─── Verse Translations (multi-language) ──────────────────────────────────────
+// One row per (verse, edition). verses.translation stays the en.sahih fallback;
+// getVerse/getVerses COALESCE to it when an edition-specific row is missing.
+export const verseTranslations = pgTable(
+  "verse_translations",
+  {
+    ref: text("ref")
+      .notNull()
+      .references(() => verses.ref, { onDelete: "cascade" }),
+    edition: text("edition").notNull(),
+    language: text("language").notNull(),
+    text: text("text").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.ref, t.edition] }),
+    index("verse_translations_edition_idx").on(t.edition),
+  ]
+);
+
 // ─── Connection Graph (the persistent knowledge graph) ────────────────────────
 // Each row is an AI-generated edge between two verses. Written once on a cache
 // miss (see lib/graph-service.ts) and shared by every subsequent reader, so AI
@@ -527,6 +547,8 @@ export type SavedWorkspace = typeof savedWorkspaces.$inferSelect;
 export type NewSavedWorkspace = typeof savedWorkspaces.$inferInsert;
 export type VerseRow = typeof verses.$inferSelect;
 export type NewVerseRow = typeof verses.$inferInsert;
+export type VerseTranslation = typeof verseTranslations.$inferSelect;
+export type NewVerseTranslation = typeof verseTranslations.$inferInsert;
 export type Connection = typeof connections.$inferSelect;
 export type NewConnection = typeof connections.$inferInsert;
 export type AiGeneration = typeof aiGenerations.$inferSelect;

--- a/lib/quran/quran-corpus.ts
+++ b/lib/quran/quran-corpus.ts
@@ -1,6 +1,6 @@
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
-import { verses, type VerseRow } from "@/lib/infra/db/schema";
+import { verses, verseTranslations, type VerseRow } from "@/lib/infra/db/schema";
 import { getSurahName } from "@/lib/quran/surah-names";
 import { SURAH_LENGTHS } from "@/lib/quran/audio";
 import type { Verse, VerseRef } from "@/types/quran";
@@ -9,16 +9,20 @@ import type { Verse, VerseRef } from "@/types/quran";
  * Local Quran corpus — reads verse data from the `verses` table instead of
  * fetching alquran.cloud / quran.com on every request. Seeded once by
  * `scripts/seed-quran.mjs`. Pure DB access: callers decide on any fallback.
+ *
+ * `edition` selects a row from `verse_translations`; `verses.translation`
+ * (the en.sahih column, present on every row) is the fallback whenever the
+ * requested edition has no row for that verse.
  */
 
-function rowToVerse(row: VerseRow): Verse {
+function rowToVerse(row: VerseRow, translationOverride?: string): Verse {
   const [surahName, surahNameArabic] = getSurahName(row.surah);
   return {
     surah: row.surah,
     ayah: row.ayah,
     ref: row.ref as VerseRef,
     arabicText: row.arabicText,
-    translation: row.translation,
+    translation: translationOverride ?? row.translation,
     surahName,
     surahNameArabic,
   };
@@ -37,17 +41,46 @@ export function isValidRef(ref: string): boolean {
   return surah >= 1 && surah <= 114 && ayah >= 1 && ayah <= SURAH_LENGTHS[surah - 1];
 }
 
-/** Returns the verse for a `"surah:ayah"` ref, or null if not in the corpus. */
-export async function getVerse(ref: string): Promise<Verse | null> {
-  const rows = await db.select().from(verses).where(eq(verses.ref, ref)).limit(1);
-  return rows[0] ? rowToVerse(rows[0]) : null;
+/**
+ * Returns the verse for a `"surah:ayah"` ref, or null if not in the corpus.
+ * `edition` (e.g. "tr.diyanet") selects a translation; omit for en.sahih.
+ */
+export async function getVerse(ref: string, edition?: string): Promise<Verse | null> {
+  if (!edition) {
+    const rows = await db.select().from(verses).where(eq(verses.ref, ref)).limit(1);
+    return rows[0] ? rowToVerse(rows[0]) : null;
+  }
+  const rows = await db
+    .select({ verse: verses, translationText: verseTranslations.text })
+    .from(verses)
+    .leftJoin(
+      verseTranslations,
+      and(eq(verseTranslations.ref, verses.ref), eq(verseTranslations.edition, edition))
+    )
+    .where(eq(verses.ref, ref))
+    .limit(1);
+  const row = rows[0];
+  return row ? rowToVerse(row.verse, row.translationText ?? undefined) : null;
 }
 
 /** Batch lookup. Returns a map keyed by ref; missing refs are simply absent. */
-export async function getVerses(refs: string[]): Promise<Map<string, Verse>> {
+export async function getVerses(refs: string[], edition?: string): Promise<Map<string, Verse>> {
   if (refs.length === 0) return new Map();
-  const rows = await db.select().from(verses).where(inArray(verses.ref, refs));
-  return new Map(rows.map((r) => [r.ref, rowToVerse(r)]));
+  if (!edition) {
+    const rows = await db.select().from(verses).where(inArray(verses.ref, refs));
+    return new Map(rows.map((r) => [r.ref, rowToVerse(r)]));
+  }
+  const rows = await db
+    .select({ verse: verses, translationText: verseTranslations.text })
+    .from(verses)
+    .leftJoin(
+      verseTranslations,
+      and(eq(verseTranslations.ref, verses.ref), eq(verseTranslations.edition, edition))
+    )
+    .where(inArray(verses.ref, refs));
+  return new Map(
+    rows.map((r) => [r.verse.ref, rowToVerse(r.verse, r.translationText ?? undefined)])
+  );
 }
 
 /** Subset of `refs` that exist in the corpus — used to reject hallucinated refs. */

--- a/lib/quran/verse-resolver.ts
+++ b/lib/quran/verse-resolver.ts
@@ -1,26 +1,32 @@
 import { getVerse } from "@/lib/quran/quran-corpus";
 import { getSurahName } from "@/lib/quran/surah-names";
+import { isValidEdition } from "@/lib/i18n/config";
 import type { Verse, VerseRef } from "@/types/quran";
+
+const DEFAULT_EDITION = "en.sahih";
 
 /**
  * Resolves a verse ref to full verse data: local corpus first, falling back to a
  * live alquran.cloud fetch while the corpus is being populated. Returns null for
  * references that resolve nowhere — which doubles as validation against
- * hallucinated references.
+ * hallucinated references. `edition` selects a translation (whitelisted against
+ * lib/i18n/config's VALID_EDITIONS — an unrecognized value falls back to en.sahih
+ * rather than being interpolated into the live-fetch URL).
  */
-export async function resolveVerse(ref: string): Promise<Verse | null> {
+export async function resolveVerse(ref: string, edition?: string): Promise<Verse | null> {
+  const safeEdition = edition && isValidEdition(edition) ? edition : DEFAULT_EDITION;
   try {
-    const local = await getVerse(ref);
+    const local = await getVerse(ref, safeEdition === DEFAULT_EDITION ? undefined : safeEdition);
     if (local) return local;
   } catch (err) {
     // `ref` is passed as a data argument, never interpolated into the first
     // (format) argument — avoids an externally-controlled format string.
     console.error("Corpus lookup failed for %s, falling back to live fetch:", ref, err);
   }
-  return fetchVerseLive(ref);
+  return fetchVerseLive(ref, safeEdition);
 }
 
-async function fetchVerseLive(ref: string): Promise<Verse | null> {
+async function fetchVerseLive(ref: string, edition: string): Promise<Verse | null> {
   const match = /^(\d+):(\d+)$/.exec(ref);
   if (!match) return null;
   const surahNum = parseInt(match[1], 10);
@@ -32,16 +38,30 @@ async function fetchVerseLive(ref: string): Promise<Verse | null> {
       fetch(`https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/ar.alafasy`, {
         next: { revalidate: 86400 },
       }),
-      fetch(`https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/en.sahih`, {
+      fetch(`https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/${edition}`, {
         next: { revalidate: 86400 },
       }),
     ]);
-    if (!arabicRes.ok || !translationRes.ok) return null;
+    if (!arabicRes.ok) return null;
 
-    const [arabicData, translationData] = await Promise.all([
-      arabicRes.json(),
-      translationRes.json(),
-    ]);
+    // The requested edition can 404 upstream even though the ayah exists (a
+    // gap in that translator's coverage) — fall back to en.sahih rather than
+    // failing the whole verse lookup.
+    let translationData: { data: { text: string } };
+    if (translationRes.ok) {
+      translationData = await translationRes.json();
+    } else if (edition !== DEFAULT_EDITION) {
+      const fallbackRes = await fetch(
+        `https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/${DEFAULT_EDITION}`,
+        { next: { revalidate: 86400 } }
+      );
+      if (!fallbackRes.ok) return null;
+      translationData = await fallbackRes.json();
+    } else {
+      return null;
+    }
+
+    const arabicData = await arabicRes.json();
     const [surahName, surahNameArabic] = getSurahName(surahNum);
 
     return {

--- a/scripts/ensure-tables.mjs
+++ b/scripts/ensure-tables.mjs
@@ -64,6 +64,18 @@ try {
   await sql`CREATE UNIQUE INDEX IF NOT EXISTS verses_surah_ayah_idx ON verses (surah, ayah)`;
 
   await sql`
+    CREATE TABLE IF NOT EXISTS verse_translations (
+      ref        text NOT NULL REFERENCES verses(ref) ON DELETE CASCADE,
+      edition    text NOT NULL,
+      language   text NOT NULL,
+      text       text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (ref, edition)
+    )
+  `;
+  await sql`CREATE INDEX IF NOT EXISTS verse_translations_edition_idx ON verse_translations (edition)`;
+
+  await sql`
     CREATE TABLE IF NOT EXISTS connections (
       id         serial PRIMARY KEY,
       from_ref   text NOT NULL,

--- a/scripts/seed-translations.mjs
+++ b/scripts/seed-translations.mjs
@@ -1,0 +1,98 @@
+/**
+ * Seeds the `verse_translations` table: backfills `en.sahih` from the existing
+ * `verses.translation` column, then pulls the default Turkish/Russian/
+ * Azerbaijani editions from alquran.cloud. Idempotent: safe to re-run.
+ *
+ * Unlike scripts/seed-quran.mjs, this asserts exactly 6236 ayahs per edition
+ * and aborts without writing anything for that edition if the count is off —
+ * multi-language epic requirement, since a partial edition would silently
+ * degrade to English mid-Quran for affected verses.
+ *
+ *   DATABASE_URL=... node scripts/seed-translations.mjs
+ */
+import postgres from "postgres";
+
+const EXPECTED_AYAH_COUNT = 6236;
+
+const EDITIONS = [
+  { edition: "tr.diyanet", language: "tr" },
+  { edition: "ru.kuliev", language: "ru" },
+  { edition: "az.mammadaliyev", language: "az" },
+];
+
+if (!process.env.DATABASE_URL) {
+  console.error("DATABASE_URL is not set");
+  process.exit(1);
+}
+
+async function fetchEdition(edition) {
+  const res = await fetch(`https://api.alquran.cloud/v1/quran/${edition}`);
+  if (!res.ok) throw new Error(`Failed to fetch edition ${edition}: ${res.status}`);
+  const json = await res.json();
+  if (!json?.data?.surahs) throw new Error(`Malformed response for edition ${edition}`);
+  return json.data.surahs;
+}
+
+function toRows(surahs, edition, language) {
+  const rows = [];
+  for (const surah of surahs) {
+    for (const ayah of surah.ayahs) {
+      rows.push({
+        ref: `${surah.number}:${ayah.numberInSurah}`,
+        edition,
+        language,
+        text: ayah.text,
+      });
+    }
+  }
+  return rows;
+}
+
+async function upsertRows(sql, rows) {
+  const BATCH = 500;
+  for (let i = 0; i < rows.length; i += BATCH) {
+    const batch = rows.slice(i, i + BATCH);
+    await sql`
+      INSERT INTO verse_translations ${sql(batch, "ref", "edition", "language", "text")}
+      ON CONFLICT (ref, edition) DO UPDATE SET text = EXCLUDED.text
+    `;
+  }
+}
+
+const sql = postgres(process.env.DATABASE_URL, { max: 1 });
+
+try {
+  console.log("Backfilling en.sahih from verses.translation…");
+  const verseRows = await sql`SELECT ref, translation FROM verses`;
+  if (verseRows.length !== EXPECTED_AYAH_COUNT) {
+    throw new Error(
+      `verses table holds ${verseRows.length} rows, expected ${EXPECTED_AYAH_COUNT} — run seed-quran.mjs first.`
+    );
+  }
+  const enRows = verseRows.map((r) => ({
+    ref: r.ref,
+    edition: "en.sahih",
+    language: "en",
+    text: r.translation,
+  }));
+  await upsertRows(sql, enRows);
+  console.log(`Backfilled ${enRows.length} en.sahih rows.`);
+
+  for (const { edition, language } of EDITIONS) {
+    console.log(`Fetching ${edition}…`);
+    const surahs = await fetchEdition(edition);
+    const rows = toRows(surahs, edition, language);
+    if (rows.length !== EXPECTED_AYAH_COUNT) {
+      throw new Error(
+        `${edition} returned ${rows.length} ayahs, expected ${EXPECTED_AYAH_COUNT} — aborting without writing this edition.`
+      );
+    }
+    await upsertRows(sql, rows);
+    console.log(`Upserted ${rows.length} rows for ${edition}.`);
+  }
+
+  const [{ count }] = await sql`SELECT count(*)::int AS count FROM verse_translations`;
+  console.log(`Done. verse_translations table now holds ${count} rows.`);
+} finally {
+  await sql.end();
+}


### PR DESCRIPTION
## Summary

Phase 1 of the multi-language epic (#331) — invisible infrastructure, no UI changes. Part of a parent/child PR stack: this PR targets `feat/331-multi-language`, not `main`; that parent branch will PR into `main` once all phases land.

- **`verse_translations` table** (`lib/infra/db/schema.ts`, migration `0018_verse_translations.sql`): composite PK `(ref, edition)`, FK cascade to `verses.ref`, index on `edition`. `verses.translation` (en.sahih) is untouched and stays the universal fallback.
- **`scripts/seed-translations.mjs`**: backfills `en.sahih` from `verses.translation`, then fetches `tr.diyanet`, `ru.kuliev`, `az.mammadaliyev` from alquran.cloud. Per the issue's binding requirement, each edition is asserted at exactly 6236 ayahs *before* being written — a row-count mismatch aborts that edition's write entirely rather than silently committing a partial translation that would degrade to English mid-Quran. Registered as an admin-triggerable job in `lib/admin/job-runner.ts`.
- **`lib/i18n/config.ts`**: framework-free `LOCALES`, `DEFAULT_EDITION_BY_LOCALE`, cookie name constants, and whitelist validators (`isValidLocale`, `isValidEdition`).
- **`lib/i18n/request-prefs.ts`**: server-side cookie readers (`getUiLocale`, `getQuranEdition`) via `next/headers`. Fails closed to English/en.sahih on any missing or unrecognized cookie value — never interpolates a raw cookie value anywhere.
- **`lib/quran/quran-corpus.ts`**: `getVerse`/`getVerses` gain an optional `edition` param — `LEFT JOIN verse_translations` + `COALESCE` to `verses.translation` when no edition row exists.
- **`lib/quran/verse-resolver.ts`**: `resolveVerse` gains an optional `edition` param. The live-fetch fallback tries the requested edition's alquran.cloud endpoint first, then falls back to `en.sahih` if that edition 404s upstream for a given ayah (a translator can have coverage gaps even within a published edition).
- **Drive-by fix**: `app/api/names/[slug]/verses/route.ts`'s `fetchVerseData` now calls `resolveVerse` instead of duplicating the inline `alquran.cloud` fetch — same behavior (defaults to en.sahih), less duplicated code.

## Test plan

- [x] `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test:ci` (pre-commit hook)
- [x] `bun run test:integration` (pre-push hook, Testcontainers) — new `verse-translations.integration.test.ts` covers edition-row-present, COALESCE-to-English-fallback, batch `getVerses`, `resolveVerse` resolving locally without a live fetch, and FK cascade-delete
- [x] New unit tests: `lib/i18n/config.ts` whitelist validators (including attacker-controlled input), `lib/i18n/request-prefs.ts` cookie fallback chain, `quran-corpus.ts`/`verse-resolver.ts` edition-param behavior (including the tr.diyanet → en.sahih upstream-404 fallback)
- [ ] Manual: no UI surface yet to exercise in-browser — this phase is DB/backend only, verified via the integration suite

Part of #331.