### PR TITLE
fix(canvas): read source node position fresh on each expansion placement

### DIFF
--- a/__tests__/components/canvas/HikmahCanvas.expansion-position.test.tsx
+++ b/__tests__/components/canvas/HikmahCanvas.expansion-position.test.tsx
@@ -1,0 +1,104 @@
+import { act, cleanup } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderWithIntl as render } from "../../test-utils/render-with-intl";
+import { useCanvasStore } from "@/store/canvas";
+import type { Verse, VerseRef } from "@/types/quran";
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>();
+  return {
+    ...actual,
+    ReactFlow: () => null,
+    Background: () => null,
+    BackgroundVariant: { Dots: "dots" },
+    MiniMap: () => null,
+    Panel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    useReactFlow: () => ({ fitView: vi.fn(), setCenter: vi.fn(), getZoom: vi.fn() }),
+    ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+import { HikmahCanvas } from "@/components/canvas/HikmahCanvas";
+
+function verseNode(id: string, ref: string, position = { x: 0, y: 0 }) {
+  const verse: Verse = {
+    surah: 1,
+    ayah: 1,
+    ref: ref as VerseRef,
+    arabicText: "نص",
+    translation: "text",
+    surahName: "Al-Fatihah",
+    surahNameArabic: "الفاتحة",
+  };
+  return { id, type: "verse", position, data: verse };
+}
+
+function connection(ref: string) {
+  return {
+    surah: 2,
+    ayah: 255,
+    ref,
+    arabicText: "نص",
+    translation: "text",
+    surahName: "Al-Baqarah",
+    surahNameArabic: "البقرة",
+    reason: "reason",
+    kind: "thematic",
+  };
+}
+
+describe("HikmahCanvas expansion node placement", () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      nodes: [verseNode("n1", "1:1", { x: 0, y: 0 })] as never,
+      edges: [],
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("places a new node near the source's current position, not its position when the expansion started", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([connection("2:255")]),
+      })
+    );
+
+    render(<HikmahCanvas onSearchOpen={vi.fn()} />);
+
+    act(() => {
+      useCanvasStore.getState().setPendingExpand({ nodeId: "n1", ref: "1:1", kind: "thematic" });
+    });
+    // Let the pendingExpand effect fire and the fetch microtask resolve.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Drag the source node far away before the staggered placement lands.
+    act(() => {
+      useCanvasStore.setState({
+        nodes: useCanvasStore
+          .getState()
+          .nodes.map((n) => (n.id === "n1" ? { ...n, position: { x: 2000, y: 2000 } } : n)),
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    const newNode = useCanvasStore.getState().nodes.find((n) => n.id !== "n1");
+    expect(newNode).toBeDefined();
+    // radialPos fans out within a 460px radius of the source; landing near the
+    // dragged-to position (not the stale x:0,y:0 snapshot) confirms the fix.
+    expect(newNode!.position.x).toBeGreaterThan(1000);
+    expect(newNode!.position.y).toBeGreaterThan(1000);
+  });
+});

--- a/components/canvas/HikmahCanvas.tsx
+++ b/components/canvas/HikmahCanvas.tsx
@@ -184,9 +184,13 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
           }
 
           // Fan out radially, then nudge off any collision with the live graph
-          // (including siblings added moments ago in this same expansion).
-          const target = radialPos(sourcePos, i, connections.length);
+          // (including siblings added moments ago in this same expansion). Read
+          // the source node's position fresh each iteration — it may have been
+          // dragged mid-expansion, and staggered placements should follow it
+          // rather than fan out from a stale pre-drag snapshot.
           const state = useCanvasStore.getState();
+          const currentSourcePos = state.nodes.find((n) => n.id === nodeId)?.position ?? sourcePos;
+          const target = radialPos(currentSourcePos, i, connections.length);
           const existing = state.nodes.map((n) => n.position);
           // Edge labels (AI explanation pills, ~120×22px) render at edge midpoints.
           // Treat them as slim obstacles so new nodes avoid overlapping them without


### PR DESCRIPTION
## Summary

- `runExpansion` (`components/canvas/HikmahCanvas.tsx`) computed every staggered node's radial position from a single `sourcePos` snapshot captured before the async placement loop began. Dragging the source node mid-expansion left new nodes fanning out from its old, now-empty position, with edges stretching across the canvas to reach the relocated source.
- Now re-reads the source node's current position from the store (`state.nodes.find((n) => n.id === nodeId)?.position`) at each placement step, falling back to the original snapshot only if the node was removed.

Closes #372

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (on changed files)
- [x] New tests added — `__tests__/components/canvas/HikmahCanvas.expansion-position.test.tsx` drags the source node mid-expansion (between the fetch resolving and the first staggered placement) and asserts the new node lands near the updated position, not the stale pre-drag snapshot. Verified the test fails against the pre-fix code.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A
- [x] `README.md` updated if the feature changes the public interface — N/A