### PR TITLE
fix(build): skip TypeScript checking in next build to stop OOM deploy failures

### DIFF
--- a/__tests__/next-config-build-policy.test.ts
+++ b/__tests__/next-config-build-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import path from "path";
+import nextConfig from "../next.config";
 
 // Regression test for the Docker-build OOM fix: next.config.ts skips
 // TypeScript checking during `next build` only because CI's separate
@@ -9,17 +10,31 @@ import path from "path";
 // production silently — this pins both halves so a future edit can't
 // drop one without failing a test.
 describe("next.config.ts build policy", () => {
-  const nextConfigSource = readFileSync(path.join(process.cwd(), "next.config.ts"), "utf8");
-  const ciWorkflowSource = readFileSync(
-    path.join(process.cwd(), ".github/workflows/ci.yml"),
-    "utf8"
-  );
-
-  it("disables in-build TypeScript checking (Coolify build container OOMs otherwise)", () => {
-    expect(nextConfigSource).toMatch(/typescript:\s*{\s*ignoreBuildErrors:\s*true/);
+  it("disables in-build TypeScript checking on the resolved config (Coolify build container OOMs otherwise)", () => {
+    // Import the actual default export (post next-intl-plugin wrapping) rather
+    // than regex-matching the source text, so a commented-out or dead-code
+    // `typescript` block can't make this pass.
+    expect(nextConfig.typescript?.ignoreBuildErrors).toBe(true);
   });
 
-  it("keeps `bun run typecheck` as a required CI step, since next.config.ts no longer checks", () => {
-    expect(ciWorkflowSource).toMatch(/run:\s*bun run typecheck/);
+  it("keeps `bun run typecheck` as an active step in CI's required lint-typecheck-test job", () => {
+    const ciWorkflowSource = readFileSync(
+      path.join(process.cwd(), ".github/workflows/ci.yml"),
+      "utf8"
+    );
+
+    // Scope the match to the lint-typecheck-test job block specifically (not
+    // just anywhere in the file — a step in some other, non-blocking job
+    // wouldn't actually gate merges), and require an uncommented `run:` line.
+    const lines = ciWorkflowSource.split("\n");
+    const jobStart = lines.findIndex((line) => /^ {2}lint-typecheck-test:\s*$/.test(line));
+    expect(jobStart).toBeGreaterThanOrEqual(0);
+    const jobEnd = lines.findIndex((line, i) => i > jobStart && /^ {2}[\w-]+:\s*$/.test(line));
+    const jobLines = lines.slice(jobStart + 1, jobEnd === -1 ? undefined : jobEnd);
+
+    const hasActiveTypecheckStep = jobLines.some(
+      (line) => /^\s*run:\s*bun run typecheck\s*$/.test(line) && !/^\s*#/.test(line)
+    );
+    expect(hasActiveTypecheckStep).toBe(true);
   });
 });

--- a/__tests__/next-config-build-policy.test.ts
+++ b/__tests__/next-config-build-policy.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+
+// Regression test for the Docker-build OOM fix: next.config.ts skips
+// TypeScript checking during `next build` only because CI's separate
+// `bun run typecheck` step is a required merge gate. If either half of
+// that pair is ever removed without the other, type errors could reach
+// production silently — this pins both halves so a future edit can't
+// drop one without failing a test.
+describe("next.config.ts build policy", () => {
+  const nextConfigSource = readFileSync(path.join(process.cwd(), "next.config.ts"), "utf8");
+  const ciWorkflowSource = readFileSync(
+    path.join(process.cwd(), ".github/workflows/ci.yml"),
+    "utf8"
+  );
+
+  it("disables in-build TypeScript checking (Coolify build container OOMs otherwise)", () => {
+    expect(nextConfigSource).toMatch(/typescript:\s*{\s*ignoreBuildErrors:\s*true/);
+  });
+
+  it("keeps `bun run typecheck` as a required CI step, since next.config.ts no longer checks", () => {
+    expect(ciWorkflowSource).toMatch(/run:\s*bun run typecheck/);
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,15 @@ const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 const nextConfig: NextConfig = {
   reactCompiler: true,
   output: "standalone",
+  // The self-hosted Coolify build container has less memory than CI's runner,
+  // and OOM-kills during `next build`'s own "Running TypeScript" pass (no
+  // output, non-zero exit) once the project grows past its ceiling. Type
+  // errors are already a hard gate in CI (`bun run typecheck`, required
+  // before merge to main), so re-running the same check here is redundant
+  // work that just risks crashing the production build.
+  typescript: {
+    ignoreBuildErrors: true,
+  },
   // Pin the workspace root to this project. Without it, Turbopack finds a stray
   // lockfile higher up (e.g. C:\Users\User\package-lock.json) and warns that it
   // guessed the wrong root. The dev/build scripts always run from the project dir.


### PR DESCRIPTION
## Summary

- The last two production deploys (self-hosted Coolify/Docker, `openhikmah-server`) failed. The build log shows `next build` compiling successfully (~53s), then crashing silently — zero output — immediately after `Running TypeScript ...`, exit code 255. That's the exact signature of the build container being OOM-killed mid type-check, not a real compile error.
- Confirmed this isn't a real type error: CI's `lint-typecheck-test` job runs the full `bun run typecheck` on every push/PR and was green on the exact commit (`49c6bb8`) that failed to deploy.
- Next.js's own docs (`node_modules/next/dist/docs/01-app/02-guides/memory-usage.md`, "Disable static analysis" section) describe this precise symptom and recommend `typescript.ignoreBuildErrors: true` when a dedicated CI runner already handles the check — which this repo has.
- Added `typescript: { ignoreBuildErrors: true }` to `next.config.ts` with a comment explaining why, so the Docker build no longer redoes the memory-heavy type-check that CI already gates on GitHub's runners.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally (confirms there are no real type errors being hidden by this change)
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (pre-existing unrelated formatting warnings in `.superpowers/sdd/*` are untouched by this diff)
- [x] `bun run build` succeeds locally with the new config
- [ ] New tests added — N/A, this is a build-config change with no runtime code path

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated — N/A, no new environment variables
- [ ] `README.md` updated — N/A, no public interface change

## Risk / rollback note

`ignoreBuildErrors: true` means a future real type error would no longer block the *Docker production build* — but it will still block *merging to main*, since CI's `lint-typecheck-test` job (`bun run typecheck`) is unaffected and still required. If that CI gate is ever weakened or bypassed, this setting would let a type error reach production; this is an accepted tradeoff to stop deploys crashing today, not a first tolerance of type errors in general.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Production builds can now complete even when TypeScript errors are present.
  * Type checking remains handled separately through the project’s CI workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->