### PR TITLE
fix(names): prefetch reflection/pairings server-side, surface fetch errors

### DIFF
--- a/__tests__/app/names/NamePairings.test.tsx
+++ b/__tests__/app/names/NamePairings.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import { renderWithIntl } from "@/__tests__/test-utils/render-with-intl";
+import { NamePairings } from "@/app/names/[slug]/NamePairings";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const PAIRING = {
+  name: "ar-rahim",
+  transliteration: "Ar-Rahim",
+  arabic: "الرَّحِيم",
+  explanation: "One sentence on why this pairing balances Ar-Rahman.",
+};
+
+describe("NamePairings", () => {
+  it("renders server-prefetched pairings immediately and never fetches", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithIntl(<NamePairings slug="ar-rahman" accent="#000" initialPairings={[PAIRING]} />);
+
+    expect(screen.getByText("Ar-Rahim")).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to fetching when no initial pairings are provided (cache miss)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [PAIRING],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithIntl(<NamePairings slug="ar-rahman" accent="#000" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/names/ar-rahman/pairings"));
+    expect(await screen.findByText("Ar-Rahim")).toBeInTheDocument();
+  });
+
+  it("shows a visible error message (not a blank render) when the fetch fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderWithIntl(<NamePairings slug="ar-rahman" accent="#000" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Could not load pairings at this time.")).toBeInTheDocument()
+    );
+    expect(container).not.toBeEmptyDOMElement();
+  });
+
+  it("still hides the section for a legitimately-empty successful result (not an error)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderWithIntl(<NamePairings slug="ar-rahman" accent="#000" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+});

--- a/__tests__/app/names/NameReflection.test.tsx
+++ b/__tests__/app/names/NameReflection.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import { renderWithIntl } from "@/__tests__/test-utils/render-with-intl";
+import { NameReflection } from "@/app/names/[slug]/NameReflection";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("NameReflection", () => {
+  it("renders server-prefetched reflection immediately and never fetches", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithIntl(
+      <NameReflection slug="ar-rahman" accent="#000" initialReflection="A prefetched reflection." />
+    );
+
+    expect(screen.getByText("A prefetched reflection.")).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to fetching when no initial reflection is provided (cache miss)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ reflection: "A fetched reflection." }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithIntl(<NameReflection slug="ar-rahman" accent="#000" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/names/ar-rahman/reflection"));
+    expect(await screen.findByText("A fetched reflection.")).toBeInTheDocument();
+  });
+
+  it("shows a visible error message (not a blank render) when the fetch fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderWithIntl(<NameReflection slug="ar-rahman" accent="#000" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Could not load the reflection at this time.")).toBeInTheDocument()
+    );
+    expect(container).not.toBeEmptyDOMElement();
+  });
+});

--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -47,7 +47,11 @@ const { mockSelect, mockInsert, mockValues, mockOnConflict, mockOnConflictDoNoth
 
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, insert: mockInsert } }));
 
-import { getOrGenerateNameContent, getOrGenerateVerseReason } from "@/lib/names/name-content";
+import {
+  getOrGenerateNameContent,
+  getOrGenerateVerseReason,
+  getCachedNameContent,
+} from "@/lib/names/name-content";
 
 const isEmptyArr = (v: unknown[]) => v.length === 0;
 
@@ -270,6 +274,60 @@ describe("getOrGenerateNameContent", () => {
     const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
     expect(out).toEqual(["ok"]);
     expect(generate).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("getCachedNameContent", () => {
+  beforeEach(() => {
+    mockSelect.mockReset();
+    mockInsert.mockClear();
+  });
+
+  it("returns the cached value on a hit at the current version", async () => {
+    mockSelect.mockReturnValue(
+      makeSelectChain([{ data: JSON.stringify("a reflection"), version: 1 }])
+    );
+
+    const out = await getCachedNameContent<string>("ar-rahman", "reflection", "en", 1);
+
+    expect(out).toBe("a reflection");
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns null on a miss (no row)", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([]));
+
+    const out = await getCachedNameContent<string>("ar-rahman", "reflection", "en", 1);
+
+    expect(out).toBeNull();
+  });
+
+  it("returns null when the stored version is older than the requested version", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([{ data: JSON.stringify("stale"), version: 1 }]));
+
+    const out = await getCachedNameContent<string>("ar-rahman", "reflection", "en", 2);
+
+    expect(out).toBeNull();
+  });
+
+  it("returns null and logs on corrupt cached JSON, without persisting anything", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockSelect.mockReturnValue(makeSelectChain([{ data: "{not json", version: 1 }]));
+
+    const out = await getCachedNameContent<string>("ar-rahman", "reflection", "en", 1);
+
+    expect(out).toBeNull();
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("never calls generate — it is read-only", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([{ data: JSON.stringify(["a", "b"]), version: 1 }]));
+
+    const out = await getCachedNameContent<string[]>("al-malik", "pairings", "en", 1);
+
+    expect(out).toEqual(["a", "b"]);
   });
 });
 

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -8,8 +8,9 @@ import { getUiLocale } from "@/lib/i18n/request-prefs";
 import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
 
-// Bump to force regeneration after a prompt change.
-const PAIRINGS_VERSION = 1;
+// Bump to force regeneration after a prompt change. Exported so page.tsx can
+// use the same version when checking the cache for a server-side prefetch.
+export const PAIRINGS_VERSION = 1;
 
 interface Pairing {
   name: string;

--- a/app/api/names/[slug]/reflection/route.ts
+++ b/app/api/names/[slug]/reflection/route.ts
@@ -8,8 +8,9 @@ import { getUiLocale } from "@/lib/i18n/request-prefs";
 import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
 
-// Bump to force regeneration after a prompt change.
-const REFLECTION_VERSION = 1;
+// Bump to force regeneration after a prompt change. Exported so page.tsx can
+// use the same version when checking the cache for a server-side prefetch.
+export const REFLECTION_VERSION = 1;
 
 function buildPrompt(
   arabic: string,

--- a/app/names/[slug]/NamePairings.tsx
+++ b/app/names/[slug]/NamePairings.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 
-interface Pairing {
+export interface Pairing {
   name: string;
   transliteration: string;
   arabic: string;
@@ -14,14 +14,18 @@ interface Pairing {
 interface Props {
   slug: string;
   accent: string;
+  /** Server-prefetched pairings, or `null` on a cache miss (the component
+   *  then falls back to its own fetch, unchanged). */
+  initialPairings?: Pairing[] | null;
 }
 
-export function NamePairings({ slug, accent }: Props) {
+export function NamePairings({ slug, accent, initialPairings }: Props) {
   const t = useTranslations("names");
-  const [pairings, setPairings] = useState<Pairing[] | null>(null);
+  const [pairings, setPairings] = useState<Pairing[] | null>(initialPairings ?? null);
   const [error, setError] = useState(false);
 
   useEffect(() => {
+    if (initialPairings != null) return; // already have it from the server
     let cancelled = false;
     fetch(`/api/names/${slug}/pairings`)
       .then((r) => (r.ok ? r.json() : Promise.reject()))
@@ -34,9 +38,19 @@ export function NamePairings({ slug, accent }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [slug]);
+  }, [slug, initialPairings]);
 
-  if (error || (pairings !== null && pairings.length === 0)) return null;
+  if (error) {
+    return (
+      <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
+        {t("couldNotLoadPairings")}
+      </p>
+    );
+  }
+
+  // A successfully-loaded empty result is a legitimate "no pairings" case,
+  // not an error — hide the section rather than showing an empty card.
+  if (pairings !== null && pairings.length === 0) return null;
 
   return (
     <div

--- a/app/names/[slug]/NameReflection.tsx
+++ b/app/names/[slug]/NameReflection.tsx
@@ -6,14 +6,18 @@ import { useTranslations } from "next-intl";
 interface Props {
   slug: string;
   accent: string;
+  /** Server-prefetched reflection text, or `null` on a cache miss (the
+   *  component then falls back to its own fetch, unchanged). */
+  initialReflection?: string | null;
 }
 
-export function NameReflection({ slug, accent }: Props) {
+export function NameReflection({ slug, accent, initialReflection }: Props) {
   const t = useTranslations("names");
-  const [reflection, setReflection] = useState<string | null>(null);
+  const [reflection, setReflection] = useState<string | null>(initialReflection ?? null);
   const [error, setError] = useState(false);
 
   useEffect(() => {
+    if (initialReflection != null) return; // already have it from the server
     let cancelled = false;
     fetch(`/api/names/${slug}/reflection`)
       .then((r) => (r.ok ? r.json() : Promise.reject()))
@@ -26,9 +30,15 @@ export function NameReflection({ slug, accent }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [slug]);
+  }, [slug, initialReflection]);
 
-  if (error) return null;
+  if (error) {
+    return (
+      <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
+        {t("couldNotLoadReflection")}
+      </p>
+    );
+  }
 
   return (
     <div

--- a/app/names/[slug]/page.tsx
+++ b/app/names/[slug]/page.tsx
@@ -11,7 +11,11 @@ import {
 import { Wordmark } from "@/components/layout/Wordmark";
 import { NameVerses } from "./NameVerses";
 import { NameReflection } from "./NameReflection";
-import { NamePairings } from "./NamePairings";
+import { NamePairings, type Pairing } from "./NamePairings";
+import { getCachedNameContent } from "@/lib/names/name-content";
+import { getUiLocale } from "@/lib/i18n/request-prefs";
+import { REFLECTION_VERSION } from "@/app/api/names/[slug]/reflection/route";
+import { PAIRINGS_VERSION } from "@/app/api/names/[slug]/pairings/route";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -50,6 +54,16 @@ export default async function NameDetailPage({ params }: Props) {
   const t = await getTranslations("names");
   const styles = CATEGORY_STYLES[name.category];
   const categoryLabelKey = CATEGORY_LABEL_KEYS[name.category].label;
+
+  // Read-only cache prefetch — a hit lets these sections render server-side
+  // (crawlers/view-source see the text immediately, no client round trip); a
+  // miss leaves the value undefined and the client components fall back to
+  // their existing fetch-and-generate behavior unchanged.
+  const locale = await getUiLocale();
+  const [initialReflection, initialPairings] = await Promise.all([
+    getCachedNameContent<string>(slug, "reflection", locale, REFLECTION_VERSION),
+    getCachedNameContent<Pairing[]>(slug, "pairings", locale, PAIRINGS_VERSION),
+  ]);
 
   const prevName = DIVINE_NAMES.find((n) => n.id === name.id - 1);
   const nextName = DIVINE_NAMES.find((n) => n.id === name.id + 1);
@@ -99,10 +113,10 @@ export default async function NameDetailPage({ params }: Props) {
       {/* Reflection + Pairings + Verses */}
       <div className="max-w-3xl mx-auto px-6 py-10 space-y-10">
         {/* Believer's Reflection */}
-        <NameReflection slug={slug} accent={styles.accent} />
+        <NameReflection slug={slug} accent={styles.accent} initialReflection={initialReflection} />
 
         {/* Structural Pairings */}
-        <NamePairings slug={slug} accent={styles.accent} />
+        <NamePairings slug={slug} accent={styles.accent} initialPairings={initialPairings} />
 
         {/* Verse Feed */}
         <div>

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -86,6 +86,35 @@ export async function getOrGenerateNameContent<T>(
   }
 }
 
+/**
+ * Read-only cache lookup for `(slug, kind, locale)` at the current `version` —
+ * never generates, never consumes rate limit. Used for server-side prefetch
+ * (e.g. SSR) where a cache miss should fall through to the existing
+ * client-fetch-and-generate path rather than block the page render on an AI call.
+ */
+export async function getCachedNameContent<T>(
+  slug: string,
+  kind: NameContentKind,
+  locale: Locale,
+  version: number
+): Promise<T | null> {
+  const [row] = await db
+    .select({ data: nameContent.data, version: nameContent.version })
+    .from(nameContent)
+    .where(
+      and(eq(nameContent.slug, slug), eq(nameContent.kind, kind), eq(nameContent.locale, locale))
+    )
+    .limit(1);
+
+  if (!row || row.version !== version) return null;
+  try {
+    return JSON.parse(row.data) as T;
+  } catch (err) {
+    console.error(`Corrupt name_content row for ${slug}/${kind}/${locale}:`, err);
+    return null;
+  }
+}
+
 async function generateAndPersist<T>(
   slug: string,
   kind: NameContentKind,

--- a/messages/az.json
+++ b/messages/az.json
@@ -176,6 +176,8 @@
     "reflectionLabel": "Möminin Təfəkkürü",
     "pairingsLabel": "Ümumi Uyğunluqlar",
     "couldNotLoadVerses": "Ayələr hazırda yüklənə bilmədi.",
+    "couldNotLoadReflection": "Təfəkkür hazırda yüklənə bilmədi.",
+    "couldNotLoadPairings": "Uyğunluqlar hazırda yüklənə bilmədi.",
     "findingVerses": "Claude ayələri tapır…",
     "noVersesFound": "Bu ad üçün ayə tapılmadı.",
     "connectionLabel": "Əlaqə: ",

--- a/messages/en.json
+++ b/messages/en.json
@@ -176,6 +176,8 @@
     "reflectionLabel": "Believer's Reflection",
     "pairingsLabel": "Common Pairings",
     "couldNotLoadVerses": "Could not load verses at this time.",
+    "couldNotLoadReflection": "Could not load the reflection at this time.",
+    "couldNotLoadPairings": "Could not load pairings at this time.",
     "findingVerses": "Claude is finding verses…",
     "noVersesFound": "No verses found for this name.",
     "connectionLabel": "Connection: ",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -176,6 +176,8 @@
     "reflectionLabel": "Размышление верующего",
     "pairingsLabel": "Частые сочетания",
     "couldNotLoadVerses": "Не удалось загрузить аяты в данный момент.",
+    "couldNotLoadReflection": "Не удалось загрузить размышление в данный момент.",
+    "couldNotLoadPairings": "Не удалось загрузить сочетания в данный момент.",
     "findingVerses": "Claude ищет аяты…",
     "noVersesFound": "Для этого имени аяты не найдены.",
     "connectionLabel": "Связь: ",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -176,6 +176,8 @@
     "reflectionLabel": "Müminin Tefekkürü",
     "pairingsLabel": "Yaygın Eşleşmeler",
     "couldNotLoadVerses": "Ayetler şu anda yüklenemedi.",
+    "couldNotLoadReflection": "Tefekkür şu anda yüklenemedi.",
+    "couldNotLoadPairings": "Eşleşmeler şu anda yüklenemedi.",
     "findingVerses": "Claude ayetleri buluyor…",
     "noVersesFound": "Bu isim için ayet bulunamadı.",
     "connectionLabel": "Bağlantı: ",


### PR DESCRIPTION
## Summary

- Add `getCachedNameContent`, a read-only cache lookup (no generation, no rate-limit consumption), and use it in `app/names/[slug]/page.tsx` to prefetch `reflection` and `pairings` in parallel on the server.
- On a cache hit, the new `initialReflection`/`initialPairings` props let `NameReflection`/`NamePairings` render immediately (no client round trip, no skeleton flash, visible in view-source). On a miss, both components fall back to their existing client fetch-and-generate behavior, unchanged.
- Replace the silent `return null` on fetch error in both components with a visible error message, matching `NameVerses.tsx`'s existing `couldNotLoadVerses`-style pattern. A legitimately-empty pairings result (not an error) still hides the section, as before.

`NameVerses.tsx` is intentionally out of scope — it already has correct error-visibility and meaningfully more complexity (live corpus resolution + per-locale reason translation), and the issue's own acceptance criteria only calls out reflection/pairings text needing to appear in view-source.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

**Details** (if applicable):
N/A — no prompt, divine-name-data, or theological-framing changes. The AI-generated content itself (reflection/pairings text) is unchanged; this PR only changes *when* and *how* already-generated, already-cached content is delivered to the page.

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality

New tests:
- `__tests__/lib/names/name-content.test.ts` — hit / miss / version-mismatch / corrupt-JSON cases for `getCachedNameContent`.
- `__tests__/app/names/NameReflection.test.tsx` and `__tests__/app/names/NamePairings.test.tsx` — confirm `initial*` props skip the client fetch, the fetch fallback still works on a cache miss, and fetch errors now render a visible message instead of nothing (plus the legitimately-empty-pairings-hides-silently case).

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added (N/A — none added)
- [x] `README.md` updated if the feature changes the public interface (N/A — no public interface change)

Closes #329

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpoT4xJwVHXHtLsu8Lp1pt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Name pages now load cached reflections and pairings earlier, reducing unnecessary client-side requests.
  * Existing fetching remains available when cached content is unavailable.

* **Bug Fixes**
  * Loading failures for reflections and pairings now display clear localized error messages.
  * Empty pairing results continue to be handled cleanly.

* **Localization**
  * Added error messages in English, Azerbaijani, Russian, and Turkish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->