### PR TITLE
fix(canvas): surface feedback when an expand click arrives during an in-flight expansion

### DIFF
--- a/__tests__/components/canvas/HikmahCanvas.test.tsx
+++ b/__tests__/components/canvas/HikmahCanvas.test.tsx
@@ -1,0 +1,69 @@
+import { screen, act, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderWithIntl as render } from "../../test-utils/render-with-intl";
+import { useCanvasStore } from "@/store/canvas";
+import type { Verse, VerseRef } from "@/types/quran";
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>();
+  return {
+    ...actual,
+    ReactFlow: () => null,
+    Background: () => null,
+    BackgroundVariant: { Dots: "dots" },
+    MiniMap: () => null,
+    Panel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    useReactFlow: () => ({ fitView: vi.fn() }),
+    ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+import { HikmahCanvas } from "@/components/canvas/HikmahCanvas";
+
+function verseNode(id: string, ref: string) {
+  const verse: Verse = {
+    surah: 1,
+    ayah: 1,
+    ref: ref as VerseRef,
+    arabicText: "نص",
+    translation: "text",
+    surahName: "Al-Fatihah",
+    surahNameArabic: "الفاتحة",
+  };
+  return { id, type: "verse", position: { x: 0, y: 0 }, data: verse };
+}
+
+describe("HikmahCanvas expand-during-expansion", () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      nodes: [verseNode("n1", "1:1"), verseNode("n2", "2:255")] as never,
+      edges: [],
+    });
+  });
+
+  it("surfaces a notice instead of silently dropping a second expand while one is in flight", async () => {
+    // Never resolves within the test — simulates an in-flight AI generation.
+    const pendingFetch = new Promise<never>(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => pendingFetch)
+    );
+
+    render(<HikmahCanvas onSearchOpen={vi.fn()} />);
+
+    act(() => {
+      useCanvasStore.getState().setPendingExpand({ nodeId: "n1", ref: "1:1", kind: "thematic" });
+    });
+
+    // Second request arrives while the first is still in flight.
+    act(() => {
+      useCanvasStore.getState().setPendingExpand({ nodeId: "n2", ref: "2:255", kind: "thematic" });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(/already running/i);
+    });
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/components/canvas/HikmahCanvas.tsx
+++ b/components/canvas/HikmahCanvas.tsx
@@ -66,7 +66,7 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
   const expandingRef = useRef(false);
   const mountedRef = useRef(true);
   const [expansionNotice, setExpansionNotice] = useState<{
-    messageKey: "noMoreConnections" | "connectionsFailed";
+    messageKey: "noMoreConnections" | "connectionsFailed" | "expansionInProgress";
     kind: "error" | "info";
   } | null>(null);
 
@@ -118,7 +118,12 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
       translation: string,
       sourcePos: { x: number; y: number }
     ) => {
-      if (expandingRef.current) return;
+      if (expandingRef.current) {
+        if (mountedRef.current) {
+          setExpansionNotice({ messageKey: "expansionInProgress", kind: "info" });
+        }
+        return;
+      }
       expandingRef.current = true;
       setExpandingNode(nodeId);
 

--- a/messages/az.json
+++ b/messages/az.json
@@ -94,6 +94,7 @@
     "workspaceName": "{count, plural, one {# ayə} other {# ayə}} — {date}",
     "noMoreConnections": "Bu növdə başqa əlaqə yoxdur.",
     "connectionsFailed": "Əlaqə tapılmadı. Fərqli növ sınayın.",
+    "expansionInProgress": "Artıq bir genişləndirmə işləyir — bir az sonra yenidən cəhd edin.",
     "dismiss": "Bağla",
     "minimapAria": "Lövhə kiçik xəritəsi",
     "saveFailedRetry": "Yadda saxlama uğursuz oldu — yenidən cəhd edin",

--- a/messages/en.json
+++ b/messages/en.json
@@ -94,6 +94,7 @@
     "workspaceName": "{count, plural, one {# verse} other {# verses}} — {date}",
     "noMoreConnections": "No more connections of this type.",
     "connectionsFailed": "Could not find connections. Try a different type.",
+    "expansionInProgress": "An expansion is already running — try again in a moment.",
     "dismiss": "Dismiss",
     "minimapAria": "Canvas minimap",
     "saveFailedRetry": "Save failed — try again",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -94,6 +94,7 @@
     "workspaceName": "{count, plural, one {# аят} few {# аята} many {# аятов} other {# аята}} — {date}",
     "noMoreConnections": "Больше нет связей этого типа.",
     "connectionsFailed": "Не удалось найти связи. Попробуйте другой тип.",
+    "expansionInProgress": "Расширение уже выполняется — попробуйте снова через мгновение.",
     "dismiss": "Закрыть",
     "minimapAria": "Миникарта холста",
     "saveFailedRetry": "Ошибка сохранения — попробуйте снова",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -94,6 +94,7 @@
     "workspaceName": "{count, plural, one {# ayet} other {# ayet}} — {date}",
     "noMoreConnections": "Bu türde başka bağlantı yok.",
     "connectionsFailed": "Bağlantı bulunamadı. Farklı bir tür deneyin.",
+    "expansionInProgress": "Bir genişletme zaten çalışıyor — biraz sonra tekrar deneyin.",
     "dismiss": "Kapat",
     "minimapAria": "Tuval küçük haritası",
     "saveFailedRetry": "Kaydetme başarısız — tekrar deneyin",


### PR DESCRIPTION
## Summary

- Clicking "expand" on a verse node while another node's expansion is still in flight did nothing — no toast, no disabled state, no queued action. The pending action was consumed (`setPendingExpand(null)`) by the effect at `HikmahCanvas.tsx:222` *before* the `expandingRef.current` guard in `runExpansion` (line 121) had a chance to bail, so the second click was silently dropped.
- Fix: when the guard trips, surface the existing `expansionNotice` toast (already used for `noMoreConnections`/`connectionsFailed`) with a new `"expansionInProgress"` message instead of silently returning. No new UI — reuses the existing toast component and its dismiss button.
- New translation key added to all 4 locales (`en`/`tr`/`ru`/`az`).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (851/851)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality — `__tests__/components/canvas/HikmahCanvas.test.tsx` (new file; no test previously existed for this component). Seeds two canvas nodes, mocks `@xyflow/react` (following the existing pattern in `CanvasToolbar.test.tsx`), triggers two rapid `setPendingExpand` calls with the first fetch left permanently pending (simulating an in-flight AI generation), and asserts the notice toast appears instead of the second request being silently dropped.

**Note on `bun run test:integration`**: not run locally — this sandbox's Docker daemon cannot pull the Testcontainers Postgres image (Docker Hub registry access blocked by this environment's network egress policy, not a local Docker misconfiguration). No database/schema changes in this PR. CI runs it independently.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added — n/a
- [ ] `README.md` updated if the feature changes the public interface — n/a

Closes #326

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpoT4xJwVHXHtLsu8Lp1pt)_