### PR TITLE
fix(ai): make the Tanzih constraint non-overridable via admin prompt overrides

### DIFF
--- a/__tests__/lib/ai/connection-generator.test.ts
+++ b/__tests__/lib/ai/connection-generator.test.ts
@@ -27,6 +27,7 @@ vi.mock("@/lib/ai/prompt-registry", async (importOriginal) => {
 });
 
 import { generateConnections, generateGroundedConnections } from "@/lib/ai/connection-generator";
+import { getPrompt } from "@/lib/ai/prompt-registry";
 
 function verse(ref: string): Verse {
   const [s, a] = ref.split(":");
@@ -131,6 +132,24 @@ describe("generateConnections", () => {
     await generateConnections("1:1", "ar", "tr", "thematic", "tr");
     const prompt = mockCallAI.mock.calls[0][0] as string;
     expect(prompt).toMatch(/write each "reason" in turkish/i);
+    expect(prompt).toMatch(/strict tanzih/i);
+  });
+
+  it("keeps the Tanzih constraint even when an admin's prompt override omits it entirely", async () => {
+    // Simulates a DB-stored prompt_versions override that dropped the Tanzih
+    // rule (with or without intent) — the constraint must still reach the
+    // model, since it's appended after the resolved template, not baked into it.
+    vi.mocked(getPrompt).mockResolvedValueOnce({
+      template: `You are a helpful assistant.
+Reference: {{fromRef}}
+Task: {{task}}
+Return ONLY a valid JSON array of { "ref": "surah:ayah", "reason": "..." }.`,
+      version: 7,
+    });
+    mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
+    await generateConnections("1:1", "ar", "tr", "thematic");
+    const prompt = mockCallAI.mock.calls[0][0] as string;
+    expect(prompt).not.toMatch(/you are a classical islamic scholar/i);
     expect(prompt).toMatch(/strict tanzih/i);
   });
 });

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -55,7 +55,6 @@ Rules:
 - Return EXACTLY 3 different verses (not the source verse).
 - Verse references must be real and accurate (format: surah:ayah, e.g. 2:255).
 - Each reason must be one concise sentence explaining the {{kind}} connection in classical Islamic terms.
-- Maintain ${TANZIH_CONSTRAINT}.
 - Return ONLY a valid JSON array. No prose, no markdown, no explanation outside the JSON.
 
 Output format:
@@ -76,6 +75,14 @@ function languageDirective(locale: Locale): string {
   return `\n\nWrite each "reason" in ${LOCALE_LANGUAGE_NAME[locale]}. Keep "ref" in "surah:ayah" format, and keep the Tanzih/Tashbih constraint above unchanged.`;
 }
 
+// Deliberately NOT part of either overridable template (see prompt-registry.ts):
+// appended after the resolved template — fallback OR an admin's DB-stored
+// override — the same way languageDirective is, so an admin override can
+// change task wording but can never omit this constraint.
+function tanzihDirective(): string {
+  return `\n\n- Maintain ${TANZIH_CONSTRAINT}.`;
+}
+
 async function buildPrompt(
   fromRef: string,
   arabicText: string,
@@ -91,7 +98,9 @@ async function buildPrompt(
       translation,
       task: KIND_INSTRUCTIONS[kind],
       kind,
-    }) + languageDirective(locale);
+    }) +
+    tanzihDirective() +
+    languageDirective(locale);
   return { text, promptVersion: version };
 }
 
@@ -183,7 +192,6 @@ Rules:
 - Choose ONLY from the candidate references listed above. Do NOT introduce any verse that is not in the list.
 - Return at most 3, fewer if fewer are genuinely appropriate.
 - Each reason must be one concise sentence explaining the {{kind}} connection in classical Islamic terms.
-- Maintain ${TANZIH_CONSTRAINT}.
 - Return ONLY a valid JSON array. No prose, no markdown, no explanation outside the JSON.
 
 Output format:
@@ -212,7 +220,9 @@ async function buildSelectionPrompt(
       task: KIND_SELECTION[kind],
       candidates: list,
       kind,
-    }) + languageDirective(locale);
+    }) +
+    tanzihDirective() +
+    languageDirective(locale);
   return { text, promptVersion: version };
 }
 


### PR DESCRIPTION
## Summary

- The Tanzih/Tashbih constraint lived inside `LEGACY_FALLBACK_TEMPLATE` and `SELECTION_FALLBACK_TEMPLATE` in `lib/ai/connection-generator.ts`, both of which an admin's active `prompt_versions` DB row (`lib/ai/prompt-registry.ts`) can **fully replace**, with no code-level check that an override preserves the constraint.
- Fix: removed the constraint from both overridable templates and append it after the template resolves (fallback or admin override) instead — mirroring the existing `languageDirective()` pattern, which already does exactly this for the same reason (an override predating locale support has no `{{language}}` placeholder to fill). Now an admin override can change task wording but can never omit the Tanzih constraint.
- Added a test simulating an admin override that completely omits the Tanzih constraint, asserting the constraint still reaches the model.

## Stacked on #351

This PR is based on `chore/345-centralize-tanzih-constraint` (#351), not `main`, because both PRs touch the same lines (the Tanzih bullet inside the two templates) via different structural approaches — #351 centralizes the wording into a shared constant interpolated into the templates; this PR removes it from the templates entirely. Basing this branch on #351's avoids a real merge conflict. Once #351 merges, this PR's base will retarget to `main` (or I'll do so manually).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [ ] No AI or theological changes in this PR
- [x] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below

**Details**: No change to the constraint's wording or meaning (imported from #351's `TANZIH_CONSTRAINT`) — only *where* it lives in the prompt-assembly pipeline. This strictly strengthens the existing safeguard: previously an admin override could omit it silently; now it's guaranteed to reach the model regardless of what the override contains.

## Testing

- [x] `bun run test:ci` passes locally (845/845)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality — added a test that mocks an admin override template with no Tanzih text and asserts the final prompt still contains it (the issue's acceptance criterion).

**Note on `bun run test:integration`**: not run locally — this sandbox's Docker daemon cannot pull the Testcontainers Postgres image (Docker Hub registry access blocked by this environment's network egress policy, not a local Docker misconfiguration). No database/schema changes in this PR. CI runs it independently.

## Checklist

- [x] Branch is up to date with `main` (via its base branch, #351)
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added — n/a
- [ ] `README.md` updated if the feature changes the public interface — n/a

Closes #344

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpoT4xJwVHXHtLsu8Lp1pt)_