### PR TITLE
fix(canvas): AI expansion silently drops a connection if any edge already exists between two nodes

### DIFF
--- a/__tests__/components/canvas/HikmahCanvas.timers.test.tsx
+++ b/__tests__/components/canvas/HikmahCanvas.timers.test.tsx
@@ -142,4 +142,44 @@ describe("HikmahCanvas expansion-notice timeout", () => {
     // Unmounting must clear the scheduled dismiss rather than letting it fire later.
     expect(clearTimeoutSpy).toHaveBeenCalled();
   });
+
+  it("surfaces a notice instead of silently dropping a connection when a different-kind edge already links the pair", async () => {
+    useCanvasStore.setState({
+      nodes: [verseNode("n1", "1:1"), verseNode("n2", "2:255")] as never,
+      edges: [
+        {
+          id: "edge-existing",
+          source: "n1",
+          target: "n2",
+          type: "hikmah",
+          data: { kind: "thematic", label: "existing" },
+        },
+      ] as never,
+    });
+    // The AI identifies a "root" connection to a verse already on the canvas,
+    // already linked to the source by a "thematic" edge — a different kind.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([{ ...connection("2:255"), kind: "root" }]),
+      })
+    );
+
+    render(<HikmahCanvas onSearchOpen={vi.fn()} />);
+
+    act(() => {
+      useCanvasStore.getState().setPendingExpand({ nodeId: "n1", ref: "1:1", kind: "root" });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "These verses are already connected a different way."
+    );
+    // The pre-existing thematic edge is untouched — no second edge was added.
+    expect(useCanvasStore.getState().edges).toHaveLength(1);
+    expect((useCanvasStore.getState().edges[0].data as { kind?: string })?.kind).toBe("thematic");
+  });
 });

--- a/__tests__/store/canvas.test.ts
+++ b/__tests__/store/canvas.test.ts
@@ -88,7 +88,7 @@ describe("canvas store", () => {
     expect(node!.id).toBe(id);
   });
 
-  it("addConnectionEdge adds an edge", () => {
+  it('addConnectionEdge adds an edge and reports "added"', () => {
     const sourceId = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
     const targetVerse = { ...baseVerse, surah: 1, ayah: 1, ref: "1:1" as const };
     const targetId = useCanvasStore.getState().addVerseNode(targetVerse, { x: 300, y: 0 });
@@ -100,11 +100,12 @@ describe("canvas store", () => {
       type: "hikmah",
       data: { kind: "thematic", label: "theme", reason: "test" },
     };
-    useCanvasStore.getState().addConnectionEdge(edge);
+    const result = useCanvasStore.getState().addConnectionEdge(edge);
+    expect(result).toBe("added");
     expect(useCanvasStore.getState().edges).toHaveLength(1);
   });
 
-  it("addConnectionEdge does not add duplicate edges", () => {
+  it('addConnectionEdge does not add a duplicate of the same kind, and reports "duplicate-same-kind"', () => {
     const id1 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
     const id2 = useCanvasStore
       .getState()
@@ -117,11 +118,12 @@ describe("canvas store", () => {
       data: { kind: "thematic", label: "theme" },
     };
     useCanvasStore.getState().addConnectionEdge(edge);
-    useCanvasStore.getState().addConnectionEdge(edge);
+    const result = useCanvasStore.getState().addConnectionEdge(edge);
+    expect(result).toBe("duplicate-same-kind");
     expect(useCanvasStore.getState().edges).toHaveLength(1);
   });
 
-  it("addConnectionEdge prevents reversed duplicate", () => {
+  it("addConnectionEdge prevents a reversed duplicate of the same kind", () => {
     const id1 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
     const id2 = useCanvasStore
       .getState()
@@ -135,8 +137,35 @@ describe("canvas store", () => {
     };
     const reversed: CanvasEdge = { ...edge, id: "edge-2", source: id2, target: id1 };
     useCanvasStore.getState().addConnectionEdge(edge);
-    useCanvasStore.getState().addConnectionEdge(reversed);
+    const result = useCanvasStore.getState().addConnectionEdge(reversed);
+    expect(result).toBe("duplicate-same-kind");
     expect(useCanvasStore.getState().edges).toHaveLength(1);
+  });
+
+  it('addConnectionEdge does not add a second edge of a different kind between the same pair, and reports "duplicate-different-kind"', () => {
+    const id1 = useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    const id2 = useCanvasStore
+      .getState()
+      .addVerseNode({ ...baseVerse, ref: "1:1" as const, ayah: 1, surah: 1 }, { x: 300, y: 0 });
+    const thematicEdge: CanvasEdge = {
+      id: "edge-1",
+      source: id1,
+      target: id2,
+      type: "hikmah",
+      data: { kind: "thematic", label: "theme" },
+    };
+    const rootEdge: CanvasEdge = {
+      id: "edge-2",
+      source: id1,
+      target: id2,
+      type: "hikmah",
+      data: { kind: "root", label: "root" },
+    };
+    useCanvasStore.getState().addConnectionEdge(thematicEdge);
+    const result = useCanvasStore.getState().addConnectionEdge(rootEdge);
+    expect(result).toBe("duplicate-different-kind");
+    expect(useCanvasStore.getState().edges).toHaveLength(1);
+    expect((useCanvasStore.getState().edges[0].data as { kind?: string })?.kind).toBe("thematic");
   });
 
   it("setSelectedNode sets selectedNodeId", () => {

--- a/components/canvas/HikmahCanvas.tsx
+++ b/components/canvas/HikmahCanvas.tsx
@@ -67,9 +67,25 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
   const mountedRef = useRef(true);
   const noticeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [expansionNotice, setExpansionNotice] = useState<{
-    messageKey: "noMoreConnections" | "connectionsFailed" | "expansionInProgress";
+    messageKey:
+      | "noMoreConnections"
+      | "connectionsFailed"
+      | "expansionInProgress"
+      | "connectionExistsDifferentKind";
     kind: "error" | "info";
   } | null>(null);
+
+  const showExpansionNotice = useCallback(
+    (messageKey: NonNullable<typeof expansionNotice>["messageKey"], kind: "error" | "info") => {
+      if (!mountedRef.current) return;
+      setExpansionNotice({ messageKey, kind });
+      if (noticeTimeoutRef.current) clearTimeout(noticeTimeoutRef.current);
+      noticeTimeoutRef.current = setTimeout(() => {
+        if (mountedRef.current) setExpansionNotice(null);
+      }, 6000);
+    },
+    []
+  );
 
   // The mobile bottom bar (in Header, outside this ReactFlowProvider) can't call
   // useReactFlow() directly, so it asks for a fit via the store instead.
@@ -121,9 +137,7 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
       sourcePos: { x: number; y: number }
     ) => {
       if (expandingRef.current) {
-        if (mountedRef.current) {
-          setExpansionNotice({ messageKey: "expansionInProgress", kind: "info" });
-        }
+        showExpansionNotice("expansionInProgress", "info");
         return;
       }
       expandingRef.current = true;
@@ -156,10 +170,16 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
             // Verse is already on the canvas elsewhere — draw the edge the AI
             // identified instead of silently dropping the connection, but
             // don't add a duplicate node. addConnectionEdge itself dedupes
-            // repeat source/target pairs, so re-expanding is a safe no-op.
+            // repeat source/target pairs; if one already exists with a
+            // *different* kind, surface that rather than dropping it silently.
             const existing = getNodeByRef(conn.ref);
             const edge = existing && buildConnectionEdge(nodeId, existing.id, conn);
-            if (edge) addConnectionEdge(edge);
+            if (edge) {
+              const result = addConnectionEdge(edge);
+              if (result === "duplicate-different-kind") {
+                showExpansionNotice("connectionExistsDifferentKind", "info");
+              }
+            }
             continue;
           }
 
@@ -200,16 +220,10 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
       } catch (err) {
         const exhausted = err instanceof ExhaustedExpansionError;
         if (!exhausted) console.error("Expansion failed:", err);
-        if (mountedRef.current) {
-          setExpansionNotice({
-            messageKey: exhausted ? "noMoreConnections" : "connectionsFailed",
-            kind: exhausted ? "info" : "error",
-          });
-          if (noticeTimeoutRef.current) clearTimeout(noticeTimeoutRef.current);
-          noticeTimeoutRef.current = setTimeout(() => {
-            if (mountedRef.current) setExpansionNotice(null);
-          }, 6000);
-        }
+        showExpansionNotice(
+          exhausted ? "noMoreConnections" : "connectionsFailed",
+          exhausted ? "info" : "error"
+        );
       } finally {
         if (mountedRef.current) setExpandingNode(null);
         expandingRef.current = false;
@@ -223,6 +237,7 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
       getNodeByRef,
       getExpansionRefs,
       reactFlow,
+      showExpansionNotice,
     ]
   );
 

--- a/messages/az.json
+++ b/messages/az.json
@@ -95,6 +95,7 @@
     "noMoreConnections": "Bu növdə başqa əlaqə yoxdur.",
     "connectionsFailed": "Əlaqə tapılmadı. Fərqli növ sınayın.",
     "expansionInProgress": "Artıq bir genişləndirmə işləyir — bir az sonra yenidən cəhd edin.",
+    "connectionExistsDifferentKind": "Bu ayələr artıq başqa cür bağlıdır.",
     "dismiss": "Bağla",
     "minimapAria": "Lövhə kiçik xəritəsi",
     "saveFailedRetry": "Yadda saxlama uğursuz oldu — yenidən cəhd edin",

--- a/messages/en.json
+++ b/messages/en.json
@@ -95,6 +95,7 @@
     "noMoreConnections": "No more connections of this type.",
     "connectionsFailed": "Could not find connections. Try a different type.",
     "expansionInProgress": "An expansion is already running — try again in a moment.",
+    "connectionExistsDifferentKind": "These verses are already connected a different way.",
     "dismiss": "Dismiss",
     "minimapAria": "Canvas minimap",
     "saveFailedRetry": "Save failed — try again",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -95,6 +95,7 @@
     "noMoreConnections": "Больше нет связей этого типа.",
     "connectionsFailed": "Не удалось найти связи. Попробуйте другой тип.",
     "expansionInProgress": "Расширение уже выполняется — попробуйте снова через мгновение.",
+    "connectionExistsDifferentKind": "Эти аяты уже связаны другим способом.",
     "dismiss": "Закрыть",
     "minimapAria": "Миникарта холста",
     "saveFailedRetry": "Ошибка сохранения — попробуйте снова",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -95,6 +95,7 @@
     "noMoreConnections": "Bu türde başka bağlantı yok.",
     "connectionsFailed": "Bağlantı bulunamadı. Farklı bir tür deneyin.",
     "expansionInProgress": "Bir genişletme zaten çalışıyor — biraz sonra tekrar deneyin.",
+    "connectionExistsDifferentKind": "Bu ayetler zaten farklı bir şekilde bağlı.",
     "dismiss": "Kapat",
     "minimapAria": "Tuval küçük haritası",
     "saveFailedRetry": "Kaydetme başarısız — tekrar deneyin",

--- a/store/canvas.ts
+++ b/store/canvas.ts
@@ -103,7 +103,7 @@ interface CanvasStore {
   setViewport: (viewport: CanvasViewport) => void;
 
   addVerseNode: (verse: Verse, position?: { x: number; y: number }) => string;
-  addConnectionEdge: (edge: CanvasEdge) => void;
+  addConnectionEdge: (edge: CanvasEdge) => AddConnectionEdgeResult;
   setSelectedNode: (id: string | null) => void;
   setExpandingNode: (id: string | null) => void;
   setOpenExpandNodeId: (id: string | null) => void;
@@ -153,6 +153,8 @@ function computeExpansionCountsMap(
   }
   return map;
 }
+
+export type AddConnectionEdgeResult = "added" | "duplicate-same-kind" | "duplicate-different-kind";
 
 export const DEFAULT_SIDEBAR_WIDTH = 288;
 
@@ -215,13 +217,19 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
   },
 
   addConnectionEdge: (edge) => {
+    let result: AddConnectionEdgeResult = "added";
     set((s) => {
-      const exists = s.edges.some(
+      const existingEdge = s.edges.find(
         (e) =>
           (e.source === edge.source && e.target === edge.target) ||
           (e.source === edge.target && e.target === edge.source)
       );
-      if (exists) return s;
+      if (existingEdge) {
+        const existingKind = (existingEdge.data as { kind?: EdgeKind })?.kind;
+        result =
+          existingKind === edge.data.kind ? "duplicate-same-kind" : "duplicate-different-kind";
+        return s;
+      }
       const edges = [
         ...s.edges,
         {
@@ -235,6 +243,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
       ];
       return { edges, expansionCountsByNode: computeExpansionCountsMap(edges) };
     });
+    return result;
   },
 
   setSelectedNode: (id) => set({ selectedNodeId: id }),


### PR DESCRIPTION
## Summary

Fixes #390.

- \`store/canvas.ts\` \`addConnectionEdge\` deduped edges purely by node pair (either direction), ignoring \`kind\`. If a thematic edge already linked two verses, a later "by root" (or any other kind) expansion that identified a connection between the same pair was silently dropped — no new edge, no feedback, even though the expansion loop already surfaces other failure states (e.g. "no more connections").
- \`addConnectionEdge\` now returns \`"added" | "duplicate-same-kind" | "duplicate-different-kind"\` instead of \`void\`, so callers can tell what happened.
- \`components/canvas/HikmahCanvas.tsx\`'s expansion loop now checks that result and, on \`"duplicate-different-kind"\`, surfaces a notice via the existing \`expansionNotice\`/\`noticeTimeoutRef\` transient-toast mechanism (already used for "no more connections" / "expansion failed") — extracted into a small \`showExpansionNotice\` helper shared by all three notice call sites to avoid tripling the timeout-scheduling logic.
- Added the new \`canvas.connectionExistsDifferentKind\` message key to all four locale files (en/tr/az/ru), with real translations (not English placeholders) for tr/az/ru, matching the existing terminology used elsewhere in the \`canvas\` namespace.
- Behavior is otherwise unchanged: still exactly one edge per node pair (the issue's suggested fix offered either "allow multiple edges" or "surface an indication" — went with surfacing, per the acceptance criteria, since allowing multiple simultaneous edges between the same pair is a larger UI/data-model change not asked for here).

## Type of change

- [x] Bug fix

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] \`bun run test:ci\` passes locally
- [x] \`bun run typecheck\` passes locally
- [x] \`bun run lint\` passes locally
- [x] \`bun run format:check\` passes locally
- [x] New tests added:
  - Store: \`addConnectionEdge\` returns \`"added"\`/\`"duplicate-same-kind"\`/\`"duplicate-different-kind"\` correctly, including the reversed-pair case.
  - Component: a full expansion flow where the AI returns a different-kind connection to a verse already linked by an existing edge — asserts the notice text renders and no second edge is added.

## Checklist

- [x] Branch is up to date with \`main\`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] \`.env.example\` updated — N/A
- [ ] \`README.md\` updated — N/A