### PR TITLE
chore(i18n): finish next-intl migration for VerseOfDayCard and PersonalHome

### DIFF
--- a/components/home/PersonalHome.tsx
+++ b/components/home/PersonalHome.tsx
@@ -44,6 +44,7 @@ export function PersonalHome({ verse }: { verse: Verse | null }) {
   const tNav = useTranslations("nav");
   const tBookmarks = useTranslations("bookmarks");
   const tErrors = useTranslations("errors");
+  const t = useTranslations("home");
   const bookmarks = useAuthStore((s) => s.bookmarks);
   const accessToken = useAuthStore((s) => s.accessToken);
   const username = useSocialStore((s) => s.username);
@@ -84,22 +85,21 @@ export function PersonalHome({ verse }: { verse: Verse | null }) {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-text-muted">
-            Assalamu alaykum
+            {t("greeting")}
           </p>
           <h1 className="mt-1.5 text-[clamp(1.5rem,3.5vw,2.1rem)] font-semibold tracking-[-0.02em] text-text-primary">
-            {username ? (
-              <>
-                Welcome back, <span className="text-gold">{username}</span>
-              </>
-            ) : (
-              "Welcome back"
-            )}
+            {username
+              ? t.rich("welcomeBackNamed", {
+                  name: username,
+                  gold: (chunks) => <span className="text-gold">{chunks}</span>,
+                })
+              : t("welcomeBack")}
           </h1>
         </div>
         {streak > 0 && (
           <div className="flex items-center gap-1.5 rounded-full border border-gold/40 bg-gold/[0.08] px-3 py-1.5 text-gold">
             <Flame className="h-3.5 w-3.5" fill="currentColor" />
-            <span className="text-sm font-semibold">{streak}-day streak</span>
+            <span className="text-sm font-semibold">{tNav("dayStreak", { count: streak })}</span>
           </div>
         )}
       </div>
@@ -117,24 +117,22 @@ export function PersonalHome({ verse }: { verse: Verse | null }) {
           <QuickLink
             href="/canvas"
             icon={LayoutTemplate}
-            title={hasContinue ? "Continue your canvas" : "Open the canvas"}
+            title={hasContinue ? t("continueCanvas") : t("openCanvas")}
             subtitle={
-              hasContinue
-                ? `${continueCount} verse${continueCount === 1 ? "" : "s"} in progress`
-                : "Search a verse and map its connections"
+              hasContinue ? t("versesInProgress", { count: continueCount }) : t("searchAVerse")
             }
           />
           {accessToken && (
             <QuickLink
               href="/workspaces"
               icon={FolderOpen}
-              title="Saved canvases"
+              title={tNav("savedCanvases")}
               subtitle={
                 savedCount !== null
-                  ? `${savedCount} saved canvas${savedCount === 1 ? "" : "es"}`
+                  ? t("savedCanvasCount", { count: savedCount })
                   : savedCountError
-                    ? "Couldn't load your saved canvases"
-                    : "Your saved graphs"
+                    ? t("savedCanvasesLoadError")
+                    : t("savedGraphs")
               }
             />
           )}

--- a/components/today/VerseOfDayCard.tsx
+++ b/components/today/VerseOfDayCard.tsx
@@ -21,6 +21,7 @@ import { useCopyFeedback } from "@/hooks/useCopyFeedback";
  */
 export function VerseOfDayCard({ verse, reflection }: { verse: Verse; reflection?: string }) {
   const tCommon = useTranslations("common");
+  const t = useTranslations("today");
   const playVerse = useAudioStore((s) => s.playVerse);
   const pauseAudio = useAudioStore((s) => s.pause);
   const resumeAudio = useAudioStore((s) => s.resume);
@@ -67,7 +68,7 @@ export function VerseOfDayCard({ verse, reflection }: { verse: Verse; reflection
       <div className="space-y-[clamp(0.85rem,2.5vh,1.25rem)] p-[clamp(1.15rem,3.5vh,2rem)]">
         <div className="flex items-center justify-between gap-3">
           <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-muted">
-            Verse of the day
+            {t("verseOfTheDay")}
           </span>
           <span className="shrink-0 rounded border border-gold bg-gold/10 px-1.5 py-0.5 font-mono text-xs text-gold">
             {verse.ref}
@@ -98,14 +99,14 @@ export function VerseOfDayCard({ verse, reflection }: { verse: Verse; reflection
             className={cn(buttonVariants({ variant: "primary", size: "md" }), "gap-2")}
           >
             <Network className="h-4 w-4" />
-            Open on canvas
+            {t("openOnCanvas")}
           </Link>
 
-          <Tooltip label={isThisPlaying ? "Pause recitation" : "Listen"}>
+          <Tooltip label={isThisPlaying ? t("pauseRecitation") : t("listen")}>
             <IconButton
               tone="teal"
               onClick={handleListen}
-              aria-label={isThisPlaying ? "Pause recitation" : "Listen to recitation"}
+              aria-label={isThisPlaying ? t("pauseRecitation") : t("listenToRecitation")}
               className={cn(isThisCurrent && "border-teal text-teal")}
             >
               {isThisPlaying ? <Pause /> : <Volume2 />}
@@ -123,10 +124,10 @@ export function VerseOfDayCard({ verse, reflection }: { verse: Verse; reflection
             </IconButton>
           </Tooltip>
 
-          <Tooltip label={copied ? "Copied!" : "Share"}>
+          <Tooltip label={copied ? t("copied") : t("share")}>
             <IconButton
               onClick={handleShare}
-              aria-label="Copy link to today's verse"
+              aria-label={t("copyLink")}
               className={cn(copied && "border-teal text-teal")}
             >
               {copied ? <Check /> : <Share2 />}

--- a/messages/az.json
+++ b/messages/az.json
@@ -141,6 +141,28 @@
     "couldNotLoadVerse": "Ayə mətni yüklənə bilmədi.",
     "savedCount": "{count, plural, =0 {Hələ əlfəcin yoxdur} one {# yadda saxlanmış ayə} other {# yadda saxlanmış ayə}}"
   },
+  "today": {
+    "verseOfTheDay": "Günün ayəsi",
+    "openOnCanvas": "Lövhədə aç",
+    "pauseRecitation": "Qiraəti dayandır",
+    "listen": "Dinlə",
+    "listenToRecitation": "Qiraəti dinlə",
+    "copied": "Kopyalandı!",
+    "share": "Paylaş",
+    "copyLink": "Günün ayəsinin bağlantısını kopyala"
+  },
+  "home": {
+    "greeting": "Əssəlamu aleykum",
+    "welcomeBack": "Yenidən xoş gəldin",
+    "welcomeBackNamed": "Yenidən xoş gəldin, <gold>{name}</gold>",
+    "continueCanvas": "Lövhənə davam et",
+    "openCanvas": "Lövhəni aç",
+    "versesInProgress": "{count, plural, one {# ayə davam edir} other {# ayə davam edir}}",
+    "searchAVerse": "Bir ayə axtarın və əlaqələrini xəritələndirin",
+    "savedCanvasCount": "{count, plural, one {# yadda saxlanmış lövhə} other {# yadda saxlanmış lövhə}}",
+    "savedCanvasesLoadError": "Yadda saxlanmış lövhələriniz yüklənə bilmədi",
+    "savedGraphs": "Yadda saxlanmış lövhələriniz"
+  },
   "names": {
     "eyebrow": "Əsmayi-Hüsna",
     "heroTitle": "Allahın 99 Gözəl Adı",

--- a/messages/en.json
+++ b/messages/en.json
@@ -141,6 +141,28 @@
     "couldNotLoadVerse": "Could not load verse text.",
     "savedCount": "{count, plural, =0 {No bookmarks yet} one {# saved verse} other {# saved verses}}"
   },
+  "today": {
+    "verseOfTheDay": "Verse of the day",
+    "openOnCanvas": "Open on canvas",
+    "pauseRecitation": "Pause recitation",
+    "listen": "Listen",
+    "listenToRecitation": "Listen to recitation",
+    "copied": "Copied!",
+    "share": "Share",
+    "copyLink": "Copy link to today's verse"
+  },
+  "home": {
+    "greeting": "Assalamu alaykum",
+    "welcomeBack": "Welcome back",
+    "welcomeBackNamed": "Welcome back, <gold>{name}</gold>",
+    "continueCanvas": "Continue your canvas",
+    "openCanvas": "Open the canvas",
+    "versesInProgress": "{count, plural, one {# verse in progress} other {# verses in progress}}",
+    "searchAVerse": "Search a verse and map its connections",
+    "savedCanvasCount": "{count, plural, one {# saved canvas} other {# saved canvases}}",
+    "savedCanvasesLoadError": "Couldn't load your saved canvases",
+    "savedGraphs": "Your saved graphs"
+  },
   "names": {
     "eyebrow": "Asmaul Husna",
     "heroTitle": "The 99 Beautiful Names of Allah",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -141,6 +141,28 @@
     "couldNotLoadVerse": "Не удалось загрузить текст аята.",
     "savedCount": "{count, plural, =0 {Пока нет закладок} one {# сохранённый аят} few {# сохранённых аята} many {# сохранённых аятов} other {# сохранённого аята}}"
   },
+  "today": {
+    "verseOfTheDay": "Аят дня",
+    "openOnCanvas": "Открыть на холсте",
+    "pauseRecitation": "Приостановить чтение",
+    "listen": "Слушать",
+    "listenToRecitation": "Слушать чтение",
+    "copied": "Скопировано!",
+    "share": "Поделиться",
+    "copyLink": "Скопировать ссылку на аят дня"
+  },
+  "home": {
+    "greeting": "Ассаляму алейкум",
+    "welcomeBack": "С возвращением",
+    "welcomeBackNamed": "С возвращением, <gold>{name}</gold>",
+    "continueCanvas": "Продолжить холст",
+    "openCanvas": "Открыть холст",
+    "versesInProgress": "{count, plural, one {# аят в процессе} few {# аята в процессе} many {# аятов в процессе} other {# аята в процессе}}",
+    "searchAVerse": "Найдите аят и отобразите его связи",
+    "savedCanvasCount": "{count, plural, one {# сохранённый холст} few {# сохранённых холста} many {# сохранённых холстов} other {# сохранённых холста}}",
+    "savedCanvasesLoadError": "Не удалось загрузить сохранённые холсты",
+    "savedGraphs": "Ваши сохранённые холсты"
+  },
   "names": {
     "eyebrow": "Асма уль-Хусна",
     "heroTitle": "99 Прекрасных Имён Аллаха",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -141,6 +141,28 @@
     "couldNotLoadVerse": "Ayet metni yüklenemedi.",
     "savedCount": "{count, plural, =0 {Henüz yer imi yok} one {# kayıtlı ayet} other {# kayıtlı ayet}}"
   },
+  "today": {
+    "verseOfTheDay": "Günün ayeti",
+    "openOnCanvas": "Tuvalde aç",
+    "pauseRecitation": "Kıraati duraklat",
+    "listen": "Dinle",
+    "listenToRecitation": "Kıraati dinle",
+    "copied": "Kopyalandı!",
+    "share": "Paylaş",
+    "copyLink": "Günün ayetinin bağlantısını kopyala"
+  },
+  "home": {
+    "greeting": "Selamün aleyküm",
+    "welcomeBack": "Tekrar hoş geldin",
+    "welcomeBackNamed": "Tekrar hoş geldin, <gold>{name}</gold>",
+    "continueCanvas": "Tuvaline devam et",
+    "openCanvas": "Tuvali aç",
+    "versesInProgress": "{count, plural, one {# ayet devam ediyor} other {# ayet devam ediyor}}",
+    "searchAVerse": "Bir ayet arayın ve bağlantılarını haritalayın",
+    "savedCanvasCount": "{count, plural, one {# kayıtlı tuval} other {# kayıtlı tuval}}",
+    "savedCanvasesLoadError": "Kayıtlı tuvalleriniz yüklenemedi",
+    "savedGraphs": "Kayıtlı tuvalleriniz"
+  },
   "names": {
     "eyebrow": "Esmaü'l Hüsna",
     "heroTitle": "Allah'ın 99 Güzel İsmi",


### PR DESCRIPTION
## Summary

- `VerseOfDayCard.tsx` and `PersonalHome.tsx` mixed hardcoded English strings with already-translated `next-intl` strings, so tr/ru/az users saw a half-translated UI on the home page. This extracts the remaining strings into new `today`/`home` message namespaces (with tr/ru/az translations added), and reuses the existing `nav.dayStreak` / `nav.savedCanvases` keys instead of duplicating those two strings under a new namespace.
- No behavior/logic changes — this is a pure text-source migration.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

**Details** (if applicable):
N/A

## Testing

- [x] `bun run test:ci` passes locally (843/843)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [ ] New tests added for new functionality — not applicable; existing `__tests__/lib/i18n/messages.test.ts` already covers key-parity/ICU-validity for the new keys, and no test asserted on the literal strings being replaced.

**Note on `bun run test:integration`**: not run for this push. This sandbox's Docker daemon cannot pull the Testcontainers Postgres image — Docker Hub registry access is blocked by this environment's network egress policy (a 403 from the registry CDN, not a local Docker misconfiguration). This PR makes no database/schema changes, so the integration suite wouldn't exercise anything relevant to this diff. CI will run it independently.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added — n/a
- [ ] `README.md` updated if the feature changes the public interface — n/a

Closes #347

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpoT4xJwVHXHtLsu8Lp1pt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized text for the Home and Verse of the Day sections.
  * Translated greetings, canvas actions, search, progress, sharing, audio controls, saved-canvas counts, and error messages.
  * Added Azerbaijani, Russian, and Turkish translations alongside English.
  * Improved dynamic messages with localized usernames and values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->