### PR TITLE
fix(canvas): clear expansion-notice timeout on unmount; fix cumulative entrance stagger

### DIFF
--- a/__tests__/components/canvas/HikmahCanvas.timers.test.tsx
+++ b/__tests__/components/canvas/HikmahCanvas.timers.test.tsx
@@ -1,0 +1,145 @@
+import { screen, act, cleanup } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderWithIntl as render } from "../../test-utils/render-with-intl";
+import { useCanvasStore } from "@/store/canvas";
+import type { Verse, VerseRef } from "@/types/quran";
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>();
+  return {
+    ...actual,
+    ReactFlow: () => null,
+    Background: () => null,
+    BackgroundVariant: { Dots: "dots" },
+    MiniMap: () => null,
+    Panel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    useReactFlow: () => ({ fitView: vi.fn(), setCenter: vi.fn(), getZoom: vi.fn() }),
+    ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+import { HikmahCanvas } from "@/components/canvas/HikmahCanvas";
+
+function verseNode(id: string, ref: string) {
+  const verse: Verse = {
+    surah: 1,
+    ayah: 1,
+    ref: ref as VerseRef,
+    arabicText: "نص",
+    translation: "text",
+    surahName: "Al-Fatihah",
+    surahNameArabic: "الفاتحة",
+  };
+  return { id, type: "verse", position: { x: 0, y: 0 }, data: verse };
+}
+
+function connection(ref: string) {
+  return {
+    surah: 2,
+    ayah: 255,
+    ref,
+    arabicText: "نص",
+    translation: "text",
+    surahName: "Al-Baqarah",
+    surahNameArabic: "البقرة",
+    reason: "reason",
+    kind: "thematic",
+  };
+}
+
+describe("HikmahCanvas entrance stagger", () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      nodes: [verseNode("n1", "1:1")] as never,
+      edges: [],
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("adds each connection at a uniform ~350ms gap instead of a cumulative one", async () => {
+    const connections = [connection("2:255"), connection("2:256"), connection("2:257")];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(connections),
+      })
+    );
+
+    render(<HikmahCanvas onSearchOpen={vi.fn()} />);
+
+    act(() => {
+      useCanvasStore.getState().setPendingExpand({ nodeId: "n1", ref: "1:1", kind: "thematic" });
+    });
+    // Let the pendingExpand effect fire and the fetch microtask resolve.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(useCanvasStore.getState().nodes).toHaveLength(1); // just the source node so far
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(349);
+    });
+    expect(useCanvasStore.getState().nodes).toHaveLength(1); // not yet at 350ms
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(useCanvasStore.getState().nodes).toHaveLength(2); // first connection lands at 350ms
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(349);
+    });
+    expect(useCanvasStore.getState().nodes).toHaveLength(2); // not yet at the next 350ms gap
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(useCanvasStore.getState().nodes).toHaveLength(3); // second connection lands exactly 350ms later, not 700ms
+  });
+});
+
+describe("HikmahCanvas expansion-notice timeout", () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      nodes: [verseNode("n1", "1:1")] as never,
+      edges: [],
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("clears the pending notice-dismiss timeout on unmount instead of firing after unmount", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+
+    const { unmount } = render(<HikmahCanvas onSearchOpen={vi.fn()} />);
+
+    act(() => {
+      useCanvasStore.getState().setPendingExpand({ nodeId: "n1", ref: "1:1", kind: "thematic" });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // The failure path should have scheduled the 6s auto-dismiss.
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    unmount();
+
+    // Unmounting must clear the scheduled dismiss rather than letting it fire later.
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});

--- a/components/canvas/HikmahCanvas.tsx
+++ b/components/canvas/HikmahCanvas.tsx
@@ -65,6 +65,7 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
   const reactFlow = useReactFlow();
   const expandingRef = useRef(false);
   const mountedRef = useRef(true);
+  const noticeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [expansionNotice, setExpansionNotice] = useState<{
     messageKey: "noMoreConnections" | "connectionsFailed";
     kind: "error" | "info";
@@ -84,6 +85,7 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      if (noticeTimeoutRef.current) clearTimeout(noticeTimeoutRef.current);
     };
   }, []);
 
@@ -141,7 +143,7 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
         }
 
         for (let i = 0; i < connections.length; i++) {
-          await new Promise<void>((resolve) => setTimeout(resolve, 350 * i));
+          await new Promise<void>((resolve) => setTimeout(resolve, 350));
           if (!mountedRef.current) break;
 
           const conn = connections[i];
@@ -198,7 +200,10 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
             messageKey: exhausted ? "noMoreConnections" : "connectionsFailed",
             kind: exhausted ? "info" : "error",
           });
-          setTimeout(() => setExpansionNotice(null), 6000);
+          if (noticeTimeoutRef.current) clearTimeout(noticeTimeoutRef.current);
+          noticeTimeoutRef.current = setTimeout(() => {
+            if (mountedRef.current) setExpansionNotice(null);
+          }, 6000);
         }
       } finally {
         if (mountedRef.current) setExpandingNode(null);


### PR DESCRIPTION
## Summary

Two small timer defects in `components/canvas/HikmahCanvas.tsx`'s expansion flow:

1. **Timer leak**: the expansion notice's auto-dismiss `setTimeout(() => setExpansionNotice(null), 6000)` was never stored/cleared, and `mountedRef.current` was only checked before scheduling, not inside the callback — so it could call `setExpansionNotice` after unmount. Fixed by storing the timeout id in a ref, clearing any previous one before scheduling a new one, clearing it on unmount, and re-checking `mountedRef.current` inside the callback itself.
2. **Cumulative stagger**: the per-node entrance delay was `350 * i` inside an already-sequential `await`ed loop, so delays compounded (0 + 350 + 700 = 1050ms total for a 3rd node) instead of a fixed ~350ms gap. Changed to a constant `350` per iteration — since each iteration already awaits the previous one, this gives a uniform ~350ms gap between each node's appearance.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (852/852)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality — `__tests__/components/canvas/HikmahCanvas.timers.test.tsx` (new file, using `vi.useFakeTimers()`/`vi.advanceTimersByTimeAsync`): one test proves nodes land at a uniform 350ms gap (not the old cumulative 350/700/1050ms), one proves `clearTimeout` is called on unmount for the notice-dismiss timer.

Note: named `HikmahCanvas.timers.test.tsx` rather than `HikmahCanvas.test.tsx` because issue #326's fix (open as a separate, independent PR) also adds a new `HikmahCanvas.test.tsx` from the same pre-existing `main` — using a distinct filename avoids a same-new-file merge conflict between the two independent PRs.

**Note on `bun run test:integration`**: not run locally — this sandbox's Docker daemon cannot pull the Testcontainers Postgres image (Docker Hub registry access blocked by this environment's network egress policy, not a local Docker misconfiguration). No database/schema changes in this PR. CI runs it independently.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added — n/a
- [ ] `README.md` updated if the feature changes the public interface — n/a

Closes #327

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpoT4xJwVHXHtLsu8Lp1pt)_