### PR TITLE
fix(stories): "Open on canvas" button can get stuck permanently disabled

### DIFF
--- a/__tests__/components/stories/OpenOnCanvasButton.test.tsx
+++ b/__tests__/components/stories/OpenOnCanvasButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Verse } from "@/types/quran";
 
@@ -83,5 +83,41 @@ describe("OpenOnCanvasButton", () => {
     fireEvent.click(button);
 
     expect(useCanvasStore.getState().nodes).toHaveLength(2);
+  });
+
+  it("re-enables the button after a grace period if navigation never unmounts it", () => {
+    vi.useFakeTimers();
+    try {
+      const verses = [verse("12:4")];
+      render(<OpenOnCanvasButton verses={verses} />);
+
+      const button = screen.getByRole("button", { name: /open on canvas/i });
+      fireEvent.click(button);
+      expect(button).toBeDisabled();
+
+      act(() => {
+        vi.advanceTimersByTime(4000);
+      });
+      expect(button).not.toBeDisabled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-enables the button immediately if adding a node throws", () => {
+    const verses = [verse("12:4")];
+    const addVerseNodeSpy = vi
+      .spyOn(useCanvasStore.getState(), "addVerseNode")
+      .mockImplementation(() => {
+        throw new Error("store write failed");
+      });
+    render(<OpenOnCanvasButton verses={verses} />);
+
+    const button = screen.getByRole("button", { name: /open on canvas/i });
+    fireEvent.click(button);
+
+    expect(button).not.toBeDisabled();
+    expect(mockPush).not.toHaveBeenCalled();
+    addVerseNodeSpy.mockRestore();
   });
 });

--- a/__tests__/components/stories/OpenOnCanvasButton.test.tsx
+++ b/__tests__/components/stories/OpenOnCanvasButton.test.tsx
@@ -104,13 +104,15 @@ describe("OpenOnCanvasButton", () => {
     }
   });
 
-  it("re-enables the button immediately if adding a node throws", () => {
+  it("re-enables the button and logs if adding a node throws", () => {
     const verses = [verse("12:4")];
+    const failure = new Error("store write failed");
     const addVerseNodeSpy = vi
       .spyOn(useCanvasStore.getState(), "addVerseNode")
       .mockImplementation(() => {
-        throw new Error("store write failed");
+        throw failure;
       });
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     render(<OpenOnCanvasButton verses={verses} />);
 
     const button = screen.getByRole("button", { name: /open on canvas/i });
@@ -118,6 +120,34 @@ describe("OpenOnCanvasButton", () => {
 
     expect(button).not.toBeDisabled();
     expect(mockPush).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("OpenOnCanvasButton"),
+      failure
+    );
+
     addVerseNodeSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("re-enables the button and logs if router.push throws", () => {
+    const verses = [verse("12:4")];
+    const failure = new Error("navigation blocked");
+    mockPush.mockImplementation(() => {
+      throw failure;
+    });
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<OpenOnCanvasButton verses={verses} />);
+
+    const button = screen.getByRole("button", { name: /open on canvas/i });
+    fireEvent.click(button);
+
+    expect(button).not.toBeDisabled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("OpenOnCanvasButton"),
+      failure
+    );
+
+    consoleErrorSpy.mockRestore();
+    mockPush.mockReset();
   });
 });

--- a/app/stories/[slug]/OpenOnCanvasButton.tsx
+++ b/app/stories/[slug]/OpenOnCanvasButton.tsx
@@ -38,9 +38,13 @@ export function OpenOnCanvasButton({ verses, label }: { verses: Verse[]; label?:
         addVerseNode(verse);
       }
       router.push("/canvas");
-    } catch {
+    } catch (err) {
       if (mountedRef.current) setPending(false);
-      return;
+      // Logged, not rethrown: React error boundaries don't catch errors
+      // thrown from event handlers, so rethrowing here would just become an
+      // unhandled exception instead of a visible error UI — console.error is
+      // what actually makes this surface instead of vanishing silently.
+      console.error("OpenOnCanvasButton: failed to add verses to the canvas or navigate", err);
     }
     // router.push normally unmounts this component before it matters. If
     // navigation is interrupted (blocked, cancelled) the component survives

--- a/app/stories/[slug]/OpenOnCanvasButton.tsx
+++ b/app/stories/[slug]/OpenOnCanvasButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Network } from "lucide-react";
 import { buttonVariants } from "@/components/ui";
@@ -18,15 +18,37 @@ import type { Verse } from "@/types/quran";
 export function OpenOnCanvasButton({ verses, label }: { verses: Verse[]; label?: string }) {
   const [pending, setPending] = useState(false);
   const router = useRouter();
+  const mountedRef = useRef(true);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
+    };
+  }, []);
 
   const handleClick = () => {
     setPending(true);
-    const { hasNode, addVerseNode } = useCanvasStore.getState();
-    for (const verse of verses) {
-      if (hasNode(verse.ref)) continue;
-      addVerseNode(verse);
+    try {
+      const { hasNode, addVerseNode } = useCanvasStore.getState();
+      for (const verse of verses) {
+        if (hasNode(verse.ref)) continue;
+        addVerseNode(verse);
+      }
+      router.push("/canvas");
+    } catch {
+      if (mountedRef.current) setPending(false);
+      return;
     }
-    router.push("/canvas");
+    // router.push normally unmounts this component before it matters. If
+    // navigation is interrupted (blocked, cancelled) the component survives
+    // with `pending` stuck true and no way to retry — unstick it after a
+    // grace period long enough that it never fires during a normal navigation.
+    resetTimeoutRef.current = setTimeout(() => {
+      if (mountedRef.current) setPending(false);
+    }, 4000);
   };
 
   return (


### PR DESCRIPTION
## Summary

Fixes #389.

- `app/stories/[slug]/OpenOnCanvasButton.tsx`: `setPending(true)` was set on click and only ever reset by the component unmounting when `router.push("/canvas")` succeeded. If navigation is interrupted (blocked, cancelled, or otherwise doesn't unmount the component), `pending` stayed stuck `true` forever, permanently disabling the button with no way to retry short of a full page reload.
- Wrapped the store-write + navigation in a `try`/`catch`: a synchronous throw now resets `pending` immediately.
- Added a 4-second fallback timeout that resets `pending` if the component is still mounted by then — long enough to never fire during a normal navigation (which unmounts the component well before that), but short enough that an interrupted navigation doesn't leave the user stuck.
- Guarded both resets with a `mountedRef` (same pattern already used in `components/canvas/HikmahCanvas.tsx`) so nothing sets state after unmount.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added: a fake-timers test confirming the button re-enables after the grace period if navigation never unmounts it, and a test confirming it re-enables immediately if adding a node throws synchronously.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated — N/A
- [ ] `README.md` updated — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The “Open on canvas” button now reliably re-enables if navigation is interrupted or an error occurs.
  * Added a fallback that restores the button after four seconds when the page remains open.
  * Improved cleanup to prevent the button from becoming stuck in a loading state.
  * Failed actions are handled safely without triggering unintended navigation, allowing the action to be retried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->