### PR TITLE
feat(ai): generate connection reasons and 99-Names content in the UI locale

### DIFF
--- a/__tests__/api/connections.test.ts
+++ b/__tests__/api/connections.test.ts
@@ -30,6 +30,10 @@ const { mockSelect, mockInsert, mockConsume } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, insert: mockInsert } }));
+// The route now calls getUiLocale() (lib/i18n/request-prefs.ts), which reads
+// next/headers' cookies() — unavailable outside a real Next request scope.
+// No cookie set here means it resolves to the "en" default.
+vi.mock("next/headers", () => ({ cookies: async () => ({ get: () => undefined }) }));
 // The legacy generate path hydrates from the local corpus via getVerses; return a
 // verse for every requested ref so the cache-miss path yields connections.
 vi.mock("@/lib/quran/quran-corpus", async (importOriginal) => {

--- a/__tests__/api/name-content-rate-limit.test.ts
+++ b/__tests__/api/name-content-rate-limit.test.ts
@@ -35,6 +35,10 @@ vi.mock("@/lib/infra/db", () => ({
     insert: () => ({ values: () => ({ onConflictDoUpdate: async () => undefined }) }),
   },
 }));
+// The routes now call getUiLocale() (lib/i18n/request-prefs.ts), which reads
+// next/headers' cookies() — unavailable outside a real Next request scope.
+// No cookie set here means it resolves to the "en" default.
+vi.mock("next/headers", () => ({ cookies: async () => ({ get: () => undefined }) }));
 
 vi.mock("@/lib/infra/rate-limit", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/infra/rate-limit")>();

--- a/__tests__/api/name-content-rate-limit.test.ts
+++ b/__tests__/api/name-content-rate-limit.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/lib/infra/db", () => ({
     insert: () => ({
       values: () => ({
         onConflictDoUpdate: async () => undefined,
-        onConflictDoNothing: async () => undefined,
+        onConflictDoNothing: () => ({ returning: async () => [{ reason: "unused" }] }),
       }),
     }),
   },

--- a/__tests__/api/name-content-rate-limit.test.ts
+++ b/__tests__/api/name-content-rate-limit.test.ts
@@ -23,22 +23,30 @@ function makeSelectChain(resolveWith: unknown[]) {
   return chain;
 }
 
-const { mockSelect, mockConsume, mockCallAI } = vi.hoisted(() => ({
+const { mockSelect, mockConsume, mockCallAI, mockCookies } = vi.hoisted(() => ({
   mockSelect: vi.fn(),
   mockConsume: vi.fn(),
   mockCallAI: vi.fn(),
+  // The routes now call getUiLocale() (lib/i18n/request-prefs.ts), which reads
+  // next/headers' cookies() — unavailable outside a real Next request scope.
+  // Defaults to no cookie set (→ "en"); individual tests can override.
+  mockCookies: vi.fn(async () => ({
+    get: (_name: string) => undefined as { value: string } | undefined,
+  })),
 }));
 
 vi.mock("@/lib/infra/db", () => ({
   db: {
     select: mockSelect,
-    insert: () => ({ values: () => ({ onConflictDoUpdate: async () => undefined }) }),
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: async () => undefined,
+        onConflictDoNothing: async () => undefined,
+      }),
+    }),
   },
 }));
-// The routes now call getUiLocale() (lib/i18n/request-prefs.ts), which reads
-// next/headers' cookies() — unavailable outside a real Next request scope.
-// No cookie set here means it resolves to the "en" default.
-vi.mock("next/headers", () => ({ cookies: async () => ({ get: () => undefined }) }));
+vi.mock("next/headers", () => ({ cookies: mockCookies }));
 
 vi.mock("@/lib/infra/rate-limit", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/infra/rate-limit")>();
@@ -79,6 +87,7 @@ describe("names AI routes — per-client rate limiting", () => {
     mockCallAI.mockReset();
     mockFetch.mockReset();
     mockFetch.mockResolvedValue({ ok: false });
+    mockCookies.mockReset().mockResolvedValue({ get: () => undefined }); // "en" default
   });
 
   for (const { label, call } of ROUTES) {
@@ -164,5 +173,45 @@ describe("names AI routes — per-client rate limiting", () => {
     expect(body).toHaveLength(1);
     expect(mockConsume).toHaveBeenCalledTimes(1);
     expect(mockCallAI).toHaveBeenCalled();
+  });
+
+  it("verses: a non-English locale with multiple uncached verse translations still consumes the rate limit exactly once", async () => {
+    mockCookies.mockResolvedValue({
+      get: (name: string) => (name === "oh_locale" ? { value: "tr" } : undefined),
+    });
+    mockSelect.mockReturnValue(makeSelectChain([])); // every select is a miss (verses + all translations)
+    mockConsume.mockResolvedValue(true);
+    // The two translation calls run concurrently (Promise.all), so they can
+    // reach mockCallAI in either order — resolve based on prompt content
+    // (each translateReason call embeds its own verse's source text) rather
+    // than call order, which a sequential mockResolvedValueOnce chain can't
+    // guarantee under concurrency.
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      if (prompt.includes("Ayat al-Kursi.")) return "Ayet el-Kürsi (tr).";
+      if (prompt.includes("Pure tawhid.")) return "Saf tevhid (tr).";
+      return JSON.stringify([
+        { ref: "2:255", reason: "Ayat al-Kursi." },
+        { ref: "112:1", reason: "Pure tawhid." },
+      ]);
+    });
+    mockFetch.mockImplementation(async (url: unknown) => {
+      if (typeof url !== "string") return { ok: false };
+      if (url.includes("api.alquran.cloud"))
+        return { ok: true, json: async () => ({ data: { text: "نص" } }) };
+      return { ok: false };
+    });
+
+    const res = await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    expect(body.map((v: { reason: string }) => v.reason)).toEqual([
+      "Ayet el-Kürsi (tr).",
+      "Saf tevhid (tr).",
+    ]);
+    // At most 2 charges total (one for the canonical verse-selection miss,
+    // one shared across the whole translation batch) — never one per verse.
+    expect(mockConsume).toHaveBeenCalledTimes(2);
   });
 });

--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -227,4 +227,18 @@ describe("names AI routes — model output validation", () => {
     expect(translatePrompt).toMatch(/translate the following sentence into azerbaijani/i);
     expect(translatePrompt).toMatch(/strict tanzih/i);
   });
+
+  it("verses: an empty/failed translation falls back to the canonical English reason instead of blanking it", async () => {
+    withLocale("az");
+    mockVerseFetch();
+    mockCallAI
+      .mockResolvedValueOnce(JSON.stringify([{ ref: "2:255", reason: "Ayat al-Kursi." }]))
+      .mockResolvedValueOnce(""); // translation call returns nothing
+
+    const res = await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body[0].reason).toBe("Ayat al-Kursi."); // canonical reason preserved, not blanked
+  });
 });

--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -39,7 +39,12 @@ vi.mock("next/headers", () => ({ cookies: mockCookies }));
 vi.mock("@/lib/infra/db", () => ({
   db: {
     select: () => makeSelectChain([]), // durable cache always misses
-    insert: () => ({ values: () => ({ onConflictDoUpdate: async () => undefined }) }),
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: async () => undefined,
+        onConflictDoNothing: () => ({ returning: async () => [{ reason: "unused" }] }),
+      }),
+    }),
   },
 }));
 

--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -23,10 +23,18 @@ function makeSelectChain(resolveWith: unknown[]) {
   return chain;
 }
 
-const { mockConsume, mockCallAI } = vi.hoisted(() => ({
+const { mockConsume, mockCallAI, mockCookies } = vi.hoisted(() => ({
   mockConsume: vi.fn(),
   mockCallAI: vi.fn(),
+  // The routes now call getUiLocale() (lib/i18n/request-prefs.ts), which reads
+  // next/headers' cookies() — unavailable outside a real Next request scope.
+  // Defaults to no cookie set (→ "en"); individual tests can override.
+  mockCookies: vi.fn(async () => ({
+    get: (_name: string) => undefined as { value: string } | undefined,
+  })),
 }));
+
+vi.mock("next/headers", () => ({ cookies: mockCookies }));
 
 vi.mock("@/lib/infra/db", () => ({
   db: {
@@ -44,6 +52,7 @@ vi.mock("@/lib/ai/ai", () => ({ callAI: mockCallAI }));
 
 import { GET as getPairings } from "@/app/api/names/[slug]/pairings/route";
 import { GET as getVerses } from "@/app/api/names/[slug]/verses/route";
+import { GET as getReflection } from "@/app/api/names/[slug]/reflection/route";
 
 // Stub fetch AFTER static imports so vi.stubGlobal wins over any fetch patch
 // applied during next/server module initialization.
@@ -63,7 +72,14 @@ describe("names AI routes — model output validation", () => {
     mockCallAI.mockReset();
     mockFetch.mockReset();
     mockFetch.mockResolvedValue({ ok: false }); // quran.com search yields no refs
+    mockCookies.mockReset().mockResolvedValue({ get: () => undefined }); // "en" default
   });
+
+  function withLocale(locale: string) {
+    mockCookies.mockResolvedValue({
+      get: (name: string) => (name === "oh_locale" ? { value: locale } : undefined),
+    });
+  }
 
   it("pairings: parseable-but-wrong-shaped JSON (string array) returns empty, not a 500", async () => {
     mockCallAI.mockResolvedValue(JSON.stringify(["Ar-Rahim", "Al-Malik"]));
@@ -138,5 +154,77 @@ describe("names AI routes — model output validation", () => {
     expect(body[0].reason).toBe("Ayat al-Kursi.");
     expect(body[0].arabicText).toBe(ARABIC);
     expect(body[0].translation).toBe(ENGLISH);
+  });
+
+  it("reflection: no language directive for the default (English) locale", async () => {
+    mockCallAI.mockResolvedValue("A reflection paragraph.");
+    await getReflection(req("ar-rahman", "reflection"), params("ar-rahman"));
+    const prompt = mockCallAI.mock.calls[0][0] as string;
+    expect(prompt).not.toMatch(/write the reflection in/i);
+    expect(prompt).toMatch(/strict tanzih/i);
+  });
+
+  it("reflection: appends a language directive for a non-English locale, keeping Tanzih rules", async () => {
+    withLocale("tr");
+    mockCallAI.mockResolvedValue("Bir yansıma paragrafı.");
+    await getReflection(req("ar-rahman", "reflection"), params("ar-rahman"));
+    const prompt = mockCallAI.mock.calls[0][0] as string;
+    expect(prompt).toMatch(/write the reflection in turkish/i);
+    expect(prompt).toMatch(/strict tanzih/i);
+  });
+
+  it("pairings: no language directive for the default (English) locale", async () => {
+    mockCallAI.mockResolvedValue(JSON.stringify([]));
+    await getPairings(req("ar-rahman", "pairings"), params("ar-rahman"));
+    const prompt = mockCallAI.mock.calls[0][0] as string;
+    expect(prompt).not.toMatch(/write each "explanation" in/i);
+  });
+
+  it("pairings: appends a language directive for a non-English locale", async () => {
+    withLocale("ru");
+    mockCallAI.mockResolvedValue(JSON.stringify([]));
+    await getPairings(req("ar-rahman", "pairings"), params("ar-rahman"));
+    const prompt = mockCallAI.mock.calls[0][0] as string;
+    expect(prompt).toMatch(/write each "explanation" in russian/i);
+  });
+
+  function mockVerseFetch() {
+    mockFetch.mockImplementation(async (url: unknown) => {
+      if (typeof url !== "string") return { ok: false };
+      if (url.includes("ar.alafasy"))
+        return { ok: true, json: async () => ({ data: { text: "نص عربي" } }) };
+      if (url.includes("en.sahih"))
+        return { ok: true, json: async () => ({ data: { text: "English text" } }) };
+      return { ok: false };
+    });
+  }
+
+  it("verses: selection stays English-only and untranslated for the default locale", async () => {
+    mockVerseFetch();
+    mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "Ayat al-Kursi." }]));
+    const res = await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+    const body = await res.json();
+    expect(body[0].reason).toBe("Ayat al-Kursi.");
+    expect(mockCallAI).toHaveBeenCalledTimes(1); // only the fallback-verses call, no translation pass
+  });
+
+  it("verses: translates only the reason for a non-English locale, leaving the verse selection unchanged", async () => {
+    withLocale("az");
+    mockVerseFetch();
+    mockCallAI
+      .mockResolvedValueOnce(JSON.stringify([{ ref: "2:255", reason: "Ayat al-Kursi." }]))
+      .mockResolvedValueOnce("Ayat əl-Kürsi.");
+
+    const res = await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].ref).toBe("2:255"); // selection unchanged
+    expect(body[0].reason).toBe("Ayat əl-Kürsi."); // reason translated
+    expect(mockCallAI).toHaveBeenCalledTimes(2);
+    const translatePrompt = mockCallAI.mock.calls[1][0] as string;
+    expect(translatePrompt).toMatch(/translate the following sentence into azerbaijani/i);
+    expect(translatePrompt).toMatch(/strict tanzih/i);
   });
 });

--- a/__tests__/api/names.test.ts
+++ b/__tests__/api/names.test.ts
@@ -38,7 +38,12 @@ function makeDbChain(resolveWith: unknown[] = []) {
 vi.mock("@/lib/infra/db", () => ({
   db: {
     select: () => makeDbChain([]), // cache miss
-    insert: () => ({ values: () => ({ onConflictDoUpdate: async () => undefined }) }),
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: async () => undefined,
+        onConflictDoNothing: () => ({ returning: async () => [{ reason: "unused" }] }),
+      }),
+    }),
   },
 }));
 

--- a/__tests__/api/names.test.ts
+++ b/__tests__/api/names.test.ts
@@ -6,6 +6,12 @@ vi.mock("next/cache", () => ({
   unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
 }));
 
+// The routes now call getUiLocale() (lib/i18n/request-prefs.ts), which reads
+// next/headers' cookies() — unavailable outside a real Next request scope.
+// No cookie set here means it resolves to the "en" default, matching this
+// suite's pre-existing English-only fixtures/assertions.
+vi.mock("next/headers", () => ({ cookies: async () => ({ get: () => undefined }) }));
+
 // The name routes now read/write a durable `name_content` cache via lib/infra/db
 // (see lib/names/name-content.ts). Mock the DB so the cache check is always a miss and
 // the persist is a no-op — the routes then exercise their real generation path.

--- a/__tests__/integration/name-content-locale.integration.test.ts
+++ b/__tests__/integration/name-content-locale.integration.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { sql, and, eq } from "drizzle-orm";
+import { db } from "@/lib/infra/db";
+import { nameContent, nameVerseReasons } from "@/lib/infra/db/schema";
+import { getOrGenerateNameContent, getOrGenerateVerseReason } from "@/lib/names/name-content";
+
+async function reset() {
+  await db.execute(sql`TRUNCATE name_content, name_verse_reasons RESTART IDENTITY CASCADE`);
+}
+
+beforeEach(reset);
+
+describe("name_content locale PK + name_verse_reasons (integration, real Postgres)", () => {
+  it("migration 0019 preserves a pre-existing (slug, kind) row as locale='en' under the new PK", async () => {
+    // Simulate a row written before migration 0019 by omitting `locale` and
+    // relying on its DB default, exactly as existing rows were left after the
+    // migration ran (see lib/infra/db/migrations/0019_name_content_locale.sql).
+    await db.execute(
+      sql`INSERT INTO name_content (slug, kind, data, version) VALUES ('ar-rahman', 'reflection', ${JSON.stringify("pre-migration reflection")}, 1)`
+    );
+
+    const [row] = await db
+      .select()
+      .from(nameContent)
+      .where(and(eq(nameContent.slug, "ar-rahman"), eq(nameContent.kind, "reflection")));
+
+    expect(row.locale).toBe("en");
+    expect(JSON.parse(row.data)).toBe("pre-migration reflection");
+  });
+
+  it("getOrGenerateNameContent stores independent rows per locale under the same (slug, kind)", async () => {
+    await getOrGenerateNameContent(
+      "ar-rahman",
+      "reflection",
+      "en",
+      1,
+      async () => "An English reflection.",
+      (s: string) => s.trim() === ""
+    );
+    await getOrGenerateNameContent(
+      "ar-rahman",
+      "reflection",
+      "tr",
+      1,
+      async () => "Türkçe bir yansıma.",
+      (s: string) => s.trim() === ""
+    );
+
+    const rows = await db
+      .select()
+      .from(nameContent)
+      .where(and(eq(nameContent.slug, "ar-rahman"), eq(nameContent.kind, "reflection")));
+
+    expect(rows).toHaveLength(2);
+    const byLocale = Object.fromEntries(rows.map((r) => [r.locale, JSON.parse(r.data)]));
+    expect(byLocale.en).toBe("An English reflection.");
+    expect(byLocale.tr).toBe("Türkçe bir yansıma.");
+  });
+
+  it("name_verse_reasons round-trips a locale-specific translation independent of the canonical row", async () => {
+    const translated = await getOrGenerateVerseReason(
+      "ar-rahman",
+      "2:255",
+      "az",
+      async () => "Ayat əl-Kürsi."
+    );
+    expect(translated).toBe("Ayat əl-Kürsi.");
+
+    const [row] = await db
+      .select()
+      .from(nameVerseReasons)
+      .where(
+        and(
+          eq(nameVerseReasons.slug, "ar-rahman"),
+          eq(nameVerseReasons.ref, "2:255"),
+          eq(nameVerseReasons.locale, "az")
+        )
+      );
+    expect(row.reason).toBe("Ayat əl-Kürsi.");
+
+    // A different locale for the same (slug, ref) gets its own row, not an overwrite.
+    await getOrGenerateVerseReason("ar-rahman", "2:255", "ru", async () => "Аят аль-Курси.");
+    const rows = await db
+      .select()
+      .from(nameVerseReasons)
+      .where(and(eq(nameVerseReasons.slug, "ar-rahman"), eq(nameVerseReasons.ref, "2:255")));
+    expect(rows).toHaveLength(2);
+  });
+
+  it("a second call for the same (slug, ref, locale) reuses the cached translation without regenerating", async () => {
+    let calls = 0;
+    const generate = async () => {
+      calls += 1;
+      return "cached translation";
+    };
+
+    await getOrGenerateVerseReason("al-malik", "1:1", "tr", generate);
+    await getOrGenerateVerseReason("al-malik", "1:1", "tr", generate);
+
+    expect(calls).toBe(1);
+  });
+});

--- a/__tests__/lib/ai/connection-generator.test.ts
+++ b/__tests__/lib/ai/connection-generator.test.ts
@@ -117,6 +117,22 @@ describe("generateConnections", () => {
     const out = await generateConnections("1:1", "ar", "tr", "thematic");
     expect(out).toHaveLength(3);
   });
+
+  it("omits any language directive and keeps the Tanzih rule for the default (English) locale", async () => {
+    mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
+    await generateConnections("1:1", "ar", "tr", "thematic");
+    const prompt = mockCallAI.mock.calls[0][0] as string;
+    expect(prompt).not.toMatch(/write each "reason" in/i);
+    expect(prompt).toMatch(/strict tanzih/i);
+  });
+
+  it("appends a language directive for a non-English locale without dropping the Tanzih rule", async () => {
+    mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
+    await generateConnections("1:1", "ar", "tr", "thematic", "tr");
+    const prompt = mockCallAI.mock.calls[0][0] as string;
+    expect(prompt).toMatch(/write each "reason" in turkish/i);
+    expect(prompt).toMatch(/strict tanzih/i);
+  });
 });
 
 describe("generateGroundedConnections", () => {
@@ -179,5 +195,21 @@ describe("generateGroundedConnections", () => {
     mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
     await generateGroundedConnections("1:1", "ar", "tr", "root", ["2:255"]);
     expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits any language directive and keeps the Tanzih rule for the default (English) locale", async () => {
+    mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
+    await generateGroundedConnections("1:1", "ar", "tr", "thematic", ["2:255"]);
+    const prompt = mockCallAI.mock.calls[0][0] as string;
+    expect(prompt).not.toMatch(/write each "reason" in/i);
+    expect(prompt).toMatch(/strict tanzih/i);
+  });
+
+  it("appends a language directive for a non-English locale without dropping the Tanzih rule", async () => {
+    mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
+    await generateGroundedConnections("1:1", "ar", "tr", "thematic", ["2:255"], "ru");
+    const prompt = mockCallAI.mock.calls[0][0] as string;
+    expect(prompt).toMatch(/write each "reason" in russian/i);
+    expect(prompt).toMatch(/strict tanzih/i);
   });
 });

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -129,7 +129,7 @@ describe("getConnections", () => {
     const out = await getConnections("1:1", "thematic", source);
 
     expect(mockGenerate).toHaveBeenCalledTimes(1);
-    expect(mockGenerate).toHaveBeenCalledWith("1:1", "ar", "tr", "thematic");
+    expect(mockGenerate).toHaveBeenCalledWith("1:1", "ar", "tr", "thematic", "en");
     expect(mockInsert).toHaveBeenCalledTimes(1);
     expect(mockValues).toHaveBeenCalledTimes(1);
     const persisted = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
@@ -201,10 +201,14 @@ describe("getConnections", () => {
 
     expect(mockDiscover).toHaveBeenCalledWith("1:1", "thematic", undefined, []);
     expect(mockGenerateGrounded).toHaveBeenCalledTimes(1);
-    expect(mockGenerateGrounded).toHaveBeenCalledWith("1:1", "ar", "tr", "thematic", [
-      "2:255",
-      "3:18",
-    ]);
+    expect(mockGenerateGrounded).toHaveBeenCalledWith(
+      "1:1",
+      "ar",
+      "tr",
+      "thematic",
+      ["2:255", "3:18"],
+      "en"
+    );
     expect(mockGenerate).not.toHaveBeenCalled(); // legacy path skipped
     expect(out).toHaveLength(1);
     expect(mockInsert).toHaveBeenCalledTimes(1);
@@ -218,7 +222,7 @@ describe("getConnections", () => {
     const out = await getConnections("1:1", "root", source);
 
     expect(mockGenerateGrounded).not.toHaveBeenCalled();
-    expect(mockGenerate).toHaveBeenCalledWith("1:1", "ar", "tr", "root");
+    expect(mockGenerate).toHaveBeenCalledWith("1:1", "ar", "tr", "root", "en");
     expect(out).toHaveLength(1);
   });
 

--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -22,20 +22,27 @@ function makeSelectChain(resolveWith: unknown[]) {
   return chain;
 }
 
-const { mockSelect, mockInsert, mockValues, mockOnConflict } = vi.hoisted(() => {
-  const mockOnConflict = vi.fn().mockResolvedValue(undefined);
-  const mockValues = vi.fn((..._args: unknown[]) => ({ onConflictDoUpdate: mockOnConflict }));
-  return {
-    mockSelect: vi.fn(),
-    mockInsert: vi.fn(() => ({ values: mockValues })),
-    mockValues,
-    mockOnConflict,
-  };
-});
+const { mockSelect, mockInsert, mockValues, mockOnConflict, mockOnConflictDoNothing } = vi.hoisted(
+  () => {
+    const mockOnConflict = vi.fn().mockResolvedValue(undefined);
+    const mockOnConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    const mockValues = vi.fn((..._args: unknown[]) => ({
+      onConflictDoUpdate: mockOnConflict,
+      onConflictDoNothing: mockOnConflictDoNothing,
+    }));
+    return {
+      mockSelect: vi.fn(),
+      mockInsert: vi.fn(() => ({ values: mockValues })),
+      mockValues,
+      mockOnConflict,
+      mockOnConflictDoNothing,
+    };
+  }
+);
 
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, insert: mockInsert } }));
 
-import { getOrGenerateNameContent } from "@/lib/names/name-content";
+import { getOrGenerateNameContent, getOrGenerateVerseReason } from "@/lib/names/name-content";
 
 const isEmptyArr = (v: unknown[]) => v.length === 0;
 
@@ -45,13 +52,14 @@ describe("getOrGenerateNameContent", () => {
     mockInsert.mockClear();
     mockValues.mockClear();
     mockOnConflict.mockClear();
+    mockOnConflictDoNothing.mockClear();
   });
 
   it("returns the cached value on a hit WITHOUT generating", async () => {
     mockSelect.mockReturnValue(makeSelectChain([{ data: JSON.stringify(["cached"]), version: 1 }]));
     const generate = vi.fn();
 
-    const out = await getOrGenerateNameContent("as-salam", "verses", 1, generate, isEmptyArr);
+    const out = await getOrGenerateNameContent("as-salam", "verses", "en", 1, generate, isEmptyArr);
 
     expect(out).toEqual(["cached"]);
     expect(generate).not.toHaveBeenCalled();
@@ -62,21 +70,41 @@ describe("getOrGenerateNameContent", () => {
     mockSelect.mockReturnValue(makeSelectChain([])); // no row
     const generate = vi.fn().mockResolvedValue(["a", "b"]);
 
-    const out = await getOrGenerateNameContent("al-malik", "verses", 2, generate, isEmptyArr);
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 2, generate, isEmptyArr);
 
     expect(generate).toHaveBeenCalledTimes(1);
     expect(out).toEqual(["a", "b"]);
     expect(mockInsert).toHaveBeenCalledTimes(1);
     const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
-    expect(values).toMatchObject({ slug: "al-malik", kind: "verses", version: 2 });
+    expect(values).toMatchObject({ slug: "al-malik", kind: "verses", locale: "en", version: 2 });
     expect(JSON.parse(values.data as string)).toEqual(["a", "b"]);
+  });
+
+  it("keys the cache by locale — a Turkish miss doesn't reuse or clobber the English row", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // no row for this (slug, kind, locale)
+    const generate = vi.fn().mockResolvedValue("bir yansıma");
+
+    const out = await getOrGenerateNameContent(
+      "ar-rahman",
+      "reflection",
+      "tr",
+      1,
+      generate,
+      (s: string) => s.trim() === ""
+    );
+
+    expect(out).toBe("bir yansıma");
+    const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
+    expect(values).toMatchObject({ slug: "ar-rahman", kind: "reflection", locale: "tr" });
+    const target = mockOnConflict.mock.calls[0][0].target as unknown[];
+    expect(target).toHaveLength(3); // [slug, kind, locale] — not the old 2-column PK
   });
 
   it("regenerates when the stored version is older than the current version", async () => {
     mockSelect.mockReturnValue(makeSelectChain([{ data: JSON.stringify(["old"]), version: 1 }]));
     const generate = vi.fn().mockResolvedValue(["new"]);
 
-    const out = await getOrGenerateNameContent("al-malik", "verses", 2, generate, isEmptyArr);
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 2, generate, isEmptyArr);
 
     expect(generate).toHaveBeenCalledTimes(1);
     expect(out).toEqual(["new"]);
@@ -87,7 +115,7 @@ describe("getOrGenerateNameContent", () => {
     mockSelect.mockReturnValue(makeSelectChain([{ data: "{not json", version: 1 }]));
     const generate = vi.fn().mockResolvedValue(["recovered"]);
 
-    const out = await getOrGenerateNameContent("al-malik", "verses", 1, generate, isEmptyArr);
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
 
     expect(generate).toHaveBeenCalledTimes(1);
     expect(out).toEqual(["recovered"]);
@@ -97,7 +125,7 @@ describe("getOrGenerateNameContent", () => {
     mockSelect.mockReturnValue(makeSelectChain([]));
     const generate = vi.fn().mockResolvedValue([]);
 
-    const out = await getOrGenerateNameContent("al-malik", "verses", 1, generate, isEmptyArr);
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
 
     expect(out).toEqual([]);
     expect(generate).toHaveBeenCalledTimes(1);
@@ -113,6 +141,7 @@ describe("getOrGenerateNameContent", () => {
     const out = await getOrGenerateNameContent(
       "ar-rahman",
       "reflection",
+      "en",
       1,
       generate,
       (s: string) => s.trim() === ""
@@ -133,9 +162,9 @@ describe("getOrGenerateNameContent", () => {
     );
 
     const all = Promise.all([
-      getOrGenerateNameContent("al-malik", "verses", 1, generate, isEmptyArr),
-      getOrGenerateNameContent("al-malik", "verses", 1, generate, isEmptyArr),
-      getOrGenerateNameContent("al-malik", "verses", 1, generate, isEmptyArr),
+      getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr),
+      getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr),
+      getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr),
     ]);
 
     await new Promise((r) => setTimeout(r, 0));
@@ -162,6 +191,7 @@ describe("getOrGenerateNameContent", () => {
     const out = await getOrGenerateNameContent(
       "al-malik",
       "verses",
+      "en",
       1,
       generate,
       isEmptyArr,
@@ -181,6 +211,7 @@ describe("getOrGenerateNameContent", () => {
     const out = await getOrGenerateNameContent(
       "as-salam",
       "verses",
+      "en",
       1,
       generate,
       isEmptyArr,
@@ -198,7 +229,15 @@ describe("getOrGenerateNameContent", () => {
     const generate = vi.fn();
 
     await expect(
-      getOrGenerateNameContent("al-malik", "verses", 1, generate, isEmptyArr, onBeforeGenerate)
+      getOrGenerateNameContent(
+        "al-malik",
+        "verses",
+        "en",
+        1,
+        generate,
+        isEmptyArr,
+        onBeforeGenerate
+      )
     ).rejects.toThrow("rate limited");
     expect(generate).not.toHaveBeenCalled();
     expect(mockInsert).not.toHaveBeenCalled();
@@ -207,6 +246,7 @@ describe("getOrGenerateNameContent", () => {
     const out = await getOrGenerateNameContent(
       "al-malik",
       "verses",
+      "en",
       1,
       vi.fn().mockResolvedValue(["ok"]),
       isEmptyArr
@@ -219,11 +259,111 @@ describe("getOrGenerateNameContent", () => {
     const generate = vi.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValue(["ok"]);
 
     await expect(
-      getOrGenerateNameContent("al-malik", "verses", 1, generate, isEmptyArr)
+      getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr)
     ).rejects.toThrow("boom");
     // lock released in finally → fresh call regenerates
-    const out = await getOrGenerateNameContent("al-malik", "verses", 1, generate, isEmptyArr);
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
     expect(out).toEqual(["ok"]);
     expect(generate).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("getOrGenerateVerseReason", () => {
+  beforeEach(() => {
+    mockSelect.mockReset();
+    mockInsert.mockClear();
+    mockValues.mockClear();
+    mockOnConflict.mockClear();
+    mockOnConflictDoNothing.mockClear();
+  });
+
+  it("returns a cached translation without calling generate", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([{ reason: "zaten çevrilmiş" }]));
+    const generate = vi.fn();
+
+    const out = await getOrGenerateVerseReason("ar-rahman", "2:255", "tr", generate);
+
+    expect(out).toBe("zaten çevrilmiş");
+    expect(generate).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("on a miss, translates and persists (insert, not upsert)", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // no row
+    const generate = vi.fn().mockResolvedValue("çevrilmiş sebep");
+
+    const out = await getOrGenerateVerseReason("ar-rahman", "2:255", "tr", generate);
+
+    expect(out).toBe("çevrilmiş sebep");
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
+    expect(values).toMatchObject({
+      slug: "ar-rahman",
+      ref: "2:255",
+      locale: "tr",
+      reason: "çevrilmiş sebep",
+    });
+    expect(mockOnConflictDoNothing).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not persist an empty translation", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([]));
+    const generate = vi.fn().mockResolvedValue("");
+
+    const out = await getOrGenerateVerseReason("ar-rahman", "2:255", "tr", generate);
+
+    expect(out).toBe("");
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("calls onBeforeGenerate on a miss, before generate", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([]));
+    const order: string[] = [];
+    const onBeforeGenerate = vi.fn(async () => {
+      order.push("gate");
+    });
+    const generate = vi.fn(async () => {
+      order.push("generate");
+      return "çeviri";
+    });
+
+    await getOrGenerateVerseReason("ar-rahman", "2:255", "tr", generate, onBeforeGenerate);
+
+    expect(onBeforeGenerate).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["gate", "generate"]);
+  });
+
+  it("does NOT call onBeforeGenerate on a cache hit", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([{ reason: "cached" }]));
+    const onBeforeGenerate = vi.fn();
+
+    await getOrGenerateVerseReason("ar-rahman", "2:255", "tr", vi.fn(), onBeforeGenerate);
+
+    expect(onBeforeGenerate).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent identical first-loads into ONE translation call", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // always a miss
+    let release!: (v: string) => void;
+    const generate = vi.fn(
+      () =>
+        new Promise<string>((res) => {
+          release = res;
+        })
+    );
+
+    const all = Promise.all([
+      getOrGenerateVerseReason("ar-rahman", "2:255", "tr", generate),
+      getOrGenerateVerseReason("ar-rahman", "2:255", "tr", generate),
+    ]);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(generate).toHaveBeenCalledTimes(1);
+
+    release("sonuç");
+    const [a, b] = await all;
+    expect(a).toBe("sonuç");
+    expect(b).toBe("sonuç");
   });
 });

--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -25,7 +25,12 @@ function makeSelectChain(resolveWith: unknown[]) {
 const { mockSelect, mockInsert, mockValues, mockOnConflict, mockOnConflictDoNothing } = vi.hoisted(
   () => {
     const mockOnConflict = vi.fn().mockResolvedValue(undefined);
-    const mockOnConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    // Default: the insert "wins" (no conflict) — `.returning()` yields a
+    // non-empty array. Tests that simulate a losing conflict override this
+    // to resolve `.returning()` to `[]`.
+    const mockOnConflictDoNothing = vi.fn(() => ({
+      returning: vi.fn().mockResolvedValue([{ reason: "unused" }]),
+    }));
     const mockValues = vi.fn((..._args: unknown[]) => ({
       onConflictDoUpdate: mockOnConflict,
       onConflictDoNothing: mockOnConflictDoNothing,
@@ -315,6 +320,20 @@ describe("getOrGenerateVerseReason", () => {
 
     expect(out).toBe("");
     expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("when another process wins the insert race, returns the persisted (stored) translation, not the local one", async () => {
+    // First select (cache check): miss. Second select (post-conflict re-read,
+    // triggered by an empty .returning()): the other writer's stored value.
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain([]))
+      .mockReturnValueOnce(makeSelectChain([{ reason: "diğer işlemin çevirisi" }]));
+    mockOnConflictDoNothing.mockReturnValueOnce({ returning: vi.fn().mockResolvedValue([]) });
+    const generate = vi.fn().mockResolvedValue("bu işlemin çevirisi");
+
+    const out = await getOrGenerateVerseReason("ar-rahman", "2:255", "tr", generate);
+
+    expect(out).toBe("diğer işlemin çevirisi");
   });
 
   it("calls onBeforeGenerate on a miss, before generate", async () => {

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -3,6 +3,7 @@ import { getConnections } from "@/lib/ai/graph-service";
 import { isValidRef } from "@/lib/quran/quran-corpus";
 import { RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
+import { getUiLocale } from "@/lib/i18n/request-prefs";
 import type { EdgeKind } from "@/types/quran";
 
 const MAX_EXCLUDE_REFS = 100;
@@ -57,11 +58,12 @@ export async function POST(req: NextRequest) {
   }
 
   try {
+    const locale = await getUiLocale();
     const results = await getConnections(
       fromRef,
       kind as EdgeKind,
       { arabicText, translation },
-      { clientKey: clientKey(req), excludeRefs }
+      { clientKey: clientKey(req), excludeRefs, locale }
     );
 
     // A "get more" request (excludeRefs non-empty) legitimately can run out of

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -26,14 +26,14 @@ function buildPrompt(
   const languageLine =
     locale === "en"
       ? ""
-      : `\nWrite each "explanation" in ${LOCALE_LANGUAGE_NAME[locale]}. Keep "transliteration" and "arabic" as-is (do not translate names). Preserve the Tanzih framing implicit in classical Islamic terms.`;
+      : `\nWrite each "explanation" in ${LOCALE_LANGUAGE_NAME[locale]}. Keep "transliteration" and "arabic" as-is (do not translate names). Keep the Tanzih constraint above unchanged.`;
   return `You are a classical Islamic scholar (Maturidi/Hanafi tradition).
 
 The divine name ${transliteration} (${arabic}) means "${meaning}".
 
 Task: Identify 2–3 other divine names from the 99 Names that most frequently appear paired with ${transliteration} in the Quran. For each, explain in ONE sentence why this pairing provides perfect theological balance in the specific contexts where they appear together.
 
-Only include pairings where both names actually co-appear in the same verse or in closely related verses as documented in classical tafsir.${languageLine}
+Only include pairings where both names actually co-appear in the same verse or in closely related verses as documented in classical tafsir. Maintain strict Tanzih: never describe or imply physical form, spatial location, or resemblance to created things.${languageLine}
 
 Return ONLY a JSON array:
 [

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -4,6 +4,8 @@ import { getNameBySlug, DIVINE_NAMES } from "@/lib/names/divine-names";
 import { getOrGenerateNameContent } from "@/lib/names/name-content";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
+import { getUiLocale } from "@/lib/i18n/request-prefs";
+import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 
 // Bump to force regeneration after a prompt change.
 const PAIRINGS_VERSION = 1;
@@ -15,14 +17,23 @@ interface Pairing {
   explanation: string;
 }
 
-function buildPrompt(transliteration: string, arabic: string, meaning: string): string {
+function buildPrompt(
+  transliteration: string,
+  arabic: string,
+  meaning: string,
+  locale: Locale
+): string {
+  const languageLine =
+    locale === "en"
+      ? ""
+      : `\nWrite each "explanation" in ${LOCALE_LANGUAGE_NAME[locale]}. Keep "transliteration" and "arabic" as-is (do not translate names). Preserve the Tanzih framing implicit in classical Islamic terms.`;
   return `You are a classical Islamic scholar (Maturidi/Hanafi tradition).
 
 The divine name ${transliteration} (${arabic}) means "${meaning}".
 
 Task: Identify 2–3 other divine names from the 99 Names that most frequently appear paired with ${transliteration} in the Quran. For each, explain in ONE sentence why this pairing provides perfect theological balance in the specific contexts where they appear together.
 
-Only include pairings where both names actually co-appear in the same verse or in closely related verses as documented in classical tafsir.
+Only include pairings where both names actually co-appear in the same verse or in closely related verses as documented in classical tafsir.${languageLine}
 
 Return ONLY a JSON array:
 [
@@ -36,6 +47,7 @@ Return ONLY a JSON array:
 
 async function getPairings(
   slug: string,
+  locale: Locale,
   onBeforeGenerate: () => Promise<void>
 ): Promise<Pairing[]> {
   const name = getNameBySlug(slug);
@@ -44,9 +56,12 @@ async function getPairings(
   return getOrGenerateNameContent(
     slug,
     "pairings",
+    locale,
     PAIRINGS_VERSION,
     async () => {
-      const text = await callAI(buildPrompt(name.transliteration, name.arabic, name.meaning));
+      const text = await callAI(
+        buildPrompt(name.transliteration, name.arabic, name.meaning, locale)
+      );
 
       let raw: unknown;
       try {
@@ -106,7 +121,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ slug
   }
 
   try {
-    const pairings = await getPairings(slug, async () => {
+    const locale = await getUiLocale();
+    const pairings = await getPairings(slug, locale, async () => {
       if (!(await consume(`names-gen:${clientKey(req)}`))) throw new RateLimitError();
     });
     return NextResponse.json(pairings);

--- a/app/api/names/[slug]/reflection/route.ts
+++ b/app/api/names/[slug]/reflection/route.ts
@@ -4,6 +4,8 @@ import { getNameBySlug } from "@/lib/names/divine-names";
 import { getOrGenerateNameContent } from "@/lib/names/name-content";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
+import { getUiLocale } from "@/lib/i18n/request-prefs";
+import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 
 // Bump to force regeneration after a prompt change.
 const REFLECTION_VERSION = 1;
@@ -12,8 +14,13 @@ function buildPrompt(
   arabic: string,
   transliteration: string,
   meaning: string,
-  description: string
+  description: string,
+  locale: Locale
 ): string {
+  const languageLine =
+    locale === "en"
+      ? ""
+      : `\n7. Write the reflection in ${LOCALE_LANGUAGE_NAME[locale]}, keeping rules 1–5 (especially Tanzih) unchanged.`;
   return `You are a classical Islamic scholar grounded in the Maturidi/Hanafi tradition (Ahl al-Sunnah wal-Jama'ah).
 
 The divine name ${transliteration} (${arabic}) means "${meaning}".
@@ -27,19 +34,27 @@ Critical rules:
 3. Frame the reflection as the believer's RESPONSE to the name, not a possession of it.
 4. Use the language of trust (tawakkul), striving (sa'y), and certainty (yaqin) as appropriate.
 5. Keep the tone reverent, orthodox, and practically grounded.
-6. Return ONLY the paragraph — no title, no labels, no JSON, just the reflection text.
+6. Return ONLY the paragraph — no title, no labels, no JSON, just the reflection text.${languageLine}
 
 Example for Al-Razzaq: "The believer's realisation of Al-Razzaq is not to claim any power over provision, but to strive with full effort in lawful means while maintaining absolute certainty in the heart that the outcome belongs solely to Allah. The servant plants, waters, and labours — yet knows that it is Allah who causes the grain to grow."`;
 }
 
-async function getReflection(slug: string, onBeforeGenerate: () => Promise<void>): Promise<string> {
+async function getReflection(
+  slug: string,
+  locale: Locale,
+  onBeforeGenerate: () => Promise<void>
+): Promise<string> {
   const name = getNameBySlug(slug);
   if (!name) return "";
   return getOrGenerateNameContent(
     slug,
     "reflection",
+    locale,
     REFLECTION_VERSION,
-    () => callAI(buildPrompt(name.arabic, name.transliteration, name.meaning, name.description)),
+    () =>
+      callAI(
+        buildPrompt(name.arabic, name.transliteration, name.meaning, name.description, locale)
+      ),
     (s) => s.trim() === "",
     onBeforeGenerate
   );
@@ -53,7 +68,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ slug
   }
 
   try {
-    const reflection = await getReflection(slug, async () => {
+    const locale = await getUiLocale();
+    const reflection = await getReflection(slug, locale, async () => {
       if (!(await consume(`names-gen:${clientKey(req)}`))) throw new RateLimitError();
     });
     return NextResponse.json({ reflection });

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -224,17 +224,42 @@ async function getVersesBySlug(
   // Localize only the per-verse reason text (a translation of the canonical
   // English reason, cached in name_verse_reasons) — the verse list itself
   // stays exactly as selected above, so it never differs by locale.
+  //
+  // The translation batch below shares ONE rate-limit charge, not one per
+  // verse — without this guard, Promise.all would call onBeforeGenerate once
+  // per uncached verse (up to 5), burning a non-English client's budget
+  // several times faster than an English client's for the same page load. A
+  // request can still consume up to 2 total (this shared charge plus the
+  // canonical-selection charge above), matching "one charge per distinct
+  // generation effort" — selecting verses and translating reasons are two
+  // separate AI-generation events, same as reflection/pairings each charging
+  // once for their one event.
+  let rateLimitChecked = false;
+  const onBeforeGenerateOnce = async () => {
+    if (rateLimitChecked) return;
+    rateLimitChecked = true;
+    await onBeforeGenerate();
+  };
+
   const language = LOCALE_LANGUAGE_NAME[locale];
   const localizedReasons = await Promise.all(
-    verses.map((v) =>
-      getOrGenerateVerseReason(
+    verses.map(async (v) => {
+      const translated = await getOrGenerateVerseReason(
         slug,
         v.ref,
         locale,
         () => translateReason(v.reason, language),
-        onBeforeGenerate
-      )
-    )
+        onBeforeGenerateOnce
+      );
+      // A blank/failed translation must never silently replace an
+      // already-generated, already-Tanzih-checked English reason — fall back
+      // to it and log, rather than serve empty text.
+      if (translated.trim() === "") {
+        console.error(`Name verses: empty translation for ${slug}/${v.ref}/${locale}`);
+        return v.reason;
+      }
+      return translated;
+    })
   );
   return verses.map((v, i) => ({ ...v, reason: localizedReasons[i] }));
 }

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -3,10 +3,12 @@ import { callAI } from "@/lib/ai/ai";
 import { getNameBySlug } from "@/lib/names/divine-names";
 import { isValidRef } from "@/lib/quran/quran-corpus";
 import { resolveVerse } from "@/lib/quran/verse-resolver";
-import { getOrGenerateNameContent } from "@/lib/names/name-content";
+import { getOrGenerateNameContent, getOrGenerateVerseReason } from "@/lib/names/name-content";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
 import { incr } from "@/lib/infra/metrics";
+import { getUiLocale } from "@/lib/i18n/request-prefs";
+import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 import sanitizeHtml from "sanitize-html";
 import type { VerseRef } from "@/types/quran";
 
@@ -140,16 +142,31 @@ function stripHtml(text: string): string {
   return sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });
 }
 
+// Translates (not re-derives) a verse's canonical English `reason` into the
+// target language, so the underlying theological justification stays exactly
+// what was already generated and validated in English.
+async function translateReason(reason: string, language: string): Promise<string> {
+  const prompt = `Translate the following sentence into ${language}. Preserve its meaning exactly — do not add, remove, or alter any theological claim, and maintain strict Tanzih (divine transcendence). Return ONLY the translated sentence, with no quotation marks, labels, or explanation.
+
+Sentence: "${reason}"`;
+  const translated = await callAI(prompt);
+  return translated.trim();
+}
+
 async function getVersesBySlug(
   slug: string,
+  locale: Locale,
   onBeforeGenerate: () => Promise<void>
 ): Promise<NameVerse[]> {
   const name = getNameBySlug(slug);
   if (!name) return [];
 
-  return getOrGenerateNameContent(
+  const verses = await getOrGenerateNameContent(
     slug,
     "verses",
+    // Verse selection is always cached/generated as "en" regardless of the
+    // requester's locale — see name_verse_reasons below for why.
+    "en",
     VERSES_VERSION,
     async (): Promise<NameVerse[]> => {
       // Try actual quran.com search first
@@ -201,6 +218,25 @@ async function getVersesBySlug(
     (v) => v.length === 0,
     onBeforeGenerate
   );
+
+  if (locale === "en" || verses.length === 0) return verses;
+
+  // Localize only the per-verse reason text (a translation of the canonical
+  // English reason, cached in name_verse_reasons) — the verse list itself
+  // stays exactly as selected above, so it never differs by locale.
+  const language = LOCALE_LANGUAGE_NAME[locale];
+  const localizedReasons = await Promise.all(
+    verses.map((v) =>
+      getOrGenerateVerseReason(
+        slug,
+        v.ref,
+        locale,
+        () => translateReason(v.reason, language),
+        onBeforeGenerate
+      )
+    )
+  );
+  return verses.map((v, i) => ({ ...v, reason: localizedReasons[i] }));
 }
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
@@ -211,7 +247,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ slug
   }
 
   try {
-    const verses = await getVersesBySlug(slug, async () => {
+    const locale = await getUiLocale();
+    const verses = await getVersesBySlug(slug, locale, async () => {
       if (!(await consume(`names-gen:${clientKey(req)}`))) throw new RateLimitError();
     });
     return NextResponse.json(verses);

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -3,6 +3,7 @@ import { getPrompt, renderTemplate } from "@/lib/ai/prompt-registry";
 import { db } from "@/lib/infra/db";
 import { aiGenerations } from "@/lib/infra/db/schema";
 import { isValidRef, getVerses } from "@/lib/quran/quran-corpus";
+import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 import type { ConnectionResult, EdgeKind, Verse } from "@/types/quran";
 
 /**
@@ -54,6 +55,7 @@ Rules:
 - Verse references must be real and accurate (format: surah:ayah, e.g. 2:255).
 - Each reason must be one concise sentence explaining the {{kind}} connection in classical Islamic terms.
 - Maintain strict Tanzih (divine transcendence). Avoid Tashbih (anthropomorphism).
+{{language}}
 - Return ONLY a valid JSON array. No prose, no markdown, no explanation outside the JSON.
 
 Output format:
@@ -63,11 +65,21 @@ Output format:
   { "ref": "surah:ayah", "reason": "one-sentence theological justification" }
 ]`;
 
+// Empty for English (the templates' own instructions are already in English).
+// Renders as a standalone rule bullet for any other locale — kept as a rule
+// among rules, not appended after the JSON-only instruction, so the model
+// doesn't mistake it for output-format guidance.
+function languageDirective(locale: Locale): string {
+  if (locale === "en") return "";
+  return `- Write each "reason" in ${LOCALE_LANGUAGE_NAME[locale]}. Keep "ref" in "surah:ayah" format, and keep the Tanzih/Tashbih constraint above unchanged.`;
+}
+
 async function buildPrompt(
   fromRef: string,
   arabicText: string,
   translation: string,
-  kind: EdgeKind
+  kind: EdgeKind,
+  locale: Locale
 ): Promise<{ text: string; promptVersion: number | null }> {
   const { template, version } = await getPrompt("connection.legacy", LEGACY_FALLBACK_TEMPLATE);
   const text = renderTemplate(template, {
@@ -76,6 +88,7 @@ async function buildPrompt(
     translation,
     task: KIND_INSTRUCTIONS[kind],
     kind,
+    language: languageDirective(locale),
   });
   return { text, promptVersion: version };
 }
@@ -103,10 +116,17 @@ export async function generateConnections(
   fromRef: string,
   arabicText: string,
   translation: string,
-  kind: EdgeKind
+  kind: EdgeKind,
+  locale: Locale = "en"
 ): Promise<ConnectionResult[]> {
   const model = process.env.ANTHROPIC_MODEL ?? null;
-  const { text: prompt, promptVersion } = await buildPrompt(fromRef, arabicText, translation, kind);
+  const { text: prompt, promptVersion } = await buildPrompt(
+    fromRef,
+    arabicText,
+    translation,
+    kind,
+    locale
+  );
   const text = await callAI(prompt);
 
   // Best-effort audit log — never fail generation because logging failed.
@@ -162,6 +182,7 @@ Rules:
 - Return at most 3, fewer if fewer are genuinely appropriate.
 - Each reason must be one concise sentence explaining the {{kind}} connection in classical Islamic terms.
 - Maintain strict Tanzih (divine transcendence). Avoid Tashbih (anthropomorphism).
+{{language}}
 - Return ONLY a valid JSON array. No prose, no markdown, no explanation outside the JSON.
 
 Output format:
@@ -174,7 +195,8 @@ async function buildSelectionPrompt(
   arabicText: string,
   translation: string,
   kind: EdgeKind,
-  candidates: Verse[]
+  candidates: Verse[],
+  locale: Locale
 ): Promise<{ text: string; promptVersion: number | null }> {
   const list = candidates.map((v) => `- ${v.ref} — ${v.translation}`).join("\n");
   const { template, version } = await getPrompt(
@@ -188,6 +210,7 @@ async function buildSelectionPrompt(
     task: KIND_SELECTION[kind],
     candidates: list,
     kind,
+    language: languageDirective(locale),
   });
   return { text, promptVersion: version };
 }
@@ -217,7 +240,8 @@ export async function generateGroundedConnections(
   arabicText: string,
   translation: string,
   kind: EdgeKind,
-  candidateRefs: string[]
+  candidateRefs: string[],
+  locale: Locale = "en"
 ): Promise<ConnectionResult[]> {
   const verseMap = await getVerses(candidateRefs);
   const candidates = candidateRefs
@@ -231,7 +255,8 @@ export async function generateGroundedConnections(
     arabicText,
     translation,
     kind,
-    candidates
+    candidates,
+    locale
   );
   const text = await callAI(prompt);
 

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -55,7 +55,6 @@ Rules:
 - Verse references must be real and accurate (format: surah:ayah, e.g. 2:255).
 - Each reason must be one concise sentence explaining the {{kind}} connection in classical Islamic terms.
 - Maintain strict Tanzih (divine transcendence). Avoid Tashbih (anthropomorphism).
-{{language}}
 - Return ONLY a valid JSON array. No prose, no markdown, no explanation outside the JSON.
 
 Output format:
@@ -65,13 +64,15 @@ Output format:
   { "ref": "surah:ayah", "reason": "one-sentence theological justification" }
 ]`;
 
-// Empty for English (the templates' own instructions are already in English).
-// Renders as a standalone rule bullet for any other locale — kept as a rule
-// among rules, not appended after the JSON-only instruction, so the model
-// doesn't mistake it for output-format guidance.
+// Empty for English. Appended AFTER the resolved template (fallback OR an
+// admin's prompt_versions override) rather than filled into a `{{language}}`
+// placeholder — an override created before this locale support existed has
+// no such placeholder, and renderTemplate silently drops unfilled ones, which
+// would silently keep generating English regardless of the requester's
+// locale. Appending guarantees the directive always reaches the model.
 function languageDirective(locale: Locale): string {
   if (locale === "en") return "";
-  return `- Write each "reason" in ${LOCALE_LANGUAGE_NAME[locale]}. Keep "ref" in "surah:ayah" format, and keep the Tanzih/Tashbih constraint above unchanged.`;
+  return `\n\nWrite each "reason" in ${LOCALE_LANGUAGE_NAME[locale]}. Keep "ref" in "surah:ayah" format, and keep the Tanzih/Tashbih constraint above unchanged.`;
 }
 
 async function buildPrompt(
@@ -82,14 +83,14 @@ async function buildPrompt(
   locale: Locale
 ): Promise<{ text: string; promptVersion: number | null }> {
   const { template, version } = await getPrompt("connection.legacy", LEGACY_FALLBACK_TEMPLATE);
-  const text = renderTemplate(template, {
-    fromRef,
-    arabicText,
-    translation,
-    task: KIND_INSTRUCTIONS[kind],
-    kind,
-    language: languageDirective(locale),
-  });
+  const text =
+    renderTemplate(template, {
+      fromRef,
+      arabicText,
+      translation,
+      task: KIND_INSTRUCTIONS[kind],
+      kind,
+    }) + languageDirective(locale);
   return { text, promptVersion: version };
 }
 
@@ -182,7 +183,6 @@ Rules:
 - Return at most 3, fewer if fewer are genuinely appropriate.
 - Each reason must be one concise sentence explaining the {{kind}} connection in classical Islamic terms.
 - Maintain strict Tanzih (divine transcendence). Avoid Tashbih (anthropomorphism).
-{{language}}
 - Return ONLY a valid JSON array. No prose, no markdown, no explanation outside the JSON.
 
 Output format:
@@ -203,15 +203,15 @@ async function buildSelectionPrompt(
     "connection.selection",
     SELECTION_FALLBACK_TEMPLATE
   );
-  const text = renderTemplate(template, {
-    fromRef,
-    arabicText,
-    translation,
-    task: KIND_SELECTION[kind],
-    candidates: list,
-    kind,
-    language: languageDirective(locale),
-  });
+  const text =
+    renderTemplate(template, {
+      fromRef,
+      arabicText,
+      translation,
+      task: KIND_SELECTION[kind],
+      candidates: list,
+      kind,
+    }) + languageDirective(locale);
   return { text, promptVersion: version };
 }
 

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -6,6 +6,7 @@ import { discoverCandidates } from "@/lib/ai/connection-discovery";
 import { resolveVerse } from "@/lib/quran/verse-resolver";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { incr } from "@/lib/infra/metrics";
+import type { Locale } from "@/lib/i18n/config";
 import type { ConnectionResult, EdgeKind } from "@/types/quran";
 
 /**
@@ -37,6 +38,12 @@ interface GetConnectionsOptions {
    *  both the cache read and any fresh generation, so a repeat "get more"
    *  request surfaces genuinely new connections instead of the same set. */
   excludeRefs?: string[];
+  /** Language the reason text should be generated in on a cache MISS only.
+   *  The `connections` table has no locale column — a stored reason is served
+   *  to every later reader regardless of their locale (an accepted v1
+   *  limitation: whichever locale first triggers generation for a given
+   *  fromRef+kind "wins" the cached reason's language). Defaults to "en". */
+  locale?: Locale;
 }
 
 /** Hydrate stored edges (which carry only refs + reason) into full results. */
@@ -117,7 +124,7 @@ export async function getConnections(
   }
 
   incr("gen_started");
-  const work = generateAndPersist(fromRef, kind, source, excludeRefs);
+  const work = generateAndPersist(fromRef, kind, source, excludeRefs, options.locale ?? "en");
   inFlight.set(key, work);
   try {
     return await work;
@@ -137,7 +144,8 @@ async function generateAndPersist(
   fromRef: string,
   kind: EdgeKind,
   source: SourceVerse,
-  excludeRefs: string[] = []
+  excludeRefs: string[] = [],
+  locale: Locale = "en"
 ): Promise<ConnectionResult[]> {
   const candidates = await discoverCandidates(fromRef, kind, undefined, excludeRefs);
   // The legacy ungrounded path has no notion of excludeRefs — it would just
@@ -152,11 +160,12 @@ async function generateAndPersist(
           source.arabicText,
           source.translation,
           kind,
-          candidates
+          candidates,
+          locale
         )
       : excludeRefs.length > 0
         ? []
-        : await generateConnections(fromRef, source.arabicText, source.translation, kind);
+        : await generateConnections(fromRef, source.arabicText, source.translation, kind, locale);
 
   if (generated.length > 0) {
     const model = process.env.ANTHROPIC_MODEL ?? null;

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -18,6 +18,16 @@ export const LOCALE_LABELS: Record<Locale, string> = {
   az: "Azərbaycan dili",
 };
 
+// English names for each locale, used only when instructing an AI model which
+// language to write in (the model follows "Turkish" more reliably than a
+// native self-name). Distinct from LOCALE_LABELS, which is for UI display.
+export const LOCALE_LANGUAGE_NAME: Record<Locale, string> = {
+  en: "English",
+  tr: "Turkish",
+  ru: "Russian",
+  az: "Azerbaijani",
+};
+
 export const DEFAULT_EDITION_BY_LOCALE: Record<Locale, string> = {
   en: "en.sahih",
   tr: "tr.diyanet",

--- a/lib/infra/db/migrations/0019_name_content_locale.sql
+++ b/lib/infra/db/migrations/0019_name_content_locale.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "name_verse_reasons" (
+	"slug" text NOT NULL,
+	"ref" text NOT NULL,
+	"locale" text NOT NULL,
+	"reason" text NOT NULL,
+	"model" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "name_verse_reasons_slug_ref_locale_pk" PRIMARY KEY("slug","ref","locale")
+);
+--> statement-breakpoint
+ALTER TABLE "name_content" ADD COLUMN "locale" text DEFAULT 'en' NOT NULL;--> statement-breakpoint
+ALTER TABLE "name_content" DROP CONSTRAINT "name_content_slug_kind_pk";--> statement-breakpoint
+ALTER TABLE "name_content" ADD CONSTRAINT "name_content_slug_kind_locale_pk" PRIMARY KEY("slug","kind","locale");

--- a/lib/infra/db/migrations/meta/0019_snapshot.json
+++ b/lib/infra/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,2268 @@
+{
+  "id": "05903c8f-6131-432f-8e80-fbd4461f8e7e",
+  "prevId": "6b309de0-818d-4201-afe5-d185dbdb51b0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_date": {
+          "name": "activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_date_idx": {
+          "name": "activity_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_type_date_idx": {
+          "name": "activity_user_type_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_user_id_users_id_fk": {
+          "name": "activity_log_user_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_qf_id": {
+          "name": "admin_qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_created_idx": {
+          "name": "admin_audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_generations": {
+      "name": "ai_generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_generations_created_idx": {
+          "name": "ai_generations_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_idx": {
+          "name": "bookmarks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookmarks_user_ref_uniq": {
+          "name": "bookmarks_user_ref_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "verse_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_suggestions": {
+      "name": "challenge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_duration": {
+          "name": "suggested_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_suggestions_active_idx": {
+          "name": "challenge_suggestions_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenger_id": {
+          "name": "challenger_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenged_id": {
+          "name": "challenged_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_challenger_status_idx": {
+          "name": "challenges_challenger_status_idx",
+          "columns": [
+            {
+              "expression": "challenger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_challenged_status_idx": {
+          "name": "challenges_challenged_status_idx",
+          "columns": [
+            {
+              "expression": "challenged_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_ends_at_idx": {
+          "name": "challenges_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_suggestion_id_idx": {
+          "name": "challenges_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_challenger_id_users_id_fk": {
+          "name": "challenges_challenger_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_challenged_id_users_id_fk": {
+          "name": "challenges_challenged_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenged_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_suggestion_id_challenge_suggestions_id_fk": {
+          "name": "challenges_suggestion_id_challenge_suggestions_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "challenge_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "challenges_winner_id_users_id_fk": {
+          "name": "challenges_winner_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_challenge": {
+          "name": "no_self_challenge",
+          "value": "\"challenges\".\"challenger_id\" != \"challenges\".\"challenged_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_ref": {
+          "name": "to_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_from_to_kind_idx": {
+          "name": "connections_from_to_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_from_kind_idx": {
+          "name": "connections_from_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_reviewed_at_idx": {
+          "name": "connections_reviewed_at_idx",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_votd": {
+      "name": "curated_votd",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "friendships_pair_idx": {
+          "name": "friendships_pair_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_addressee_status_idx": {
+          "name": "friendships_addressee_status_idx",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_requester_status_idx": {
+          "name": "friendships_requester_status_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_requester_id_users_id_fk": {
+          "name": "friendships_requester_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_addressee_id_users_id_fk": {
+          "name": "friendships_addressee_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_friendship": {
+          "name": "no_self_friendship",
+          "value": "\"friendships\".\"requester_id\" != \"friendships\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_runs": {
+      "name": "job_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_tail": {
+          "name": "log_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_runs_type_started_idx": {
+          "name": "job_runs_type_started_idx",
+          "columns": [
+            {
+              "expression": "job_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.name_content": {
+      "name": "name_content",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "name_content_slug_kind_locale_pk": {
+          "name": "name_content_slug_kind_locale_pk",
+          "columns": [
+            "slug",
+            "kind",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.name_verse_reasons": {
+      "name": "name_verse_reasons",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "name_verse_reasons_slug_ref_locale_pk": {
+          "name": "name_verse_reasons_slug_ref_locale_pk",
+          "columns": [
+            "slug",
+            "ref",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_mentions": {
+      "name": "note_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioning_user_id": {
+          "name": "mentioning_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_id": {
+          "name": "mentioned_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_mentions_mentioned_user_read_idx": {
+          "name": "note_mentions_mentioned_user_read_idx",
+          "columns": [
+            {
+              "expression": "mentioned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_mentions_note_id_verse_notes_id_fk": {
+          "name": "note_mentions_note_id_verse_notes_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "verse_notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_mentions_mentioning_user_id_users_id_fk": {
+          "name": "note_mentions_mentioning_user_id_users_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentioning_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_mentions_mentioned_user_id_users_id_fk": {
+          "name": "note_mentions_mentioned_user_id_users_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentioned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_versions": {
+      "name": "prompt_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "prompt_versions_key_idx": {
+          "name": "prompt_versions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_key_active_idx": {
+          "name": "prompt_versions_key_active_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_one_active_per_key_uidx": {
+          "name": "prompt_versions_one_active_per_key_uidx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_versions\".\"active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_workspaces": {
+      "name": "saved_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_workspaces_user_idx": {
+          "name": "saved_workspaces_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_workspaces_user_id_users_id_fk": {
+          "name": "saved_workspaces_user_id_users_id_fk",
+          "tableFrom": "saved_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_log": {
+      "name": "search_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zero_result": {
+          "name": "zero_result",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "search_log_created_idx": {
+          "name": "search_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_log_zero_result_idx": {
+          "name": "search_log_zero_result_idx",
+          "columns": [
+            {
+              "expression": "zero_result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_canvases": {
+      "name": "shared_canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qf_id": {
+          "name": "qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_qf_id_idx": {
+          "name": "users_qf_id_idx",
+          "columns": [
+            {
+              "expression": "qf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_active_idx": {
+          "name": "users_last_active_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_qf_id_unique": {
+          "name": "users_qf_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qf_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_embeddings": {
+      "name": "verse_embeddings",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_embeddings_hnsw_idx": {
+          "name": "verse_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_notes": {
+      "name": "verse_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_notes_user_ref_idx": {
+          "name": "verse_notes_user_ref_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_notes_user_id_users_id_fk": {
+          "name": "verse_notes_user_id_users_id_fk",
+          "tableFrom": "verse_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_translations": {
+      "name": "verse_translations",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edition": {
+          "name": "edition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_translations_edition_idx": {
+          "name": "verse_translations_edition_idx",
+          "columns": [
+            {
+              "expression": "edition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_translations_ref_verses_ref_fk": {
+          "name": "verse_translations_ref_verses_ref_fk",
+          "tableFrom": "verse_translations",
+          "tableTo": "verses",
+          "columnsFrom": [
+            "ref"
+          ],
+          "columnsTo": [
+            "ref"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "verse_translations_ref_edition_pk": {
+          "name": "verse_translations_ref_edition_pk",
+          "columns": [
+            "ref",
+            "edition"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verses": {
+      "name": "verses",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "surah": {
+          "name": "surah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ayah": {
+          "name": "ayah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arabic_text": {
+          "name": "arabic_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transliteration": {
+          "name": "transliteration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verses_surah_ayah_idx": {
+          "name": "verses_surah_ayah_idx",
+          "columns": [
+            {
+              "expression": "surah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ayah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_morphology": {
+      "name": "word_morphology",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "word_morphology_ref_pos_idx": {
+          "name": "word_morphology_ref_pos_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_ref_idx": {
+          "name": "word_morphology_ref_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_root_idx": {
+          "name": "word_morphology_root_idx",
+          "columns": [
+            {
+              "expression": "root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/infra/db/migrations/meta/_journal.json
+++ b/lib/infra/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1785337523680,
       "tag": "0018_verse_translations",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1785433310602,
+      "tag": "0019_name_content_locale",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/infra/db/schema.ts
+++ b/lib/infra/db/schema.ts
@@ -391,13 +391,37 @@ export const nameContent = pgTable(
   {
     slug: text("slug").notNull(),
     kind: text("kind").$type<NameContentKind>().notNull(),
+    // Locale the AI-generated `data` was written in. Defaults to "en" so
+    // existing rows keep their identity unchanged under the extended PK below.
+    // The "verses" kind is always written under "en" — verse *selection* stays
+    // locale-independent (see name_verse_reasons for the per-locale part).
+    locale: text("locale").notNull().default("en"),
     data: text("data").notNull(),
     model: text("model"),
     version: integer("version").notNull().default(1),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (t) => [primaryKey({ columns: [t.slug, t.kind] })]
+  (t) => [primaryKey({ columns: [t.slug, t.kind, t.locale] })]
+);
+
+// Locale-specific translations of a name_content "verses" entry's per-verse
+// `reason` field. Kept separate from name_content rather than folded into its
+// PK because the verse *selection* for a name must stay identical across
+// locales (an AI re-selection per locale could surface a different verse set
+// for the same name) — only the reason text is localized, as a translation
+// of the canonical English reason, not a fresh generation.
+export const nameVerseReasons = pgTable(
+  "name_verse_reasons",
+  {
+    slug: text("slug").notNull(),
+    ref: text("ref").notNull(),
+    locale: text("locale").notNull(),
+    reason: text("reason").notNull(),
+    model: text("model"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [primaryKey({ columns: [t.slug, t.ref, t.locale] })]
 );
 
 // ─── Curated Verse of the Day ─────────────────────────────────────────────────
@@ -561,6 +585,8 @@ export type WordMorphology = typeof wordMorphology.$inferSelect;
 export type NewWordMorphology = typeof wordMorphology.$inferInsert;
 export type NameContent = typeof nameContent.$inferSelect;
 export type NewNameContent = typeof nameContent.$inferInsert;
+export type NameVerseReason = typeof nameVerseReasons.$inferSelect;
+export type NewNameVerseReason = typeof nameVerseReasons.$inferInsert;
 export type CuratedVotd = typeof curatedVotd.$inferSelect;
 export type NewCuratedVotd = typeof curatedVotd.$inferInsert;
 export type AdminAuditEntry = typeof adminAuditLog.$inferSelect;

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -157,16 +157,36 @@ export async function getOrGenerateVerseReason(
 
   const work = (async () => {
     const reason = await generate();
-    if (reason.trim() !== "") {
-      const model = process.env.ANTHROPIC_MODEL ?? null;
-      try {
-        await db
-          .insert(nameVerseReasons)
-          .values({ slug, ref, locale, reason, model })
-          .onConflictDoNothing();
-      } catch (err) {
-        console.error("Failed to persist name_verse_reasons:", err);
+    if (reason.trim() === "") return reason;
+
+    const model = process.env.ANTHROPIC_MODEL ?? null;
+    try {
+      // `reasonInFlight` only coalesces callers within this process — a
+      // concurrent request on another instance can win the same (slug, ref,
+      // locale) row first. RETURNING is empty exactly when DO NOTHING
+      // discarded our insert; re-read in that case so this call returns the
+      // translation that's actually persisted, not the one that lost.
+      const inserted = await db
+        .insert(nameVerseReasons)
+        .values({ slug, ref, locale, reason, model })
+        .onConflictDoNothing()
+        .returning({ reason: nameVerseReasons.reason });
+      if (inserted.length === 0) {
+        const [existing] = await db
+          .select({ reason: nameVerseReasons.reason })
+          .from(nameVerseReasons)
+          .where(
+            and(
+              eq(nameVerseReasons.slug, slug),
+              eq(nameVerseReasons.ref, ref),
+              eq(nameVerseReasons.locale, locale)
+            )
+          )
+          .limit(1);
+        if (existing) return existing.reason;
       }
+    } catch (err) {
+      console.error("Failed to persist name_verse_reasons:", err);
     }
     return reason;
   })();

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -7,9 +7,9 @@ import type { Locale } from "@/lib/i18n/config";
  * Durable, write-once/read-many cache for the AI-generated 99-Names content
  * (verses, reflection, pairings). Replaces Next's `unstable_cache`, which is
  * wiped on every redeploy and so re-runs Claude for each name after each deploy.
- * Persisting to Postgres means each (name, kind) is generated at most once per
- * prompt `version` and served from the DB forever — the same pattern the
- * connection graph uses (see lib/graph-service.ts).
+ * Persisting to Postgres means each (slug, kind, locale) is generated at most
+ * once per prompt `version` and served from the DB forever — the same pattern
+ * the connection graph uses (see lib/graph-service.ts).
  */
 
 export type { NameContentKind };

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
-import { nameContent, type NameContentKind } from "@/lib/infra/db/schema";
+import { nameContent, nameVerseReasons, type NameContentKind } from "@/lib/infra/db/schema";
+import type { Locale } from "@/lib/i18n/config";
 
 /**
  * Durable, write-once/read-many cache for the AI-generated 99-Names content
@@ -21,9 +22,9 @@ export type { NameContentKind };
 const inFlight = new Map<string, Promise<unknown>>();
 
 /**
- * Returns the cached content for `(slug, kind)` when present at the current
- * `version`; otherwise runs `generate()`, persists the result (unless empty),
- * and returns it.
+ * Returns the cached content for `(slug, kind, locale)` when present at the
+ * current `version`; otherwise runs `generate()`, persists the result (unless
+ * empty), and returns it.
  *
  * `isEmpty` decides whether a result is worth caching — an empty array or blank
  * string usually means a transient search/AI failure, so we return it but do NOT
@@ -40,6 +41,7 @@ const inFlight = new Map<string, Promise<unknown>>();
 export async function getOrGenerateNameContent<T>(
   slug: string,
   kind: NameContentKind,
+  locale: Locale,
   version: number,
   generate: () => Promise<T>,
   isEmpty: (value: T) => boolean,
@@ -49,7 +51,9 @@ export async function getOrGenerateNameContent<T>(
   const [row] = await db
     .select({ data: nameContent.data, version: nameContent.version })
     .from(nameContent)
-    .where(and(eq(nameContent.slug, slug), eq(nameContent.kind, kind)))
+    .where(
+      and(eq(nameContent.slug, slug), eq(nameContent.kind, kind), eq(nameContent.locale, locale))
+    )
     .limit(1);
 
   if (row && row.version === version) {
@@ -59,7 +63,7 @@ export async function getOrGenerateNameContent<T>(
       // Corrupt cache row — log (it's a genuine anomaly that would otherwise
       // silently re-trigger AI generation every request) then regenerate, which
       // overwrites it via the upsert below.
-      console.error(`Corrupt name_content row for ${slug}/${kind}, regenerating:`, err);
+      console.error(`Corrupt name_content row for ${slug}/${kind}/${locale}, regenerating:`, err);
     }
   }
 
@@ -69,11 +73,11 @@ export async function getOrGenerateNameContent<T>(
   // can't both become the leader. `version` is part of the key so a follower can
   // never join a generation running under a different version (defensive — the
   // version is a per-route constant, so this only differs across a deploy).
-  const key = `${slug}:${kind}:${version}`;
+  const key = `${slug}:${kind}:${locale}:${version}`;
   const pending = inFlight.get(key);
   if (pending) return pending as Promise<T>;
 
-  const work = generateAndPersist(slug, kind, version, generate, isEmpty);
+  const work = generateAndPersist(slug, kind, locale, version, generate, isEmpty);
   inFlight.set(key, work);
   try {
     return await work;
@@ -85,6 +89,7 @@ export async function getOrGenerateNameContent<T>(
 async function generateAndPersist<T>(
   slug: string,
   kind: NameContentKind,
+  locale: Locale,
   version: number,
   generate: () => Promise<T>,
   isEmpty: (value: T) => boolean
@@ -97,9 +102,9 @@ async function generateAndPersist<T>(
     try {
       await db
         .insert(nameContent)
-        .values({ slug, kind, data, model, version })
+        .values({ slug, kind, locale, data, model, version })
         .onConflictDoUpdate({
-          target: [nameContent.slug, nameContent.kind],
+          target: [nameContent.slug, nameContent.kind, nameContent.locale],
           set: { data, model, version, updatedAt: new Date() },
         });
     } catch (err) {
@@ -109,4 +114,66 @@ async function generateAndPersist<T>(
   }
 
   return result;
+}
+
+// Per-process single-flight for verse-reason translations, mirroring `inFlight`
+// above but keyed into name_verse_reasons instead of name_content.
+const reasonInFlight = new Map<string, Promise<string>>();
+
+/**
+ * Returns a locale-specific translation of a "verses" entry's per-verse
+ * `reason`, generating and persisting it on first request for that
+ * `(slug, ref, locale)`. Verse *selection* is never re-run here — callers
+ * pass the already-resolved canonical reason into `generate` to translate,
+ * not to re-derive from scratch (see lib/infra/db/schema.ts's comment on
+ * name_verse_reasons for why).
+ */
+export async function getOrGenerateVerseReason(
+  slug: string,
+  ref: string,
+  locale: Locale,
+  generate: () => Promise<string>,
+  onBeforeGenerate?: () => Promise<void>
+): Promise<string> {
+  const [row] = await db
+    .select({ reason: nameVerseReasons.reason })
+    .from(nameVerseReasons)
+    .where(
+      and(
+        eq(nameVerseReasons.slug, slug),
+        eq(nameVerseReasons.ref, ref),
+        eq(nameVerseReasons.locale, locale)
+      )
+    )
+    .limit(1);
+
+  if (row) return row.reason;
+
+  if (onBeforeGenerate) await onBeforeGenerate();
+
+  const key = `${slug}:${ref}:${locale}`;
+  const pending = reasonInFlight.get(key);
+  if (pending) return pending;
+
+  const work = (async () => {
+    const reason = await generate();
+    if (reason.trim() !== "") {
+      const model = process.env.ANTHROPIC_MODEL ?? null;
+      try {
+        await db
+          .insert(nameVerseReasons)
+          .values({ slug, ref, locale, reason, model })
+          .onConflictDoNothing();
+      } catch (err) {
+        console.error("Failed to persist name_verse_reasons:", err);
+      }
+    }
+    return reason;
+  })();
+  reasonInFlight.set(key, work);
+  try {
+    return await work;
+  } finally {
+    reasonInFlight.delete(key);
+  }
 }


### PR DESCRIPTION
## Summary

Phase 4 of #331: AI-generated text now writes in the user's interface language instead of always English, with theological framing and constraints carried over verbatim.

- **Canvas connection reasons** (`lib/ai/connection-generator.ts`): `generateConnections`/`generateGroundedConnections` take a `locale` and append a language directive to both prompt templates, placed alongside (not after) the Tanzih/Tashbih rule so it reads as one more constraint, not output-format guidance. The `connections` table has no locale column and won't get one in this phase — a stored reason is served to every later reader regardless of locale (whichever locale's request first triggers generation for a given verse+kind "wins" that cache entry's language). This is a deliberate, accepted v1 limitation, not an oversight.
- **Reflection & Pairings** (`/api/names/[slug]/{reflection,pairings}`): `name_content` gets a real `locale` column — migration `0019` extends its primary key to `(slug, kind, locale)`, so each language caches independently. Both routes call `getUiLocale()` and append a language instruction to their existing inline prompts.
- **Verses** is handled differently by design: the AI both *selects* which verses connect to a name and writes a *reason* for each. Making the whole kind locale-aware risked the AI picking a different verse set per locale for the same name. So verse **selection** stays keyed under locale `"en"` always (unchanged), and only the per-verse **reason** gets a second, translation-only pass (explicit "do not add or remove any theological claim" instruction) — cached in a new `name_verse_reasons` table keyed `(slug, ref, locale)`, kept separate from `name_content` on purpose.
- Caught and fixed a `drizzle-kit`-generated migration ordering bug: the generated `0019` SQL tried to `ADD CONSTRAINT ... PRIMARY KEY (..., "locale")` *before* the `ADD COLUMN "locale"` statement that creates it. Unit tests didn't catch this (they mock the DB); the integration test against real Postgres did.

## AI / Theological changes

Checking this box — this PR changes AI *output language* only. The Tanzih/Maturidi-Hanafi framing, rules, and verse-reference validation are unchanged; the language directive is injected as an additional rule alongside the existing ones, and the verses-kind translation pass is explicitly instructed to preserve the canonical English reason's meaning rather than re-derive it.

## Notes

- The tracking issue's stated Phase 4 blocker ("missing rate limit on names routes") is stale — `app/api/names/[slug]/{reflection,pairings,verses}/route.ts` already call the shared `names-gen:` `consume()` limiter (added in an earlier phase). No prerequisite PR was needed.

## Test plan
- [x] `bun run lint` / `format:check` / `typecheck` / `test:ci` clean (840 unit tests, +17 new)
- [x] `bun run test:integration` (Testcontainers) — new `name-content-locale.integration.test.ts` covers migration `0019` preserving existing rows as `locale='en'`, per-locale `name_content` rows staying independent, and `name_verse_reasons` round-tripping
- [x] `bun run test:e2e` — `a11y.spec.ts` today/names index/names detail, all passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-generated connection explanations, reflections, and pairing details now support the selected interface language.
  * Verse explanations can be translated while preserving the original verse selection and theological meaning.
  * Localized content is stored independently, improving consistency across supported languages.
  * Added caching for translated verse explanations to avoid unnecessary regeneration.

* **Bug Fixes**
  * Improved locale handling for API requests and content generation when no language preference is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->