### PR TITLE
fix(a11y): trap focus, handle Escape, and fix tab order in mobile More sheet

### DIFF
--- a/__tests__/components/layout/Header.more-sheet-a11y.test.tsx
+++ b/__tests__/components/layout/Header.more-sheet-a11y.test.tsx
@@ -1,0 +1,74 @@
+import { screen, fireEvent, act } from "@testing-library/react";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/canvas",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+import { Header } from "@/components/layout/Header";
+import { useCanvasStore } from "@/store/canvas";
+import type { Verse } from "@/types/quran";
+
+const baseVerse: Verse = {
+  surah: 2,
+  ayah: 255,
+  ref: "2:255",
+  arabicText: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ",
+  translation: "Allah — there is no deity except Him.",
+  surahName: "Al-Baqarah",
+  surahNameArabic: "البقرة",
+};
+
+beforeEach(() => {
+  useCanvasStore.getState().reset();
+  useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+});
+
+describe("Header mobile More sheet — keyboard accessibility", () => {
+  it("moves focus into the sheet when it opens", async () => {
+    renderWithIntl(<Header onSearchOpen={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    const pngButton = await screen.findByRole("button", { name: "Export as PNG" });
+    expect(document.activeElement).toBe(pngButton);
+  });
+
+  it("traps Tab within the sheet, wrapping from the last control back to the first instead of leaking to the bar behind it", async () => {
+    renderWithIntl(<Header onSearchOpen={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    const pngButton = await screen.findByRole("button", { name: "Export as PNG" });
+    const pdfButton = screen.getByRole("button", { name: "Export as PDF" });
+
+    await act(async () => {
+      pdfButton.focus();
+    });
+    fireEvent.keyDown(pdfButton, { key: "Tab" });
+    expect(document.activeElement).toBe(pngButton);
+
+    fireEvent.keyDown(pngButton, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(pdfButton);
+  });
+
+  it("closes on Escape and returns focus to the More trigger", async () => {
+    renderWithIntl(<Header onSearchOpen={() => {}} />);
+
+    const trigger = screen.getByRole("button", { name: "More" });
+    await act(async () => {
+      trigger.focus();
+    });
+    fireEvent.click(trigger);
+    await screen.findByRole("button", { name: "Export as PNG" });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("button", { name: "Export as PNG" })).not.toBeInTheDocument();
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+});

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -14,6 +14,7 @@ import {
   Check,
   AlertCircle,
 } from "lucide-react";
+import { FocusScope } from "@radix-ui/react-focus-scope";
 import { useTranslations, useFormatter } from "next-intl";
 import { useCanvasStore, serializeCanvas } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
@@ -115,62 +116,77 @@ function MoreSheet({
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [onClose, triggerRef]);
 
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   return (
-    <div
-      ref={sheetRef}
-      className="fixed inset-x-3 bottom-[calc(58px+env(safe-area-inset-bottom)+8px)] z-50 rounded-lg border border-border bg-surface-overlay shadow-floating md:hidden"
-    >
-      {onSave && (
+    <FocusScope asChild trapped loop>
+      <div
+        ref={sheetRef}
+        className="fixed inset-x-3 bottom-[calc(58px+env(safe-area-inset-bottom)+8px)] z-50 rounded-lg border border-border bg-surface-overlay shadow-floating md:hidden"
+      >
+        {onSave && (
+          <button
+            onClick={onSave}
+            disabled={saving || !canSave}
+            className="flex w-full items-center gap-2.5 px-4 py-3 text-left disabled:opacity-40"
+          >
+            {saving ? (
+              <Loader2 className="h-4 w-4 shrink-0 animate-spin text-text-muted" />
+            ) : saved ? (
+              <Check className="h-4 w-4 shrink-0 text-teal" />
+            ) : saveError ? (
+              <AlertCircle className="h-4 w-4 shrink-0 text-error" />
+            ) : (
+              <Save className="h-4 w-4 shrink-0 text-text-muted" />
+            )}
+            <span
+              className={cn("text-sm font-medium text-text-primary", saveError && "text-error")}
+            >
+              {saving
+                ? t("saving")
+                : saved
+                  ? t("saved")
+                  : saveError
+                    ? t("saveFailedRetry")
+                    : t("saveWorkspace")}
+            </span>
+          </button>
+        )}
         <button
-          onClick={onSave}
-          disabled={saving || !canSave}
+          onClick={() => onExport("png")}
+          disabled={exporting}
           className="flex w-full items-center gap-2.5 px-4 py-3 text-left disabled:opacity-40"
         >
-          {saving ? (
-            <Loader2 className="h-4 w-4 shrink-0 animate-spin text-text-muted" />
-          ) : saved ? (
-            <Check className="h-4 w-4 shrink-0 text-teal" />
-          ) : saveError ? (
-            <AlertCircle className="h-4 w-4 shrink-0 text-error" />
-          ) : (
-            <Save className="h-4 w-4 shrink-0 text-text-muted" />
-          )}
-          <span className={cn("text-sm font-medium text-text-primary", saveError && "text-error")}>
-            {saving
-              ? t("saving")
-              : saved
-                ? t("saved")
-                : saveError
-                  ? t("saveFailedRetry")
-                  : t("saveWorkspace")}
-          </span>
+          <ImageIcon className="h-4 w-4 shrink-0 text-text-muted" />
+          <span className="text-sm font-medium text-text-primary">{t("exportAsPng")}</span>
         </button>
-      )}
-      <button
-        onClick={() => onExport("png")}
-        disabled={exporting}
-        className="flex w-full items-center gap-2.5 px-4 py-3 text-left disabled:opacity-40"
-      >
-        <ImageIcon className="h-4 w-4 shrink-0 text-text-muted" />
-        <span className="text-sm font-medium text-text-primary">{t("exportAsPng")}</span>
-      </button>
-      <button
-        onClick={() => onExport("pdf")}
-        disabled={exporting}
-        className="flex w-full items-center gap-2.5 px-4 py-3 text-left disabled:opacity-40"
-      >
-        <FileText className="h-4 w-4 shrink-0 text-text-muted" />
-        <span className="text-sm font-medium text-text-primary">{t("exportAsPdf")}</span>
-      </button>
-      <div className="flex items-center gap-3 border-t border-border-subtle px-4 py-3">
-        {CANVAS_LEGEND_ITEMS.map((item) => (
-          <div key={item.key} className="flex items-center gap-1.5">
-            <span className={`h-0.5 w-3.5 rounded-full ${item.className}`} />
-            <span className="text-[11px] text-text-secondary">{t(item.key)}</span>
-          </div>
-        ))}
+        <button
+          onClick={() => onExport("pdf")}
+          disabled={exporting}
+          className="flex w-full items-center gap-2.5 px-4 py-3 text-left disabled:opacity-40"
+        >
+          <FileText className="h-4 w-4 shrink-0 text-text-muted" />
+          <span className="text-sm font-medium text-text-primary">{t("exportAsPdf")}</span>
+        </button>
+        <div className="flex items-center gap-3 border-t border-border-subtle px-4 py-3">
+          {CANVAS_LEGEND_ITEMS.map((item) => (
+            <div key={item.key} className="flex items-center gap-1.5">
+              <span className={`h-0.5 w-3.5 rounded-full ${item.className}`} />
+              <span className="text-[11px] text-text-secondary">{t(item.key)}</span>
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+    </FocusScope>
   );
 }
 
@@ -350,19 +366,6 @@ export function Header({ onSearchOpen }: HeaderProps) {
       {/* Mobile: bottom action bar — primary canvas actions (<md, only with nodes) */}
       {nodeCount > 0 && (
         <>
-          {moreOpen && (
-            <MoreSheet
-              onClose={() => setMoreOpen(false)}
-              onExport={handleExport}
-              exporting={exporting}
-              onSave={accessToken ? handleSave : null}
-              saving={saving}
-              saved={saved}
-              saveError={saveError}
-              canSave={nodes.length > 0}
-              triggerRef={moreButtonRef}
-            />
-          )}
           <div className="fixed inset-x-0 bottom-0 z-40 flex md:hidden bg-surface/95 backdrop-blur border-t border-border pb-[env(safe-area-inset-bottom)]">
             <BarButton icon={<Search />} label={t("toolbarSearch")} onClick={onSearchOpen} />
             <BarButton icon={<Maximize2 />} label={t("fit")} onClick={requestFit} />
@@ -388,6 +391,19 @@ export function Header({ onSearchOpen }: HeaderProps) {
             />
             <BarButton icon={<RotateCcw />} label={t("clear")} onClick={reset} danger />
           </div>
+          {moreOpen && (
+            <MoreSheet
+              onClose={() => setMoreOpen(false)}
+              onExport={handleExport}
+              exporting={exporting}
+              onSave={accessToken ? handleSave : null}
+              saving={saving}
+              saved={saved}
+              saveError={saveError}
+              canSave={nodes.length > 0}
+              triggerRef={moreButtonRef}
+            />
+          )}
         </>
       )}
     </>


### PR DESCRIPTION
## Summary

The mobile header's "More" sheet (Save/Export PNG/Export PDF) had no focus trap, no Escape handling, and was positioned before the bottom action bar in the JSX — putting its buttons behind the "More" trigger in DOM/tab order. A keyboard user who Tabbed to "More" and activated it with Enter/Space could not then Tab forward into the sheet, and had no way to close it via keyboard.

## Fix

Adopted the same Radix `FocusScope trapped loop` pattern already used by `ExpandMenu`, `ExportMenu`, and `CanvasTour` in this codebase:
- Wrapped the sheet in `FocusScope`, moving focus into it on open (Radix's default auto-focus of the first tabbable element) and returning focus to the trigger on close.
- Added an `Escape` keydown handler matching `ExportMenu`'s existing pattern.
- Moved the sheet's JSX after the bottom bar so it no longer sits ahead of its own trigger in document order.

## Testing

Added `__tests__/components/layout/Header.more-sheet-a11y.test.tsx`, covering: focus moves into the sheet on open; Tab traps/loops within the sheet (doesn't leak to the bar behind it); Escape closes the sheet and returns focus to the trigger. Verified all three fail against the pre-fix code and pass with the fix. Full suite, lint, and typecheck all pass.

Closes #377