### PR TITLE
chore(test): raise timeout on flaky stories-page first-import test

### DIFF
--- a/__tests__/app/stories-pages.test.tsx
+++ b/__tests__/app/stories-pages.test.tsx
@@ -100,13 +100,16 @@ describe("Stories pages — locale-aware rendering", () => {
   });
 
   it("index page shows the locale-specific name/tagline when present", async () => {
+    // First dynamic import of this module in the suite — under full-suite
+    // parallel load, first-time module transform/eval can exceed the
+    // default 5s test timeout even though the test itself is fast.
     mockGetUiLocale.mockResolvedValue("tr");
     const { default: StoriesPage } = await import("@/app/stories/page");
     const text = extractText(await StoriesPage());
     expect(text).toContain("Test Hikayesi");
     expect(text).toContain("Türkçe bir slogan");
     expect(text).not.toContain("Test Story");
-  });
+  }, 15000);
 
   it("index page falls back to English when no locale-specific field exists", async () => {
     mockGetUiLocale.mockResolvedValue("az");


### PR DESCRIPTION
## Summary

- Discovered while working the #370-388 batch: `__tests__/app/stories-pages.test.tsx`'s first test consistently times out at the default 5s under full `bun run test:ci` load (blocking every pre-commit hook run), but passes reliably in isolation and with a larger timeout. The first dynamic `import("@/app/stories/page")` in the suite pays a one-time module transform/eval cost that exceeds 5s under parallel test-suite CPU contention.
- Bumped this one test's timeout to 15s rather than the global default, since it's an isolated one-time-cost issue, not a systemic slowness problem.
- Not tied to any of the #370-388 issues — a standalone infra fix so it doesn't block those commits.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (on changed file)
- [ ] New tests added for new functionality — N/A, timeout adjustment only

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A
- [x] `README.md` updated if the feature changes the public interface — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for a stories index-page locale test to improve reliability during slower test-suite runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->