### PR TITLE
fix(canvas): clear CanvasToolbar save/share/export timers on unmount

### DIFF
--- a/__tests__/app/stories-pages.test.tsx
+++ b/__tests__/app/stories-pages.test.tsx
@@ -100,13 +100,16 @@ describe("Stories pages — locale-aware rendering", () => {
   });
 
   it("index page shows the locale-specific name/tagline when present", async () => {
+    // First dynamic import of this module in the suite — under full-suite
+    // parallel load, first-time module transform/eval can exceed the
+    // default 5s test timeout even though the test itself is fast.
     mockGetUiLocale.mockResolvedValue("tr");
     const { default: StoriesPage } = await import("@/app/stories/page");
     const text = extractText(await StoriesPage());
     expect(text).toContain("Test Hikayesi");
     expect(text).toContain("Türkçe bir slogan");
     expect(text).not.toContain("Test Story");
-  });
+  }, 15000);
 
   it("index page falls back to English when no locale-specific field exists", async () => {
     mockGetUiLocale.mockResolvedValue("az");

--- a/__tests__/components/canvas/CanvasToolbar.unmount.test.tsx
+++ b/__tests__/components/canvas/CanvasToolbar.unmount.test.tsx
@@ -1,0 +1,124 @@
+import { screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderWithIntl as render } from "../../test-utils/render-with-intl";
+import { useCanvasStore } from "@/store/canvas";
+import { useAuthStore } from "@/store/auth";
+import type { Verse, VerseRef } from "@/types/quran";
+
+vi.mock("@xyflow/react", () => ({
+  Panel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useReactFlow: () => ({ fitView: vi.fn() }),
+}));
+
+vi.mock("@/lib/canvas/canvas-export", () => ({
+  exportCanvasToPng: vi.fn().mockRejectedValue(new Error("export failed")),
+  exportCanvasToPdf: vi.fn().mockRejectedValue(new Error("export failed")),
+  downloadDataUrl: vi.fn(),
+  downloadBlob: vi.fn(),
+}));
+
+import { CanvasToolbar } from "@/components/canvas/CanvasToolbar";
+
+function verseNode() {
+  const verse: Verse = {
+    surah: 1,
+    ayah: 1,
+    ref: "1:1" as VerseRef,
+    arabicText: "نص",
+    translation: "text",
+    surahName: "Al-Fatihah",
+    surahNameArabic: "الفاتحة",
+  };
+  return { id: "n1", type: "verse", position: { x: 0, y: 0 }, data: verse };
+}
+
+describe("CanvasToolbar unmount while a request is in flight", () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useCanvasStore.setState({ nodes: [verseNode() as any], edges: [] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAuthStore.setState({ accessToken: "test-token" as any });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("clears the pending save-error reset timeout on unmount", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+
+    const { unmount } = render(<CanvasToolbar onSearchOpen={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    // Let the failed save settle and schedule its error-reset timeout.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+
+  it("clears the pending share-error reset timeout on unmount", async () => {
+    const originalClipboard = navigator.clipboard;
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("clipboard denied")) },
+    });
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+
+    const { unmount } = render(<CanvasToolbar onSearchOpen={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /share/i }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    Object.assign(navigator, { clipboard: originalClipboard });
+  });
+
+  it("clears the pending export-error reset timeout on unmount", async () => {
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+
+    const { unmount } = render(<CanvasToolbar onSearchOpen={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    fireEvent.click(screen.getByRole("button", { name: /PNG/ }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+
+  it("does not throw when a save request resolves after the component has unmounted", async () => {
+    let resolveFetch: (value: { ok: boolean }) => void;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+      )
+    );
+
+    const { unmount } = render(<CanvasToolbar onSearchOpen={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    unmount();
+
+    expect(() => {
+      resolveFetch!({ ok: false });
+    }).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});

--- a/__tests__/components/canvas/CanvasToolbar.unmount.test.tsx
+++ b/__tests__/components/canvas/CanvasToolbar.unmount.test.tsx
@@ -1,5 +1,6 @@
-import { screen, fireEvent, cleanup } from "@testing-library/react";
+import { screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { Node } from "@xyflow/react";
 import { renderWithIntl as render } from "../../test-utils/render-with-intl";
 import { useCanvasStore } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
@@ -19,25 +20,25 @@ vi.mock("@/lib/canvas/canvas-export", () => ({
 
 import { CanvasToolbar } from "@/components/canvas/CanvasToolbar";
 
-function verseNode() {
+function verseNode(): Node {
+  // en.sahih (Saheeh International, alquran.cloud) — Al-Fatihah 1:1.
   const verse: Verse = {
     surah: 1,
     ayah: 1,
     ref: "1:1" as VerseRef,
-    arabicText: "نص",
-    translation: "text",
+    arabicText: "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ",
+    translation: "In the name of Allah, the Entirely Merciful, the Especially Merciful.",
     surahName: "Al-Fatihah",
     surahNameArabic: "الفاتحة",
   };
-  return { id: "n1", type: "verse", position: { x: 0, y: 0 }, data: verse };
+  // Matches the cast used for the same Verse -> Node data shape in store/canvas.ts.
+  return { id: "n1", type: "verse", position: { x: 0, y: 0 }, data: { ...verse } } as Node;
 }
 
 describe("CanvasToolbar unmount while a request is in flight", () => {
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    useCanvasStore.setState({ nodes: [verseNode() as any], edges: [] });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    useAuthStore.setState({ accessToken: "test-token" as any });
+    useCanvasStore.setState({ nodes: [verseNode()], edges: [] });
+    useAuthStore.setState({ accessToken: "test-token" });
   });
 
   afterEach(() => {
@@ -46,24 +47,30 @@ describe("CanvasToolbar unmount while a request is in flight", () => {
     vi.restoreAllMocks();
   });
 
-  it("clears the pending save-error reset timeout on unmount", async () => {
+  it("clears the previous save-error timeout when a second save fails, and clears it again on unmount", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
     const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
 
     const { unmount } = render(<CanvasToolbar onSearchOpen={vi.fn()} />);
-    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    fireEvent.click(saveButton);
 
-    // Let the failed save settle and schedule its error-reset timeout.
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    // Let the first failed save settle and schedule its error-reset timeout.
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
+
+    // A second failed save must clear the first timeout before scheduling its own.
+    fireEvent.click(saveButton);
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockClear();
 
     unmount();
 
     expect(clearTimeoutSpy).toHaveBeenCalled();
   });
 
-  it("clears the pending share-error reset timeout on unmount", async () => {
+  it("clears the previous share-error timeout when a second share fails, and clears it again on unmount", async () => {
     const originalClipboard = navigator.clipboard;
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockRejectedValue(new Error("clipboard denied")) },
@@ -71,11 +78,16 @@ describe("CanvasToolbar unmount while a request is in flight", () => {
     const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
 
     const { unmount } = render(<CanvasToolbar onSearchOpen={vi.fn()} />);
-    fireEvent.click(screen.getByRole("button", { name: /share/i }));
+    const shareButton = screen.getByRole("button", { name: /share/i });
+    fireEvent.click(shareButton);
 
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitFor(() => expect(shareButton).not.toBeDisabled());
+
+    fireEvent.click(shareButton);
+    await waitFor(() => expect(shareButton).not.toBeDisabled());
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockClear();
 
     unmount();
 
@@ -83,16 +95,22 @@ describe("CanvasToolbar unmount while a request is in flight", () => {
     Object.assign(navigator, { clipboard: originalClipboard });
   });
 
-  it("clears the pending export-error reset timeout on unmount", async () => {
+  it("clears the previous export-error timeout when a second export fails, and clears it again on unmount", async () => {
     const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
 
     const { unmount } = render(<CanvasToolbar onSearchOpen={vi.fn()} />);
-    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    const exportButton = screen.getByRole("button", { name: /export/i });
+    fireEvent.click(exportButton);
     fireEvent.click(screen.getByRole("button", { name: /PNG/ }));
 
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitFor(() => expect(exportButton).not.toBeDisabled());
+
+    fireEvent.click(exportButton);
+    fireEvent.click(screen.getByRole("button", { name: /PNG/ }));
+    await waitFor(() => expect(exportButton).not.toBeDisabled());
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockClear();
 
     unmount();
 
@@ -120,5 +138,34 @@ describe("CanvasToolbar unmount while a request is in flight", () => {
     }).not.toThrow();
     await Promise.resolve();
     await Promise.resolve();
+  });
+
+  it("does not schedule a feedback timer when a share succeeds after unmount", async () => {
+    let resolveClipboard: () => void;
+    const originalClipboard = navigator.clipboard;
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockReturnValue(
+          new Promise<void>((resolve) => {
+            resolveClipboard = resolve;
+          })
+        ),
+      },
+    });
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+
+    const { unmount } = render(<CanvasToolbar onSearchOpen={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /share/i }));
+
+    unmount();
+    setTimeoutSpy.mockClear();
+
+    expect(() => resolveClipboard!()).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+    Object.assign(navigator, { clipboard: originalClipboard });
   });
 });

--- a/components/canvas/CanvasToolbar.tsx
+++ b/components/canvas/CanvasToolbar.tsx
@@ -83,6 +83,23 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState(false);
   const exportContainerRef = useRef<HTMLDivElement>(null);
+  const mountedRef = useRef(true);
+  const shareTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const exportTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // CanvasToolbar unmounts whenever nodes.length hits 0 (e.g. select-all +
+  // delete while a save/share/export request is still in flight) — clear any
+  // pending feedback-reset timeout and stop setting state after that point.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (shareTimeoutRef.current) clearTimeout(shareTimeoutRef.current);
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+      if (exportTimeoutRef.current) clearTimeout(exportTimeoutRef.current);
+    };
+  }, []);
 
   // Close on any click outside the export button/menu — panning the canvas,
   // clicking a node, or clicking the minimap would otherwise leave it open
@@ -116,10 +133,13 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
       const url = await buildShareUrl(serializeCanvas(nodes, edges));
       await copy(url);
     } catch {
+      if (!mountedRef.current) return;
       setShareError(true);
-      setTimeout(() => setShareError(false), 2500);
+      shareTimeoutRef.current = setTimeout(() => {
+        if (mountedRef.current) setShareError(false);
+      }, 2500);
     } finally {
-      setSharing(false);
+      if (mountedRef.current) setSharing(false);
     }
   };
 
@@ -135,18 +155,26 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
         body: JSON.stringify({ name, data: serializeCanvas(nodes, edges), nodeCount: count }),
       });
+      if (!mountedRef.current) return;
       if (res.ok) {
         setSaved(true);
-        setTimeout(() => setSaved(false), 2000);
+        saveTimeoutRef.current = setTimeout(() => {
+          if (mountedRef.current) setSaved(false);
+        }, 2000);
       } else {
         setSaveError(true);
-        setTimeout(() => setSaveError(false), 2000);
+        saveTimeoutRef.current = setTimeout(() => {
+          if (mountedRef.current) setSaveError(false);
+        }, 2000);
       }
     } catch {
+      if (!mountedRef.current) return;
       setSaveError(true);
-      setTimeout(() => setSaveError(false), 2000);
+      saveTimeoutRef.current = setTimeout(() => {
+        if (mountedRef.current) setSaveError(false);
+      }, 2000);
     } finally {
-      setSaving(false);
+      if (mountedRef.current) setSaving(false);
     }
   };
 
@@ -181,10 +209,13 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
         downloadBlob(blob, `hikmah-canvas-${stamp}.pdf`);
       }
     } catch {
+      if (!mountedRef.current) return;
       setExportError(true);
-      setTimeout(() => setExportError(false), 2500);
+      exportTimeoutRef.current = setTimeout(() => {
+        if (mountedRef.current) setExportError(false);
+      }, 2500);
     } finally {
-      setExporting(false);
+      if (mountedRef.current) setExporting(false);
     }
   };
 

--- a/components/canvas/CanvasToolbar.tsx
+++ b/components/canvas/CanvasToolbar.tsx
@@ -131,10 +131,12 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
     setSharing(true);
     try {
       const url = await buildShareUrl(serializeCanvas(nodes, edges));
+      if (!mountedRef.current) return;
       await copy(url);
     } catch {
       if (!mountedRef.current) return;
       setShareError(true);
+      if (shareTimeoutRef.current) clearTimeout(shareTimeoutRef.current);
       shareTimeoutRef.current = setTimeout(() => {
         if (mountedRef.current) setShareError(false);
       }, 2500);
@@ -156,6 +158,7 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
         body: JSON.stringify({ name, data: serializeCanvas(nodes, edges), nodeCount: count }),
       });
       if (!mountedRef.current) return;
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
       if (res.ok) {
         setSaved(true);
         saveTimeoutRef.current = setTimeout(() => {
@@ -170,6 +173,7 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
     } catch {
       if (!mountedRef.current) return;
       setSaveError(true);
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
       saveTimeoutRef.current = setTimeout(() => {
         if (mountedRef.current) setSaveError(false);
       }, 2000);
@@ -211,6 +215,7 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
     } catch {
       if (!mountedRef.current) return;
       setExportError(true);
+      if (exportTimeoutRef.current) clearTimeout(exportTimeoutRef.current);
       exportTimeoutRef.current = setTimeout(() => {
         if (mountedRef.current) setExportError(false);
       }, 2500);

--- a/hooks/useCopyFeedback.ts
+++ b/hooks/useCopyFeedback.ts
@@ -11,14 +11,18 @@ import { useCallback, useEffect, useRef, useState } from "react";
 export function useCopyFeedback(resetMs = 2000) {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
 
   const copy = useCallback(
     async (text: string): Promise<boolean> => {
       try {
         await navigator.clipboard.writeText(text);
+        if (!mountedRef.current) return true;
         setCopied(true);
         if (timeoutRef.current) clearTimeout(timeoutRef.current);
-        timeoutRef.current = setTimeout(() => setCopied(false), resetMs);
+        timeoutRef.current = setTimeout(() => {
+          if (mountedRef.current) setCopied(false);
+        }, resetMs);
         return true;
       } catch {
         return false;
@@ -28,12 +32,13 @@ export function useCopyFeedback(resetMs = 2000) {
   );
 
   // Clear a pending reset on unmount so it can't fire on a gone component.
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    },
-    []
-  );
+    };
+  }, []);
 
   return { copied, copy };
 }


### PR DESCRIPTION
## Summary

- `CanvasToolbar`'s save/share/export handlers scheduled `setTimeout`s to clear their feedback state (error/success flashes), but none were cancelled on unmount. The toolbar unmounts whenever `nodes.length` hits 0 (e.g. select-all + delete while a request is in flight), so a settling request could set state on an unmounted component and leave a dangling timer running.
- Added a `mountedRef` plus per-handler timeout refs, matching the `noticeTimeoutRef` pattern already used in `HikmahCanvas.tsx`: all three timeouts are cleared on unmount, and every post-await `setState` call is guarded by the mounted check.

Note: this branch also carries #418 (`chore(test): raise timeout on flaky stories-page first-import test`), an unrelated pre-existing test flake I hit while working through this batch — it was blocking every commit's pre-commit hook, so I fixed it as its own small PR first and it's included here until it merges to main.

Closes #373

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (on changed files)
- [x] New tests added — `__tests__/components/canvas/CanvasToolbar.unmount.test.tsx` covers: clearTimeout called on unmount for save/share/export error-reset timers, and no throw when a save resolves after unmount. Verified 3 of the 4 new tests fail against the pre-fix code.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A
- [x] `README.md` updated if the feature changes the public interface — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canvas toolbar stability when navigating away during save, share, or export operations.
  * Prevented delayed feedback messages and asynchronous responses from updating unmounted components.
  * Added cleanup for pending status-reset timers.

* **Tests**
  * Added coverage for toolbar unmount behavior and asynchronous operation handling.
  * Extended the stories index-page locale test timeout to support dynamic loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->