### PR TITLE
fix(a11y): give the friend-select in "New challenge" a programmatic label

### DIFF
--- a/__tests__/components/social/CreateChallengeForm.test.tsx
+++ b/__tests__/components/social/CreateChallengeForm.test.tsx
@@ -1,0 +1,21 @@
+import { screen } from "@testing-library/react";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+import { describe, expect, it } from "vitest";
+import { CreateChallengeForm } from "@/components/social/CreateChallengeForm";
+
+const friends = [
+  { id: 1, username: "alice" },
+  { id: 2, username: "bob" },
+];
+
+describe("CreateChallengeForm — friend select accessible label", () => {
+  it("gives the friend select a programmatic accessible name in the full layout", () => {
+    renderWithIntl(<CreateChallengeForm friends={friends} onCreated={() => {}} />);
+    expect(screen.getByRole("combobox", { name: "Choose a friend" })).toBeInTheDocument();
+  });
+
+  it("gives the friend select a programmatic accessible name in the compact layout", () => {
+    renderWithIntl(<CreateChallengeForm friends={friends} onCreated={() => {}} compact />);
+    expect(screen.getByRole("combobox", { name: "Choose a friend" })).toBeInTheDocument();
+  });
+});

--- a/components/social/CreateChallengeForm.tsx
+++ b/components/social/CreateChallengeForm.tsx
@@ -153,6 +153,7 @@ export function CreateChallengeForm({
           {prefillChip}
           <form onSubmit={handleSubmit} className="flex flex-wrap items-center gap-2">
             <select
+              aria-label="Choose a friend"
               value={selectedFriend}
               onChange={(e) => {
                 setSelectedFriend(e.target.value);
@@ -218,6 +219,7 @@ export function CreateChallengeForm({
         {prefillChip}
 
         <select
+          aria-label="Choose a friend"
           value={selectedFriend}
           onChange={(e) => {
             setSelectedFriend(e.target.value);


### PR DESCRIPTION
## Summary

The `<select>` used to choose a friend when creating a challenge (both the compact and full form layouts in `components/social/CreateChallengeForm.tsx`) had no `<label htmlFor>`, `aria-label`, or `aria-labelledby`. A disabled placeholder `<option>` isn't exposed as an accessible name for the control, so screen-reader users heard only "combo box" — an inconsistency against every other field on this form, which is labeled.

## Fix

Added `aria-label="Choose a friend"` to both `<select>` elements.

## Testing

Added `__tests__/components/social/CreateChallengeForm.test.tsx`, asserting `getByRole("combobox", { name: "Choose a friend" })` resolves in both the compact and full layouts. Verified both assertions fail against the pre-fix code and pass with the fix. Full suite, lint, and typecheck all pass.

Closes #378