### PR TITLE
fix(quran): correct trailing "?" in az.mammadaliyev translation of 103:2

### DIFF
--- a/__tests__/lib/quran/quran-corpus.test.ts
+++ b/__tests__/lib/quran/quran-corpus.test.ts
@@ -158,6 +158,22 @@ describe("quran-corpus", () => {
       expect(map.get("1:1")?.translation).toBe("Türkçe 1");
       expect(map.get("2:255")?.translation).toBe("text");
     });
+
+    it("applies the verified correction for 103:2/az.mammadaliyev in the batch path", async () => {
+      mockSelect.mockReturnValue(
+        makeDbChain([
+          {
+            verse: row("103:2", 103, 2),
+            translationText:
+              "İnsan (ömrünü bihudə işlərə sərf etməklə, dünyanı axirətdən üstün tutmaqla) ziyan içindədir?",
+          },
+        ])
+      );
+      const map = await getVerses(["103:2"], "az.mammadaliyev");
+      expect(map.get("103:2")?.translation).toBe(
+        "İnsan (ömrünü bihudə işlərə sərf etməklə, dünyanı axirətdən üstün tutmaqla) ziyan içindədir."
+      );
+    });
   });
 
   describe("existingRefs", () => {

--- a/__tests__/lib/quran/quran-corpus.test.ts
+++ b/__tests__/lib/quran/quran-corpus.test.ts
@@ -128,6 +128,22 @@ describe("quran-corpus", () => {
       const verse = await getVerse("2:255", "tr.diyanet");
       expect(verse?.translation).toBe("text"); // row()'s default translation
     });
+
+    it("applies the verified correction for 103:2/az.mammadaliyev", async () => {
+      mockSelect.mockReturnValue(
+        makeDbChain([
+          {
+            verse: row("103:2", 103, 2),
+            translationText:
+              "İnsan (ömrünü bihudə işlərə sərf etməklə, dünyanı axirətdən üstün tutmaqla) ziyan içindədir?",
+          },
+        ])
+      );
+      const verse = await getVerse("103:2", "az.mammadaliyev");
+      expect(verse?.translation).toBe(
+        "İnsan (ömrünü bihudə işlərə sərf etməklə, dünyanı axirətdən üstün tutmaqla) ziyan içindədir."
+      );
+    });
   });
 
   describe("getVerses with edition", () => {

--- a/__tests__/lib/quran/translation-corrections.test.ts
+++ b/__tests__/lib/quran/translation-corrections.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { correctTranslation } from "@/lib/quran/translation-corrections";
+
+describe("correctTranslation", () => {
+  it("returns the verified correction for an exact (ref, edition) match", () => {
+    const result = correctTranslation(
+      "103:2",
+      "az.mammadaliyev",
+      "İnsan (ömrünü bihudə işlərə sərf etməklə, dünyanı axirətdən üstün tutmaqla) ziyan içindədir?"
+    );
+    expect(result).toBe(
+      "İnsan (ömrünü bihudə işlərə sərf etməklə, dünyanı axirətdən üstün tutmaqla) ziyan içindədir."
+    );
+  });
+
+  it("passes text through unchanged for a different edition of the same ref", () => {
+    const text = "some tr.diyanet text";
+    expect(correctTranslation("103:2", "tr.diyanet", text)).toBe(text);
+  });
+
+  it("passes text through unchanged for a different ref of the same edition", () => {
+    const text = "some other ayah's text";
+    expect(correctTranslation("1:1", "az.mammadaliyev", text)).toBe(text);
+  });
+
+  it("passes text through unchanged when no edition is given", () => {
+    const text = "en.sahih text";
+    expect(correctTranslation("103:2", undefined, text)).toBe(text);
+  });
+});

--- a/__tests__/lib/quran/verse-resolver.test.ts
+++ b/__tests__/lib/quran/verse-resolver.test.ts
@@ -140,4 +140,46 @@ describe("resolveVerse", () => {
     const result = await resolveVerse("2:255", "tr.diyanet");
     expect(result?.translation).toBe("English fallback");
   });
+
+  it("live fallback applies the verified correction for 103:2/az.mammadaliyev", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    vi.mocked(fetch).mockImplementation(async (url: string | URL | Request) => {
+      const isArabic = String(url).includes("ar.alafasy");
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            text: isArabic
+              ? "نص عربي"
+              : "İnsan (ömrünü bihudə işlərə sərf etməklə, dünyanı axirətdən üstün tutmaqla) ziyan içindədir?",
+          },
+        }),
+      } as Response;
+    });
+    const result = await resolveVerse("103:2", "az.mammadaliyev");
+    expect(result?.translation).toBe(
+      "İnsan (ömrünü bihudə işlərə sərf etməklə, dünyanı axirətdən üstün tutmaqla) ziyan içindədir."
+    );
+  });
+
+  it("does not apply the az.mammadaliyev correction when that edition 404s and falls back to en.sahih", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    vi.mocked(fetch).mockImplementation(async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("ar.alafasy")) {
+        return { ok: true, json: async () => ({ data: { text: "نص عربي" } }) } as Response;
+      }
+      if (u.includes("az.mammadaliyev")) {
+        return { ok: false } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({ data: { text: "Indeed, mankind is in loss?" } }),
+      } as Response;
+    });
+    const result = await resolveVerse("103:2", "az.mammadaliyev");
+    // The correction table only has an entry for (103:2, az.mammadaliyev) —
+    // since the resolved edition is en.sahih here, it must not fire.
+    expect(result?.translation).toBe("Indeed, mankind is in loss?");
+  });
 });

--- a/__tests__/lib/quran/verse-resolver.test.ts
+++ b/__tests__/lib/quran/verse-resolver.test.ts
@@ -174,12 +174,12 @@ describe("resolveVerse", () => {
       }
       return {
         ok: true,
-        json: async () => ({ data: { text: "Indeed, mankind is in loss?" } }),
+        json: async () => ({ data: { text: "Indeed, mankind is in loss," } }),
       } as Response;
     });
     const result = await resolveVerse("103:2", "az.mammadaliyev");
     // The correction table only has an entry for (103:2, az.mammadaliyev) —
     // since the resolved edition is en.sahih here, it must not fire.
-    expect(result?.translation).toBe("Indeed, mankind is in loss?");
+    expect(result?.translation).toBe("Indeed, mankind is in loss,");
   });
 });

--- a/lib/quran/quran-corpus.ts
+++ b/lib/quran/quran-corpus.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/infra/db";
 import { verses, verseTranslations, type VerseRow } from "@/lib/infra/db/schema";
 import { getSurahName } from "@/lib/quran/surah-names";
 import { SURAH_LENGTHS } from "@/lib/quran/audio";
+import { correctTranslation } from "@/lib/quran/translation-corrections";
 import type { Verse, VerseRef } from "@/types/quran";
 
 /**
@@ -15,14 +16,18 @@ import type { Verse, VerseRef } from "@/types/quran";
  * requested edition has no row for that verse.
  */
 
-function rowToVerse(row: VerseRow, translationOverride?: string): Verse {
+function rowToVerse(
+  row: VerseRow,
+  opts?: { edition?: string; translationOverride?: string }
+): Verse {
   const [surahName, surahNameArabic] = getSurahName(row.surah);
+  const rawTranslation = opts?.translationOverride ?? row.translation;
   return {
     surah: row.surah,
     ayah: row.ayah,
     ref: row.ref as VerseRef,
     arabicText: row.arabicText,
-    translation: translationOverride ?? row.translation,
+    translation: correctTranslation(row.ref, opts?.edition, rawTranslation),
     surahName,
     surahNameArabic,
   };
@@ -60,7 +65,9 @@ export async function getVerse(ref: string, edition?: string): Promise<Verse | n
     .where(eq(verses.ref, ref))
     .limit(1);
   const row = rows[0];
-  return row ? rowToVerse(row.verse, row.translationText ?? undefined) : null;
+  return row
+    ? rowToVerse(row.verse, { edition, translationOverride: row.translationText ?? undefined })
+    : null;
 }
 
 /** Batch lookup. Returns a map keyed by ref; missing refs are simply absent. */
@@ -79,7 +86,10 @@ export async function getVerses(refs: string[], edition?: string): Promise<Map<s
     )
     .where(inArray(verses.ref, refs));
   return new Map(
-    rows.map((r) => [r.verse.ref, rowToVerse(r.verse, r.translationText ?? undefined)])
+    rows.map((r) => [
+      r.verse.ref,
+      rowToVerse(r.verse, { edition, translationOverride: r.translationText ?? undefined }),
+    ])
   );
 }
 

--- a/lib/quran/translation-corrections.ts
+++ b/lib/quran/translation-corrections.ts
@@ -1,0 +1,32 @@
+/**
+ * Manually verified fixes for upstream alquran.cloud translation text copied
+ * verbatim by scripts/seed-translations.mjs and verse-resolver.ts's live-fetch
+ * fallback. Exact (ref, edition) matching only — never a heuristic applied to
+ * unverified verses. See scripts/audit-translation-punctuation.mjs for
+ * finding further candidates; each must be independently verified before an
+ * entry is added here.
+ */
+
+interface TranslationCorrection {
+  ref: string;
+  edition: string;
+  correctedText: string;
+  source: string;
+}
+
+const CORRECTIONS: readonly TranslationCorrection[] = [
+  {
+    ref: "103:2",
+    edition: "az.mammadaliyev",
+    correctedText:
+      "İnsan (ömrünü bihudə işlərə sərf etməklə, dünyanı axirətdən üstün tutmaqla) ziyan içindədir.",
+    source:
+      'api.alquran.cloud az.mammadaliyev ends this ayah with a stray "?" instead of "." — verified against an independent Azerbaijani Quran reference, 2026-08-02.',
+  },
+];
+
+/** Returns the verified correction for (ref, edition) if one exists, else `text` unchanged. */
+export function correctTranslation(ref: string, edition: string | undefined, text: string): string {
+  if (!edition) return text;
+  return CORRECTIONS.find((c) => c.ref === ref && c.edition === edition)?.correctedText ?? text;
+}

--- a/lib/quran/verse-resolver.ts
+++ b/lib/quran/verse-resolver.ts
@@ -1,6 +1,7 @@
 import { getVerse } from "@/lib/quran/quran-corpus";
 import { getSurahName } from "@/lib/quran/surah-names";
 import { isValidEdition } from "@/lib/i18n/config";
+import { correctTranslation } from "@/lib/quran/translation-corrections";
 import type { Verse, VerseRef } from "@/types/quran";
 
 const DEFAULT_EDITION = "en.sahih";
@@ -48,6 +49,7 @@ async function fetchVerseLive(ref: string, edition: string): Promise<Verse | nul
     // gap in that translator's coverage) — fall back to en.sahih rather than
     // failing the whole verse lookup.
     let translationData: { data: { text: string } };
+    let resolvedEdition = edition;
     if (translationRes.ok) {
       translationData = await translationRes.json();
     } else if (edition !== DEFAULT_EDITION) {
@@ -57,6 +59,7 @@ async function fetchVerseLive(ref: string, edition: string): Promise<Verse | nul
       );
       if (!fallbackRes.ok) return null;
       translationData = await fallbackRes.json();
+      resolvedEdition = DEFAULT_EDITION;
     } else {
       return null;
     }
@@ -69,7 +72,7 @@ async function fetchVerseLive(ref: string, edition: string): Promise<Verse | nul
       ayah: ayahNum,
       ref: ref as VerseRef,
       arabicText: arabicData.data.text,
-      translation: translationData.data.text,
+      translation: correctTranslation(ref, resolvedEdition, translationData.data.text),
       surahName,
       surahNameArabic,
     };

--- a/scripts/audit-translation-punctuation.mjs
+++ b/scripts/audit-translation-punctuation.mjs
@@ -1,0 +1,42 @@
+/**
+ * Reports every ayah in a given alquran.cloud edition whose translation text
+ * ends in "?" — candidates for manual review (see the trailing-"?" defect
+ * fixed for 103:2/az.mammadaliyev in lib/quran/translation-corrections.ts).
+ * Report-only: does not touch the DB, does not judge which candidates are
+ * genuinely wrong (that requires human/scholarly review), never auto-fixes.
+ *
+ *   node scripts/audit-translation-punctuation.mjs [edition]
+ *   node scripts/audit-translation-punctuation.mjs az.mammadaliyev
+ */
+const edition = process.argv[2] ?? "az.mammadaliyev";
+
+const res = await fetch(`https://api.alquran.cloud/v1/quran/${edition}`);
+if (!res.ok) {
+  console.error(`Failed to fetch edition ${edition}: ${res.status}`);
+  process.exit(1);
+}
+const json = await res.json();
+const surahs = json?.data?.surahs;
+if (!surahs) {
+  console.error(`Malformed response for edition ${edition}`);
+  process.exit(1);
+}
+
+const candidates = [];
+for (const surah of surahs) {
+  for (const ayah of surah.ayahs) {
+    if (ayah.text.trim().endsWith("?")) {
+      candidates.push({ ref: `${surah.number}:${ayah.numberInSurah}`, text: ayah.text });
+    }
+  }
+}
+
+console.log(`Edition: ${edition}`);
+console.log(`Ayahs ending in "?": ${candidates.length}`);
+for (const c of candidates) {
+  console.log(`${c.ref}: ${c.text}`);
+}
+console.log(
+  "\nThese are candidates only — review each manually against an independent reference " +
+    "before adding an entry to lib/quran/translation-corrections.ts."
+);


### PR DESCRIPTION
## Summary

- The "Verse of the Day" strip showed the Azerbaijani translation of 103:2 ending in a stray `?` instead of `.`, copied verbatim from the upstream `az.mammadaliyev` edition on alquran.cloud — every step of the pipeline (`scripts/seed-translations.mjs`, `lib/quran/quran-corpus.ts`, `lib/quran/verse-resolver.ts`) passes translation text through unmodified, so no app code was introducing it.
- Add a small, source-attributed correction table (`lib/quran/translation-corrections.ts`) with a single verified entry for `103:2`/`az.mammadaliyev`, wired into both the DB-read path (`quran-corpus.ts`) and the live-fetch fallback (`verse-resolver.ts`), scoped to exact `(ref, edition)` matches only.
- Add a report-only diagnostic script (`scripts/audit-translation-punctuation.mjs`) to surface other ayahs in this edition ending in `?` for manual review — it does not write to the DB or auto-classify/auto-fix anything, since only human verification against an independent source can confirm a given ayah's translation is genuinely wrong.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [ ] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below
- [x] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)

**Details:**

This PR corrects one word of Quran *translation* text (not the Arabic text itself, and not a verse reference), for exactly one verified `(ref, edition)` pair: `103:2` / `az.mammadaliyev`. The correction was verified against an independent Azerbaijani Quran reference supplied by the repo maintainer (screenshot showing the same wording ending in `.`), not generated or guessed by the AI — the corrected string is source-attributed with a `source` field in `lib/quran/translation-corrections.ts` explaining the discrepancy and how it was verified. No other verse's translation text is touched; the correction mechanism only fires on an exact match, never a heuristic.

## Testing

- [x] `bun run test:ci` passes locally (890/890)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality

Manually reviewed the diff (CodeRabbit CLI isn't available in this environment) — no findings.

**Follow-up (not in this PR):** `scripts/audit-translation-punctuation.mjs` needs to be run against `api.alquran.cloud` (blocked from this sandbox by network policy) to find other candidate ayahs in the `az.mammadaliyev` edition with the same trailing-`?` defect, for future manually-verified corrections.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A, none added
- [x] `README.md` updated if the feature changes the public interface — N/A, internal fix only


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJiLhuAn38fw7M6pKckcQf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Azerbaijani translation punctuation for verse 103:2.
  * Ensured corrections apply only to the matching translation edition and verse, including fallback scenarios.

* **Tests**
  * Added coverage for translation corrections, unchanged translations, and edition fallback behavior.

* **Chores**
  * Added a report-only tool to identify potential translation punctuation issues for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->