### PR TITLE
fix(names,search): honor selected language for ayah text

### DIFF
--- a/__tests__/api/names.test.ts
+++ b/__tests__/api/names.test.ts
@@ -6,11 +6,19 @@ vi.mock("next/cache", () => ({
   unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
 }));
 
-// The routes now call getUiLocale() (lib/i18n/request-prefs.ts), which reads
-// next/headers' cookies() — unavailable outside a real Next request scope.
-// No cookie set here means it resolves to the "en" default, matching this
-// suite's pre-existing English-only fixtures/assertions.
-vi.mock("next/headers", () => ({ cookies: async () => ({ get: () => undefined }) }));
+// The routes now call getUiLocale()/getQuranEdition() (lib/i18n/request-prefs.ts),
+// which read next/headers' cookies() — unavailable outside a real Next request
+// scope. Mock the module directly (same pattern as __tests__/api/search.test.ts)
+// so individual tests can override the locale/edition; the defaults below match
+// this suite's pre-existing English-only fixtures/assertions.
+const { mockGetUiLocale, mockGetQuranEdition } = vi.hoisted(() => ({
+  mockGetUiLocale: vi.fn(async () => "en" as const),
+  mockGetQuranEdition: vi.fn(async () => "en.sahih"),
+}));
+vi.mock("@/lib/i18n/request-prefs", () => ({
+  getUiLocale: mockGetUiLocale,
+  getQuranEdition: mockGetQuranEdition,
+}));
 
 // The name routes now read/write a durable `name_content` cache via lib/infra/db
 // (see lib/names/name-content.ts). Mock the DB so the cache check is always a miss and
@@ -106,7 +114,13 @@ describe("GET /api/names", () => {
 });
 
 describe("GET /api/names/[slug]/verses", () => {
-  beforeEach(() => mockFetch.mockReset());
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockGetUiLocale.mockReset();
+    mockGetUiLocale.mockResolvedValue("en");
+    mockGetQuranEdition.mockReset();
+    mockGetQuranEdition.mockResolvedValue("en.sahih");
+  });
 
   function params(slug: string) {
     return { params: Promise.resolve({ slug }) };
@@ -153,6 +167,26 @@ describe("GET /api/names/[slug]/verses", () => {
       expect(verse).toHaveProperty("translation");
       expect(verse).toHaveProperty("reason");
       expect(verse).toHaveProperty("surahName");
+    }
+  });
+
+  it("hydrates verse translation for the requester's edition, not the en.sahih the selection was cached with", async () => {
+    mockGetQuranEdition.mockResolvedValue("tr.diyanet");
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url !== "string") return { ok: false };
+      if (url.includes("ar.alafasy")) return arabicResp();
+      if (url.includes("tr.diyanet")) return transResp("Türkçe çeviri");
+      if (url.includes("en.sahih")) return transResp("English translation");
+      return { ok: false };
+    });
+
+    const req = new NextRequest("http://localhost/api/names/al-alim/verses");
+    const res = await getNameVerses(req, params("al-alim"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.length).toBeGreaterThan(0);
+    for (const verse of body) {
+      expect(verse.translation).toBe("Türkçe çeviri");
     }
   });
 });

--- a/__tests__/app/search/SearchPageClient.test.tsx
+++ b/__tests__/app/search/SearchPageClient.test.tsx
@@ -10,6 +10,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 import { SearchPageClient } from "@/app/search/SearchPageClient";
+import { usePreferencesStore } from "@/store/preferences";
 
 describe("SearchPageClient — rate-limit vs. genuine empty results", () => {
   const mockFetch = vi.fn();
@@ -57,5 +58,59 @@ describe("SearchPageClient — rate-limit vs. genuine empty results", () => {
     });
 
     expect(screen.getByText(/no exact matches/i)).toBeInTheDocument();
+  });
+});
+
+describe("SearchPageClient — re-fetches when the UI language changes", () => {
+  const mockFetch = vi.fn();
+  const previousUiLocale = usePreferencesStore.getState().uiLocale;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    usePreferencesStore.setState({ uiLocale: "en" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    usePreferencesStore.setState({ uiLocale: previousUiLocale });
+  });
+
+  it("re-fetches results with the newly selected language once already on screen", async () => {
+    const englishResult = {
+      ref: "2:255",
+      surahName: "Al-Baqarah",
+      surahNameArabic: "البقرة",
+      snippet: "Allah - there is no deity except Him.",
+      arabicText: "الله لا إله إلا هو",
+      translation: "Allah - there is no deity except Him.",
+    };
+    const turkishResult = { ...englishResult, translation: "Allah, O'ndan başka ilah yoktur." };
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ results: [englishResult], total: 1, page: 1, pageSize: 20 }), {
+        status: 200,
+      })
+    );
+
+    await act(async () => {
+      renderWithIntl(<SearchPageClient />);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(englishResult.translation)).toBeInTheDocument();
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ results: [turkishResult], total: 1, page: 1, pageSize: 20 }), {
+        status: 200,
+      })
+    );
+
+    await act(async () => {
+      usePreferencesStore.setState({ uiLocale: "tr" });
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(screen.getByText(turkishResult.translation)).toBeInTheDocument();
   });
 });

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -7,8 +7,8 @@ import { getOrGenerateNameContent, getOrGenerateVerseReason } from "@/lib/names/
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
 import { incr } from "@/lib/infra/metrics";
-import { getUiLocale } from "@/lib/i18n/request-prefs";
-import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
+import { getUiLocale, getQuranEdition } from "@/lib/i18n/request-prefs";
+import { LOCALE_LANGUAGE_NAME, DEFAULT_EDITION_BY_LOCALE, type Locale } from "@/lib/i18n/config";
 import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
 import sanitizeHtml from "sanitize-html";
 import type { VerseRef } from "@/types/quran";
@@ -158,6 +158,7 @@ Sentence: "${reason}"`;
 async function getVersesBySlug(
   slug: string,
   locale: Locale,
+  edition: string,
   onBeforeGenerate: () => Promise<void>
 ): Promise<NameVerse[]> {
   const name = getNameBySlug(slug);
@@ -221,7 +222,29 @@ async function getVersesBySlug(
     onBeforeGenerate
   );
 
-  if (locale === "en" || verses.length === 0) return verses;
+  if (verses.length === 0) return verses;
+
+  // The cache above is keyed to "en" regardless of locale — verse *selection*
+  // (and its arabicText/translation as generated) never varies by request, so
+  // it isn't re-fetched per locale. But the displayed text must still honor
+  // the requester's edition, so re-hydrate arabicText/translation here when
+  // it differs from the canonical en.sahih the cache was built with.
+  const hydratedVerses =
+    edition === DEFAULT_EDITION_BY_LOCALE.en
+      ? verses
+      : await Promise.all(
+          verses.map(async (v) => {
+            const localized = await resolveVerse(v.ref, edition);
+            if (!localized) return v;
+            return {
+              ...v,
+              arabicText: localized.arabicText,
+              translation: stripHtml(localized.translation),
+            };
+          })
+        );
+
+  if (locale === "en") return hydratedVerses;
 
   // Localize only the per-verse reason text (a translation of the canonical
   // English reason, cached in name_verse_reasons) — the verse list itself
@@ -245,7 +268,7 @@ async function getVersesBySlug(
 
   const language = LOCALE_LANGUAGE_NAME[locale];
   const localizedReasons = await Promise.all(
-    verses.map(async (v) => {
+    hydratedVerses.map(async (v) => {
       const translated = await getOrGenerateVerseReason(
         slug,
         v.ref,
@@ -263,7 +286,7 @@ async function getVersesBySlug(
       return translated;
     })
   );
-  return verses.map((v, i) => ({ ...v, reason: localizedReasons[i] }));
+  return hydratedVerses.map((v, i) => ({ ...v, reason: localizedReasons[i] }));
 }
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
@@ -275,7 +298,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ slug
 
   try {
     const locale = await getUiLocale();
-    const verses = await getVersesBySlug(slug, locale, async () => {
+    const edition = await getQuranEdition();
+    const verses = await getVersesBySlug(slug, locale, edition, async () => {
       if (!(await consume(`names-gen:${clientKey(req)}`))) throw new RateLimitError();
     });
     return NextResponse.json(verses);

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -237,7 +237,14 @@ async function getVersesBySlug(
       : await Promise.all(
           verses.map(async (v) => {
             const localized = await resolveVerse(v.ref, edition);
-            if (!localized) return v;
+            if (!localized) {
+              // Same reasoning as fetchVerseData: falling back to the cached
+              // en.sahih text (rather than failing the whole names/verses
+              // response over one edition) must still be visible, not silent.
+              console.error(`Name verses: edition hydration failed for ${v.ref}/${edition}`);
+              incr("quran_api_fetch_error");
+              return v;
+            }
             return {
               ...v,
               translation: stripHtml(localized.translation),

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -226,9 +226,11 @@ async function getVersesBySlug(
 
   // The cache above is keyed to "en" regardless of locale — verse *selection*
   // (and its arabicText/translation as generated) never varies by request, so
-  // it isn't re-fetched per locale. But the displayed text must still honor
-  // the requester's edition, so re-hydrate arabicText/translation here when
-  // it differs from the canonical en.sahih the cache was built with.
+  // it isn't re-fetched per locale. But the displayed translation must still
+  // honor the requester's edition, so re-hydrate it here when it differs from
+  // the canonical en.sahih the cache was built with. arabicText is left as-is
+  // — resolveVerse always sources it from ar.alafasy regardless of `edition`,
+  // so re-fetching it would be a same-value round trip.
   const hydratedVerses =
     edition === DEFAULT_EDITION_BY_LOCALE.en
       ? verses
@@ -238,7 +240,6 @@ async function getVersesBySlug(
             if (!localized) return v;
             return {
               ...v,
-              arabicText: localized.arabicText,
               translation: stripHtml(localized.translation),
             };
           })

--- a/app/search/SearchPageClient.tsx
+++ b/app/search/SearchPageClient.tsx
@@ -123,7 +123,7 @@ export function SearchPageClient() {
       });
 
     return () => controller.abort();
-  }, [q, mode, page, retryCount]);
+  }, [q, mode, page, retryCount, uiLocale]);
 
   const navigate = useCallback(
     (nextQ: string, nextMode: SearchMode, nextPage: number) => {


### PR DESCRIPTION
## Summary

- Divine-name verse cards (`/names/[slug]`) always showed English translations regardless of the selected language: verse *selection* for each name is cached once (deliberately, to avoid re-running AI/quran.com search per locale), but the cached Arabic/translation text was served as-is forever — `resolveVerse()` was called with no `edition`, silently defaulting to `en.sahih`. Verse text is now re-hydrated for the requester's `oh_edition` cookie after reading the cached selection; the reason sentences (already correctly localized) are unaffected.
- Search results (`/search`) didn't re-fetch when the language was switched after results were already on screen — the results-fetch effect was missing `uiLocale` from its dependency array. The search API route itself was already correctly wired.
- Narratives (`/stories`) were checked and found already correct — no change needed there.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [ ] No AI or theological changes in this PR
- [x] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)

**Details**: No prompt or theological-framing changes. This only affects which cached translation edition is used to render already-selected, already-Tanzih-checked verse text — verse selection, AI reasons, and theological content are unchanged.

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality (locale/edition hydration regression test in `__tests__/api/names.test.ts`)

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A, none added
- [x] `README.md` updated if the feature changes the public interface — N/A, internal fix only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verse translations now use the Quran edition selected in your preferences.
  * Non-English Quran editions now correctly display Arabic text and matching translations.
  * Localized explanations now reflect the selected verse content.
  * Search results now refresh automatically when the interface language changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->