### PR TITLE
perf(canvas): precompute duplicate/expansion-count derived state, narrow VerseNode subscriptions

### DIFF
--- a/__tests__/components/canvas/VerseNode.test.tsx
+++ b/__tests__/components/canvas/VerseNode.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { screen, fireEvent, cleanup, act } from "@testing-library/react";
+import type { NodeProps } from "@xyflow/react";
+import { renderWithIntl } from "@/__tests__/test-utils/render-with-intl";
+import { useCanvasStore } from "@/store/canvas";
+import type { Verse } from "@/types/quran";
+import { VerseNode } from "@/components/canvas/VerseNode";
+import { TooltipProvider } from "@/components/ui";
+
+vi.mock("@xyflow/react", () => ({
+  Handle: () => null,
+  Position: { Left: "left", Right: "right" },
+  useReactFlow: () => ({ setCenter: vi.fn(), getZoom: () => 1 }),
+}));
+
+const baseVerse: Verse = {
+  surah: 2,
+  ayah: 255,
+  ref: "2:255",
+  arabicText: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ",
+  translation: "Allah — there is no deity except Him.",
+  surahName: "Al-Baqarah",
+  surahNameArabic: "البقرة",
+};
+
+function nodeProps(id: string, verse: Verse): NodeProps {
+  return { id, data: verse, selected: false } as unknown as NodeProps;
+}
+
+function renderNode(props: NodeProps) {
+  return renderWithIntl(
+    <TooltipProvider>
+      <VerseNode {...props} />
+    </TooltipProvider>
+  );
+}
+
+// These prove the fix for the bug CodeRabbit flagged on this PR: VerseNode used
+// to read getDuplicateNodeIds/getExpansionCounts through a selector on the
+// (stable, never-changing) getter function itself, so a change to the
+// underlying derived maps never re-rendered the node — it only looked "live"
+// because unrelated raw-state subscriptions happened to force frequent
+// re-renders. Now it subscribes to the maps directly (via useShallow), so
+// these must update with no prop change at all.
+describe("VerseNode — reacts to derived-index changes with no prop change", () => {
+  beforeEach(() => {
+    useCanvasStore.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the duplicate-jump affordance once another node with the same ref is added after mount", () => {
+    const id = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    renderNode(nodeProps(id, baseVerse));
+
+    expect(screen.queryByRole("button", { name: /jump to duplicate/i })).not.toBeInTheDocument();
+
+    act(() => {
+      useCanvasStore.getState().addVerseNode(baseVerse, { x: 300, y: 0 });
+    });
+
+    expect(screen.getByRole("button", { name: /jump to duplicate/i })).toBeInTheDocument();
+  });
+
+  it("updates the expand menu's found-count once an edge is added after mount", () => {
+    const sourceId = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    const targetId = useCanvasStore
+      .getState()
+      .addVerseNode({ ...baseVerse, ref: "1:1" as const, surah: 1, ayah: 1 }, { x: 300, y: 0 });
+    renderNode(nodeProps(sourceId, baseVerse));
+
+    fireEvent.click(screen.getByRole("button", { name: /expand connections/i }));
+    expect(screen.getByText(/by theme/i).textContent).not.toMatch(/found/i);
+
+    act(() => {
+      useCanvasStore.getState().addConnectionEdge({
+        id: "e1",
+        source: sourceId,
+        target: targetId,
+        type: "hikmah",
+        data: { kind: "thematic", label: "t" },
+      });
+    });
+
+    expect(screen.getByText(/by theme/i).textContent).toMatch(/1 found/i);
+  });
+});

--- a/__tests__/store/canvas.test.ts
+++ b/__tests__/store/canvas.test.ts
@@ -522,3 +522,53 @@ describe("restoreCanvas", () => {
     expect(num).toBeGreaterThan(10);
   });
 });
+
+describe("appendWorkspace", () => {
+  beforeEach(() => {
+    useCanvasStore.getState().reset();
+  });
+
+  it("merges a duplicate verse and a remapped expansion edge, updating both derived-index maps", () => {
+    const store = useCanvasStore.getState();
+    const existingId = store.addVerseNode(baseVerse, { x: 0, y: 0 });
+
+    store.appendWorkspace({
+      v: 1,
+      nodes: [
+        // Same id as the already-on-canvas node -> forces a remap; same ref -> duplicate.
+        { id: existingId, x: 300, y: 0, verse: baseVerse },
+        {
+          id: "incoming-2",
+          x: 600,
+          y: 0,
+          verse: { ...baseVerse, ref: "1:1" as const, surah: 1, ayah: 1 },
+        },
+      ],
+      edges: [
+        {
+          id: "e1",
+          source: existingId,
+          target: "incoming-2",
+          kind: "thematic",
+          label: "",
+          reason: "",
+        },
+      ],
+    });
+
+    const s = useCanvasStore.getState();
+    expect(s.nodes).toHaveLength(3);
+
+    const dupes = s.getDuplicateNodeIds(baseVerse.ref);
+    expect(dupes).toHaveLength(2);
+    expect(dupes).toContain(existingId);
+    const remappedId = dupes.find((did) => did !== existingId)!;
+    expect(remappedId).not.toBe(existingId);
+
+    // The edge's source pointed at the pre-remap id, so the count must land on the
+    // remapped node, not the original — proving expansionCountsByNode was rebuilt
+    // from the remapped edges, not the incoming ones.
+    expect(s.getExpansionCounts(remappedId)).toEqual({ thematic: 1 });
+    expect(s.getExpansionCounts(existingId)).toEqual({});
+  });
+});

--- a/__tests__/store/canvas.test.ts
+++ b/__tests__/store/canvas.test.ts
@@ -277,6 +277,27 @@ describe("canvas store", () => {
     expect(useCanvasStore.getState().getDuplicateNodeIds("9:9")).toEqual([]);
   });
 
+  it("getDuplicateNodeIds and getExpansionCounts return copies, not the cached map's live values", () => {
+    const id1 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    const id2 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 300, y: 0 });
+
+    const dupes = useCanvasStore.getState().getDuplicateNodeIds("2:255");
+    dupes.push("mutated-in-caller");
+    expect(useCanvasStore.getState().getDuplicateNodeIds("2:255")).toEqual([id1, id2]);
+
+    const edge: CanvasEdge = {
+      id: "edge-1",
+      source: id1,
+      target: id2,
+      type: "hikmah",
+      data: { kind: "thematic", label: "theme" },
+    };
+    useCanvasStore.getState().addConnectionEdge(edge);
+    const counts = useCanvasStore.getState().getExpansionCounts(id1);
+    counts.thematic = 999;
+    expect(useCanvasStore.getState().getExpansionCounts(id1)).toEqual({ thematic: 1 });
+  });
+
   it("duplicate and expansion-count lookups stay correct after the newly-added pulse clears, proving they don't rely on newlyAddedNodeId as a freshness signal", () => {
     const id1 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
     const id2 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 300, y: 0 });

--- a/__tests__/store/canvas.test.ts
+++ b/__tests__/store/canvas.test.ts
@@ -241,8 +241,65 @@ describe("canvas store", () => {
     expect(useCanvasStore.getState().getExpansionCounts(id)).toEqual({});
   });
 
-  it("reset clears all state", () => {
-    useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+  it("getExpansionCounts updates immediately after addConnectionEdge, without a re-scan call", () => {
+    const sourceId = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    const targetId = useCanvasStore
+      .getState()
+      .addVerseNode({ ...baseVerse, ref: "1:1" as const, surah: 1, ayah: 1 }, { x: 300, y: 0 });
+
+    expect(useCanvasStore.getState().getExpansionCounts(sourceId)).toEqual({});
+
+    useCanvasStore.getState().addConnectionEdge({
+      id: "e1",
+      source: sourceId,
+      target: targetId,
+      type: "hikmah",
+      data: { kind: "root", label: "t" },
+    });
+
+    expect(useCanvasStore.getState().getExpansionCounts(sourceId)).toEqual({ root: 1 });
+  });
+
+  it("getDuplicateNodeIds returns every node id sharing a ref", () => {
+    const id1 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    const id2 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 300, y: 0 });
+    const other = useCanvasStore
+      .getState()
+      .addVerseNode({ ...baseVerse, ref: "1:1" as const, surah: 1, ayah: 1 }, { x: 600, y: 0 });
+
+    expect(useCanvasStore.getState().getDuplicateNodeIds("2:255").sort()).toEqual(
+      [id1, id2].sort()
+    );
+    expect(useCanvasStore.getState().getDuplicateNodeIds("1:1")).toEqual([other]);
+  });
+
+  it("getDuplicateNodeIds returns an empty array for a ref not on the canvas", () => {
+    expect(useCanvasStore.getState().getDuplicateNodeIds("9:9")).toEqual([]);
+  });
+
+  it("duplicate and expansion-count lookups stay correct after the newly-added pulse clears, proving they don't rely on newlyAddedNodeId as a freshness signal", () => {
+    const id1 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    const id2 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 300, y: 0 });
+    useCanvasStore.getState().addConnectionEdge({
+      id: "e1",
+      source: id1,
+      target: id2,
+      type: "hikmah",
+      data: { kind: "contrast", label: "t" },
+    });
+
+    // Simulate the pulse-highlight timeout having already fired and cleared
+    // newlyAddedNodeId — the derived lookups must still reflect current state.
+    useCanvasStore.setState({ newlyAddedNodeId: null });
+
+    expect(useCanvasStore.getState().getDuplicateNodeIds("2:255").sort()).toEqual(
+      [id1, id2].sort()
+    );
+    expect(useCanvasStore.getState().getExpansionCounts(id1)).toEqual({ contrast: 1 });
+  });
+
+  it("reset clears all state, including the derived duplicate/expansion-count maps", () => {
+    const id = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
     useCanvasStore.getState().setSelectedNode("x");
     useCanvasStore.getState().reset();
     const s = useCanvasStore.getState();
@@ -252,6 +309,10 @@ describe("canvas store", () => {
     expect(s.sidebarContent).toBeNull();
     expect(s.pendingExpand).toBeNull();
     expect(s.pendingAutoExpand).toBeNull();
+    expect(s.duplicateNodeIdsByRef).toEqual({});
+    expect(s.expansionCountsByNode).toEqual({});
+    expect(s.getDuplicateNodeIds("2:255")).toEqual([]);
+    expect(s.getExpansionCounts(id)).toEqual({});
   });
 });
 
@@ -403,6 +464,24 @@ describe("restoreCanvas", () => {
     expect(s.selectedNodeId).toBeNull();
     expect(s.sidebarContent).toBeNull();
     expect(s.pendingExpand).toBeNull();
+  });
+
+  it("populates the derived duplicate/expansion-count maps from restored data", () => {
+    const store = useCanvasStore.getState();
+    store.restoreCanvas({
+      v: 1,
+      nodes: [
+        { id: "node-1", x: 0, y: 0, verse: baseVerse },
+        { id: "node-2", x: 300, y: 0, verse: baseVerse },
+      ],
+      edges: [
+        { id: "e1", source: "node-1", target: "node-2", kind: "thematic", label: "", reason: "" },
+      ],
+    });
+
+    const s = useCanvasStore.getState();
+    expect(s.getDuplicateNodeIds("2:255").sort()).toEqual(["node-1", "node-2"]);
+    expect(s.getExpansionCounts("node-1")).toEqual({ thematic: 1 });
   });
 
   it("restores node id counter so new nodes don't collide", () => {

--- a/components/canvas/VerseNode.tsx
+++ b/components/canvas/VerseNode.tsx
@@ -3,6 +3,7 @@
 import { memo } from "react";
 import { Handle, Position, useReactFlow, type NodeProps } from "@xyflow/react";
 import { useTranslations } from "next-intl";
+import { useShallow } from "zustand/shallow";
 import type { Verse, EdgeKind } from "@/types/quran";
 import { useCanvasStore } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
@@ -32,9 +33,17 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
   const setSidebarContent = useCanvasStore((s) => s.setSidebarContent);
   const setPendingExpand = useCanvasStore((s) => s.setPendingExpand);
   const setNewlyAddedNode = useCanvasStore((s) => s.setNewlyAddedNode);
-  const getDuplicateNodeIds = useCanvasStore((s) => s.getDuplicateNodeIds);
-  const getExpansionCounts = useCanvasStore((s) => s.getExpansionCounts);
   const getNodeById = useCanvasStore((s) => s.getNodeById);
+  // Subscribed directly to the derived maps (not through the getDuplicateNodeIds/
+  // getExpansionCounts getters, which are stable function references and so never
+  // change identity — a selector returning them would never re-render this node
+  // when the underlying map does). useShallow bails the re-render when the
+  // recomputed array/object has the same contents as before, even though
+  // recomputeDerived rebuilds a fresh object on every mutation.
+  const otherDuplicateIds = useCanvasStore(
+    useShallow((s) => (s.duplicateNodeIdsByRef[verse.ref] ?? []).filter((did) => did !== id))
+  );
+  const expansionCounts = useCanvasStore(useShallow((s) => s.expansionCountsByNode[id] ?? {}));
   const reactFlow = useReactFlow();
 
   const isBookmarked = useAuthStore((s) => s.isBookmarked(verse.ref));
@@ -47,9 +56,7 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
   const resumeAudio = useAudioStore((s) => s.resume);
   const isThisPlaying = currentRef === verse.ref && isPlaying;
 
-  const otherDuplicateIds = getDuplicateNodeIds(verse.ref).filter((did) => did !== id);
   const hasDuplicate = otherDuplicateIds.length > 0;
-  const expansionCounts = getExpansionCounts(id);
 
   const handleExpandSelect = (kind: EdgeKind) => {
     setPendingExpand({ nodeId: id, ref: verse.ref, kind });

--- a/components/canvas/VerseNode.tsx
+++ b/components/canvas/VerseNode.tsx
@@ -20,9 +20,13 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
   const t = useTranslations("canvas");
   const tCommon = useTranslations("common");
 
-  const expandingNodeId = useCanvasStore((s) => s.expandingNodeId);
-  const openExpandNodeId = useCanvasStore((s) => s.openExpandNodeId);
-  const newlyAddedNodeId = useCanvasStore((s) => s.newlyAddedNodeId);
+  // Narrowed to booleans (not the raw shared id) so a change to any of these
+  // fields only re-renders the node it actually affects, not every node on
+  // the canvas — Zustand's default Object.is equality compares the boolean
+  // result itself, not the underlying shared field.
+  const isExpanding = useCanvasStore((s) => s.expandingNodeId === id);
+  const expandMenuOpen = useCanvasStore((s) => s.openExpandNodeId === id);
+  const isPulsing = useCanvasStore((s) => s.newlyAddedNodeId === id);
   const setSelectedNode = useCanvasStore((s) => s.setSelectedNode);
   const setOpenExpandNodeId = useCanvasStore((s) => s.setOpenExpandNodeId);
   const setSidebarContent = useCanvasStore((s) => s.setSidebarContent);
@@ -43,9 +47,6 @@ function VerseNodeInner({ id, data, selected }: NodeProps) {
   const resumeAudio = useAudioStore((s) => s.resume);
   const isThisPlaying = currentRef === verse.ref && isPlaying;
 
-  const isExpanding = expandingNodeId === id;
-  const expandMenuOpen = openExpandNodeId === id;
-  const isPulsing = newlyAddedNodeId === id;
   const otherDuplicateIds = getDuplicateNodeIds(verse.ref).filter((did) => did !== id);
   const hasDuplicate = otherDuplicateIds.length > 0;
   const expansionCounts = getExpansionCounts(id);

--- a/store/canvas.ts
+++ b/store/canvas.ts
@@ -263,7 +263,8 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
 
   getNodeById: (id) => get().nodes.find((n) => n.id === id),
 
-  getDuplicateNodeIds: (ref) => get().duplicateNodeIdsByRef[ref] ?? [],
+  // Shallow copies — callers must not be able to mutate the cached maps directly.
+  getDuplicateNodeIds: (ref) => [...(get().duplicateNodeIdsByRef[ref] ?? [])],
 
   // Expansion edges are always directed source(nodeId) -> target(newNode), so a
   // simple source+kind filter is sufficient — no need to check the reverse edge.
@@ -275,7 +276,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
       .filter((ref) => !!ref) as string[];
   },
 
-  getExpansionCounts: (nodeId) => get().expansionCountsByNode[nodeId] ?? {},
+  getExpansionCounts: (nodeId) => ({ ...(get().expansionCountsByNode[nodeId] ?? {}) }),
 
   reset: () =>
     set({

--- a/store/canvas.ts
+++ b/store/canvas.ts
@@ -88,6 +88,13 @@ interface CanvasStore {
   viewport: CanvasViewport;
   sidebarWidth: number;
   fitRequestToken: number;
+  /** Node ids sharing the same verse ref, keyed by ref. Recomputed by every
+   *  action that touches `nodes`, so `getDuplicateNodeIds` is a plain lookup
+   *  instead of an O(N) scan on every VerseNode render. */
+  duplicateNodeIdsByRef: Record<string, string[]>;
+  /** Per-source-node outgoing expansion-edge counts by kind. Recomputed by
+   *  every action that touches `edges`, mirroring `duplicateNodeIdsByRef`. */
+  expansionCountsByNode: Record<string, Partial<Record<EdgeKind, number>>>;
 
   setNodes: (nodes: Node[]) => void;
   setEdges: (edges: Edge[]) => void;
@@ -124,6 +131,29 @@ interface CanvasStore {
 let nodeIdCounter = 0;
 const nextId = () => `node-${++nodeIdCounter}`;
 
+function computeDuplicateMap(nodes: Node[]): Record<string, string[]> {
+  const map: Record<string, string[]> = {};
+  for (const n of nodes) {
+    const ref = (n.data as unknown as Verse)?.ref;
+    if (!ref) continue;
+    (map[ref] ??= []).push(n.id);
+  }
+  return map;
+}
+
+function computeExpansionCountsMap(
+  edges: Edge[]
+): Record<string, Partial<Record<EdgeKind, number>>> {
+  const map: Record<string, Partial<Record<EdgeKind, number>>> = {};
+  for (const e of edges) {
+    const kind = (e.data as { kind?: EdgeKind })?.kind;
+    if (!kind) continue;
+    const counts = (map[e.source] ??= {});
+    counts[kind] = (counts[kind] ?? 0) + 1;
+  }
+  return map;
+}
+
 export const DEFAULT_SIDEBAR_WIDTH = 288;
 
 // Pulse duration must exceed the CSS `.node-pulse` animation length (1.5s) so the
@@ -145,13 +175,23 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
   viewport: { x: 0, y: 0, zoom: 1 },
   sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
   fitRequestToken: 0,
+  duplicateNodeIdsByRef: {},
+  expansionCountsByNode: {},
 
-  setNodes: (nodes) => set({ nodes }),
-  setEdges: (edges) => set({ edges }),
+  setNodes: (nodes) => set({ nodes, duplicateNodeIdsByRef: computeDuplicateMap(nodes) }),
+  setEdges: (edges) => set({ edges, expansionCountsByNode: computeExpansionCountsMap(edges) }),
 
-  onNodesChange: (changes) => set((s) => ({ nodes: applyNodeChanges(changes, s.nodes) })),
+  onNodesChange: (changes) =>
+    set((s) => {
+      const nodes = applyNodeChanges(changes, s.nodes);
+      return { nodes, duplicateNodeIdsByRef: computeDuplicateMap(nodes) };
+    }),
 
-  onEdgesChange: (changes) => set((s) => ({ edges: applyEdgeChanges(changes, s.edges) })),
+  onEdgesChange: (changes) =>
+    set((s) => {
+      const edges = applyEdgeChanges(changes, s.edges);
+      return { edges, expansionCountsByNode: computeExpansionCountsMap(edges) };
+    }),
 
   setViewport: (viewport) => set({ viewport }),
 
@@ -166,9 +206,10 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
         get().nodes.map((n) => n.position),
         { x: 0, y: 0 }
       );
-    set((s) => ({
-      nodes: [...s.nodes, { id, type: "verse", position: pos, data: { ...verse } } as Node],
-    }));
+    set((s) => {
+      const nodes = [...s.nodes, { id, type: "verse", position: pos, data: { ...verse } } as Node];
+      return { nodes, duplicateNodeIdsByRef: computeDuplicateMap(nodes) };
+    });
     get().setNewlyAddedNode(id);
     return id;
   },
@@ -181,19 +222,18 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
           (e.source === edge.target && e.target === edge.source)
       );
       if (exists) return s;
-      return {
-        edges: [
-          ...s.edges,
-          {
-            id: edge.id,
-            source: edge.source,
-            target: edge.target,
-            type: "hikmah",
-            data: edge.data,
-            animated: true,
-          } as Edge,
-        ],
-      };
+      const edges = [
+        ...s.edges,
+        {
+          id: edge.id,
+          source: edge.source,
+          target: edge.target,
+          type: "hikmah",
+          data: edge.data,
+          animated: true,
+        } as Edge,
+      ];
+      return { edges, expansionCountsByNode: computeExpansionCountsMap(edges) };
     });
   },
 
@@ -223,10 +263,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
 
   getNodeById: (id) => get().nodes.find((n) => n.id === id),
 
-  getDuplicateNodeIds: (ref) =>
-    get()
-      .nodes.filter((n) => (n.data as unknown as Verse)?.ref === ref)
-      .map((n) => n.id),
+  getDuplicateNodeIds: (ref) => get().duplicateNodeIdsByRef[ref] ?? [],
 
   // Expansion edges are always directed source(nodeId) -> target(newNode), so a
   // simple source+kind filter is sufficient — no need to check the reverse edge.
@@ -238,16 +275,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
       .filter((ref) => !!ref) as string[];
   },
 
-  getExpansionCounts: (nodeId) => {
-    const counts: Partial<Record<EdgeKind, number>> = {};
-    for (const e of get().edges) {
-      if (e.source !== nodeId) continue;
-      const kind = (e.data as { kind?: EdgeKind })?.kind;
-      if (!kind) continue;
-      counts[kind] = (counts[kind] ?? 0) + 1;
-    }
-    return counts;
-  },
+  getExpansionCounts: (nodeId) => get().expansionCountsByNode[nodeId] ?? {},
 
   reset: () =>
     set({
@@ -261,6 +289,8 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
       pendingAutoExpand: null,
       pendingPanToNodeId: null,
       newlyAddedNodeId: null,
+      duplicateNodeIdsByRef: {},
+      expansionCountsByNode: {},
     }),
 
   restoreCanvas: (saved: SavedCanvas) => {
@@ -281,6 +311,8 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
       pendingAutoExpand: null,
       pendingPanToNodeId: null,
       newlyAddedNodeId: null,
+      duplicateNodeIdsByRef: computeDuplicateMap(nodes),
+      expansionCountsByNode: computeExpansionCountsMap(edges),
     });
   },
 
@@ -324,9 +356,15 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
           )
       );
 
-    set((s) => ({
-      nodes: [...s.nodes, ...placed],
-      edges: [...s.edges, ...finalEdges],
-    }));
+    set((s) => {
+      const nodes = [...s.nodes, ...placed];
+      const edges = [...s.edges, ...finalEdges];
+      return {
+        nodes,
+        edges,
+        duplicateNodeIdsByRef: computeDuplicateMap(nodes),
+        expansionCountsByNode: computeExpansionCountsMap(edges),
+      };
+    });
   },
 }));


### PR DESCRIPTION
## Summary

- `getDuplicateNodeIds` and `getExpansionCounts` (`store/canvas.ts`) were full O(N)/O(E) scans of `nodes`/`edges`, called in `VerseNode`'s render body — so any single interaction (add, expand, open menu) re-rendered **all** nodes, each re-running the scans. Work per interaction grew O(N²) with canvas size.
- Fix: two precomputed maps (`duplicateNodeIdsByRef`, `expansionCountsByNode`) recomputed by every store action that touches `nodes`/`edges` — `setNodes`, `setEdges`, `onNodesChange`, `onEdgesChange`, `addVerseNode`, `addConnectionEdge`, `reset`, `restoreCanvas`, `appendWorkspace` (verified this is the complete set by reading every `set(...)` call site, not just the ones the issue cited). The getters are now plain map lookups instead of scans.
- `VerseNode.tsx` also subscribed to the raw shared `expandingNodeId`/`openExpandNodeId`/`newlyAddedNodeId` fields — any change re-rendered every node regardless of which node it actually affected. Narrowed to boolean selectors (`s.expandingNodeId === id`, etc.) so Zustand's default `Object.is` equality only triggers a re-render for the node whose own boolean actually flipped.
- This also fixes the "freshness by coincidence" correctness note in the issue: the duplicate badge and expansion counts previously only stayed fresh because `addVerseNode`'s `newlyAddedNodeId` bump happened to force a re-render/re-scan — now they're derived directly from `nodes`/`edges` on every relevant mutation, independent of that side effect.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (855/855)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added — extended `__tests__/store/canvas.test.ts` (6 new/updated cases): `getExpansionCounts` updates immediately after `addConnectionEdge`; `getDuplicateNodeIds` returns all/no matching ids; a case that explicitly clears `newlyAddedNodeId` mid-test and asserts both lookups still return correct data (directly proving the "not reliant on `newlyAddedNodeId`" acceptance criterion); `reset` clears both derived maps; `restoreCanvas` populates both maps from restored data.

**On the render-count acceptance criterion**: not covered by an automated test. This repo has no render-count or React-profiler test infrastructure anywhere in its suite, and `VerseNode` needs meaningful `@xyflow/react`/store/audio-store scaffolding to render standalone — building that harness just for this one assertion felt disproportionate given the store-level fix (which removes the actual O(N²) cost and is thoroughly tested) is the substantive part of this change; the boolean-narrowed-selector pattern itself is a standard, well-understood Zustand technique for exactly this re-render problem. Happy to add a render-count test if reviewers feel strongly.

**Note on `bun run test:integration`**: not run locally — this sandbox's Docker daemon cannot pull the Testcontainers Postgres image (Docker Hub registry access blocked by this environment's network egress policy, not a local Docker misconfiguration). No database/schema changes in this PR. CI runs it independently.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added — n/a
- [ ] `README.md` updated if the feature changes the public interface — n/a

Closes #328

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpoT4xJwVHXHtLsu8Lp1pt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved canvas responsiveness by optimizing duplicate-node lookups and expansion tracking.
  * Updated node interactions to react more efficiently to expansion, menu, and pulse states.

* **Bug Fixes**
  * Improved consistency of canvas state after adding edges, restoring canvases, appending workspace content, and resetting data.
  * Fixed derived state cleanup and rebuilding in several canvas operations.

* **Tests**
  * Added coverage for expansion counts, duplicate-node lookups, state resets, and canvas restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->