### PR TITLE
fix(canvas): use a distinct icon for the export-failed indicator

### DIFF
--- a/__tests__/components/layout/Header.mobile-bar.test.tsx
+++ b/__tests__/components/layout/Header.mobile-bar.test.tsx
@@ -1,0 +1,49 @@
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/canvas",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+import { Header } from "@/components/layout/Header";
+import { useCanvasStore } from "@/store/canvas";
+import * as canvasExport from "@/lib/canvas/canvas-export";
+import type { Verse } from "@/types/quran";
+
+const baseVerse: Verse = {
+  surah: 2,
+  ayah: 255,
+  ref: "2:255",
+  arabicText: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ",
+  translation: "Allah — there is no deity except Him.",
+  surahName: "Al-Baqarah",
+  surahNameArabic: "البقرة",
+};
+
+beforeEach(() => {
+  useCanvasStore.getState().reset();
+  useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+});
+
+describe("Header mobile bar — export-failed vs. clear icon", () => {
+  it("uses a distinct icon for the export-failed indicator, not the same one as Clear", async () => {
+    vi.spyOn(canvasExport, "exportCanvasToPng").mockRejectedValue(new Error("export failed"));
+
+    renderWithIntl(<Header onSearchOpen={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    fireEvent.click(screen.getByRole("button", { name: "Export as PNG" }));
+
+    const failedButton = await screen.findByRole("button", { name: "Failed" });
+    const clearButton = screen.getByRole("button", { name: "Clear" });
+
+    const failedIconSvg = failedButton.querySelector("svg")?.innerHTML;
+    const clearIconSvg = clearButton.querySelector("svg")?.innerHTML;
+
+    expect(failedIconSvg).toBeTruthy();
+    expect(clearIconSvg).toBeTruthy();
+    expect(failedIconSvg).not.toBe(clearIconSvg);
+  });
+});

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -381,7 +381,7 @@ export function Header({ onSearchOpen }: HeaderProps) {
             />
             <BarButton
               ref={moreButtonRef}
-              icon={exportError ? <RotateCcw /> : <MoreHorizontal />}
+              icon={exportError ? <AlertCircle /> : <MoreHorizontal />}
               label={exportError ? t("exportFailed") : t("more")}
               onClick={() => setMoreOpen((v) => !v)}
               active={moreOpen}


### PR DESCRIPTION
## Summary

On the mobile bottom bar, the "export failed" state (shown on the More button after a failed export) and the always-present Clear button both used the `RotateCcw` icon, distinguished only by small text labels. Since Clear is an irreversible destructive action and the export-failed indicator is a harmless retry affordance, this was a real mis-tap risk on mobile.

## Fix

The export-failed indicator now uses `AlertCircle` — the icon already used elsewhere in this file (`components/layout/Header.tsx:134`) for the equivalent save-failed state — instead of reusing Clear's icon.

## Testing

Added `__tests__/components/layout/Header.mobile-bar.test.tsx`, which renders `Header` with a canvas node present, mocks `exportCanvasToPng` to reject, triggers the export, and asserts the resulting "Failed" button's icon SVG differs from the Clear button's icon SVG. Verified the test fails against the pre-fix code (both icons identical) and passes with the fix. Full suite, lint, and typecheck all pass.

Closes #376