### PR TITLE
fix(search): abort the result-select fetch when the dialog closes

### DIFF
--- a/__tests__/components/search/SearchDialog.select-abort.test.tsx
+++ b/__tests__/components/search/SearchDialog.select-abort.test.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+import type { Verse, SearchResult, SearchResponse } from "@/types/quran";
+
+vi.mock("@xyflow/react", () => ({
+  applyNodeChanges: vi.fn((changes: unknown[], nodes: unknown[]) => nodes),
+  applyEdgeChanges: vi.fn((changes: unknown[], edges: unknown[]) => edges),
+}));
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+import { useCanvasStore } from "@/store/canvas";
+import { SearchDialog } from "@/components/search/SearchDialog";
+
+const VERSE_TEXT: Record<string, { arabic: string; translation: string }> = {
+  "2:1": { arabic: "الم", translation: "Alif, Lam, Meem." },
+  "2:2": {
+    arabic: "ذَٰلِكَ الْكِتَابُ لَا رَيْبَ ۛ فِيهِ ۛ هُدًى لِّلْمُتَّقِينَ",
+    translation:
+      "This is the Book about which there is no doubt, a guidance for those conscious of Allah -",
+  },
+};
+
+function makeResult(ref: string, surahName: string): SearchResult {
+  const text = VERSE_TEXT[ref];
+  return {
+    ref: ref as SearchResult["ref"],
+    surahName,
+    surahNameArabic: "سورة البقرة",
+    snippet: text.translation,
+    arabicText: text.arabic,
+    translation: text.translation,
+  };
+}
+
+function makeVerse(ref: string): Verse {
+  const [s, a] = ref.split(":");
+  const text = VERSE_TEXT[ref];
+  return {
+    surah: Number(s),
+    ayah: Number(a),
+    ref: ref as Verse["ref"],
+    arabicText: text.arabic,
+    translation: text.translation,
+    surahName: "Al-Baqarah",
+    surahNameArabic: "سورة البقرة",
+  };
+}
+
+function DialogHarness() {
+  const [open, setOpen] = useState(true);
+  return <SearchDialog open={open} onClose={() => setOpen(false)} />;
+}
+
+describe("SearchDialog — result-select fetch aborted on close", () => {
+  const results = [makeResult("2:1", "Al-Baqarah"), makeResult("2:2", "Al-Baqarah")];
+
+  beforeEach(() => {
+    useCanvasStore.getState().reset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not add a canvas node if the dialog closes before the selected result's fetch resolves", async () => {
+    // Simulates the network genuinely completing sometime after the user acts —
+    // whether that "arrival" wins the race against an abort depends on whether
+    // the fetch call was wired with the AbortSignal (the fix under test).
+    const settle: { withVerse: (() => void) | null } = { withVerse: null };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.startsWith("/api/search")) {
+          const body: SearchResponse = { results, total: results.length, page: 1, pageSize: 10 };
+          return { ok: true, json: async () => body, headers: new Headers() } as Response;
+        }
+        if (url.startsWith("/api/verse/2/1")) {
+          const signal = init?.signal;
+          return new Promise<Response>((resolve, reject) => {
+            settle.withVerse = () =>
+              resolve({ ok: true, json: async () => makeVerse("2:1") } as Response);
+            signal?.addEventListener("abort", () =>
+              reject(new DOMException("Aborted", "AbortError"))
+            );
+          });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      })
+    );
+
+    renderWithIntl(<DialogHarness />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "guidance" } });
+    await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(2), { timeout: 2000 });
+
+    fireEvent.click(screen.getAllByRole("option")[0]);
+
+    // Close the dialog (Escape) before the /api/verse fetch resolves.
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    // The network request "arrives" only now — after the close. With the fix,
+    // it was already aborted (rejected) by this point, so this is a no-op.
+    settle.withVerse?.();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(useCanvasStore.getState().nodes).toHaveLength(0);
+  });
+});

--- a/__tests__/components/search/SearchDialog.select-abort.test.tsx
+++ b/__tests__/components/search/SearchDialog.select-abort.test.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { NextIntlClientProvider } from "next-intl";
+import en from "@/messages/en.json";
 import { renderWithIntl } from "../../test-utils/render-with-intl";
 import type { Verse, SearchResult, SearchResponse } from "@/types/quran";
 
@@ -14,6 +16,7 @@ vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 import { useCanvasStore } from "@/store/canvas";
 import { SearchDialog } from "@/components/search/SearchDialog";
 
+// en.sahih (Saheeh International, alquran.cloud) — Al-Baqarah 2:1-2.
 const VERSE_TEXT: Record<string, { arabic: string; translation: string }> = {
   "2:1": { arabic: "الم", translation: "Alif, Lam, Meem." },
   "2:2": {
@@ -98,12 +101,63 @@ describe("SearchDialog — result-select fetch aborted on close", () => {
 
     fireEvent.click(screen.getAllByRole("option")[0]);
 
+    // Confirm the verse request actually started before we close the dialog —
+    // otherwise the test below would pass vacuously.
+    await waitFor(() => expect(settle.withVerse).not.toBeNull());
+
     // Close the dialog (Escape) before the /api/verse fetch resolves.
     fireEvent.keyDown(document, { key: "Escape" });
 
     // The network request "arrives" only now — after the close. With the fix,
     // it was already aborted (rejected) by this point, so this is a no-op.
-    settle.withVerse?.();
+    settle.withVerse!();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(useCanvasStore.getState().nodes).toHaveLength(0);
+  });
+
+  it("does not add a canvas node if the parent flips `open` to false directly before the selected result's fetch resolves", async () => {
+    // Distinct from the Escape-key case above: here the parent sets `open={false}`
+    // directly — not Escape, not the overlay, not the dialog's X button — the
+    // case the shared cancelAndReset effect (keyed on the `open` prop) exists for.
+    const settle: { withVerse: (() => void) | null } = { withVerse: null };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.startsWith("/api/search")) {
+          const body: SearchResponse = { results, total: results.length, page: 1, pageSize: 10 };
+          return { ok: true, json: async () => body, headers: new Headers() } as Response;
+        }
+        if (url.startsWith("/api/verse/2/1")) {
+          const signal = init?.signal;
+          return new Promise<Response>((resolve, reject) => {
+            settle.withVerse = () =>
+              resolve({ ok: true, json: async () => makeVerse("2:1") } as Response);
+            signal?.addEventListener("abort", () =>
+              reject(new DOMException("Aborted", "AbortError"))
+            );
+          });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      })
+    );
+
+    const onClose = vi.fn();
+    const { rerender } = renderWithIntl(<SearchDialog open onClose={onClose} />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "guidance" } });
+    await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(2), { timeout: 2000 });
+
+    fireEvent.click(screen.getAllByRole("option")[0]);
+    await waitFor(() => expect(settle.withVerse).not.toBeNull());
+
+    rerender(
+      <NextIntlClientProvider locale="en" messages={en}>
+        <SearchDialog open={false} onClose={onClose} />
+      </NextIntlClientProvider>
+    );
+
+    settle.withVerse!();
     await new Promise((r) => setTimeout(r, 0));
 
     expect(useCanvasStore.getState().nodes).toHaveLength(0);

--- a/components/search/SearchDialog.tsx
+++ b/components/search/SearchDialog.tsx
@@ -51,6 +51,10 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  // Separate from `abortRef` (the search/preview debounce) so selecting a result
+  // doesn't get cancelled by unrelated search-input activity — only by the
+  // dialog closing, which is the actual bug this guards against.
+  const selectAbortRef = useRef<AbortController | null>(null);
 
   const addVerseNode = useCanvasStore((s) => s.addVerseNode);
   const setPendingAutoExpand = useCanvasStore((s) => s.setPendingAutoExpand);
@@ -183,16 +187,23 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
 
   const loadSeedVerse = useCallback(
     async (ref: string) => {
+      selectAbortRef.current?.abort();
+      const controller = new AbortController();
+      selectAbortRef.current = controller;
       setLoading(true);
       try {
-        const res = await fetch(`/api/verse/${ref.replace(":", "/")}`);
+        const res = await fetch(`/api/verse/${ref.replace(":", "/")}`, {
+          signal: controller.signal,
+        });
         if (!res.ok) throw new Error();
         const verse: Verse = await res.json();
         mapConnections(verse);
-      } catch {
-        // silent — seed verses are curated and should always exist
+      } catch (err) {
+        // silent — seed verses are curated and should always exist; an abort
+        // (dialog closed mid-fetch) is expected, not a failure to surface
+        if ((err as Error).name === "AbortError") return;
       } finally {
-        setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     },
     [mapConnections]
@@ -200,18 +211,24 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
 
   const selectResult = useCallback(
     async (result: SearchResult) => {
+      selectAbortRef.current?.abort();
+      const controller = new AbortController();
+      selectAbortRef.current = controller;
       setLoading(true);
       setSelectError(false);
       try {
-        const res = await fetch(`/api/verse/${result.ref.replace(":", "/")}`);
+        const res = await fetch(`/api/verse/${result.ref.replace(":", "/")}`, {
+          signal: controller.signal,
+        });
         if (!res.ok) throw new Error();
         const verse: Verse = await res.json();
         mapConnections(verse);
       } catch (err) {
+        if ((err as Error).name === "AbortError") return;
         console.error("Failed to fetch selected search result:", err);
         setSelectError(true);
       } finally {
-        setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     },
     [mapConnections]
@@ -236,6 +253,7 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
         if (!o) {
           // Reset all state and cancel requests when dialog closes
           abortRef.current?.abort();
+          selectAbortRef.current?.abort();
           if (debounceRef.current) clearTimeout(debounceRef.current);
           setQuery("");
           setPreviewVerse(null);

--- a/components/search/SearchDialog.tsx
+++ b/components/search/SearchDialog.tsx
@@ -199,9 +199,10 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
         const verse: Verse = await res.json();
         mapConnections(verse);
       } catch (err) {
-        // silent — seed verses are curated and should always exist; an abort
-        // (dialog closed mid-fetch) is expected, not a failure to surface
+        // An abort (dialog closed mid-fetch) is expected, not a failure to surface.
         if ((err as Error).name === "AbortError") return;
+        console.error("Failed to fetch seed verse:", err);
+        setSelectError(true);
       } finally {
         if (!controller.signal.aborted) setLoading(false);
       }
@@ -241,6 +242,37 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
     onClose();
   }, [query, mode, router, onClose]);
 
+  // Cancels in-flight requests and resets all dialog state. Run from an effect
+  // on `open` rather than inline in onOpenChange/onClose, so a parent-controlled
+  // close (the `open` prop flipping to false from outside a Radix-internal
+  // trigger — e.g. the X button's onClick calling onClose directly) can't leave
+  // the selection request running with stale state underneath it.
+  const cancelAndReset = useCallback(() => {
+    abortRef.current?.abort();
+    selectAbortRef.current?.abort();
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setQuery("");
+    setPreviewVerse(null);
+    setSearchResults([]);
+    setTotalResults(0);
+    setPreviewError(false);
+    setLoading(false);
+    setIsSearching(false);
+    setFellBackToKeyword(false);
+    setSearchError(null);
+    setMode("keyword");
+    setHighlightedIndex(-1);
+    setSelectError(false);
+  }, []);
+
+  useEffect(() => {
+    // Legitimate external-prop sync: `open` is owned by the parent, not derived
+    // from this component's own state, so reacting to it here isn't the
+    // derived-state antipattern the set-state-in-effect rule normally guards.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (!open) cancelAndReset();
+  }, [open, cancelAndReset]);
+
   const busy = loading || isSearching;
   const showSeedVerses = !query.trim();
   const showPreview = !!previewVerse && !loading;
@@ -250,25 +282,9 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
     <Dialog.Root
       open={open}
       onOpenChange={(o) => {
-        if (!o) {
-          // Reset all state and cancel requests when dialog closes
-          abortRef.current?.abort();
-          selectAbortRef.current?.abort();
-          if (debounceRef.current) clearTimeout(debounceRef.current);
-          setQuery("");
-          setPreviewVerse(null);
-          setSearchResults([]);
-          setTotalResults(0);
-          setPreviewError(false);
-          setLoading(false);
-          setIsSearching(false);
-          setFellBackToKeyword(false);
-          setSearchError(null);
-          setMode("keyword");
-          setHighlightedIndex(-1);
-          setSelectError(false);
-          onClose();
-        }
+        // cancelAndReset runs from the `open` effect above, regardless of what
+        // triggered the close — this just notifies the parent.
+        if (!o) onClose();
       }}
     >
       <Dialog.Portal>


### PR DESCRIPTION
## Summary

Selecting a search result and immediately closing the dialog before the fetch resolved would still silently add a node to the canvas and pan the camera to it — a visible, surprising side effect after the user believed they'd cancelled the action.

The debounced search/preview requests in `SearchDialog.tsx` are correctly cancelled via `abortRef` in the `onOpenChange` close handler, but `selectResult` and `loadSeedVerse` used bare `fetch()` calls with no `AbortSignal` at all.

## Fix

Added a separate `selectAbortRef` (kept independent from the search/preview `abortRef` so unrelated typing in the input doesn't cancel an in-flight result selection), wired into both `selectResult` and `loadSeedVerse`, and aborted alongside the existing cleanup in the dialog's close handler. An `AbortError` is treated as expected cancellation, not a failure to surface via `selectError`.

## Testing

Added `__tests__/components/search/SearchDialog.select-abort.test.tsx`: selects a result, closes the dialog (Escape) before the `/api/verse/...` fetch resolves, then lets the network response "arrive" afterward — asserts no canvas node was added. Verified the test fails against the pre-fix code (the node is added) and passes with the fix. Full suite, lint, and typecheck all pass.

Closes #381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search dialog behavior when closing during an in-progress verse selection.
  - Prevented canceled requests from adding unwanted content or incorrectly changing loading states.
  - Closing the dialog now reliably cancels active search and preview requests.

- **Tests**
  - Added coverage for canceling a verse fetch by closing the dialog before the response completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->