### PR TITLE
fix(stories): wire up resolveLocalized instead of hardcoded .en access

### DIFF
--- a/__tests__/app/stories-pages.test.tsx
+++ b/__tests__/app/stories-pages.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+import type { Story } from "@/lib/stories";
+
+// A synthetic story with a populated `tr` field (no real story data has one yet),
+// so these tests can exercise the actual locale-swap branch of resolveLocalized,
+// not just its English-fallback branch (already covered by __tests__/lib/stories.test.ts).
+const SYNTHETIC_STORY: Story = {
+  slug: "test-story",
+  name: { en: "Test Story", tr: "Test Hikayesi" },
+  arabicName: "قصة الاختبار",
+  tagline: { en: "An English tagline", tr: "Türkçe bir slogan" },
+  intro: { en: "An English intro." },
+  primarySurahs: [12],
+  chapters: [
+    {
+      id: "chapter-1",
+      title: { en: "Chapter One", tr: "Birinci Bölüm" },
+      narrative: { en: "English narrative." },
+      verseRefs: ["12:1"],
+    },
+  ],
+  themes: [],
+};
+
+const { mockGetUiLocale, mockGetQuranEdition, mockResolveVerse } = vi.hoisted(() => ({
+  mockGetUiLocale: vi.fn(),
+  mockGetQuranEdition: vi.fn().mockResolvedValue("en.sahih"),
+  mockResolveVerse: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/i18n/request-prefs", () => ({
+  getUiLocale: mockGetUiLocale,
+  getQuranEdition: mockGetQuranEdition,
+}));
+vi.mock("@/lib/quran/verse-resolver", () => ({ resolveVerse: mockResolveVerse }));
+vi.mock("@/lib/stories", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/stories")>();
+  return {
+    ...actual,
+    STORIES: [SYNTHETIC_STORY],
+    getStoryBySlug: (slug: string) => (slug === SYNTHETIC_STORY.slug ? SYNTHETIC_STORY : undefined),
+  };
+});
+
+// Both pages are async Server Components. Calling them directly (without a DOM
+// renderer) resolves their data-fetching and returns a plain React element tree
+// — LandingHeader/MobileNavBar's own hooks never execute since nothing renders
+// them, so no next-intl/next-navigation providers are needed for this.
+function extractText(node: unknown): string[] {
+  if (typeof node === "string") return [node];
+  if (typeof node === "number") return [String(node)];
+  if (Array.isArray(node)) return node.flatMap(extractText);
+  if (node && typeof node === "object" && "props" in node) {
+    return extractText((node as { props?: { children?: ReactNode } }).props?.children);
+  }
+  return [];
+}
+
+describe("Stories pages — locale-aware rendering", () => {
+  beforeEach(() => {
+    mockGetUiLocale.mockReset();
+    mockResolveVerse.mockReset().mockResolvedValue(null);
+  });
+
+  it("index page shows the locale-specific name/tagline when present", async () => {
+    mockGetUiLocale.mockResolvedValue("tr");
+    const { default: StoriesPage } = await import("@/app/stories/page");
+    const text = extractText(await StoriesPage());
+    expect(text).toContain("Test Hikayesi");
+    expect(text).toContain("Türkçe bir slogan");
+    expect(text).not.toContain("Test Story");
+  });
+
+  it("index page falls back to English when no locale-specific field exists", async () => {
+    mockGetUiLocale.mockResolvedValue("az");
+    const { default: StoriesPage } = await import("@/app/stories/page");
+    const text = extractText(await StoriesPage());
+    expect(text).toContain("Test Story");
+    expect(text).toContain("An English tagline");
+  });
+
+  it("detail page hero and chapter content resolve the locale-specific text", async () => {
+    mockGetUiLocale.mockResolvedValue("tr");
+    const { default: StoryDetailPage } = await import("@/app/stories/[slug]/page");
+    const text = extractText(
+      await StoryDetailPage({ params: Promise.resolve({ slug: "test-story" }) })
+    );
+    expect(text).toContain("Test Hikayesi");
+    expect(text).toContain("Türkçe bir slogan");
+    expect(text).toContain("Birinci Bölüm");
+    // intro/narrative have no `tr` field on the fixture — English fallback.
+    expect(text).toContain("An English intro.");
+    expect(text).toContain("English narrative.");
+  });
+
+  it("generateMetadata resolves the locale-specific name/tagline", async () => {
+    mockGetUiLocale.mockResolvedValue("tr");
+    const { generateMetadata } = await import("@/app/stories/[slug]/page");
+    const metadata = await generateMetadata({ params: Promise.resolve({ slug: "test-story" }) });
+    expect(metadata.title).toContain("Test Hikayesi");
+    expect(metadata.description).toBe("Türkçe bir slogan");
+  });
+});

--- a/app/stories/[slug]/page.tsx
+++ b/app/stories/[slug]/page.tsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { LandingHeader } from "@/components/layout/LandingHeader";
 import { MobileNavBar } from "@/components/layout/MobileNavBar";
-import { STORIES, getStoryBySlug } from "@/lib/stories";
+import { STORIES, getStoryBySlug, resolveLocalized } from "@/lib/stories";
 import { resolveVerse } from "@/lib/quran/verse-resolver";
-import { getQuranEdition } from "@/lib/i18n/request-prefs";
+import { getQuranEdition, getUiLocale } from "@/lib/i18n/request-prefs";
 import { StoryVerseCard } from "./StoryVerseCard";
 import { OpenOnCanvasButton } from "./OpenOnCanvasButton";
 import type { Verse } from "@/types/quran";
@@ -27,9 +27,10 @@ export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
   const story = getStoryBySlug(slug);
   if (!story) return {};
+  const locale = await getUiLocale();
   return {
-    title: `${story.name.en} — Open Hikmah`,
-    description: story.tagline.en,
+    title: `${resolveLocalized(story.name, locale)} — Open Hikmah`,
+    description: resolveLocalized(story.tagline, locale),
   };
 }
 
@@ -38,6 +39,7 @@ export default async function StoryDetailPage({ params }: Props) {
   const story = getStoryBySlug(slug);
   if (!story) notFound();
 
+  const locale = await getUiLocale();
   const allRefs = story.chapters.flatMap((c) => c.verseRefs);
   const edition = await getQuranEdition();
   // Per-ref resolveVerse (corpus first, live alquran.cloud fallback) rather than
@@ -64,10 +66,12 @@ export default async function StoryDetailPage({ params }: Props) {
         </Link>
 
         <h1 className="mb-3 font-arabic text-6xl text-gold">{story.arabicName}</h1>
-        <p className="mb-2 text-xl text-text-primary">{story.name.en}</p>
-        <p className="mb-6 text-sm text-text-secondary">{story.tagline.en}</p>
+        <p className="mb-2 text-xl text-text-primary">{resolveLocalized(story.name, locale)}</p>
+        <p className="mb-6 text-sm text-text-secondary">
+          {resolveLocalized(story.tagline, locale)}
+        </p>
         <p className="mx-auto max-w-xl text-sm leading-relaxed text-text-secondary">
-          {story.intro.en}
+          {resolveLocalized(story.intro, locale)}
         </p>
       </div>
 
@@ -81,9 +85,11 @@ export default async function StoryDetailPage({ params }: Props) {
 
           return (
             <section key={chapter.id}>
-              <h2 className="mb-3 text-lg font-medium text-text-primary">{chapter.title.en}</h2>
+              <h2 className="mb-3 text-lg font-medium text-text-primary">
+                {resolveLocalized(chapter.title, locale)}
+              </h2>
               <p className="mb-6 text-sm leading-relaxed text-text-secondary">
-                {chapter.narrative.en}
+                {resolveLocalized(chapter.narrative, locale)}
               </p>
 
               <div className="space-y-3">

--- a/app/stories/page.tsx
+++ b/app/stories/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { LandingHeader } from "@/components/layout/LandingHeader";
 import { MobileNavBar } from "@/components/layout/MobileNavBar";
-import { STORIES } from "@/lib/stories";
+import { STORIES, resolveLocalized } from "@/lib/stories";
+import { getUiLocale } from "@/lib/i18n/request-prefs";
 
 export const metadata = {
   title: "Prophetic Stories — Open Hikmah",
@@ -9,7 +10,8 @@ export const metadata = {
     "Curated stories of the Prophets mentioned in the Quran, with verified verse mappings and a direct path to the connection canvas.",
 };
 
-export default function StoriesPage() {
+export default async function StoriesPage() {
+  const locale = await getUiLocale();
   return (
     <div className="min-h-screen bg-bg pb-[calc(72px+env(safe-area-inset-bottom))] text-text-primary md:pb-0">
       <LandingHeader />
@@ -38,8 +40,12 @@ export default function StoriesPage() {
               className="group rounded-lg border border-border bg-surface p-5 transition-all duration-200 hover:scale-[1.01] hover:border-gold"
             >
               <div className="mb-2 font-arabic text-3xl text-gold">{story.arabicName}</div>
-              <h2 className="text-lg font-medium text-text-primary">{story.name.en}</h2>
-              <p className="mt-1.5 text-sm text-text-secondary">{story.tagline.en}</p>
+              <h2 className="text-lg font-medium text-text-primary">
+                {resolveLocalized(story.name, locale)}
+              </h2>
+              <p className="mt-1.5 text-sm text-text-secondary">
+                {resolveLocalized(story.tagline, locale)}
+              </p>
               <p className="mt-3 text-xs text-text-muted">
                 {story.chapters.length} chapter{story.chapters.length === 1 ? "" : "s"} ·{" "}
                 {verseCount} verse{verseCount === 1 ? "" : "s"}


### PR DESCRIPTION
## Summary

- `lib/stories/index.ts` exports `resolveLocalized(text, locale)` specifically so per-locale story content activates automatically once authored (falls back to `.en` when a locale-specific field hasn't been added yet), but `app/stories/page.tsx` and `app/stories/[slug]/page.tsx` (including `generateMetadata`) bypassed it entirely and hardcoded `.en` directly.
- Fix: both pages now call `getUiLocale()` (same helper other server components already use) and route all localized text through `resolveLocalized`.
- No content/behavior change for current data — every story field is English-only today, so `resolveLocalized` still resolves to `.en` for all users. This is a plumbing fix so translations "just work" once story content is authored in other locales, distinct from the already-acknowledged non-goal in #332 (authoring non-English story content itself).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

**Details** (if applicable):
N/A

## Testing

- [x] `bun run test:ci` passes locally (843/843)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [ ] New tests added for new functionality — not applicable; `__tests__/lib/stories.test.ts` already covers `resolveLocalized` directly and asserts no page-level HTML, so it's unaffected and still passes unchanged.

**Note on `bun run test:integration`**: not run locally — this sandbox's Docker daemon cannot pull the Testcontainers Postgres image (Docker Hub registry access blocked by this environment's network egress policy, not a local Docker misconfiguration). No database/schema changes in this PR. CI runs it independently.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added — n/a
- [ ] `README.md` updated if the feature changes the public interface — n/a

Closes #346

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpoT4xJwVHXHtLsu8Lp1pt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Story listings now display names and taglines in the selected UI language.
  * Story detail pages now localize headings, introductions, chapter content, and metadata.
  * English fallback text is used when translations are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->