### PR TITLE
fix(names): don't crash name detail page on DB read failure

### DIFF
--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -329,6 +329,23 @@ describe("getCachedNameContent", () => {
 
     expect(out).toEqual(["a", "b"]);
   });
+
+  it("returns null and logs (instead of throwing) when the query itself rejects", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockSelect.mockReturnValue({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.reject(new Error("connection refused")),
+        }),
+      }),
+    });
+
+    const out = await getCachedNameContent<string>("ar-rahman", "reflection", "en", 1);
+
+    expect(out).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });
 
 describe("getOrGenerateVerseReason", () => {

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -98,13 +98,22 @@ export async function getCachedNameContent<T>(
   locale: Locale,
   version: number
 ): Promise<T | null> {
-  const [row] = await db
-    .select({ data: nameContent.data, version: nameContent.version })
-    .from(nameContent)
-    .where(
-      and(eq(nameContent.slug, slug), eq(nameContent.kind, kind), eq(nameContent.locale, locale))
-    )
-    .limit(1);
+  let row: { data: string; version: number } | undefined;
+  try {
+    [row] = await db
+      .select({ data: nameContent.data, version: nameContent.version })
+      .from(nameContent)
+      .where(
+        and(eq(nameContent.slug, slug), eq(nameContent.kind, kind), eq(nameContent.locale, locale))
+      )
+      .limit(1);
+  } catch (err) {
+    // This is a read-only SSR prefetch (see call site in page.tsx) — a DB
+    // hiccup here must fall through to the client-side fetch-and-generate
+    // path, not crash the whole page render.
+    console.error(`Failed to read name_content for ${slug}/${kind}/${locale}:`, err);
+    return null;
+  }
 
   if (!row || row.version !== version) return null;
   try {


### PR DESCRIPTION
## Summary

- `getCachedNameContent` (`lib/names/name-content.ts`) ran `db.select(...)` with no error handling. Since PR #356 wired this function directly into the `/names/[slug]` Server Component to prefetch reflection/pairings, any DB hiccup during that query threw an uncaught exception out of the page render, which Next.js routed to the route's error boundary — replacing the entire name detail page (Arabic text, meaning, everything) with a bare "Route failed" screen, for all 99 names.
- Wrapped the query in a try/catch: a failed read now logs and returns `null`, same as a cache miss, so the page falls back to the existing client-side fetch-and-generate path instead of crashing.
- Added a regression test simulating a rejected query — the existing test suite only ever mocked `db.select` to resolve, so this gap wasn't caught by CI on the original PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added — N/A, no new env vars
- [ ] `README.md` updated if the feature changes the public interface — N/A, no public interface change


---
_Generated by [Claude Code](https://claude.ai/code/session_01N94y8yoGGiUm2xGcuaF7Zr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when cached content cannot be retrieved during server-side rendering.
  * Pages now fall back to client-side content generation instead of failing when a database read encounters an error.
  * Existing validation and parsing behavior remains unchanged.

* **Tests**
  * Added coverage for database read failures and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->