### PR TITLE
fix(social): surface PATCH errors on challenge accept/decline/cancel

### DIFF
--- a/__tests__/components/social/ChallengeList.test.tsx
+++ b/__tests__/components/social/ChallengeList.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ChallengeList, type EnrichedChallenge } from "@/components/social/ChallengeList";
+import { useAuthStore } from "@/store/auth";
+import { useSocialStore } from "@/store/social";
+
+function challenge(overrides: Partial<EnrichedChallenge> = {}): EnrichedChallenge {
+  return {
+    id: 1,
+    challengerId: 2,
+    challengedId: 1,
+    challengerUsername: "yusuf",
+    challengedUsername: "me",
+    verseRef: "2:255",
+    status: "pending",
+    startsAt: new Date().toISOString(),
+    endsAt: new Date(Date.now() + 86_400_000).toISOString(),
+    winnerId: null,
+    challengerScore: 0,
+    challengedScore: 0,
+    ...overrides,
+  };
+}
+
+describe("ChallengeCard PATCH error handling", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "test-token" });
+    useSocialStore.setState({ userId: 1 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not call onUpdate and shows an error when the accept PATCH fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 409, json: () => Promise.resolve({}) })
+    );
+    const onUpdate = vi.fn();
+    render(<ChallengeList challenges={[challenge()]} onUpdate={onUpdate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /accept/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Couldn't accept — try again.")).toBeInTheDocument();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does not call onUpdate and shows a network error when the PATCH throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    const onUpdate = vi.fn();
+    render(<ChallengeList challenges={[challenge()]} onUpdate={onUpdate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /decline/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Network error — try again.")).toBeInTheDocument();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("calls onUpdate on a successful accept PATCH", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    );
+    const onUpdate = vi.fn();
+    render(<ChallengeList challenges={[challenge()]} onUpdate={onUpdate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /accept/i }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalled();
+    });
+  });
+});

--- a/components/social/ChallengeList.tsx
+++ b/components/social/ChallengeList.tsx
@@ -111,6 +111,7 @@ function ChallengeCard({
 }) {
   const accessToken = useAuthStore((s) => s.accessToken);
   const [acting, setActing] = useState<"accept" | "decline" | "cancel" | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const countdown = useCountdown(c.endsAt);
 
   const isChallenger = c.challengerId === myId;
@@ -132,13 +133,20 @@ function ChallengeCard({
   const handleAction = async (action: "accept" | "decline" | "cancel") => {
     if (!accessToken) return;
     setActing(action);
+    setError(null);
     try {
-      await fetch(`/api/social/challenges/${c.id}`, {
+      const res = await fetch(`/api/social/challenges/${c.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
         body: JSON.stringify({ action }),
       });
+      if (!res.ok) {
+        setError(`Couldn't ${action} — try again.`);
+        return;
+      }
       onUpdate();
+    } catch {
+      setError("Network error — try again.");
     } finally {
       setActing(null);
     }
@@ -202,6 +210,7 @@ function ChallengeCard({
         </p>
       )}
       {theyWon && <p className="text-center text-xs text-text-muted">@{opponentName} won</p>}
+      {error && <p className="text-center text-xs text-error">{error}</p>}
 
       {/* Actions */}
       {incoming && (


### PR DESCRIPTION
## Summary

- `ChallengeCard.handleAction` (in `components/social/ChallengeList.tsx`) called `onUpdate()` unconditionally after the PATCH request, without checking `res.ok` — a failed accept/decline/cancel silently reverted the card with no feedback to the user.
- Now checks `res.ok` before calling `onUpdate()`, catches network errors, and surfaces a per-card error message, matching the existing pattern in `components/social/FriendList.tsx`.

Closes #370

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (on changed files)
- [x] New tests added for new functionality — `__tests__/components/social/ChallengeList.test.tsx` covers failed PATCH (non-ok response), network error (rejected fetch), and the success path

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A
- [x] `README.md` updated if the feature changes the public interface — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved challenge actions to show clear errors when requests fail or encounter network issues.
  * Prevented challenge lists from refreshing when an action is unsuccessful.
  * Challenge updates now refresh only after successful requests.

* **Tests**
  * Added coverage for successful, failed, and network-error challenge actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->