### PR TITLE
chore(ai): centralize the Tanzih/Tashbih constraint text

### DIFF
--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -161,6 +161,14 @@ describe("names AI routes — model output validation", () => {
     expect(body[0].translation).toBe(ENGLISH);
   });
 
+  it("verses: the AI-fallback prompt includes the Tanzih constraint", async () => {
+    mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "Ayat al-Kursi." }]));
+    await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+    expect(mockCallAI).toHaveBeenCalled();
+    const prompt = mockCallAI.mock.calls[0][0] as string;
+    expect(prompt).toMatch(/strict tanzih/i);
+  });
+
   it("reflection: no language directive for the default (English) locale", async () => {
     mockCallAI.mockResolvedValue("A reflection paragraph.");
     await getReflection(req("ar-rahman", "reflection"), params("ar-rahman"));

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -6,6 +6,7 @@ import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
 import { getUiLocale } from "@/lib/i18n/request-prefs";
 import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
+import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
 
 // Bump to force regeneration after a prompt change.
 const PAIRINGS_VERSION = 1;
@@ -33,7 +34,7 @@ The divine name ${transliteration} (${arabic}) means "${meaning}".
 
 Task: Identify 2–3 other divine names from the 99 Names that most frequently appear paired with ${transliteration} in the Quran. For each, explain in ONE sentence why this pairing provides perfect theological balance in the specific contexts where they appear together.
 
-Only include pairings where both names actually co-appear in the same verse or in closely related verses as documented in classical tafsir. Maintain strict Tanzih: never describe or imply physical form, spatial location, or resemblance to created things.${languageLine}
+Only include pairings where both names actually co-appear in the same verse or in closely related verses as documented in classical tafsir. Maintain ${TANZIH_CONSTRAINT}.${languageLine}
 
 Return ONLY a JSON array:
 [

--- a/app/api/names/[slug]/reflection/route.ts
+++ b/app/api/names/[slug]/reflection/route.ts
@@ -6,6 +6,7 @@ import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
 import { getUiLocale } from "@/lib/i18n/request-prefs";
 import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
+import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
 
 // Bump to force regeneration after a prompt change.
 const REFLECTION_VERSION = 1;
@@ -30,7 +31,7 @@ Task: Write a "Believer's Reflection" — a single paragraph (3–5 sentences) d
 
 Critical rules:
 1. NEVER equate the divine attribute directly to a human action or quality.
-2. ALWAYS maintain strict Tanzih — the attribute belongs exclusively and infinitely to Allah.
+2. ALWAYS maintain ${TANZIH_CONSTRAINT}. The attribute belongs exclusively and infinitely to Allah.
 3. Frame the reflection as the believer's RESPONSE to the name, not a possession of it.
 4. Use the language of trust (tawakkul), striving (sa'y), and certainty (yaqin) as appropriate.
 5. Keep the tone reverent, orthodox, and practically grounded.

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -9,6 +9,7 @@ import { clientKey } from "@/lib/infra/http";
 import { incr } from "@/lib/infra/metrics";
 import { getUiLocale } from "@/lib/i18n/request-prefs";
 import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
+import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
 import sanitizeHtml from "sanitize-html";
 import type { VerseRef } from "@/types/quran";
 
@@ -75,7 +76,7 @@ async function buildReasons(
 Divine name: ${transliteration} — "${meaning}"
 
 For each verse reference below, write ONE concise sentence (max 20 words) explaining how this verse manifests or relates to this divine name.
-Maintain strict Tanzih. Return ONLY a JSON object mapping ref → reason.
+Maintain ${TANZIH_CONSTRAINT}. Return ONLY a JSON object mapping ref → reason.
 
 Refs: ${refs.join(", ")}
 
@@ -112,6 +113,7 @@ The divine name ${transliteration} (${arabic}) means "${meaning}".
 Context: ${description}
 
 Find exactly 5 Quran verse references where this name's Arabic root appears or the verse concludes with a form of this name.
+Maintain ${TANZIH_CONSTRAINT}.
 Return ONLY a JSON array:
 [{ "ref": "surah:ayah", "reason": "one sentence" }, ...]`;
 

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -1,5 +1,6 @@
 import { callAI } from "@/lib/ai/ai";
 import { getPrompt, renderTemplate } from "@/lib/ai/prompt-registry";
+import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
 import { db } from "@/lib/infra/db";
 import { aiGenerations } from "@/lib/infra/db/schema";
 import { isValidRef, getVerses } from "@/lib/quran/quran-corpus";
@@ -54,7 +55,7 @@ Rules:
 - Return EXACTLY 3 different verses (not the source verse).
 - Verse references must be real and accurate (format: surah:ayah, e.g. 2:255).
 - Each reason must be one concise sentence explaining the {{kind}} connection in classical Islamic terms.
-- Maintain strict Tanzih (divine transcendence). Avoid Tashbih (anthropomorphism).
+- Maintain ${TANZIH_CONSTRAINT}.
 - Return ONLY a valid JSON array. No prose, no markdown, no explanation outside the JSON.
 
 Output format:
@@ -182,7 +183,7 @@ Rules:
 - Choose ONLY from the candidate references listed above. Do NOT introduce any verse that is not in the list.
 - Return at most 3, fewer if fewer are genuinely appropriate.
 - Each reason must be one concise sentence explaining the {{kind}} connection in classical Islamic terms.
-- Maintain strict Tanzih (divine transcendence). Avoid Tashbih (anthropomorphism).
+- Maintain ${TANZIH_CONSTRAINT}.
 - Return ONLY a valid JSON array. No prose, no markdown, no explanation outside the JSON.
 
 Output format:

--- a/lib/ai/theological-constraints.ts
+++ b/lib/ai/theological-constraints.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared Tanzih/Tashbih constraint text — see AGENTS.md's theological
+ * standards ("Maintain strict Tanzih (transcendence)... never describe
+ * divine attributes in ways that imply physical form, spatial location,
+ * or resemblance to created things (Tashbih)"). Every AI prompt that could
+ * describe a divine attribute must include this. Defined as a noun phrase
+ * (not a full imperative sentence) so each call site keeps its own natural
+ * grammar/framing while only the constraint definition itself — the part
+ * at risk of drifting — is centralized.
+ */
+export const TANZIH_CONSTRAINT =
+  "strict Tanzih (divine transcendence): never describe or imply physical form, spatial location, or resemblance to created things (Tashbih)";


### PR DESCRIPTION
## Summary

- The Tanzih/Maturidi theological constraint was hand-copied with slightly different wording across `lib/ai/connection-generator.ts` (x2), `app/api/names/[slug]/reflection/route.ts`, `pairings/route.ts`, and `verses/route.ts` (x2) — risk of drift the next time this wording needs updating.
- Extracted a shared `TANZIH_CONSTRAINT` into a new `lib/ai/theological-constraints.ts`. It's a noun-phrase (not a full sentence) so each call site keeps its own natural grammar/framing (e.g. reflection's numbered-rule style, pairings' embedded-sentence style) — only the constraint definition itself is centralized.
- **Bonus fix found while doing this**: `verses/route.ts`'s AI-fallback verse-finding path (`fallbackAIVerses`) had **no Tanzih instruction at all** — its sibling function (`buildReasons`, the search-results path) had one, but the fallback path was missing it entirely. Added.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [ ] No AI or theological changes in this PR
- [x] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below

**Details**: This is a wording consolidation, not a framing change — the constraint's meaning is unchanged (still: never describe or imply physical form, spatial location, or resemblance to created things). One path (`fallbackAIVerses` in `verses/route.ts`) gains the constraint where it was previously entirely absent — a strengthening, not a weakening, of the existing safeguard. All existing tests asserting `toMatch(/strict tanzih/i)` on generated prompts continue to pass since that phrase appears verbatim in every substitution.

## Testing

- [x] `bun run test:ci` passes locally (844/844)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality — added a test asserting the AI-fallback verses prompt now includes the Tanzih constraint (`__tests__/api/names-ai-validation.test.ts`).

**Note on `bun run test:integration`**: not run locally — this sandbox's Docker daemon cannot pull the Testcontainers Postgres image (Docker Hub registry access blocked by this environment's network egress policy, not a local Docker misconfiguration). No database/schema changes in this PR. CI runs it independently.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added — n/a
- [ ] `README.md` updated if the feature changes the public interface — n/a

Closes #345

**Note for reviewers**: issue #344 (making this constraint non-overridable via admin `prompt_versions` overrides) depends on this PR's `TANZIH_CONSTRAINT` constant — its branch is stacked on top of this one rather than `main`, and its PR will target this branch until this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpoT4xJwVHXHtLsu8Lp1pt)_