### PR TITLE
feat(i18n): Phase 3a — next-intl infra + nav/settings string extraction

### DIFF
--- a/__tests__/components/layout/HeaderNavLinks.test.tsx
+++ b/__tests__/components/layout/HeaderNavLinks.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { HeaderNavLinks } from "@/components/layout/HeaderNavLinks";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
 
 const { mockUsePathname } = vi.hoisted(() => ({ mockUsePathname: vi.fn() }));
 vi.mock("next/navigation", () => ({ usePathname: mockUsePathname }));
@@ -8,7 +9,7 @@ vi.mock("next/navigation", () => ({ usePathname: mockUsePathname }));
 describe("HeaderNavLinks", () => {
   it("renders all 5 desktop items including Bookmarks", () => {
     mockUsePathname.mockReturnValue("/search");
-    render(<HeaderNavLinks />);
+    renderWithIntl(<HeaderNavLinks />);
     expect(screen.getAllByRole("link")).toHaveLength(5);
     expect(screen.getByRole("link", { name: /Bookmarks/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Stories/i })).toBeInTheDocument();

--- a/__tests__/components/layout/MobileNavBar.test.tsx
+++ b/__tests__/components/layout/MobileNavBar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { MobileNavBar } from "@/components/layout/MobileNavBar";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
 
 const { mockUsePathname } = vi.hoisted(() => ({ mockUsePathname: vi.fn() }));
 vi.mock("next/navigation", () => ({ usePathname: mockUsePathname }));
@@ -14,14 +15,14 @@ describe("MobileNavBar", () => {
   it("renders the tab bar when the shared hook reports visible", () => {
     mockUsePathname.mockReturnValue("/search");
     mockMobileNavVisible.mockReturnValue(true);
-    render(<MobileNavBar />);
+    renderWithIntl(<MobileNavBar />);
     expect(screen.getByRole("link", { name: /Search/i })).toBeInTheDocument();
   });
 
   it("renders exactly 4 tabs and omits Bookmarks", () => {
     mockUsePathname.mockReturnValue("/search");
     mockMobileNavVisible.mockReturnValue(true);
-    render(<MobileNavBar />);
+    renderWithIntl(<MobileNavBar />);
     expect(screen.getAllByRole("link")).toHaveLength(4);
     expect(screen.queryByRole("link", { name: /Bookmarks/i })).not.toBeInTheDocument();
   });
@@ -29,7 +30,7 @@ describe("MobileNavBar", () => {
   it("renders nothing when the shared hook reports hidden", () => {
     mockUsePathname.mockReturnValue("/canvas");
     mockMobileNavVisible.mockReturnValue(false);
-    const { container } = render(<MobileNavBar />);
+    const { container } = renderWithIntl(<MobileNavBar />);
     expect(container).toBeEmptyDOMElement();
   });
 });

--- a/__tests__/components/providers.test.tsx
+++ b/__tests__/components/providers.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { usePreferencesStore } from "@/store/preferences";
+import { LocaleRehydrationSync } from "@/components/providers";
+
+const { mockRefresh } = vi.hoisted(() => ({ mockRefresh: vi.fn() }));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: mockRefresh }) }));
+
+describe("LocaleRehydrationSync", () => {
+  beforeEach(() => {
+    mockRefresh.mockClear();
+    usePreferencesStore.setState({ uiLocale: "en" });
+  });
+
+  it("does not refresh when the store's locale already matches the SSR locale", async () => {
+    render(<LocaleRehydrationSync ssrLocale="en" />);
+    await waitFor(() => expect(mockRefresh).not.toHaveBeenCalled());
+  });
+
+  it("refreshes once when the persisted store locale diverges from the SSR-rendered locale", async () => {
+    // Simulates the store rehydrating client-side to a locale different from
+    // the one the server resolved from a stale/missing cookie.
+    usePreferencesStore.setState({ uiLocale: "tr" });
+
+    render(<LocaleRehydrationSync ssrLocale="en" />);
+
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalledTimes(1));
+    // A later, unrelated re-render with the same mismatch must not refresh again.
+    usePreferencesStore.setState({ uiLocale: "tr" });
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalledTimes(1));
+  });
+});

--- a/__tests__/lib/i18n/messages.test.ts
+++ b/__tests__/lib/i18n/messages.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import IntlMessageFormat from "intl-messageformat";
+import { LOCALES } from "@/lib/i18n/config";
+import en from "@/messages/en.json";
+import tr from "@/messages/tr.json";
+import ru from "@/messages/ru.json";
+import az from "@/messages/az.json";
+
+const MESSAGES: Record<string, Record<string, Record<string, string>>> = { en, tr, ru, az };
+
+function flatten(messages: Record<string, Record<string, string>>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [namespace, keys] of Object.entries(messages)) {
+    for (const [key, value] of Object.entries(keys)) {
+      out[`${namespace}.${key}`] = value;
+    }
+  }
+  return out;
+}
+
+describe("i18n messages", () => {
+  it("every non-en locale has no keys beyond en (no orphans)", () => {
+    const enKeys = new Set(Object.keys(flatten(en)));
+    for (const locale of LOCALES) {
+      if (locale === "en") continue;
+      const localeKeys = Object.keys(flatten(MESSAGES[locale]));
+      const orphans = localeKeys.filter((k) => !enKeys.has(k));
+      expect(orphans, `${locale} has orphan keys not present in en`).toEqual([]);
+    }
+  });
+
+  it("en has every key present in each non-en locale (locales don't add keys silently missing from en)", () => {
+    for (const locale of LOCALES) {
+      if (locale === "en") continue;
+      const enKeys = new Set(Object.keys(flatten(en)));
+      const localeKeys = Object.keys(flatten(MESSAGES[locale]));
+      for (const key of localeKeys) {
+        expect(enKeys.has(key), `en is missing key ${key} used by ${locale}`).toBe(true);
+      }
+    }
+  });
+
+  it("every message parses as valid ICU syntax in every locale", () => {
+    for (const locale of LOCALES) {
+      const flat = flatten(MESSAGES[locale]);
+      for (const [key, value] of Object.entries(flat)) {
+        expect(() => new IntlMessageFormat(value, locale), `${locale}.${key}`).not.toThrow();
+      }
+    }
+  });
+});

--- a/__tests__/test-utils/render-with-intl.tsx
+++ b/__tests__/test-utils/render-with-intl.tsx
@@ -1,0 +1,12 @@
+import type { ReactElement } from "react";
+import { render, type RenderResult } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import en from "@/messages/en.json";
+
+export function renderWithIntl(ui: ReactElement): RenderResult {
+  return render(
+    <NextIntlClientProvider locale="en" messages={en}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,10 @@ import "@/lib/env";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Amiri } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import { getMessages } from "next-intl/server";
 import "./globals.css";
 import { Providers } from "@/components/providers";
+import { getUiLocale } from "@/lib/i18n/request-prefs";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -43,18 +45,22 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const locale = await getUiLocale();
+  const messages = await getMessages();
   return (
     <html
-      lang="en"
+      lang={locale}
       className={`${geistSans.variable} ${geistMono.variable} ${amiri.variable} h-full`}
     >
       <body className="min-h-full flex flex-col antialiased">
-        <Providers>{children}</Providers>
+        <Providers locale={locale} messages={messages}>
+          {children}
+        </Providers>
       </body>
       <GoogleAnalytics gaId="G-7R460Z8BZX" />
     </html>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Settings as SettingsIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
 import { LandingHeader } from "@/components/layout/LandingHeader";
 import { Card, Select, Switch, type SelectOption } from "@/components/ui";
 import { RECITERS } from "@/lib/quran/audio";
@@ -47,6 +49,8 @@ function SettingsSection({
 }
 
 export default function SettingsPage() {
+  const t = useTranslations("settings");
+  const router = useRouter();
   const uiLocale = usePreferencesStore((s) => s.uiLocale);
   const setUiLocale = usePreferencesStore((s) => s.setUiLocale);
   const quranEditionByLocale = usePreferencesStore((s) => s.quranEditionByLocale);
@@ -66,47 +70,53 @@ export default function SettingsPage() {
       <div className="mx-auto w-full max-w-2xl flex-1 space-y-4">
         <div className="mb-4 flex items-center gap-3">
           <SettingsIcon className="h-5 w-5 text-gold" />
-          <h1 className="text-lg font-semibold text-text-primary">Settings</h1>
+          <h1 className="text-lg font-semibold text-text-primary">{t("title")}</h1>
         </div>
 
-        <SettingsSection title="Language" description="Sets the app interface language.">
+        <SettingsSection title={t("language")} description={t("languageDescription")}>
           <Select
-            aria-label="Interface language"
+            aria-label={t("interfaceLanguage")}
             value={uiLocale}
-            onValueChange={(v) => setUiLocale(v as UiLocale)}
+            onValueChange={(v) => {
+              setUiLocale(v as UiLocale);
+              router.refresh();
+            }}
             options={LOCALE_OPTIONS}
           />
         </SettingsSection>
 
         <SettingsSection
-          title="Quran translation"
-          description={`Currently ${activeAttribution} (${activeEdition}).`}
+          title={t("quranTranslation")}
+          description={t("quranTranslationDescription", {
+            attribution: activeAttribution,
+            edition: activeEdition,
+          })}
         >
           <Select
-            aria-label="Quran translation edition"
+            aria-label={t("quranTranslationEdition")}
             value={activeEdition}
             onValueChange={(v) => setQuranEdition(uiLocale, v)}
             options={[{ value: activeEditionDefault, label: activeAttribution }]}
           />
         </SettingsSection>
 
-        <SettingsSection title="Recitation" description="Reciter used for verse audio playback.">
+        <SettingsSection title={t("recitation")} description={t("recitationDescription")}>
           <Select
-            aria-label="Reciter"
+            aria-label={t("reciter")}
             value={reciter}
             onValueChange={setReciter}
             options={RECITER_OPTIONS}
           />
         </SettingsSection>
 
-        <SettingsSection title="Canvas">
+        <SettingsSection title={t("canvas")}>
           <div className="flex items-center justify-between">
             <label htmlFor="canvas-minimap" className="text-sm text-text-secondary">
-              Show minimap
+              {t("showMinimap")}
             </label>
             <Switch
               id="canvas-minimap"
-              aria-label="Show canvas minimap"
+              aria-label={t("showCanvasMinimap")}
               checked={canvasPrefs.showMinimap}
               onCheckedChange={(checked) => setCanvasPrefs({ showMinimap: checked })}
             />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -6,15 +6,17 @@ import { useRouter } from "next/navigation";
 import { LandingHeader } from "@/components/layout/LandingHeader";
 import { Card, Select, Switch, type SelectOption } from "@/components/ui";
 import { RECITERS } from "@/lib/quran/audio";
-import { DEFAULT_EDITION_BY_LOCALE as EDITION_BY_LOCALE } from "@/lib/i18n/config";
+import {
+  DEFAULT_EDITION_BY_LOCALE as EDITION_BY_LOCALE,
+  LOCALES as LOCALE_CODES,
+  LOCALE_LABELS,
+} from "@/lib/i18n/config";
 import { usePreferencesStore, type UiLocale } from "@/store/preferences";
 
-const LOCALE_OPTIONS: SelectOption[] = [
-  { value: "en", label: "English" },
-  { value: "tr", label: "Türkçe" },
-  { value: "ru", label: "Русский" },
-  { value: "az", label: "Azərbaycan dili" },
-];
+const LOCALE_OPTIONS: SelectOption[] = LOCALE_CODES.map((value) => ({
+  value,
+  label: LOCALE_LABELS[value],
+}));
 
 // Translator attribution per locale, shown alongside the edition code from
 // lib/i18n/config's DEFAULT_EDITION_BY_LOCALE (the whitelisted source of
@@ -75,6 +77,7 @@ export default function SettingsPage() {
 
         <SettingsSection title={t("language")} description={t("languageDescription")}>
           <Select
+            id="interface-language"
             aria-label={t("interfaceLanguage")}
             value={uiLocale}
             onValueChange={(v) => {

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "jspdf": "^4.2.1",
         "lucide-react": "^1.25.0",
         "next": "16.2.10",
+        "next-intl": "^4.13.4",
         "postgres": "^3.4.9",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -225,6 +226,14 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
+    "@formatjs/fast-memoize": ["@formatjs/fast-memoize@3.1.7", "", {}, "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA=="],
+
+    "@formatjs/icu-messageformat-parser": ["@formatjs/icu-messageformat-parser@3.5.15", "", { "dependencies": { "@formatjs/icu-skeleton-parser": "2.1.11" } }, "sha512-5o4grXKotAB3JqQuisLApHG43g17N+paoRTa92Jiz35Zvfemq0cVf4EDvuxyHAzmsJji7igaEowicLO/VmfJ8Q=="],
+
+    "@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@2.1.11", "", {}, "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA=="],
+
+    "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.8.13", "", { "dependencies": { "@formatjs/fast-memoize": "3.1.7" } }, "sha512-kHEAFOkeJSPNi7c5PaKaRjxcBrJwzzt81ifUu+8uve1EDW/VJl83KsxmqgqNZLzcFEhSliZGvx3+pk/RH0IOmg=="],
+
     "@google/generative-ai": ["@google/generative-ai@0.24.1", "", {}, "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
@@ -346,6 +355,32 @@
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+
+    "@parcel/watcher": ["@parcel/watcher@2.6.0", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.4" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.6.0", "@parcel/watcher-darwin-arm64": "2.6.0", "@parcel/watcher-darwin-x64": "2.6.0", "@parcel/watcher-freebsd-x64": "2.6.0", "@parcel/watcher-linux-arm-glibc": "2.6.0", "@parcel/watcher-linux-arm-musl": "2.6.0", "@parcel/watcher-linux-arm64-glibc": "2.6.0", "@parcel/watcher-linux-arm64-musl": "2.6.0", "@parcel/watcher-linux-x64-glibc": "2.6.0", "@parcel/watcher-linux-x64-musl": "2.6.0", "@parcel/watcher-win32-arm64": "2.6.0", "@parcel/watcher-win32-x64": "2.6.0" } }, "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w=="],
+
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.6.0", "", { "os": "android", "cpu": "arm64" }, "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA=="],
+
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.6.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw=="],
+
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.6.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw=="],
+
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.6.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ=="],
+
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.6.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg=="],
+
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.6.0", "", { "os": "linux", "cpu": "arm" }, "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw=="],
+
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.6.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g=="],
+
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.6.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA=="],
+
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.6.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A=="],
+
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.6.0", "", { "os": "linux", "cpu": "x64" }, "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw=="],
+
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.6.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ=="],
+
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.6.0", "", { "os": "win32", "cpu": "x64" }, "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -469,13 +504,45 @@
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
+    "@schummar/icu-type-parser": ["@schummar/icu-type-parser@1.21.5", "", {}, "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw=="],
+
     "@size-limit/file": ["@size-limit/file@13.0.1", "", { "peerDependencies": { "size-limit": "13.0.1" } }, "sha512-qdbGUxRAjym5gnkYEjsNsdOfmkDUvDX06FLhLGUxQ0oJtIWDd2lsOmTMwh5JuAV1XmJCplbqpMJ2b5eIhHl7Lg=="],
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@swc/core": ["@swc/core@1.15.47", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.27" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.47", "@swc/core-darwin-x64": "1.15.47", "@swc/core-linux-arm-gnueabihf": "1.15.47", "@swc/core-linux-arm64-gnu": "1.15.47", "@swc/core-linux-arm64-musl": "1.15.47", "@swc/core-linux-ppc64-gnu": "1.15.47", "@swc/core-linux-s390x-gnu": "1.15.47", "@swc/core-linux-x64-gnu": "1.15.47", "@swc/core-linux-x64-musl": "1.15.47", "@swc/core-win32-arm64-msvc": "1.15.47", "@swc/core-win32-ia32-msvc": "1.15.47", "@swc/core-win32-x64-msvc": "1.15.47" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg=="],
+
+    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.47", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA=="],
+
+    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.47", "", { "os": "darwin", "cpu": "x64" }, "sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg=="],
+
+    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.47", "", { "os": "linux", "cpu": "arm" }, "sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g=="],
+
+    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.47", "", { "os": "linux", "cpu": "arm64" }, "sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA=="],
+
+    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.47", "", { "os": "linux", "cpu": "arm64" }, "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w=="],
+
+    "@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.47", "", { "os": "linux", "cpu": "ppc64" }, "sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ=="],
+
+    "@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.47", "", { "os": "linux", "cpu": "s390x" }, "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ=="],
+
+    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.47", "", { "os": "linux", "cpu": "x64" }, "sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ=="],
+
+    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.47", "", { "os": "linux", "cpu": "x64" }, "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ=="],
+
+    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.47", "", { "os": "win32", "cpu": "arm64" }, "sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A=="],
+
+    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.47", "", { "os": "win32", "cpu": "ia32" }, "sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA=="],
+
+    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.47", "", { "os": "win32", "cpu": "x64" }, "sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw=="],
+
+    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
+    "@swc/types": ["@swc/types@0.1.27", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
@@ -1139,6 +1206,8 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "icu-minify": ["icu-minify@4.13.4", "", { "dependencies": { "@formatjs/icu-messageformat-parser": "^3.4.0" } }, "sha512-yK6HyPLGlQjqm8fTKtnBpM77z7vl7JdDBN2EXLvmgAu/b7XaOHWZb73M3ISl9ahBTehBv7RYeqqWSHfk1v2YcA=="],
+
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -1152,6 +1221,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "intl-messageformat": ["intl-messageformat@11.2.12", "", { "dependencies": { "@formatjs/fast-memoize": "3.1.7", "@formatjs/icu-messageformat-parser": "3.5.15" } }, "sha512-KW70Xxfcvy7vV3qODfvShWkFDPMqKDAa4N+hSyVBWGNtVhTUFYaqlD/l88DaYPKiVcPP4rPQ3qnH7i5K82Mg7g=="],
 
     "iobuffer": ["iobuffer@5.4.0", "", {}, "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="],
 
@@ -1383,6 +1454,12 @@
 
     "next": ["next@16.2.10", "", { "dependencies": { "@next/env": "16.2.10", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.10", "@next/swc-darwin-x64": "16.2.10", "@next/swc-linux-arm64-gnu": "16.2.10", "@next/swc-linux-arm64-musl": "16.2.10", "@next/swc-linux-x64-gnu": "16.2.10", "@next/swc-linux-x64-musl": "16.2.10", "@next/swc-win32-arm64-msvc": "16.2.10", "@next/swc-win32-x64-msvc": "16.2.10", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA=="],
 
+    "next-intl": ["next-intl@4.13.4", "", { "dependencies": { "@formatjs/intl-localematcher": "^0.8.1", "@parcel/watcher": "^2.4.1", "@swc/core": "^1.15.2", "icu-minify": "^4.13.4", "negotiator": "^1.0.0", "next-intl-swc-plugin-extractor": "^4.13.4", "po-parser": "^2.1.1", "use-intl": "^4.13.4" }, "peerDependencies": { "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0", "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-jhPAT0u0lahIK6E4gVdZAehugWCosBhLG8sV7xMzgSVoJpxHObP+Fiu+z2FfkEW0XPPtr7uEXoUlLEfhxhNMTg=="],
+
+    "next-intl-swc-plugin-extractor": ["next-intl-swc-plugin-extractor@4.13.4", "", {}, "sha512-uN1+NMUYbG6YkO3q+rjc2bvAPX9nQ23owemvHJAyW0pRbQjVDwvNhmrV5qaak0oQc/9okbK17KLT49AoMGhVEQ=="],
+
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
     "node-releases": ["node-releases@2.0.47", "", {}, "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og=="],
@@ -1456,6 +1533,8 @@
     "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+
+    "po-parser": ["po-parser@2.1.1", "", {}, "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1760,6 +1839,8 @@
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-intl": ["use-intl@4.13.4", "", { "dependencies": { "@formatjs/fast-memoize": "^3.1.0", "@schummar/icu-type-parser": "1.21.5", "icu-minify": "^4.13.4", "intl-messageformat": "^11.1.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0" } }, "sha512-wRhU5zyPNgu845++EJ8ckQsi89b22QUop7NlGxNXpsnKSwEJr7WErAkdAYeVQgFTmDWsa8e2NI1e14XbWz9Ecw=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 

--- a/components/layout/AccountMenu.tsx
+++ b/components/layout/AccountMenu.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import {
   Flame,
   Award,
@@ -33,6 +34,8 @@ export function AccountMenu() {
   const [open, setOpen] = useState(false);
   const [signingIn, setSigningIn] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const t = useTranslations("common");
+  const tNav = useTranslations("nav");
 
   useEffect(() => {
     if (!open) return;
@@ -96,12 +99,16 @@ export function AccountMenu() {
             regardless of sign-in, so logged-out mobile users must not lose it. */}
         <Link
           href="/bookmarks"
-          aria-label="Bookmarks"
+          aria-label={tNav("bookmarks")}
           className={cn(linkRow, "h-9 px-2 md:hidden")}
         >
           <Bookmark />
         </Link>
-        <Link href="/settings" aria-label="Settings" className={cn(linkRow, "h-9 px-2 md:hidden")}>
+        <Link
+          href="/settings"
+          aria-label={t("settings")}
+          className={cn(linkRow, "h-9 px-2 md:hidden")}
+        >
           <Settings />
         </Link>
         <button
@@ -114,7 +121,7 @@ export function AccountMenu() {
           ) : (
             <LogIn className="size-3.5" />
           )}
-          {signingIn ? "Signing in…" : "Sign in"}
+          {signingIn ? t("signingIn") : t("signIn")}
         </button>
       </div>
     );
@@ -128,7 +135,7 @@ export function AccountMenu() {
         onClick={() => setOpen((o) => !o)}
         aria-haspopup="menu"
         aria-expanded={open}
-        aria-label="Account menu"
+        aria-label={tNav("accountMenu")}
         className={cn(
           "flex items-center gap-2 rounded-full border bg-surface-raised py-[3px] pl-[3px] pr-2 transition-colors sm:pr-3",
           open ? "border-gold-muted" : "border-border hover:border-gold-muted/70"
@@ -173,10 +180,10 @@ export function AccountMenu() {
             </span>
             <div className="min-w-0">
               <p className="truncate text-[15px] font-semibold text-text-primary">
-                {username ?? "Signed in"}
+                {username ?? tNav("signedIn")}
               </p>
               <p className="text-xs text-text-secondary">
-                {streak > 0 ? `On a ${streak}-day streak` : "Signed in"}
+                {streak > 0 ? tNav("dayStreak", { count: streak }) : tNav("signedIn")}
               </p>
             </div>
           </div>
@@ -188,7 +195,7 @@ export function AccountMenu() {
                 <span className="text-[18px] font-bold leading-none text-gold">{streak}</span>
               </div>
               <p className="mt-1 text-[10.5px] uppercase tracking-[0.04em] text-text-muted">
-                Day streak
+                {tNav("dayStreakLabel")}
               </p>
             </div>
             <div className="flex-1 rounded-[10px] border border-border bg-surface px-2.5 py-2">
@@ -199,7 +206,7 @@ export function AccountMenu() {
                 </span>
               </div>
               <p className="mt-1 text-[10.5px] uppercase tracking-[0.04em] text-text-muted">
-                Longest
+                {tNav("longest")}
               </p>
             </div>
           </div>
@@ -208,10 +215,10 @@ export function AccountMenu() {
 
           <div className="p-1.5">
             <Link href="/workspaces" onClick={() => setOpen(false)} className={linkRow}>
-              <FolderOpen /> Saved canvases
+              <FolderOpen /> {tNav("savedCanvases")}
             </Link>
             <Link href="/social" onClick={() => setOpen(false)} className={linkRow}>
-              <Trophy /> Friends &amp; Leaderboard
+              <Trophy /> {tNav("friendsLeaderboard")}
               {pendingFriendCount > 0 && (
                 <span className="ml-auto grid h-[18px] min-w-[18px] place-items-center rounded-full bg-gold px-1 text-[10px] font-bold text-bg">
                   {pendingFriendCount > 9 ? "9+" : pendingFriendCount}
@@ -219,7 +226,7 @@ export function AccountMenu() {
               )}
             </Link>
             <Link href="/mentions" onClick={() => setOpen(false)} className={linkRow}>
-              <AtSign /> Mentions
+              <AtSign /> {tNav("mentions")}
               {pendingMentionCount > 0 && (
                 <span className="ml-auto grid h-[18px] min-w-[18px] place-items-center rounded-full bg-gold px-1 text-[10px] font-bold text-bg">
                   {pendingMentionCount > 9 ? "9+" : pendingMentionCount}
@@ -232,10 +239,10 @@ export function AccountMenu() {
               onClick={() => setOpen(false)}
               className={cn(linkRow, "md:hidden")}
             >
-              <Bookmark /> Bookmarks
+              <Bookmark /> {tNav("bookmarks")}
             </Link>
             <Link href="/settings" onClick={() => setOpen(false)} className={linkRow}>
-              <Settings /> Settings
+              <Settings /> {t("settings")}
             </Link>
           </div>
 
@@ -247,7 +254,7 @@ export function AccountMenu() {
               role="menuitem"
               className="flex h-11 w-full items-center gap-3 rounded-lg px-3 text-[13.5px] text-text-primary transition-colors hover:bg-error/10 hover:text-error [&_svg]:size-[17px] [&_svg]:text-text-secondary [&:hover_svg]:text-error"
             >
-              <LogOut /> Sign out
+              <LogOut /> {t("signOut")}
             </button>
           </div>
         </div>

--- a/components/layout/HeaderNavLinks.tsx
+++ b/components/layout/HeaderNavLinks.tsx
@@ -2,15 +2,17 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { NAV_ITEMS, isNavItemActive } from "./nav-items";
 
 export function HeaderNavLinks() {
   const pathname = usePathname();
+  const t = useTranslations("nav");
 
   return (
     <nav className="hidden md:flex h-full items-center gap-0.5">
-      {NAV_ITEMS.map(({ href, label }) => (
+      {NAV_ITEMS.map(({ href, labelKey }) => (
         <Link
           key={href}
           href={href}
@@ -21,7 +23,7 @@ export function HeaderNavLinks() {
               : "text-text-muted hover:text-text-secondary hover:bg-white/5"
           )}
         >
-          {label}
+          {t(labelKey)}
         </Link>
       ))}
     </nav>

--- a/components/layout/LanguagePopover.tsx
+++ b/components/layout/LanguagePopover.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import * as Popover from "@radix-ui/react-popover";
 import { Globe } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore, type UiLocale } from "@/store/preferences";
 
@@ -18,12 +20,14 @@ const LOCALES: Array<{ value: UiLocale; label: string }> = [
 export function LanguagePopover() {
   const uiLocale = usePreferencesStore((s) => s.uiLocale);
   const setUiLocale = usePreferencesStore((s) => s.setUiLocale);
+  const t = useTranslations("common");
+  const router = useRouter();
 
   return (
     <Popover.Root>
       <Popover.Trigger asChild>
         <button
-          aria-label="Change language"
+          aria-label={t("changeLanguage")}
           className="grid size-9 shrink-0 place-items-center rounded-full border border-border text-text-secondary transition-colors hover:border-gold-muted/70 hover:text-text-primary"
         >
           <Globe className="size-[17px]" />
@@ -38,7 +42,13 @@ export function LanguagePopover() {
           {LOCALES.map((locale) => (
             <button
               key={locale.value}
-              onClick={() => setUiLocale(locale.value)}
+              onClick={() => {
+                setUiLocale(locale.value);
+                // The cookie write above is synchronous; refresh so the
+                // server-rendered layout (locale, next-intl messages) picks
+                // it up without requiring a full navigation.
+                router.refresh();
+              }}
               className={cn(
                 "flex h-9 w-full items-center rounded-lg px-3 text-[13.5px] transition-colors hover:bg-white/5",
                 uiLocale === locale.value ? "font-medium text-text-primary" : "text-text-secondary"
@@ -53,7 +63,7 @@ export function LanguagePopover() {
               href="/settings"
               className="flex h-9 w-full items-center rounded-lg px-3 text-[13.5px] text-teal transition-colors hover:bg-white/5"
             >
-              All settings →
+              {t("allSettings")}
             </Link>
           </Popover.Close>
         </Popover.Content>

--- a/components/layout/LanguagePopover.tsx
+++ b/components/layout/LanguagePopover.tsx
@@ -7,13 +7,12 @@ import { Globe } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore, type UiLocale } from "@/store/preferences";
+import { LOCALES as LOCALE_CODES, LOCALE_LABELS } from "@/lib/i18n/config";
 
-const LOCALES: Array<{ value: UiLocale; label: string }> = [
-  { value: "en", label: "English" },
-  { value: "tr", label: "Türkçe" },
-  { value: "ru", label: "Русский" },
-  { value: "az", label: "Azərbaycan dili" },
-];
+const LOCALES: Array<{ value: UiLocale; label: string }> = LOCALE_CODES.map((value) => ({
+  value,
+  label: LOCALE_LABELS[value],
+}));
 
 /** Globe-icon quick-switcher next to the account menu — zero-navigation
  *  language switching from any page, including mid-canvas. */

--- a/components/layout/MobileNavBar.tsx
+++ b/components/layout/MobileNavBar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { useMobileNavVisible } from "@/hooks/useMobileNavVisible";
 import { NAV_ITEMS, isNavItemActive } from "./nav-items";
@@ -15,13 +16,14 @@ const MOBILE_ITEMS = NAV_ITEMS.filter((item) => item.mobile !== false);
 export function MobileNavBar() {
   const pathname = usePathname();
   const visible = useMobileNavVisible();
+  const t = useTranslations("nav");
 
   // See useMobileNavVisible for the hide condition (populated /canvas only).
   if (!visible) return null;
 
   return (
     <nav className="fixed inset-x-0 bottom-0 z-30 flex md:hidden border-t border-border bg-surface/95 backdrop-blur pb-[env(safe-area-inset-bottom)]">
-      {MOBILE_ITEMS.map(({ href, label, icon: Icon }) => (
+      {MOBILE_ITEMS.map(({ href, labelKey, icon: Icon }) => (
         <Link
           key={href}
           href={href}
@@ -31,7 +33,7 @@ export function MobileNavBar() {
           )}
         >
           <Icon />
-          <span>{label}</span>
+          <span>{t(labelKey)}</span>
         </Link>
       ))}
     </nav>

--- a/components/layout/nav-items.ts
+++ b/components/layout/nav-items.ts
@@ -9,7 +9,8 @@ import {
 
 export interface NavItem {
   href: string;
-  label: string;
+  /** Key into the "nav" messages namespace — resolve with useTranslations("nav"). */
+  labelKey: "canvas" | "search" | "stories" | "names" | "bookmarks";
   icon: LucideIcon;
   /** Shown in the mobile bottom tab bar. Defaults to true. */
   mobile?: boolean;
@@ -20,11 +21,11 @@ export interface NavItem {
 // mobile !== false). Bookmarks is desktop-only — on mobile it lives in the
 // account menu to keep the bottom bar to 4 tabs.
 export const NAV_ITEMS: readonly NavItem[] = [
-  { href: "/canvas", label: "Canvas", icon: LayoutTemplate },
-  { href: "/search", label: "Search", icon: Search },
-  { href: "/stories", label: "Stories", icon: ScrollText },
-  { href: "/names", label: "Asma'ul Husna", icon: Sparkles },
-  { href: "/bookmarks", label: "Bookmarks", icon: Bookmark, mobile: false },
+  { href: "/canvas", labelKey: "canvas", icon: LayoutTemplate },
+  { href: "/search", labelKey: "search", icon: Search },
+  { href: "/stories", labelKey: "stories", icon: ScrollText },
+  { href: "/names", labelKey: "names", icon: Sparkles },
+  { href: "/bookmarks", labelKey: "bookmarks", icon: Bookmark, mobile: false },
 ] as const;
 
 export function isNavItemActive(pathname: string, href: string): boolean {

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { NextIntlClientProvider, type AbstractIntlMessages } from "next-intl";
 import { MiniPlayer } from "@/components/audio/MiniPlayer";
 import { TooltipProvider } from "@/components/ui";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
 import { mergeGuestWorkspace } from "@/hooks/useCanvasPersistence";
+import type { Locale } from "@/lib/i18n/config";
 
 function SessionRestorer() {
   const setTokens = useAuthStore((s) => s.setTokens);
@@ -106,12 +108,22 @@ function SessionRestorer() {
   return null;
 }
 
-export function Providers({ children }: { children: React.ReactNode }) {
+export function Providers({
+  children,
+  locale,
+  messages,
+}: {
+  children: React.ReactNode;
+  locale: Locale;
+  messages: AbstractIntlMessages;
+}) {
   return (
-    <TooltipProvider delayDuration={300}>
-      <SessionRestorer />
-      {children}
-      <MiniPlayer />
-    </TooltipProvider>
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <TooltipProvider delayDuration={300}>
+        <SessionRestorer />
+        {children}
+        <MiniPlayer />
+      </TooltipProvider>
+    </NextIntlClientProvider>
   );
 }

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,13 +1,37 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { NextIntlClientProvider, type AbstractIntlMessages } from "next-intl";
 import { MiniPlayer } from "@/components/audio/MiniPlayer";
 import { TooltipProvider } from "@/components/ui";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
+import { usePreferencesStore } from "@/store/preferences";
 import { mergeGuestWorkspace } from "@/hooks/useCanvasPersistence";
 import type { Locale } from "@/lib/i18n/config";
+
+// The persisted-store rehydration path (store/preferences.ts's
+// onRehydrateStorage) re-syncs the oh_locale cookie from localStorage on
+// mount, but it runs outside React and has no router access — so if the
+// cookie was missing/stale when this server component tree rendered (e.g. a
+// privacy tool cleared cookies but not localStorage), the just-rehydrated
+// cookie fixes *future* requests but the already-rendered next-intl
+// `messages` for *this* page stay in the wrong locale. Catch that one-time
+// divergence here and refresh once to pick up the corrected cookie.
+export function LocaleRehydrationSync({ ssrLocale }: { ssrLocale: Locale }) {
+  const uiLocale = usePreferencesStore((s) => s.uiLocale);
+  const router = useRouter();
+  const refreshed = useRef(false);
+
+  useEffect(() => {
+    if (refreshed.current || uiLocale === ssrLocale) return;
+    refreshed.current = true;
+    router.refresh();
+  }, [uiLocale, ssrLocale, router]);
+
+  return null;
+}
 
 function SessionRestorer() {
   const setTokens = useAuthStore((s) => s.setTokens);
@@ -121,6 +145,7 @@ export function Providers({
     <NextIntlClientProvider locale={locale} messages={messages}>
       <TooltipProvider delayDuration={300}>
         <SessionRestorer />
+        <LocaleRehydrationSync ssrLocale={locale} />
         {children}
         <MiniPlayer />
       </TooltipProvider>

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -17,6 +17,8 @@ export interface SelectProps {
   className?: string;
   disabled?: boolean;
   "aria-label"?: string;
+  /** Locale-invariant hook for e2e selectors — aria-label text may be translated. */
+  id?: string;
 }
 
 export function Select({
@@ -27,10 +29,12 @@ export function Select({
   className,
   disabled,
   "aria-label": ariaLabel,
+  id,
 }: SelectProps) {
   return (
     <RadixSelect.Root value={value} onValueChange={onValueChange} disabled={disabled}>
       <RadixSelect.Trigger
+        id={id}
         aria-label={ariaLabel}
         className={cn(
           "flex h-10 w-full items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 text-sm text-text-primary transition-[border-color] duration-[120ms] hover:border-border-subtle focus:border-gold-muted disabled:cursor-not-allowed disabled:opacity-50",

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -39,14 +39,17 @@ test.describe("language switching", () => {
     await expect(page.locator("html")).toHaveAttribute("lang", "tr");
 
     // /settings reads the same preferences store — its Interface language
-    // select reflects the switch made via the header popover.
+    // select reflects the switch made via the header popover. Select by #id
+    // rather than accessible name — the aria-label is now translation-driven
+    // (settings.interfaceLanguage), so it no longer reads "Interface language"
+    // once the locale is tr.
     await page.goto("/settings");
-    await expect(page.getByRole("combobox", { name: /interface language/i })).toHaveText("Türkçe");
+    await expect(page.locator("#interface-language")).toHaveText("Türkçe");
 
     // The store persists to localStorage and re-syncs the oh_locale cookie on
     // rehydration, so the choice survives a full reload, not just client nav.
     await page.reload();
-    await expect(page.getByRole("combobox", { name: /interface language/i })).toHaveText("Türkçe");
+    await expect(page.locator("#interface-language")).toHaveText("Türkçe");
     const cookies = await page.context().cookies();
     expect(cookies.find((c) => c.name === "oh_locale")?.value).toBe("tr");
     await expect(page.locator("html")).toHaveAttribute("lang", "tr");

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -33,6 +33,11 @@ test.describe("language switching", () => {
     await page.getByRole("button", { name: /change language/i }).click();
     await page.getByRole("button", { name: "Türkçe" }).click();
 
+    // Nav chrome (server-rendered from the cookie-resolved locale) shows the
+    // Turkish next-intl strings once router.refresh() re-renders the layout.
+    await expect(page.getByRole("link", { name: "Tuval" })).toBeVisible();
+    await expect(page.locator("html")).toHaveAttribute("lang", "tr");
+
     // /settings reads the same preferences store — its Interface language
     // select reflects the switch made via the header popover.
     await page.goto("/settings");
@@ -44,6 +49,7 @@ test.describe("language switching", () => {
     await expect(page.getByRole("combobox", { name: /interface language/i })).toHaveText("Türkçe");
     const cookies = await page.context().cookies();
     expect(cookies.find((c) => c.name === "oh_locale")?.value).toBe("tr");
+    await expect(page.locator("html")).toHaveAttribute("lang", "tr");
   });
 });
 

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -1,0 +1,10 @@
+import { getRequestConfig } from "next-intl/server";
+import { getUiLocale } from "@/lib/i18n/request-prefs";
+
+export default getRequestConfig(async () => {
+  const locale = await getUiLocale();
+  return {
+    locale,
+    messages: (await import(`../messages/${locale}.json`)).default,
+  };
+});

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -7,6 +7,17 @@ export type Locale = (typeof LOCALES)[number];
 
 export const DEFAULT_LOCALE: Locale = "en";
 
+// Each locale's own name for itself (never translated — a language's own
+// name is shown the same way regardless of the active UI locale). Single
+// source for the LanguagePopover and /settings language pickers, which
+// previously each hand-maintained their own copy of this list.
+export const LOCALE_LABELS: Record<Locale, string> = {
+  en: "English",
+  tr: "Türkçe",
+  ru: "Русский",
+  az: "Azərbaycan dili",
+};
+
 export const DEFAULT_EDITION_BY_LOCALE: Record<Locale, string> = {
   en: "en.sahih",
   tr: "tr.diyanet",

--- a/messages/az.json
+++ b/messages/az.json
@@ -1,0 +1,40 @@
+{
+  "common": {
+    "signIn": "Daxil ol",
+    "signingIn": "Daxil olunur…",
+    "signOut": "Çıxış et",
+    "settings": "Tənzimləmələr",
+    "allSettings": "Bütün tənzimləmələr →",
+    "changeLanguage": "Dili dəyiş"
+  },
+  "nav": {
+    "canvas": "Lövhə",
+    "search": "Axtar",
+    "stories": "Hekayələr",
+    "names": "Əsmayi-Hüsna",
+    "bookmarks": "Əlfəcinlər",
+    "savedCanvases": "Yadda saxlanmış lövhələr",
+    "friendsLeaderboard": "Dostlar və Reytinq",
+    "mentions": "Qeyd edilmələr",
+    "accountMenu": "Hesab menyusu",
+    "signedIn": "Daxil olunub",
+    "dayStreak": "{count} günlük seriya",
+    "dayStreakLabel": "Günlük seriya",
+    "longest": "Ən uzun"
+  },
+  "settings": {
+    "title": "Tənzimləmələr",
+    "language": "Dil",
+    "languageDescription": "Tətbiqin interfeys dilini təyin edir.",
+    "interfaceLanguage": "İnterfeys dili",
+    "quranTranslation": "Quran tərcüməsi",
+    "quranTranslationDescription": "Hazırda {attribution} ({edition}).",
+    "quranTranslationEdition": "Quran tərcümə nəşri",
+    "recitation": "Qiraət",
+    "recitationDescription": "Ayə səsləndirməsi üçün istifadə olunan qari.",
+    "reciter": "Qari",
+    "canvas": "Lövhə",
+    "showMinimap": "Kiçik xəritəni göstər",
+    "showCanvasMinimap": "Lövhə kiçik xəritəsini göstər"
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,40 @@
+{
+  "common": {
+    "signIn": "Sign in",
+    "signingIn": "Signing in…",
+    "signOut": "Sign out",
+    "settings": "Settings",
+    "allSettings": "All settings →",
+    "changeLanguage": "Change language"
+  },
+  "nav": {
+    "canvas": "Canvas",
+    "search": "Search",
+    "stories": "Stories",
+    "names": "Asma'ul Husna",
+    "bookmarks": "Bookmarks",
+    "savedCanvases": "Saved canvases",
+    "friendsLeaderboard": "Friends & Leaderboard",
+    "mentions": "Mentions",
+    "accountMenu": "Account menu",
+    "signedIn": "Signed in",
+    "dayStreak": "On a {count}-day streak",
+    "dayStreakLabel": "Day streak",
+    "longest": "Longest"
+  },
+  "settings": {
+    "title": "Settings",
+    "language": "Language",
+    "languageDescription": "Sets the app interface language.",
+    "interfaceLanguage": "Interface language",
+    "quranTranslation": "Quran translation",
+    "quranTranslationDescription": "Currently {attribution} ({edition}).",
+    "quranTranslationEdition": "Quran translation edition",
+    "recitation": "Recitation",
+    "recitationDescription": "Reciter used for verse audio playback.",
+    "reciter": "Reciter",
+    "canvas": "Canvas",
+    "showMinimap": "Show minimap",
+    "showCanvasMinimap": "Show canvas minimap"
+  }
+}

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,0 +1,40 @@
+{
+  "common": {
+    "signIn": "Войти",
+    "signingIn": "Выполняется вход…",
+    "signOut": "Выйти",
+    "settings": "Настройки",
+    "allSettings": "Все настройки →",
+    "changeLanguage": "Изменить язык"
+  },
+  "nav": {
+    "canvas": "Холст",
+    "search": "Поиск",
+    "stories": "Истории",
+    "names": "Асма уль-Хусна",
+    "bookmarks": "Закладки",
+    "savedCanvases": "Сохранённые холсты",
+    "friendsLeaderboard": "Друзья и рейтинг",
+    "mentions": "Упоминания",
+    "accountMenu": "Меню аккаунта",
+    "signedIn": "Вы вошли в систему",
+    "dayStreak": "Серия дней: {count}",
+    "dayStreakLabel": "Серия дней",
+    "longest": "Рекорд"
+  },
+  "settings": {
+    "title": "Настройки",
+    "language": "Язык",
+    "languageDescription": "Устанавливает язык интерфейса приложения.",
+    "interfaceLanguage": "Язык интерфейса",
+    "quranTranslation": "Перевод Корана",
+    "quranTranslationDescription": "Сейчас используется {attribution} ({edition}).",
+    "quranTranslationEdition": "Издание перевода Корана",
+    "recitation": "Чтение",
+    "recitationDescription": "Чтец, используемый для аудио аятов.",
+    "reciter": "Чтец",
+    "canvas": "Холст",
+    "showMinimap": "Показать миникарту",
+    "showCanvasMinimap": "Показать миникарту холста"
+  }
+}

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -1,0 +1,40 @@
+{
+  "common": {
+    "signIn": "Giriş yap",
+    "signingIn": "Giriş yapılıyor…",
+    "signOut": "Çıkış yap",
+    "settings": "Ayarlar",
+    "allSettings": "Tüm ayarlar →",
+    "changeLanguage": "Dili değiştir"
+  },
+  "nav": {
+    "canvas": "Tuval",
+    "search": "Ara",
+    "stories": "Hikayeler",
+    "names": "Esmaü'l Hüsna",
+    "bookmarks": "Yer imleri",
+    "savedCanvases": "Kayıtlı tuvaller",
+    "friendsLeaderboard": "Arkadaşlar ve Sıralama",
+    "mentions": "Bahsetmeler",
+    "accountMenu": "Hesap menüsü",
+    "signedIn": "Giriş yapıldı",
+    "dayStreak": "{count} günlük seri",
+    "dayStreakLabel": "Günlük seri",
+    "longest": "En uzun"
+  },
+  "settings": {
+    "title": "Ayarlar",
+    "language": "Dil",
+    "languageDescription": "Uygulama arayüz dilini ayarlar.",
+    "interfaceLanguage": "Arayüz dili",
+    "quranTranslation": "Kur'an meali",
+    "quranTranslationDescription": "Şu anda {attribution} ({edition}).",
+    "quranTranslationEdition": "Kur'an meal baskısı",
+    "recitation": "Kıraat",
+    "recitationDescription": "Ayet seslendirmesi için kullanılan kâri.",
+    "reciter": "Kâri",
+    "canvas": "Tuval",
+    "showMinimap": "Küçük haritayı göster",
+    "showCanvasMinimap": "Tuval küçük haritasını göster"
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,7 @@
 import type { NextConfig } from "next";
+import createNextIntlPlugin from "next-intl/plugin";
+
+const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
@@ -70,4 +73,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jspdf": "^4.2.1",
     "lucide-react": "^1.25.0",
     "next": "16.2.10",
+    "next-intl": "^4.13.4",
     "postgres": "^3.4.9",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION
## Summary

Phase 3 of issue #331 (multi-language epic): UI string extraction via next-intl, without locale-based routing.

- Adds `next-intl` (dependency addition — flagging per AGENTS.md). Locale still resolves entirely from the existing `oh_locale` cookie set up in Phase 1/2 (`lib/i18n/config.ts`, `lib/i18n/request-prefs.ts`) — no `/tr`, `/ru`, `/az` URL segments, no locale middleware.
- `i18n/request.ts` + `next.config.ts` plugin wiring, `NextIntlClientProvider` in `components/providers.tsx`, `app/layout.tsx` now renders `lang={locale}` instead of a hardcoded `"en"`.
- `messages/{en,tr,ru,az}.json` with `common`, `nav`, `settings` namespaces populated (other namespaces reserved for follow-up PRs per the incremental extraction plan: nav/layout → settings → canvas → search → bookmarks/names → toasts/errors).
- Extracted first slice of UI strings: header/mobile nav labels, account menu, language popover, `/settings` page. Admin stays English (out of scope, unchanged).

## Bug fix found along the way

`store/preferences.ts`'s `setUiLocale` never called `router.refresh()`. That was fine pre-next-intl (only the cookie mattered), but now that `app/layout.tsx` resolves next-intl `messages` server-side from that same cookie, a client-side locale switch needs a router refresh to actually re-render the (server) layout with new messages — otherwise nav strings stay in the old language until the next hard navigation. Fixed at both call sites (`LanguagePopover`, `/settings`).

## Tests

- New `__tests__/lib/i18n/messages.test.ts`: asserts no orphan keys in tr/ru/az vs en (and vice versa), and that every message parses as valid ICU syntax (`intl-messageformat`) in every locale — catches broken plurals/interpolation at CI time.
- New `__tests__/test-utils/render-with-intl.tsx` helper (wraps RTL's `render` with `NextIntlClientProvider`) — reused by `HeaderNavLinks`/`MobileNavBar` tests, and will be reused by the canvas/search/bookmarks extraction PRs that follow.
- Extended `e2e/settings.spec.ts`'s existing language-switching test to assert nav labels update to Turkish and `html[lang]` flips to `tr`, both immediately after the popover click (no navigation) and after a full reload.

## Test plan

- [x] `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test:ci` — all clean
- [x] `bun run test:integration` (Testcontainers) — clean
- [ ] CI green (Analyze, Build, CodeQL, Integration, Lint·Typecheck·Test, E2E, Secret Scan)

Merge order: this PR targets `feat/331-multi-language`, not `main` — same as the earlier Phase 1/2/Stories PRs on this epic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized interface support for English, Turkish, Russian, and Azerbaijani.
  * Navigation, account menus, settings, accessibility labels, and status messages now display in the selected language.
  * Language changes update the interface and document language without requiring a full navigation.
  * Settings descriptions support dynamic translation and recitation details.

* **Tests**
  * Added coverage for translation completeness and ICU message validity.
  * Updated navigation tests to run with internationalization support.
  * Expanded language-switching checks to verify translated content and locale updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->