### PR TITLE
fix(canvas): move first-visit tour to top-right so it doesn't overlap the legend

### DIFF
--- a/__tests__/components/canvas/CanvasTour.test.tsx
+++ b/__tests__/components/canvas/CanvasTour.test.tsx
@@ -49,4 +49,15 @@ describe("CanvasTour", () => {
 
     document.body.removeChild(outside);
   });
+
+  it("positions in the top-right on desktop, not bottom-left where the canvas legend sits", async () => {
+    renderWithIntl(<CanvasTour />);
+    const dialog = await screen.findByRole("dialog");
+    const container = dialog.parentElement;
+
+    expect(container?.className).toMatch(/md:right-6/);
+    expect(container?.className).toMatch(/md:top-6/);
+    expect(container?.className).not.toMatch(/md:bottom-6/);
+    expect(container?.className).not.toMatch(/md:left-6/);
+  });
 });

--- a/__tests__/components/canvas/CanvasTour.test.tsx
+++ b/__tests__/components/canvas/CanvasTour.test.tsx
@@ -50,14 +50,14 @@ describe("CanvasTour", () => {
     document.body.removeChild(outside);
   });
 
-  it("positions in the top-right on desktop, not bottom-left where the canvas legend sits", async () => {
+  it("positions in the top-left on desktop, clear of the legend (bottom-left) and context sidebar (right edge)", async () => {
     renderWithIntl(<CanvasTour />);
     const dialog = await screen.findByRole("dialog");
     const container = dialog.parentElement;
 
-    expect(container?.className).toMatch(/md:right-6/);
+    expect(container?.className).toMatch(/md:left-6/);
     expect(container?.className).toMatch(/md:top-6/);
     expect(container?.className).not.toMatch(/md:bottom-6/);
-    expect(container?.className).not.toMatch(/md:left-6/);
+    expect(container?.className).not.toMatch(/md:right-6/);
   });
 });

--- a/components/canvas/CanvasTour.tsx
+++ b/components/canvas/CanvasTour.tsx
@@ -64,7 +64,7 @@ export function CanvasTour() {
   const isLast = step === STEPS.length - 1;
 
   return (
-    <div className="pointer-events-none absolute bottom-[calc(70px+env(safe-area-inset-bottom))] left-1/2 z-50 w-[min(360px,calc(100vw-2rem))] -translate-x-1/2 md:bottom-auto md:left-auto md:right-6 md:top-6 md:translate-x-0">
+    <div className="pointer-events-none absolute bottom-[calc(70px+env(safe-area-inset-bottom))] left-1/2 z-50 w-[min(360px,calc(100vw-2rem))] -translate-x-1/2 md:bottom-auto md:left-6 md:top-6 md:translate-x-0">
       <FocusScope
         asChild
         trapped

--- a/components/canvas/CanvasTour.tsx
+++ b/components/canvas/CanvasTour.tsx
@@ -64,7 +64,7 @@ export function CanvasTour() {
   const isLast = step === STEPS.length - 1;
 
   return (
-    <div className="pointer-events-none absolute bottom-[calc(70px+env(safe-area-inset-bottom))] left-1/2 z-50 w-[min(360px,calc(100vw-2rem))] -translate-x-1/2 md:bottom-6 md:left-6 md:translate-x-0">
+    <div className="pointer-events-none absolute bottom-[calc(70px+env(safe-area-inset-bottom))] left-1/2 z-50 w-[min(360px,calc(100vw-2rem))] -translate-x-1/2 md:bottom-auto md:left-auto md:right-6 md:top-6 md:translate-x-0">
       <FocusScope
         asChild
         trapped


### PR DESCRIPTION
## Summary

On desktop, the first-visit onboarding tour card (`CanvasTour`) was anchored `bottom-6 left-6`, the same corner as the connection-kind legend panel (`CanvasLegend`, rendered via `<Panel position="bottom-left">`). Since the legend only renders once `nodes.length > 0`, a new visitor who adds their first verse during the tour would see the tour card overlapping the legend.

## Fix

Moved the tour's desktop anchor to `top-right` (`md:right-6 md:top-6`), a corner nothing else occupies (the minimap defaults to bottom-right but the tour no longer competes with it since they're on different rows). The mobile position (bottom-center, above the mobile toolbar) is unchanged — the legend is hidden below the `sm` breakpoint (`hidden ... sm:flex`), so there's no overlap on mobile to begin with.

## Testing

Added a test asserting the container's desktop classes place it top-right (`md:right-6`, `md:top-6`) and not bottom-left (`md:bottom-6`, `md:left-6`). Verified the new test fails against the pre-fix code and passes with the fix. Full suite (`bun run test:ci`), lint, and typecheck all pass.

Closes #375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Repositioned the Canvas tour on desktop from the lower-left corner to the upper-right.
  * Preserved the existing mobile placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->