### PR TITLE
fix(social): remove-friend and cancel-sent-request have no confirmation

### DIFF
--- a/__tests__/components/social/FriendList.test.tsx
+++ b/__tests__/components/social/FriendList.test.tsx
@@ -1,0 +1,111 @@
+import { render as rtlRender, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { FriendList } from "@/components/social/FriendList";
+import { TooltipProvider } from "@/components/ui";
+import { useAuthStore } from "@/store/auth";
+
+function render(ui: React.ReactElement) {
+  return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+function friend(overrides: Partial<Parameters<typeof FriendList>[0]["friends"][number]> = {}) {
+  return {
+    id: 1,
+    status: "accepted" as const,
+    direction: "sent" as const,
+    friend: { id: 2, username: "yusuf", streak: 3 },
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("FriendList confirm-before-destroy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAuthStore.setState({ accessToken: "test-token" as any });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not fire the DELETE request on a single click of remove friend", () => {
+    render(<FriendList friends={[friend()]} onUpdate={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove friend" }));
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("fires the DELETE request only after a second confirming click", () => {
+    render(<FriendList friends={[friend()]} onUpdate={vi.fn()} />);
+
+    const button = screen.getByRole("button", { name: "Remove friend" });
+    fireEvent.click(button);
+    fireEvent.click(screen.getByRole("button", { name: "Click again to confirm" }));
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/social/friends/1",
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+
+  it("re-arms instead of confirming if the window elapses between clicks", () => {
+    render(<FriendList friends={[friend()]} onUpdate={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove friend" }));
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    // Back to the idle label — the armed state auto-disarmed.
+    expect(screen.getByRole("button", { name: "Remove friend" })).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not fire the DELETE request on a single click of cancel sent request", () => {
+    render(
+      <FriendList friends={[friend({ status: "pending", direction: "sent" })]} onUpdate={vi.fn()} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel request" }));
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("fires the DELETE request for a sent request only after a second confirming click", () => {
+    render(
+      <FriendList friends={[friend({ status: "pending", direction: "sent" })]} onUpdate={vi.fn()} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel request" }));
+    fireEvent.click(screen.getByRole("button", { name: "Click again to confirm" }));
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/social/friends/1",
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+
+  it("does not require confirmation to accept or decline a received request", () => {
+    render(
+      <FriendList
+        friends={[friend({ status: "pending", direction: "received" })]}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Decline request" }));
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/social/friends/1",
+      expect.objectContaining({ method: "PATCH" })
+    );
+  });
+});

--- a/__tests__/components/social/FriendList.test.tsx
+++ b/__tests__/components/social/FriendList.test.tsx
@@ -22,8 +22,7 @@ function friend(overrides: Partial<Parameters<typeof FriendList>[0]["friends"][n
 describe("FriendList confirm-before-destroy", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    useAuthStore.setState({ accessToken: "test-token" as any });
+    useAuthStore.setState({ accessToken: "test-token" });
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })

--- a/__tests__/hooks/useArmedConfirm.test.ts
+++ b/__tests__/hooks/useArmedConfirm.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useArmedConfirm } from "@/hooks/useArmedConfirm";
+
+describe("useArmedConfirm", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts disarmed and does not call onConfirm on the first trigger", () => {
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useArmedConfirm(onConfirm));
+
+    expect(result.current.armed).toBe(false);
+    act(() => result.current.trigger());
+
+    expect(result.current.armed).toBe(true);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("calls onConfirm and disarms on a second trigger within the window", () => {
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useArmedConfirm(onConfirm));
+
+    act(() => result.current.trigger());
+    act(() => result.current.trigger());
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(result.current.armed).toBe(false);
+  });
+
+  it("auto-disarms after the window elapses, requiring a fresh two-click sequence", () => {
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useArmedConfirm(onConfirm));
+
+    act(() => result.current.trigger());
+    expect(result.current.armed).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.armed).toBe(false);
+
+    // A trigger after auto-disarm re-arms instead of confirming.
+    act(() => result.current.trigger());
+    expect(result.current.armed).toBe(true);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("clears the pending disarm timer on unmount", () => {
+    const onConfirm = vi.fn();
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+    const { result, unmount } = renderHook(() => useArmedConfirm(onConfirm));
+
+    act(() => result.current.trigger());
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});

--- a/components/admin/primitives.tsx
+++ b/components/admin/primitives.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Button, type ButtonProps } from "@/components/ui";
+import { useArmedConfirm } from "@/hooks/useArmedConfirm";
 import { InfoHint } from "./InfoHint";
 
 /** A compact dashboard stat: a label, a large gold value, and optional hint. An
@@ -117,33 +117,10 @@ export function ConfirmButton({
   children: React.ReactNode;
   confirmLabel?: string;
 } & Omit<ButtonProps, "onClick">) {
-  const [armed, setArmed] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Clear any pending disarm timer on unmount.
-  useEffect(
-    () => () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    },
-    []
-  );
+  const { armed, trigger } = useArmedConfirm(onConfirm);
 
   return (
-    <Button
-      variant={armed ? "danger" : variant}
-      size={size}
-      onClick={() => {
-        if (timerRef.current) clearTimeout(timerRef.current);
-        if (armed) {
-          setArmed(false);
-          onConfirm();
-        } else {
-          setArmed(true);
-          timerRef.current = setTimeout(() => setArmed(false), 3000);
-        }
-      }}
-      {...props}
-    >
+    <Button variant={armed ? "danger" : variant} size={size} onClick={trigger} {...props}>
       {armed ? confirmLabel : children}
     </Button>
   );

--- a/components/social/FriendList.tsx
+++ b/components/social/FriendList.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from "@/store/auth";
 import { Check, X, UserMinus, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { Card, IconButton, Tooltip } from "@/components/ui";
+import { useArmedConfirm } from "@/hooks/useArmedConfirm";
 
 interface FriendEntry {
   id: number;
@@ -16,6 +17,41 @@ interface FriendEntry {
 interface Props {
   friends: FriendEntry[];
   onUpdate: () => void;
+}
+
+/** Icon button requiring a second click to confirm, for a destructive action
+ *  (removing a friend, cancelling a sent request) — consistent with the
+ *  confirm-before-destroy pattern used elsewhere in the app. */
+function DestructiveIconButton({
+  onConfirm,
+  disabled,
+  busy,
+  idleIcon,
+  label,
+  confirmLabel,
+}: {
+  onConfirm: () => void;
+  disabled: boolean;
+  busy: boolean;
+  idleIcon: React.ReactNode;
+  label: string;
+  confirmLabel: string;
+}) {
+  const { armed, trigger } = useArmedConfirm(onConfirm);
+  return (
+    <Tooltip label={armed ? confirmLabel : label}>
+      <IconButton
+        tone="danger"
+        size="xs"
+        onClick={trigger}
+        disabled={disabled}
+        aria-label={armed ? confirmLabel : label}
+        className={armed ? "border-error/40 bg-error/10 text-error" : undefined}
+      >
+        {busy ? <Loader2 className="animate-spin" /> : armed ? <Check /> : idleIcon}
+      </IconButton>
+    </Tooltip>
+  );
 }
 
 export function FriendList({ friends, onUpdate }: Props) {
@@ -124,17 +160,14 @@ export function FriendList({ friends, onUpdate }: Props) {
                   </Tooltip>
                 </div>
               ) : (
-                <Tooltip label="Cancel request">
-                  <IconButton
-                    tone="danger"
-                    size="xs"
-                    onClick={() => remove(f.id)}
-                    disabled={busy === f.id}
-                    aria-label="Cancel request"
-                  >
-                    {busy === f.id ? <Loader2 className="animate-spin" /> : <X />}
-                  </IconButton>
-                </Tooltip>
+                <DestructiveIconButton
+                  onConfirm={() => remove(f.id)}
+                  disabled={busy === f.id}
+                  busy={busy === f.id}
+                  idleIcon={<X />}
+                  label="Cancel request"
+                  confirmLabel="Click again to confirm"
+                />
               )}
             </Card>
           ))}
@@ -154,17 +187,14 @@ export function FriendList({ friends, onUpdate }: Props) {
                 <span className="text-sm text-text-primary">{f.friend?.username ?? "—"}</span>
                 <span className="font-mono text-xs text-gold">🔥 {f.friend?.streak ?? 0}</span>
               </div>
-              <Tooltip label="Remove friend">
-                <IconButton
-                  tone="danger"
-                  size="xs"
-                  onClick={() => remove(f.id)}
-                  disabled={busy === f.id}
-                  aria-label="Remove friend"
-                >
-                  {busy === f.id ? <Loader2 className="animate-spin" /> : <UserMinus />}
-                </IconButton>
-              </Tooltip>
+              <DestructiveIconButton
+                onConfirm={() => remove(f.id)}
+                disabled={busy === f.id}
+                busy={busy === f.id}
+                idleIcon={<UserMinus />}
+                label="Remove friend"
+                confirmLabel="Click again to confirm"
+              />
             </Card>
           ))}
         </div>

--- a/hooks/useArmedConfirm.ts
+++ b/hooks/useArmedConfirm.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from "react";
+
+const ARM_WINDOW_MS = 3000;
+
+/**
+ * Two-click confirm for a destructive action: the first call arms it and
+ * auto-disarms after a few seconds; a second call within that window runs
+ * `onConfirm`. Cheaper than a modal for inline destructive controls (icon
+ * buttons, table row actions) where a dialog would be disruptive.
+ */
+export function useArmedConfirm(onConfirm: () => void) {
+  const [armed, setArmed] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    []
+  );
+
+  const trigger = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (armed) {
+      setArmed(false);
+      onConfirm();
+    } else {
+      setArmed(true);
+      timerRef.current = setTimeout(() => setArmed(false), ARM_WINDOW_MS);
+    }
+  };
+
+  return { armed, trigger };
+}


### PR DESCRIPTION
## Summary

Fixes #391.

- \`components/social/FriendList.tsx\`'s \`remove()\` fired the \`DELETE /api/social/friends/:id\` request directly from the icon button's \`onClick\`, with no confirmation step — a single misclick permanently removed a friendship or cancelled a sent request.
- Extracted the "armed / second-click-within-3s / auto-disarm" logic already used by \`components/admin/primitives.tsx\`'s \`ConfirmButton\` into a small reusable \`useArmedConfirm\` hook (\`hooks/useArmedConfirm.ts\`). \`ConfirmButton\` now uses the hook internally — no behavior change there.
- Applied the hook to \`FriendList\`'s two \`remove()\`-triggering icon buttons (cancel-sent-request, remove-friend) via a new small \`DestructiveIconButton\` wrapper local to the file: first click swaps the icon to a check mark and applies a persistent danger tone (not just on hover), with an updated tooltip/aria-label ("Click again to confirm"); a second click within 3s runs the delete. Auto-disarms after 3s if not confirmed, consistent with \`ConfirmButton\`'s existing window.
- Accept/decline (PATCH, not DELETE) are intentionally left as single-click — the issue and its acceptance criteria are scoped to the destructive DELETE action, and declining a request is easily undone by re-sending it.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] \`bun run test:ci\` passes locally
- [x] \`bun run typecheck\` passes locally
- [x] \`bun run lint\` passes locally
- [x] \`bun run format:check\` passes locally
- [x] New tests added:
  - \`useArmedConfirm\`: first trigger arms without confirming, second trigger within the window confirms and disarms, auto-disarm after the window requires a fresh two-click sequence, timer cleared on unmount.
  - \`FriendList\`: single click never fires the DELETE for either remove-friend or cancel-sent-request; a second click does; the button re-arms (doesn't confirm) if the window elapses between clicks; accept/decline remain single-click.

## Checklist

- [x] Branch is up to date with \`main\`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] \`.env.example\` updated — N/A
- [ ] \`README.md\` updated — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two-step confirmation for removing friends and canceling sent requests.
  * Confirmation expires after three seconds and can be re-armed safely.
  * Received friend requests can still be declined immediately.
  * Extended consistent confirmation behavior to other destructive actions.

* **Bug Fixes**
  * Improved confirmation handling when actions are interrupted or canceled.

* **Tests**
  * Added coverage for confirmation flows, expiration, re-arming, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->