### PR TITLE
fix(social): header polling badges no longer reset to zero on failure

### DIFF
--- a/__tests__/components/layout/Header.polling-failure.test.tsx
+++ b/__tests__/components/layout/Header.polling-failure.test.tsx
@@ -1,0 +1,101 @@
+import { act } from "@testing-library/react";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/canvas",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+import { Header } from "@/components/layout/Header";
+import { useAuthStore } from "@/store/auth";
+import { useSocialStore } from "@/store/social";
+
+describe("Header — polling badges survive a transient failure", () => {
+  const mockFetch = vi.fn();
+  const previousAuth = useAuthStore.getState();
+  const previousSocial = useSocialStore.getState();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    useAuthStore.setState({ accessToken: "test-token" });
+    useSocialStore.setState({ userId: 1, pendingFriendCount: 0, pendingMentionCount: 0 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    useAuthStore.setState(previousAuth);
+    useSocialStore.setState(previousSocial);
+  });
+
+  it("keeps a non-zero friend-request badge after one failed poll", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.startsWith("/api/social/friends")) {
+        // First (initial) call succeeds with 2 pending; the second (60s
+        // later, triggered by setInterval) fails with a 500.
+        if (
+          mockFetch.mock.calls.filter((c) => String(c[0]).startsWith("/api/social/friends"))
+            .length === 1
+        ) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                items: [
+                  { status: "pending", direction: "received" },
+                  { status: "pending", direction: "received" },
+                ],
+              }),
+              { status: 200 }
+            )
+          );
+        }
+        return Promise.resolve(new Response(null, { status: 500 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ unreadCount: 0 }), { status: 200 }));
+    });
+
+    await act(async () => {
+      renderWithIntl(<Header onSearchOpen={() => {}} />);
+    });
+
+    expect(useSocialStore.getState().pendingFriendCount).toBe(2);
+
+    // Advance past the next 60s poll, which fails.
+    await act(async () => {
+      vi.advanceTimersByTime(61_000);
+    });
+
+    // A single failed poll must not clear the already-displayed count.
+    expect(useSocialStore.getState().pendingFriendCount).toBe(2);
+  });
+
+  it("keeps a non-zero mention badge after one failed poll", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.startsWith("/api/social/mentions")) {
+        if (
+          mockFetch.mock.calls.filter((c) => String(c[0]).startsWith("/api/social/mentions"))
+            .length === 1
+        ) {
+          return Promise.resolve(new Response(JSON.stringify({ unreadCount: 3 }), { status: 200 }));
+        }
+        return Promise.resolve(new Response(null, { status: 500 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ items: [] }), { status: 200 }));
+    });
+
+    await act(async () => {
+      renderWithIntl(<Header onSearchOpen={() => {}} />);
+    });
+
+    expect(useSocialStore.getState().pendingMentionCount).toBe(3);
+
+    await act(async () => {
+      vi.advanceTimersByTime(61_000);
+    });
+
+    expect(useSocialStore.getState().pendingMentionCount).toBe(3);
+  });
+});

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -242,8 +242,12 @@ export function Header({ onSearchOpen }: HeaderProps) {
       fetch("/api/social/friends?limit=200", {
         headers: { Authorization: `Bearer ${accessToken}` },
       })
-        .then((r) => (r.ok ? r.json() : { items: [] }))
-        .then((data: { items: { status: string; direction: string }[] }) => {
+        // A failed poll keeps the previously-displayed count rather than
+        // resetting it to 0 — a transient 5xx/network hiccup shouldn't make
+        // an already-shown badge disappear.
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data: { items: { status: string; direction: string }[] } | null) => {
+          if (!data) return;
           const count = data.items.filter(
             (f) => f.status === "pending" && f.direction === "received"
           ).length;
@@ -264,8 +268,13 @@ export function Header({ onSearchOpen }: HeaderProps) {
       fetch("/api/social/mentions?limit=1", {
         headers: { Authorization: `Bearer ${accessToken}` },
       })
-        .then((r) => (r.ok ? r.json() : { unreadCount: 0 }))
-        .then((data: { unreadCount: number }) => setPendingMentionCount(data.unreadCount))
+        // Same reasoning as the friend-request poll above: keep the
+        // previously-displayed count on failure instead of zeroing it.
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data: { unreadCount: number } | null) => {
+          if (!data) return;
+          setPendingMentionCount(data.unreadCount);
+        })
         .catch((e) => console.error("header: mention poll failed", e));
     load();
     const interval = setInterval(load, 60_000);


### PR DESCRIPTION
## Summary

The friends/mentions unread badges in the header silently reset to zero on a single transient network failure, even though the user still has real pending items — indistinguishable from a legitimate "nothing pending" state.

## Evidence

`components/layout/Header.tsx`: both 60-second polls (friend requests, mentions) fell back to an empty/zero result on any non-OK response:

```js
fetch("/api/social/friends?limit=200", {...})
  .then((r) => (r.ok ? r.json() : { items: [] }))
  ...
fetch("/api/social/mentions?limit=1", {...})
  .then((r) => (r.ok ? r.json() : { unreadCount: 0 }))
```

## Fix

Both polls now resolve to `null` on a non-OK response and skip the state update entirely in that case, keeping the previously-known count until the next successful poll.

## Testing

Added `__tests__/components/layout/Header.polling-failure.test.tsx`, covering both the friend-request and mentions polls: a badge with a non-zero count survives one failed poll 60s later. Verified both tests fail without the fix and pass with it. `bun run lint`, `bun run typecheck`, `bun run format:check`, and the full unit suite pass.

Closes #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Friend-request and unread-mention badges now retain their previous counts when polling encounters an error.
  * Badge counts continue updating normally after successful polling responses.
* **Tests**
  * Added coverage to verify badge counts remain visible when a scheduled polling request fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->