### PR TITLE
fix(search): use resolveVerse's live-fetch fallback so a DB error doesn't crash ref lookups

### DIFF
--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -105,6 +105,15 @@ describe("GET /api/search", () => {
     expect(mockFetch).not.toHaveBeenCalled(); // no external call for ref lookup
   });
 
+  it("does not crash when the local DB lookup throws for a ref-format query", async () => {
+    mockGetVerse.mockRejectedValueOnce(new Error("connection refused"));
+    const req = makeSearchReq("2:255");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results[0].ref).toBe("2:255");
+  });
+
   it("includes correct surahNameArabic for ref-format query", async () => {
     mockGetVerse.mockResolvedValueOnce(null);
     const req = makeSearchReq("1:1");

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import type { SearchResponse, SearchResult, VerseRef } from "@/types/quran";
 import { getSurahName } from "@/lib/quran/surah-names";
 import { searchByMeaning } from "@/lib/quran/semantic-search";
-import { getVerse, getVerses } from "@/lib/quran/quran-corpus";
+import { getVerses } from "@/lib/quran/quran-corpus";
+import { resolveVerse } from "@/lib/quran/verse-resolver";
 import {
   consume,
   SEARCH_LOG_LIMIT,
@@ -141,7 +142,9 @@ export async function GET(req: NextRequest) {
   const edition = await getQuranEdition();
 
   if (/^\d+:\d+$/.test(q)) {
-    const verse = await getVerse(q, edition);
+    // resolveVerse falls back to a live alquran.cloud fetch on a local DB
+    // failure — unlike a bare getVerse() call, this never crashes the route.
+    const verse = await resolveVerse(q, edition);
     const [surahName, surahNameArabic] = getSurahName(parseInt(q.split(":")[0], 10));
     const result: SearchResult = {
       ref: q as VerseRef,


### PR DESCRIPTION
## Summary

- Production is currently returning a bare `500` on ref-style search queries (e.g. `/api/search?q=2:25`) — confirmed live against openhikmah.com after PR #408's deploy fix went out.
- Root cause: the ref-format branch in `app/api/search/route.ts` called `getVerse()` directly with no try/catch. Any DB error there is an unhandled rejection, surfacing as a bare 500 with no JSON body. The sibling `/api/verse/[surah]/[ayah]` route already avoids this — it goes through `resolveVerse()` (`lib/quran/verse-resolver.ts`), which wraps the same DB call in try/catch and falls back to a live `alquran.cloud` fetch on failure.
- This PR swaps the search route's ref-lookup branch to use `resolveVerse()` too, so a DB hiccup degrades gracefully instead of crashing the endpoint.

Note: this does not fix a possible underlying DB/infra issue in production (still being investigated separately), nor the parallel keyword-search `x-search-error: keyword-unavailable` symptom, which has no live-fallback path today. It only stops this specific endpoint from hard-crashing when the DB call fails.

## Changes

- `app/api/search/route.ts`: ref-format branch now calls `resolveVerse(q, edition)` instead of `getVerse(q, edition)` directly.
- `__tests__/api/search.test.ts`: added a regression test asserting the route returns `200` (not a crash) when the local DB lookup throws for a ref-format query.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (928/928)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally on changed files
- [x] New regression test added (DB throw → still 200, not 500)

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verse-reference searches by adding a fallback when local lookup fails.
  * Search requests now continue successfully and return the requested verse reference when available from the live service.

* **Tests**
  * Added regression coverage to verify failed local lookups do not crash the search endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->