### PR TITLE
fix(admin): guard Challenge Suggestions form against duplicate writes

### DIFF
--- a/__tests__/components/admin/ChallengeSuggestionsManager.test.tsx
+++ b/__tests__/components/admin/ChallengeSuggestionsManager.test.tsx
@@ -43,9 +43,8 @@ describe("ChallengeSuggestionsManager — duplicate-request guards", () => {
     render(<ChallengeSuggestionsManager />);
     await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1));
 
-    fireEvent.change(screen.getByPlaceholderText("e.g. A week of patience"), {
-      target: { value: "New suggestion" },
-    });
+    const titleInput = screen.getByPlaceholderText("e.g. A week of patience");
+    fireEvent.change(titleInput, { target: { value: "New suggestion" } });
 
     const createButton = screen.getByRole("button", { name: "Create" });
     fireEvent.click(createButton);
@@ -53,7 +52,12 @@ describe("ChallengeSuggestionsManager — duplicate-request guards", () => {
     fireEvent.click(createButton);
 
     expect(mockApi).toHaveBeenCalledTimes(2); // initial load + exactly one POST
+
+    mockApi.mockResolvedValueOnce({ suggestions: [] }); // the reload() triggered after save
     save.resolve({});
+
+    // Settled: save() reset the form and re-enabled the (now-empty) input.
+    await waitFor(() => expect(titleInput).toHaveValue(""));
   });
 
   it("guards a row's toggle against a duplicate PUT on rapid double-click", async () => {
@@ -72,7 +76,12 @@ describe("ChallengeSuggestionsManager — duplicate-request guards", () => {
     fireEvent.click(toggleButton);
 
     expect(mockApi).toHaveBeenCalledTimes(2); // initial load + exactly one PUT
+
+    mockApi.mockResolvedValueOnce({ suggestions: [suggestion] }); // the reload() triggered after the PUT
     toggle.resolve({});
+
+    // Settled: busyId cleared, so the toggle can be clicked again.
+    await waitFor(() => expect(toggleButton).not.toBeDisabled());
   });
 
   it("disables Edit/Delete for other rows while one row's action is in flight", async () => {
@@ -88,9 +97,16 @@ describe("ChallengeSuggestionsManager — duplicate-request guards", () => {
     });
     fireEvent.click(toggleButton);
 
-    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
+    const editButton = screen.getByRole("button", { name: "Edit" });
+    const deleteButton = screen.getByRole("button", { name: "Delete" });
+    expect(editButton).toBeDisabled();
+    expect(deleteButton).toBeDisabled();
 
+    mockApi.mockResolvedValueOnce({ suggestions: [suggestion] }); // the reload() triggered after the PUT
     toggle.resolve({});
+
+    // Settled: busyId cleared, so the other row's controls are usable again.
+    await waitFor(() => expect(editButton).not.toBeDisabled());
+    expect(deleteButton).not.toBeDisabled();
   });
 });

--- a/__tests__/components/admin/ChallengeSuggestionsManager.test.tsx
+++ b/__tests__/components/admin/ChallengeSuggestionsManager.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const suggestion = {
+  id: 1,
+  title: "A week of patience",
+  description: null,
+  verseRef: "2:155",
+  suggestedDuration: "7d",
+  isActive: true,
+  sortOrder: 0,
+};
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const mockApi = vi.fn();
+vi.mock("@/components/admin/AdminContext", async () => {
+  const actual = await vi.importActual("@/components/admin/AdminContext");
+  return {
+    ...actual,
+    useAdminFetch: () => mockApi,
+  };
+});
+
+import { ChallengeSuggestionsManager } from "@/components/admin/ChallengeSuggestionsManager";
+
+describe("ChallengeSuggestionsManager — duplicate-request guards", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+  });
+
+  it("guards Create against a duplicate POST on rapid double-click", async () => {
+    mockApi.mockResolvedValueOnce({ suggestions: [] }); // initial load
+    const save = deferred<unknown>();
+    mockApi.mockReturnValueOnce(save.promise); // the POST itself
+
+    render(<ChallengeSuggestionsManager />);
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. A week of patience"), {
+      target: { value: "New suggestion" },
+    });
+
+    const createButton = screen.getByRole("button", { name: "Create" });
+    fireEvent.click(createButton);
+    fireEvent.click(createButton);
+    fireEvent.click(createButton);
+
+    expect(mockApi).toHaveBeenCalledTimes(2); // initial load + exactly one POST
+    save.resolve({});
+  });
+
+  it("guards a row's toggle against a duplicate PUT on rapid double-click", async () => {
+    mockApi.mockResolvedValueOnce({ suggestions: [suggestion] }); // initial load
+    const toggle = deferred<unknown>();
+    mockApi.mockReturnValueOnce(toggle.promise); // the PUT itself
+
+    render(<ChallengeSuggestionsManager />);
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1));
+
+    const toggleButton = await screen.findByRole("button", {
+      name: 'Deactivate suggestion "A week of patience"',
+    });
+    fireEvent.click(toggleButton);
+    fireEvent.click(toggleButton);
+    fireEvent.click(toggleButton);
+
+    expect(mockApi).toHaveBeenCalledTimes(2); // initial load + exactly one PUT
+    toggle.resolve({});
+  });
+
+  it("disables Edit/Delete for other rows while one row's action is in flight", async () => {
+    mockApi.mockResolvedValueOnce({ suggestions: [suggestion] }); // initial load
+    const toggle = deferred<unknown>();
+    mockApi.mockReturnValueOnce(toggle.promise); // the PUT itself
+
+    render(<ChallengeSuggestionsManager />);
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1));
+
+    const toggleButton = await screen.findByRole("button", {
+      name: 'Deactivate suggestion "A week of patience"',
+    });
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
+
+    toggle.resolve({});
+  });
+});

--- a/components/admin/ChallengeSuggestionsManager.tsx
+++ b/components/admin/ChallengeSuggestionsManager.tsx
@@ -43,9 +43,12 @@ export function ChallengeSuggestionsManager() {
 
   const editing = form.id !== null;
   const reset = () => setForm({ ...EMPTY });
+  // One request in flight at a time — save and row actions (toggle/remove)
+  // must not overlap, so guard and disable both against this single condition.
+  const busy = saving || busyId !== null;
 
   const save = async () => {
-    if (saving) return;
+    if (busy) return;
     setSaving(true);
     setMsg(null);
     const payload = {
@@ -80,7 +83,7 @@ export function ChallengeSuggestionsManager() {
     });
 
   const remove = async (id: number) => {
-    if (busyId !== null) return;
+    if (busy) return;
     setBusyId(id);
     setMsg(null);
     try {
@@ -95,7 +98,7 @@ export function ChallengeSuggestionsManager() {
   };
 
   const toggleActive = async (s: Suggestion) => {
-    if (busyId !== null) return;
+    if (busy) return;
     setBusyId(s.id);
     setMsg(null);
     try {
@@ -188,11 +191,11 @@ export function ChallengeSuggestionsManager() {
           </label>
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="primary" onClick={save} disabled={saving || !form.title.trim()}>
+          <Button variant="primary" onClick={save} disabled={busy || !form.title.trim()}>
             {editing ? "Update" : "Create"}
           </Button>
           {editing && (
-            <Button variant="ghost" onClick={reset} disabled={saving}>
+            <Button variant="ghost" onClick={reset} disabled={busy}>
               Cancel
             </Button>
           )}
@@ -224,7 +227,7 @@ export function ChallengeSuggestionsManager() {
                 <Td>
                   <button
                     onClick={() => toggleActive(s)}
-                    disabled={busyId !== null}
+                    disabled={busy}
                     aria-label={`${s.isActive ? "Deactivate" : "Activate"} suggestion "${s.title}"`}
                     className="disabled:opacity-50"
                   >
@@ -235,17 +238,12 @@ export function ChallengeSuggestionsManager() {
                 </Td>
                 <Td>
                   <div className="flex justify-end gap-1.5">
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={() => edit(s)}
-                      disabled={busyId !== null}
-                    >
+                    <Button size="sm" variant="secondary" onClick={() => edit(s)} disabled={busy}>
                       Edit
                     </Button>
                     <ConfirmButton
                       onConfirm={() => remove(s.id)}
-                      disabled={busyId !== null}
+                      disabled={busy}
                       confirmLabel="Delete?"
                     >
                       Delete

--- a/components/admin/ChallengeSuggestionsManager.tsx
+++ b/components/admin/ChallengeSuggestionsManager.tsx
@@ -36,11 +36,17 @@ export function ChallengeSuggestionsManager() {
   );
   const [form, setForm] = useState({ ...EMPTY });
   const [msg, setMsg] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  // Id of the suggestion currently being toggled/removed — blocks overlapping
+  // row actions so a double-click can't fire duplicate PUT/DELETE requests.
+  const [busyId, setBusyId] = useState<number | null>(null);
 
   const editing = form.id !== null;
   const reset = () => setForm({ ...EMPTY });
 
   const save = async () => {
+    if (saving) return;
+    setSaving(true);
     setMsg(null);
     const payload = {
       ...(editing ? { id: form.id } : {}),
@@ -57,6 +63,8 @@ export function ChallengeSuggestionsManager() {
       reload();
     } catch (e) {
       setMsg(e instanceof AdminApiError ? e.message : "Save failed.");
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -72,6 +80,8 @@ export function ChallengeSuggestionsManager() {
     });
 
   const remove = async (id: number) => {
+    if (busyId !== null) return;
+    setBusyId(id);
     setMsg(null);
     try {
       await api(`/challenge-suggestions?id=${id}`, { method: "DELETE" });
@@ -79,10 +89,14 @@ export function ChallengeSuggestionsManager() {
       reload();
     } catch (e) {
       setMsg(e instanceof AdminApiError ? e.message : "Delete failed.");
+    } finally {
+      setBusyId(null);
     }
   };
 
   const toggleActive = async (s: Suggestion) => {
+    if (busyId !== null) return;
+    setBusyId(s.id);
     setMsg(null);
     try {
       await api("/challenge-suggestions", {
@@ -100,6 +114,8 @@ export function ChallengeSuggestionsManager() {
       reload();
     } catch (e) {
       setMsg(e instanceof AdminApiError ? e.message : "Update failed.");
+    } finally {
+      setBusyId(null);
     }
   };
 
@@ -172,11 +188,11 @@ export function ChallengeSuggestionsManager() {
           </label>
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="primary" onClick={save} disabled={!form.title.trim()}>
+          <Button variant="primary" onClick={save} disabled={saving || !form.title.trim()}>
             {editing ? "Update" : "Create"}
           </Button>
           {editing && (
-            <Button variant="ghost" onClick={reset}>
+            <Button variant="ghost" onClick={reset} disabled={saving}>
               Cancel
             </Button>
           )}
@@ -208,7 +224,9 @@ export function ChallengeSuggestionsManager() {
                 <Td>
                   <button
                     onClick={() => toggleActive(s)}
+                    disabled={busyId !== null}
                     aria-label={`${s.isActive ? "Deactivate" : "Activate"} suggestion "${s.title}"`}
+                    className="disabled:opacity-50"
                   >
                     <Pill tone={s.isActive ? "active" : "retired"}>
                       {s.isActive ? "on" : "off"}
@@ -217,10 +235,19 @@ export function ChallengeSuggestionsManager() {
                 </Td>
                 <Td>
                   <div className="flex justify-end gap-1.5">
-                    <Button size="sm" variant="secondary" onClick={() => edit(s)}>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => edit(s)}
+                      disabled={busyId !== null}
+                    >
                       Edit
                     </Button>
-                    <ConfirmButton onConfirm={() => remove(s.id)} confirmLabel="Delete?">
+                    <ConfirmButton
+                      onConfirm={() => remove(s.id)}
+                      disabled={busyId !== null}
+                      confirmLabel="Delete?"
+                    >
                       Delete
                     </ConfirmButton>
                   </div>


### PR DESCRIPTION
## Summary

`ChallengeSuggestionsManager`'s `save()`, `toggleActive()`, and `remove()` performed async POST/PUT/DELETE requests with no in-flight state anywhere in the component. The Create/Update button was only disabled by an empty title, not by a request in flight, and the per-row toggle/edit/delete controls had no busy guard at all — a double-click (or slow connection) could fire duplicate requests, creating duplicate suggestions or firing overlapping PUT/DELETE calls.

## Fix

Added a `saving` flag guarding `save()` and disabling the Create/Update/Cancel buttons while a request is in flight, and a `busyId` (the suggestion currently being toggled/removed) guarding `toggleActive()`/`remove()` and disabling the toggle/Edit/Delete controls for all rows while any row action is in flight — matching the `busy` pattern already used in `app/admin/votd/page.tsx`.

## Testing

Added `__tests__/components/admin/ChallengeSuggestionsManager.test.tsx` with a mocked `useAdminFetch` and a deferred (controllable) promise for the in-flight request, covering: rapid double-click on Create only fires one POST; rapid double-click on a row's toggle only fires one PUT; Edit/Delete are disabled on other rows while one row's action is in flight. Verified all three fail against the pre-fix code and pass with the fix. Full suite, lint, and typecheck all pass.

Closes #380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate create, update, delete, and activation requests from rapid repeated clicks.
  * Disabled related controls while an action is processing, reducing accidental overlapping changes.
  * Added clearer disabled-state styling for activation controls.

* **Tests**
  * Added coverage for duplicate-request protection and disabling actions across affected rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->