### PR TITLE
fix(social): mentions mark-as-read no longer clears badge on failure

### DIFF
--- a/__tests__/app/mentions/page.test.tsx
+++ b/__tests__/app/mentions/page.test.tsx
@@ -1,0 +1,66 @@
+import { screen, act } from "@testing-library/react";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("@/components/layout/LandingHeader", () => ({
+  LandingHeader: () => <div data-testid="landing-header" />,
+}));
+
+import MentionsPage from "@/app/mentions/page";
+import { useAuthStore } from "@/store/auth";
+import { useSocialStore } from "@/store/social";
+
+describe("MentionsPage — mark-as-read failure handling", () => {
+  const mockFetch = vi.fn();
+  const previousAuth = useAuthStore.getState();
+  const previousSocial = useSocialStore.getState();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    useAuthStore.setState({ accessToken: "test-token", isSessionLoading: false });
+    useSocialStore.setState({ pendingMentionCount: 3 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useAuthStore.setState(previousAuth);
+    useSocialStore.setState(previousSocial);
+  });
+
+  it("does not clear the mention badge when the mark-as-read PATCH fails", async () => {
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === "PATCH") {
+        return Promise.resolve(new Response(null, { status: 500 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ items: [] }), { status: 200 }));
+    });
+
+    await act(async () => {
+      renderWithIntl(<MentionsPage />);
+    });
+
+    expect(useSocialStore.getState().pendingMentionCount).toBe(3);
+    expect(await screen.findByText(/couldn.t mark mentions as read/i)).toBeInTheDocument();
+  });
+
+  it("clears the mention badge when the mark-as-read PATCH succeeds", async () => {
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === "PATCH") {
+        return Promise.resolve(new Response(null, { status: 200 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ items: [] }), { status: 200 }));
+    });
+
+    await act(async () => {
+      renderWithIntl(<MentionsPage />);
+    });
+
+    expect(useSocialStore.getState().pendingMentionCount).toBe(0);
+    expect(screen.queryByText(/couldn.t mark mentions as read/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/app/mentions/page.test.tsx
+++ b/__tests__/app/mentions/page.test.tsx
@@ -63,4 +63,29 @@ describe("MentionsPage — mark-as-read failure handling", () => {
     expect(useSocialStore.getState().pendingMentionCount).toBe(0);
     expect(screen.queryByText(/couldn.t mark mentions as read/i)).not.toBeInTheDocument();
   });
+
+  it("clears a stale mark-as-read error once a later retry succeeds", async () => {
+    let shouldFail = true;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === "PATCH") {
+        return Promise.resolve(new Response(null, { status: shouldFail ? 500 : 200 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ items: [] }), { status: 200 }));
+    });
+
+    await act(async () => {
+      renderWithIntl(<MentionsPage />);
+    });
+
+    expect(await screen.findByText(/couldn.t mark mentions as read/i)).toBeInTheDocument();
+
+    // Simulate a token refresh, which re-runs the effect (deps: [accessToken]).
+    shouldFail = false;
+    await act(async () => {
+      useAuthStore.setState({ accessToken: "refreshed-token" });
+    });
+
+    expect(useSocialStore.getState().pendingMentionCount).toBe(0);
+    expect(screen.queryByText(/couldn.t mark mentions as read/i)).not.toBeInTheDocument();
+  });
 });

--- a/app/mentions/page.tsx
+++ b/app/mentions/page.tsx
@@ -56,6 +56,7 @@ export default function MentionsPage() {
         if (cancelled) return;
         if (r.ok) {
           setPendingMentionCount(0);
+          setMarkReadError(false);
         } else {
           setMarkReadError(true);
         }

--- a/app/mentions/page.tsx
+++ b/app/mentions/page.tsx
@@ -24,6 +24,7 @@ export default function MentionsPage() {
   const [mentions, setMentions] = useState<Mention[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [markReadError, setMarkReadError] = useState(false);
 
   useEffect(() => {
     if (!accessToken) return;
@@ -51,10 +52,18 @@ export default function MentionsPage() {
       method: "PATCH",
       headers: { Authorization: `Bearer ${accessToken}` },
     })
-      .then(() => {
-        if (!cancelled) setPendingMentionCount(0);
+      .then((r) => {
+        if (cancelled) return;
+        if (r.ok) {
+          setPendingMentionCount(0);
+        } else {
+          setMarkReadError(true);
+        }
       })
-      .catch((e) => console.error("mentions page: mark-read failed", e));
+      .catch((e) => {
+        console.error("mentions page: mark-read failed", e);
+        if (!cancelled) setMarkReadError(true);
+      });
 
     return () => {
       cancelled = true;
@@ -74,6 +83,12 @@ export default function MentionsPage() {
             </span>
           )}
         </div>
+
+        {markReadError && (
+          <p className="mb-4 text-xs text-error">
+            Couldn&apos;t mark mentions as read. The unread count may be out of sync.
+          </p>
+        )}
 
         {error ? (
           <p className="py-10 text-center text-sm text-error">Couldn&apos;t load mentions.</p>


### PR DESCRIPTION
## Summary

The mentions page cleared the unread badge to 0 client-side even when the server-side "mark as read" request failed, causing a client/server state desync with no error surfaced.

## Evidence

`app/mentions/page.tsx` (mark-as-read PATCH):

```js
fetch("/api/social/mentions", { method: "PATCH", ... })
  .then(() => { if (!cancelled) setPendingMentionCount(0); })
  .catch((e) => console.error("mentions page: mark-read failed", e));
```

`fetch()` only rejects on network failure, not on HTTP error status, so the `.then()` ran (and cleared the badge to 0) even if the PATCH returned 4xx/5xx.

## Fix

Check `r.ok` before clearing the local count. On failure (either a non-OK response or a network rejection), the previous count is kept and an inline error message is shown ("Couldn't mark mentions as read. The unread count may be out of sync.").

## Testing

Added `__tests__/app/mentions/page.test.tsx` with two tests: a failed PATCH keeps the count and shows the error message; a successful PATCH clears the count with no error shown. Verified the failure-path test fails without the fix. `bun run lint`, `bun run typecheck`, `bun run format:check`, and the full unit suite (965 tests) pass.

Closes #385