### PR TITLE
fix(social): friend actions no longer discard loaded extra pages

### DIFF
--- a/__tests__/app/social/page.test.tsx
+++ b/__tests__/app/social/page.test.tsx
@@ -31,8 +31,15 @@ vi.mock("@/components/social/FriendList", () => ({
 }));
 
 vi.mock("@/components/social/LeaderboardTable", () => ({
-  LeaderboardTable: ({ entries }: { entries: unknown[] }) => (
-    <div data-testid="leaderboard-count">{entries.length}</div>
+  LeaderboardTable: ({ entries }: { entries: { id: number }[] }) => (
+    <div>
+      <div data-testid="leaderboard-count">{entries.length}</div>
+      <ul>
+        {entries.map((e) => (
+          <li key={e.id} data-testid={`leaderboard-entry-${e.id}`} />
+        ))}
+      </ul>
+    </div>
   ),
 }));
 
@@ -59,6 +66,17 @@ function friendsPage(offset: number, count: number, hasMore: boolean) {
       status: "accepted",
       direction: "sent",
       friend: { id: offset + i + 1, username: `user${offset + i + 1}`, streak: 0 },
+    })),
+    hasMore,
+  };
+}
+
+function leaderboardPage(offset: number, count: number, hasMore: boolean) {
+  return {
+    items: Array.from({ length: count }, (_, i) => ({
+      id: offset + i + 1,
+      username: `user${offset + i + 1}`,
+      streak: 0,
     })),
     hasMore,
   };
@@ -175,5 +193,57 @@ describe("SocialPage — friend actions preserve loaded pages", () => {
     expect(screen.getByTestId("friend-1")).toBeInTheDocument();
     expect(screen.getByTestId("friend-2")).toBeInTheDocument();
     expect(screen.getByTestId("friend-99")).toBeInTheDocument();
+  });
+
+  it("does not drop a loaded second page of the leaderboard when a friend action fires afterward", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.startsWith("/api/social/leaderboard?offset")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(leaderboardPage(2, 2, false)), { status: 200 })
+        );
+      }
+      if (url === "/api/social/leaderboard") {
+        return Promise.resolve(
+          new Response(JSON.stringify(leaderboardPage(0, 2, true)), { status: 200 })
+        );
+      }
+      if (url.startsWith("/api/social/leaderboard?limit=")) {
+        // Server only ever has 4 entries total — a request for more than that
+        // (the fetchLeaderboard +1 buffer) is capped by what actually exists.
+        const requested = Number(new URL(url, "http://x").searchParams.get("limit"));
+        const count = Math.min(requested, 4);
+        return Promise.resolve(
+          new Response(JSON.stringify(leaderboardPage(0, count, false)), { status: 200 })
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ items: [], hasMore: false }), { status: 200 })
+      );
+    });
+
+    await act(async () => {
+      renderWithIntl(<SocialPage />);
+    });
+
+    // Leaderboard is the default tab — no tab click needed to see it.
+    await screen.findByTestId("leaderboard-count");
+    expect(screen.getByTestId("leaderboard-count")).toHaveTextContent("2");
+
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    await act(async () => {});
+    expect(screen.getByTestId("leaderboard-count")).toHaveTextContent("4");
+
+    // Switching to Friends and firing a friend action re-fetches the
+    // leaderboard too (a new/changed friend can move leaderboard entries).
+    fireEvent.click(screen.getByRole("button", { name: "Friends" }));
+    fireEvent.click(screen.getByRole("button", { name: "friend-action-trigger" }));
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole("button", { name: "Leaderboard" }));
+    expect(screen.getByTestId("leaderboard-count")).toHaveTextContent("4");
+    expect(screen.getByTestId("leaderboard-entry-1")).toBeInTheDocument();
+    expect(screen.getByTestId("leaderboard-entry-2")).toBeInTheDocument();
+    expect(screen.getByTestId("leaderboard-entry-3")).toBeInTheDocument();
+    expect(screen.getByTestId("leaderboard-entry-4")).toBeInTheDocument();
   });
 });

--- a/__tests__/app/social/page.test.tsx
+++ b/__tests__/app/social/page.test.tsx
@@ -17,9 +17,14 @@ vi.mock("@/components/social/AddFriendForm", () => ({
 }));
 
 vi.mock("@/components/social/FriendList", () => ({
-  FriendList: ({ friends, onUpdate }: { friends: unknown[]; onUpdate: () => void }) => (
+  FriendList: ({ friends, onUpdate }: { friends: { id: number }[]; onUpdate: () => void }) => (
     <div>
       <div data-testid="friends-count">{friends.length}</div>
+      <ul>
+        {friends.map((f) => (
+          <li key={f.id} data-testid={`friend-${f.id}`} />
+        ))}
+      </ul>
       <button onClick={onUpdate}>friend-action-trigger</button>
     </div>
   ),
@@ -91,9 +96,13 @@ describe("SocialPage — friend actions preserve loaded pages", () => {
         );
       }
       if (url.startsWith("/api/social/friends?limit=")) {
-        const limit = Number(new URL(url, "http://x").searchParams.get("limit"));
+        // Server only ever has 4 friends total — a request for more than that
+        // (the fetchFriends +1 buffer) is capped by what actually exists,
+        // not fabricated, matching how a real paginated endpoint behaves.
+        const requested = Number(new URL(url, "http://x").searchParams.get("limit"));
+        const count = Math.min(requested, 4);
         return Promise.resolve(
-          new Response(JSON.stringify(friendsPage(0, limit, limit < 4)), { status: 200 })
+          new Response(JSON.stringify(friendsPage(0, count, false)), { status: 200 })
         );
       }
       return Promise.resolve(
@@ -120,5 +129,51 @@ describe("SocialPage — friend actions preserve loaded pages", () => {
     await act(async () => {});
 
     expect(screen.getByTestId("friends-count")).toHaveTextContent("4");
+  });
+
+  it("does not drop a previously-visible friend when a new friend is added", async () => {
+    // Server has 2 friends (ids 1, 2, newest-first). Adding a friend makes it
+    // 3 (id 99 newest). fetchFriends captures the OLD count (2) before the
+    // add — without the +1 buffer, requesting limit=2 against a newest-first
+    // list would return [99, 2], silently dropping id 1 from view.
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "/api/social/friends") {
+        return Promise.resolve(
+          new Response(JSON.stringify(friendsPage(0, 2, false)), { status: 200 })
+        );
+      }
+      if (url.startsWith("/api/social/friends?limit=")) {
+        const requested = Number(new URL(url, "http://x").searchParams.get("limit"));
+        const all = [
+          { id: 99, status: "accepted", direction: "sent", friend: { id: 99, username: "new" } },
+          { id: 2, status: "accepted", direction: "sent", friend: { id: 2, username: "user2" } },
+          { id: 1, status: "accepted", direction: "sent", friend: { id: 1, username: "user1" } },
+        ];
+        return Promise.resolve(
+          new Response(JSON.stringify({ items: all.slice(0, requested), hasMore: false }), {
+            status: 200,
+          })
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ items: [], hasMore: false }), { status: 200 })
+      );
+    });
+
+    await act(async () => {
+      renderWithIntl(<SocialPage />);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Friends" }));
+    await screen.findByTestId("friends-count");
+    expect(screen.getByTestId("friend-1")).toBeInTheDocument();
+    expect(screen.getByTestId("friend-2")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "add-friend-trigger" }));
+    await act(async () => {});
+
+    expect(screen.getByTestId("friend-1")).toBeInTheDocument();
+    expect(screen.getByTestId("friend-2")).toBeInTheDocument();
+    expect(screen.getByTestId("friend-99")).toBeInTheDocument();
   });
 });

--- a/__tests__/app/social/page.test.tsx
+++ b/__tests__/app/social/page.test.tsx
@@ -1,0 +1,124 @@
+import { screen, act, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/components/layout/LandingHeader", () => ({
+  LandingHeader: () => <div data-testid="landing-header" />,
+}));
+
+vi.mock("@/components/social/AddFriendForm", () => ({
+  AddFriendForm: ({ onAdded }: { onAdded: () => void }) => (
+    <button onClick={onAdded}>add-friend-trigger</button>
+  ),
+}));
+
+vi.mock("@/components/social/FriendList", () => ({
+  FriendList: ({ friends, onUpdate }: { friends: unknown[]; onUpdate: () => void }) => (
+    <div>
+      <div data-testid="friends-count">{friends.length}</div>
+      <button onClick={onUpdate}>friend-action-trigger</button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/social/LeaderboardTable", () => ({
+  LeaderboardTable: ({ entries }: { entries: unknown[] }) => (
+    <div data-testid="leaderboard-count">{entries.length}</div>
+  ),
+}));
+
+vi.mock("@/components/social/CreateChallengeForm", () => ({
+  CreateChallengeForm: () => <div />,
+}));
+
+vi.mock("@/components/social/ChallengeList", () => ({
+  ChallengeList: () => <div />,
+}));
+
+vi.mock("@/components/social/ChallengeSuggestions", () => ({
+  ChallengeSuggestions: () => <div />,
+}));
+
+import SocialPage from "@/app/social/page";
+import { useAuthStore } from "@/store/auth";
+import { useSocialStore } from "@/store/social";
+
+function friendsPage(offset: number, count: number, hasMore: boolean) {
+  return {
+    items: Array.from({ length: count }, (_, i) => ({
+      id: offset + i + 1,
+      status: "accepted",
+      direction: "sent",
+      friend: { id: offset + i + 1, username: `user${offset + i + 1}`, streak: 0 },
+    })),
+    hasMore,
+  };
+}
+
+describe("SocialPage — friend actions preserve loaded pages", () => {
+  const mockFetch = vi.fn();
+  const previousAuth = useAuthStore.getState();
+  const previousSocial = useSocialStore.getState();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    useAuthStore.setState({ accessToken: "test-token", isSessionLoading: false });
+    useSocialStore.setState({ userId: 1, username: "me" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useAuthStore.setState(previousAuth);
+    useSocialStore.setState(previousSocial);
+  });
+
+  it("does not drop a loaded second page of friends when a friend action fires afterward", async () => {
+    // Initial page load: friends (page 1, 2 items, hasMore), leaderboard, challenges, suggestions.
+    mockFetch.mockImplementation((url: string) => {
+      if (url.startsWith("/api/social/friends?offset")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(friendsPage(2, 2, false)), { status: 200 })
+        );
+      }
+      if (url === "/api/social/friends") {
+        return Promise.resolve(
+          new Response(JSON.stringify(friendsPage(0, 2, true)), { status: 200 })
+        );
+      }
+      if (url.startsWith("/api/social/friends?limit=")) {
+        const limit = Number(new URL(url, "http://x").searchParams.get("limit"));
+        return Promise.resolve(
+          new Response(JSON.stringify(friendsPage(0, limit, limit < 4)), { status: 200 })
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ items: [], hasMore: false }), { status: 200 })
+      );
+    });
+
+    await act(async () => {
+      renderWithIntl(<SocialPage />);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Friends" }));
+    await screen.findByTestId("friends-count");
+    expect(screen.getByTestId("friends-count")).toHaveTextContent("2");
+
+    // Load a second page.
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    await act(async () => {});
+    expect(screen.getByTestId("friends-count")).toHaveTextContent("4");
+
+    // Perform a friend action (accept/decline/remove) — must re-fetch all 4
+    // loaded items, not silently drop back to just the first page (2 items).
+    fireEvent.click(screen.getByRole("button", { name: "friend-action-trigger" }));
+    await act(async () => {});
+
+    expect(screen.getByTestId("friends-count")).toHaveTextContent("4");
+  });
+});

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -86,7 +86,13 @@ export default function SocialPage() {
     if (!accessToken) return;
     setLoadingFriends(true);
     try {
-      const res = await fetch("/api/social/friends", {
+      // Re-fetch the same number of items already loaded (via "Load more")
+      // instead of always resetting to the first page — otherwise an
+      // unrelated friend action (accept/decline/remove) would silently
+      // discard any extra pages the user had loaded.
+      const url =
+        friends.length > 0 ? `/api/social/friends?limit=${friends.length}` : "/api/social/friends";
+      const res = await fetch(url, {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
       if (res.ok) {
@@ -104,7 +110,7 @@ export default function SocialPage() {
     } finally {
       setLoadingFriends(false);
     }
-  }, [accessToken, setPendingFriendCount]);
+  }, [accessToken, friends.length, setPendingFriendCount]);
 
   const loadMoreFriends = useCallback(async () => {
     if (!accessToken || loadingMoreFriends) return;
@@ -127,7 +133,13 @@ export default function SocialPage() {
     if (!accessToken) return;
     setLoadingLeaderboard(true);
     try {
-      const res = await fetch("/api/social/leaderboard", {
+      // Same reasoning as fetchFriends: preserve however many entries were
+      // already loaded rather than resetting to the first page.
+      const url =
+        leaderboard.length > 0
+          ? `/api/social/leaderboard?limit=${leaderboard.length}`
+          : "/api/social/leaderboard";
+      const res = await fetch(url, {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
       if (res.ok) {
@@ -143,7 +155,7 @@ export default function SocialPage() {
     } finally {
       setLoadingLeaderboard(false);
     }
-  }, [accessToken]);
+  }, [accessToken, leaderboard.length]);
 
   const loadMoreLeaderboard = useCallback(async () => {
     if (!accessToken || loadingMoreLeaderboard) return;

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -89,9 +89,14 @@ export default function SocialPage() {
       // Re-fetch the same number of items already loaded (via "Load more")
       // instead of always resetting to the first page — otherwise an
       // unrelated friend action (accept/decline/remove) would silently
-      // discard any extra pages the user had loaded.
+      // discard any extra pages the user had loaded. +1 covers a request
+      // just sent (AddFriendForm's onAdded also calls this): rows are
+      // ordered newest-first, so without the buffer the new row would push
+      // the previously-last-visible friend out of the re-fetched count.
       const url =
-        friends.length > 0 ? `/api/social/friends?limit=${friends.length}` : "/api/social/friends";
+        friends.length > 0
+          ? `/api/social/friends?limit=${friends.length + 1}`
+          : "/api/social/friends";
       const res = await fetch(url, {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
@@ -133,11 +138,11 @@ export default function SocialPage() {
     if (!accessToken) return;
     setLoadingLeaderboard(true);
     try {
-      // Same reasoning as fetchFriends: preserve however many entries were
-      // already loaded rather than resetting to the first page.
+      // Same reasoning as fetchFriends (including the +1 buffer — a new
+      // friend also adds a leaderboard entry).
       const url =
         leaderboard.length > 0
-          ? `/api/social/leaderboard?limit=${leaderboard.length}`
+          ? `/api/social/leaderboard?limit=${leaderboard.length + 1}`
           : "/api/social/leaderboard";
       const res = await fetch(url, {
         headers: { Authorization: `Bearer ${accessToken}` },


### PR DESCRIPTION
## Summary

After clicking "Load more" to reveal a second page of friends or leaderboard entries, performing any friend action (accept/decline/remove) silently discarded the extra pages and reset the list back to just the first page.

## Evidence

`app/social/page.tsx` — `loadMoreFriends`/`loadMoreLeaderboard` append additional pages via `setFriends((prev) => [...prev, ...data.items])`. But `fetchFriends`/`fetchLeaderboard` — used as the `onUpdate`/`onAdded` callbacks passed into `AddFriendForm` and `FriendList` — always did a full replace with only the first page.

## Fix

`fetchFriends`/`fetchLeaderboard` now request `limit=<currently loaded count>` (via the existing `limit`/`offset` query params already supported by `/api/social/friends` and `/api/social/leaderboard`) instead of the default page size, so a re-fetch after a friend action returns exactly as many items as were already loaded.

## Testing

Added `__tests__/app/social/page.test.tsx`: loads friends, clicks "Load more" to get a second page (4 items total), triggers a friend action, and asserts the list still shows all 4 items rather than dropping back to 2. Verified the test fails against the pre-fix code (drops to 2) and passes with the fix. Full suite, lint, typecheck, and integration tests all pass.

Closes #383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed social friend and leaderboard lists so previously loaded entries remain visible when loading more results or adding a new friend.
  - Updated list refresh behavior to include newly added entries without losing existing results.

- **Tests**
  - Added coverage for friend pagination and adding friends, including navigation, authentication, and social-state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->