### PR TITLE
fix(ai): log parseRawConnections failures instead of failing silently

### DIFF
--- a/__tests__/lib/ai/connection-generator.test.ts
+++ b/__tests__/lib/ai/connection-generator.test.ts
@@ -105,6 +105,14 @@ describe("generateConnections", () => {
     expect(out).toEqual([]);
   });
 
+  it("logs when the AI response fails to parse instead of failing silently", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockCallAI.mockResolvedValue("[{ not: valid json }]");
+    await generateConnections("1:1", "ar", "tr", "thematic");
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
   it("caps at 3 connections even if the model returns more", async () => {
     mockCallAI.mockResolvedValue(
       JSON.stringify([

--- a/__tests__/lib/ai/connection-generator.test.ts
+++ b/__tests__/lib/ai/connection-generator.test.ts
@@ -105,12 +105,35 @@ describe("generateConnections", () => {
     expect(out).toEqual([]);
   });
 
-  it("logs when the AI response fails to parse instead of failing silently", async () => {
+  it("logs when the AI response contains no JSON array", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    mockCallAI.mockResolvedValue("[{ not: valid json }]");
-    await generateConnections("1:1", "ar", "tr", "thematic");
-    expect(consoleErrorSpy).toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
+    try {
+      mockCallAI.mockResolvedValue("Sorry, I cannot help with that.");
+      const out = await generateConnections("1:1", "ar", "tr", "thematic");
+      expect(out).toEqual([]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no JSON array"),
+        expect.stringContaining("Sorry, I cannot help")
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("logs when the AI response's JSON array is malformed", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      mockCallAI.mockResolvedValue("[{ not: valid json }]");
+      const out = await generateConnections("1:1", "ar", "tr", "thematic");
+      expect(out).toEqual([]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("failed to parse"),
+        expect.stringContaining("not: valid json"),
+        expect.any(Error)
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("caps at 3 connections even if the model returns more", async () => {

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -95,11 +95,17 @@ async function buildPrompt(
 }
 
 function parseRawConnections(text: string): Array<{ ref: string; reason: string }> {
+  const jsonMatch = text.match(/\[[\s\S]*\]/);
+  if (!jsonMatch) {
+    console.error("Connections: no JSON array found in AI response:", text.slice(0, 500));
+    return [];
+  }
   try {
-    const jsonMatch = text.match(/\[[\s\S]*\]/);
-    if (!jsonMatch) return [];
     const parsed = JSON.parse(jsonMatch[0]);
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) {
+      console.error("Connections: AI response JSON was not an array:", jsonMatch[0].slice(0, 500));
+      return [];
+    }
     return parsed.filter(
       (c): c is { ref: string; reason: string } =>
         c && typeof c.ref === "string" && typeof c.reason === "string"

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -104,7 +104,8 @@ function parseRawConnections(text: string): Array<{ ref: string; reason: string 
       (c): c is { ref: string; reason: string } =>
         c && typeof c.ref === "string" && typeof c.reason === "string"
     );
-  } catch {
+  } catch (err) {
+    console.error("Connections: failed to parse AI response:", text.slice(0, 500), err);
     return [];
   }
 }


### PR DESCRIPTION
## Summary

- `parseRawConnections` in `lib/ai/connection-generator.ts` had a fully silent `catch { return []; }` around the AI response JSON parse — no logging, unlike every sibling AI-response parser in the codebase (`pairings/route.ts`, `verses/route.ts`, `lib/names/name-content.ts`, all of which log before degrading). A persistently malformed model response for the connections feature was invisible in logs/metrics.
- Fix: log the failure with truncated raw text + error before returning `[]`, matching the sibling pattern.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

**Details** (if applicable):
N/A — this only adds logging around an existing parse failure path; no prompt or generated-content behavior changes.

## Testing

- [x] `bun run test:ci` passes locally (844/844)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality — added a test asserting `console.error` is called when the AI response fails to parse.

**Note on `bun run test:integration`**: not run locally — this sandbox's Docker daemon cannot pull the Testcontainers Postgres image (Docker Hub registry access blocked by this environment's network egress policy, not a local Docker misconfiguration). No database/schema changes in this PR. CI runs it independently.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added — n/a
- [ ] `README.md` updated if the feature changes the public interface — n/a

Closes #343

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpoT4xJwVHXHtLsu8Lp1pt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when AI-generated connection data cannot be parsed.
  * Malformed or unexpected responses now provide diagnostic details, helping identify connection-generation issues more quickly.
  * Invalid responses continue to be handled safely without disrupting the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->