### PR TITLE
fix(canvas): don't credit streak activity for a restored canvas

### DIFF
--- a/__tests__/hooks/useActivityTracker.test.ts
+++ b/__tests__/hooks/useActivityTracker.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("@xyflow/react", () => ({
+  applyNodeChanges: vi.fn((changes: unknown[], nodes: unknown[]) => nodes),
+  applyEdgeChanges: vi.fn((changes: unknown[], edges: unknown[]) => edges),
+}));
+
+import { useCanvasStore } from "@/store/canvas";
+import { useAuthStore } from "@/store/auth";
+import { useActivityTracker } from "@/hooks/useActivityTracker";
+import type { Verse } from "@/types/quran";
+
+const baseVerse: Verse = {
+  surah: 2,
+  ayah: 255,
+  ref: "2:255",
+  arabicText: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ",
+  translation: "Allah — there is no deity except Him.",
+  surahName: "Al-Baqarah",
+  surahNameArabic: "البقرة",
+};
+
+function savedCanvasWith(count: number) {
+  return {
+    v: 1 as const,
+    nodes: Array.from({ length: count }, (_, i) => ({
+      id: `node-${i + 1}`,
+      x: i * 300,
+      y: 0,
+      verse: {
+        ...baseVerse,
+        ayah: 255 + i,
+        ref: `2:${255 + i}` as Verse["ref"],
+      },
+    })),
+    edges: [],
+  };
+}
+
+describe("useActivityTracker restore vs. genuine activity", () => {
+  beforeEach(() => {
+    useCanvasStore.getState().reset();
+    useAuthStore.setState({ accessToken: "test-token" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not fire an activity POST when restoreCanvas repopulates the store", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useActivityTracker());
+
+    act(() => {
+      useCanvasStore.getState().restoreCanvas(savedCanvasWith(3));
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fire an activity POST for nodes already present when the hook mounts", () => {
+    useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useActivityTracker());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fires an activity POST when a node is genuinely added while mounted", () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useActivityTracker());
+
+    act(() => {
+      useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/social/activity",
+      expect.objectContaining({
+        body: expect.stringContaining("verse_added"),
+      })
+    );
+  });
+
+  it("resumes firing for genuine additions after a restore", () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useActivityTracker());
+
+    act(() => {
+      useCanvasStore.getState().restoreCanvas(savedCanvasWith(2));
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    act(() => {
+      useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/social/activity",
+      expect.objectContaining({ body: expect.stringContaining("verse_added") })
+    );
+  });
+});

--- a/__tests__/hooks/useActivityTracker.test.ts
+++ b/__tests__/hooks/useActivityTracker.test.ts
@@ -89,6 +89,19 @@ describe("useActivityTracker restore vs. genuine activity", () => {
     );
   });
 
+  it("does not fire an activity POST when appendWorkspace merges a loaded workspace", () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useActivityTracker());
+
+    act(() => {
+      useCanvasStore.getState().appendWorkspace(savedCanvasWith(2));
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("resumes firing for genuine additions after a restore", () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
     vi.stubGlobal("fetch", fetchMock);

--- a/__tests__/hooks/useActivityTracker.test.ts
+++ b/__tests__/hooks/useActivityTracker.test.ts
@@ -21,6 +21,8 @@ const baseVerse: Verse = {
   surahNameArabic: "البقرة",
 };
 
+// Every generated node reuses baseVerse's real ref/text — only id and position
+// vary — so no fixture ever pairs a synthetic ref with mismatched Arabic/translation.
 function savedCanvasWith(count: number) {
   return {
     v: 1 as const,
@@ -28,11 +30,7 @@ function savedCanvasWith(count: number) {
       id: `node-${i + 1}`,
       x: i * 300,
       y: 0,
-      verse: {
-        ...baseVerse,
-        ayah: 255 + i,
-        ref: `2:${255 + i}` as Verse["ref"],
-      },
+      verse: baseVerse,
     })),
     edges: [],
   };

--- a/hooks/useActivityTracker.ts
+++ b/hooks/useActivityTracker.ts
@@ -9,15 +9,33 @@ export function useActivityTracker() {
   const accessToken = useAuthStore((s) => s.accessToken);
   const { bumpStreak } = useSocialStore();
 
-  const prevNodeCount = useRef(0);
-  const prevEdgeCount = useRef(0);
+  // Seeded from the store's current counts (not 0) so a canvas that's already
+  // populated by the time this hook first mounts — e.g. "Open on canvas" from
+  // a story page added verses before navigating here — isn't mistaken for a
+  // pile of brand-new additions on the very first render.
+  const prevNodeCount = useRef(useCanvasStore.getState().nodes.length);
+  const prevEdgeCount = useRef(useCanvasStore.getState().edges.length);
+  const prevRestoreToken = useRef(useCanvasStore.getState().restoreToken);
 
   const nodeCount = useCanvasStore((s) => s.nodes.length);
   const edgeCount = useCanvasStore((s) => s.edges.length);
   const nodes = useCanvasStore((s) => s.nodes);
+  const restoreToken = useCanvasStore((s) => s.restoreToken);
 
   useEffect(() => {
     if (!accessToken) {
+      prevNodeCount.current = nodeCount;
+      prevEdgeCount.current = edgeCount;
+      prevRestoreToken.current = restoreToken;
+      return;
+    }
+
+    // A bulk restore (localStorage reload, share link, workspace load) bumps
+    // restoreToken atomically with the node/edge counts — treat it as a new
+    // baseline, not activity, so loading a page never credits the streak.
+    const restored = restoreToken !== prevRestoreToken.current;
+    prevRestoreToken.current = restoreToken;
+    if (restored) {
       prevNodeCount.current = nodeCount;
       prevEdgeCount.current = edgeCount;
       return;
@@ -70,6 +88,6 @@ export function useActivityTracker() {
         // Non-blocking — ignore errors
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nodeCount, edgeCount]);
+  }, [nodeCount, edgeCount, restoreToken]);
   // ^ watches counts only — re-fetching accessToken/bumpStreak on every render would re-fire
 }

--- a/store/canvas.ts
+++ b/store/canvas.ts
@@ -380,6 +380,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
         edges,
         duplicateNodeIdsByRef: computeDuplicateMap(nodes),
         expansionCountsByNode: computeExpansionCountsMap(edges),
+        restoreToken: s.restoreToken + 1,
       };
     });
   },

--- a/store/canvas.ts
+++ b/store/canvas.ts
@@ -88,6 +88,10 @@ interface CanvasStore {
   viewport: CanvasViewport;
   sidebarWidth: number;
   fitRequestToken: number;
+  /** Bumped by restoreCanvas so consumers (the activity tracker) can tell a
+   *  bulk restore apart from a genuine one-at-a-time user addition, without
+   *  relying on effect-ordering/timing to distinguish the two. */
+  restoreToken: number;
   /** Node ids sharing the same verse ref, keyed by ref. Recomputed by every
    *  action that touches `nodes`, so `getDuplicateNodeIds` is a plain lookup
    *  instead of an O(N) scan on every VerseNode render. */
@@ -177,6 +181,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
   viewport: { x: 0, y: 0, zoom: 1 },
   sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
   fitRequestToken: 0,
+  restoreToken: 0,
   duplicateNodeIdsByRef: {},
   expansionCountsByNode: {},
 
@@ -310,7 +315,7 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
       return m ? Math.max(max, parseInt(m[1], 10)) : max;
     }, 0);
     nodeIdCounter = maxNum;
-    set({
+    set((s) => ({
       nodes,
       edges,
       selectedNodeId: null,
@@ -323,7 +328,8 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
       newlyAddedNodeId: null,
       duplicateNodeIdsByRef: computeDuplicateMap(nodes),
       expansionCountsByNode: computeExpansionCountsMap(edges),
-    });
+      restoreToken: s.restoreToken + 1,
+    }));
   },
 
   appendWorkspace: (saved: SavedCanvas) => {


### PR DESCRIPTION
## Summary

- `useActivityTracker` diffed raw `nodes.length`/`edges.length` against refs initialized to 0, with no way to distinguish a genuine addition from the store being repopulated by a restore (localStorage reload, share link). Reloading `/canvas` or opening a share link for an existing multi-node canvas fired `verse_added`/`connection_made` activity events — and could bump the streak — purely from loading a page.
- Added a `restoreToken` to the canvas store, bumped atomically with the node/edge counts inside `restoreCanvas`. The tracker treats a token change as a new baseline instead of activity, so it's immune to effect-ordering/timing races between the persistence hook and the tracker.
- Also seeded the tracker's baseline refs from the store's *current* counts at mount (not hardcoded 0), so verses added before navigating to `/canvas` (e.g. "Open on canvas" from a story page) aren't miscounted as activity either.

Closes #374

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (on changed files)
- [x] New tests added — `__tests__/hooks/useActivityTracker.test.ts` covers: no POST on `restoreCanvas`, no POST for nodes already present at mount, POST fires for a genuine add while mounted, and activity resumes correctly after a restore. Verified 3 of 4 tests fail against the pre-fix code.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A
- [x] `README.md` updated if the feature changes the public interface — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented restored or appended canvas content from being incorrectly counted as new activity.
  * Activity tracking now accurately distinguishes genuine node additions from bulk restoration actions.

* **Tests**
  * Added coverage for canvas restoration, workspace appending, initial tracking state, and legitimate activity reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->