### PR TITLE
fix(bookmarks): add per-ref in-flight guard to toggleBookmark

### DIFF
--- a/__tests__/app/bookmarks/page.test.tsx
+++ b/__tests__/app/bookmarks/page.test.tsx
@@ -1,0 +1,64 @@
+import { screen, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/bookmarks",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+import BookmarksPage from "@/app/bookmarks/page";
+import { useAuthStore } from "@/store/auth";
+import { TooltipProvider } from "@/components/ui";
+
+describe("BookmarksPage — bookmark button busy state", () => {
+  const mockFetch = vi.fn();
+  const previousAuthState = useAuthStore.getState();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useAuthStore.setState(previousAuthState);
+  });
+
+  it("disables the remove-bookmark button while its ref is busy", async () => {
+    useAuthStore.setState({
+      bookmarks: ["2:255"],
+      bookmarksLoadError: false,
+      bookmarkBusy: { "2:255": true },
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          surah: 2,
+          ayah: 255,
+          ref: "2:255",
+          arabicText: "الله لا إله إلا هو الحي القيوم",
+          translation: "Allah - there is no deity except Him, the Ever-Living, the Sustainer.",
+          surahName: "Al-Baqarah",
+          surahNameArabic: "البقرة",
+        }),
+        { status: 200 }
+      )
+    );
+
+    await act(async () => {
+      renderWithIntl(
+        <TooltipProvider>
+          <BookmarksPage />
+        </TooltipProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /remove bookmark/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: /remove bookmark/i })).toBeDisabled();
+  });
+});

--- a/__tests__/app/bookmarks/page.test.tsx
+++ b/__tests__/app/bookmarks/page.test.tsx
@@ -39,6 +39,7 @@ describe("BookmarksPage — bookmark button busy state", () => {
           ayah: 255,
           ref: "2:255",
           arabicText: "الله لا إله إلا هو الحي القيوم",
+          // en.sahih (Saheeh International, alquran.cloud) excerpt.
           translation: "Allah - there is no deity except Him, the Ever-Living, the Sustainer.",
           surahName: "Al-Baqarah",
           surahNameArabic: "البقرة",

--- a/__tests__/app/search/SearchPageClient.test.tsx
+++ b/__tests__/app/search/SearchPageClient.test.tsx
@@ -11,6 +11,8 @@ vi.mock("next/navigation", () => ({
 
 import { SearchPageClient } from "@/app/search/SearchPageClient";
 import { usePreferencesStore } from "@/store/preferences";
+import { useAuthStore } from "@/store/auth";
+import { TooltipProvider } from "@/components/ui";
 
 describe("SearchPageClient — rate-limit vs. genuine empty results", () => {
   const mockFetch = vi.fn();
@@ -112,5 +114,53 @@ describe("SearchPageClient — re-fetches when the UI language changes", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(screen.getByText(turkishResult.translation)).toBeInTheDocument();
+  });
+});
+
+describe("SearchPageClient — bookmark button busy state", () => {
+  const mockFetch = vi.fn();
+  const previousAuthState = useAuthStore.getState();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useAuthStore.setState(previousAuthState);
+  });
+
+  it("disables a search result's bookmark button while that ref is busy", async () => {
+    const result = {
+      ref: "2:255",
+      surahName: "Al-Baqarah",
+      surahNameArabic: "البقرة",
+      snippet: "Allah - there is no deity except Him.",
+      arabicText: "الله لا إله إلا هو",
+      translation: "Allah - there is no deity except Him.",
+    };
+
+    useAuthStore.setState({
+      accessToken: "token-123",
+      bookmarks: [],
+      bookmarkBusy: { "2:255": true },
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ results: [result], total: 1, page: 1, pageSize: 20 }), {
+        status: 200,
+      })
+    );
+
+    await act(async () => {
+      renderWithIntl(
+        <TooltipProvider>
+          <SearchPageClient />
+        </TooltipProvider>
+      );
+    });
+
+    expect(screen.getByRole("button", { name: /bookmark verse/i })).toBeDisabled();
   });
 });

--- a/__tests__/app/search/SearchPageClient.test.tsx
+++ b/__tests__/app/search/SearchPageClient.test.tsx
@@ -139,6 +139,7 @@ describe("SearchPageClient — bookmark button busy state", () => {
       surahNameArabic: "البقرة",
       snippet: "Allah - there is no deity except Him.",
       arabicText: "الله لا إله إلا هو",
+      // en.sahih (Saheeh International, alquran.cloud) excerpt.
       translation: "Allah - there is no deity except Him.",
     };
 

--- a/__tests__/store/auth.test.ts
+++ b/__tests__/store/auth.test.ts
@@ -8,7 +8,12 @@ describe("auth store", () => {
   beforeEach(() => {
     mockFetch.mockReset();
     localStorage.clear();
-    useAuthStore.setState({ accessToken: null, bookmarks: [], bookmarksLoadError: false });
+    useAuthStore.setState({
+      accessToken: null,
+      bookmarks: [],
+      bookmarksLoadError: false,
+      bookmarkBusy: {},
+    });
   });
 
   it("initial state has null token and empty bookmarks", () => {
@@ -103,6 +108,56 @@ describe("auth store", () => {
     // Wait for the API call to resolve and rollback
     await new Promise((r) => setTimeout(r, 0));
     expect(useAuthStore.getState().bookmarks).toContain("5:1");
+  });
+
+  it("toggleBookmark ignores a rapid second click while a request for the same ref is in flight", async () => {
+    let resolveFetch!: (v: { ok: boolean }) => void;
+    mockFetch.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveFetch = res;
+      })
+    );
+    useAuthStore.setState({ accessToken: "token-123", bookmarks: [] });
+
+    useAuthStore.getState().toggleBookmark("5:1");
+    expect(useAuthStore.getState().isBookmarkBusy("5:1")).toBe(true);
+    expect(useAuthStore.getState().bookmarks).toContain("5:1");
+
+    // Second click before the first request resolves must be a no-op — no
+    // second fetch, and the optimistic state must not flip back to removed.
+    useAuthStore.getState().toggleBookmark("5:1");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().bookmarks).toContain("5:1");
+
+    resolveFetch({ ok: true });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useAuthStore.getState().isBookmarkBusy("5:1")).toBe(false);
+    expect(useAuthStore.getState().bookmarks).toContain("5:1");
+  });
+
+  it("toggleBookmark clears the busy flag after the request settles, allowing a later toggle", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    useAuthStore.setState({ accessToken: "token-123", bookmarks: [] });
+
+    useAuthStore.getState().toggleBookmark("5:1");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useAuthStore.getState().isBookmarkBusy("5:1")).toBe(false);
+
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    useAuthStore.getState().toggleBookmark("5:1");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(useAuthStore.getState().bookmarks).not.toContain("5:1");
+  });
+
+  it("toggleBookmark busy-guard is per-ref, not global", () => {
+    mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    useAuthStore.setState({ accessToken: "token-123", bookmarks: [] });
+
+    useAuthStore.getState().toggleBookmark("5:1");
+    useAuthStore.getState().toggleBookmark("2:255");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(useAuthStore.getState().bookmarks).toEqual(expect.arrayContaining(["5:1", "2:255"]));
   });
 
   it("loadRemoteBookmarks does nothing when no token", async () => {

--- a/__tests__/store/auth.test.ts
+++ b/__tests__/store/auth.test.ts
@@ -13,6 +13,7 @@ describe("auth store", () => {
       bookmarks: [],
       bookmarksLoadError: false,
       bookmarkBusy: {},
+      bookmarkGeneration: 0,
     });
   });
 
@@ -158,6 +159,54 @@ describe("auth store", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(useAuthStore.getState().bookmarks).toEqual(expect.arrayContaining(["5:1", "2:255"]));
+  });
+
+  it("a sign-out during an in-flight toggle does not corrupt a later session's toggle of the same ref", async () => {
+    let resolveStaleFetch!: (v: { ok: boolean }) => void;
+    mockFetch.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveStaleFetch = res;
+      })
+    );
+    useAuthStore.setState({ accessToken: "old-session-token", bookmarks: [] });
+
+    // Old session: start toggling "5:1" — request never settles yet.
+    useAuthStore.getState().toggleBookmark("5:1");
+    expect(useAuthStore.getState().isBookmarkBusy("5:1")).toBe(true);
+
+    // Sign out mid-request — busy state must clear immediately so the next
+    // session isn't blocked by a request that belongs to the old session.
+    useAuthStore.getState().clearAuth();
+    expect(useAuthStore.getState().isBookmarkBusy("5:1")).toBe(false);
+    expect(useAuthStore.getState().bookmarks).toEqual([]);
+
+    // New session: sign in and toggle the same ref — must not be blocked.
+    let resolveNewFetch!: (v: { ok: boolean }) => void;
+    mockFetch.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveNewFetch = res;
+      })
+    );
+    useAuthStore.setState({ accessToken: "new-session-token" });
+    useAuthStore.getState().toggleBookmark("5:1");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(useAuthStore.getState().bookmarks).toContain("5:1");
+    expect(useAuthStore.getState().isBookmarkBusy("5:1")).toBe(true);
+
+    // The stale request from the old session finally settles (as a failure,
+    // which would normally roll back and clear busy) — its clearBusy/rollback
+    // must be a no-op against the new session's still-in-flight request.
+    resolveStaleFetch({ ok: false });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useAuthStore.getState().isBookmarkBusy("5:1")).toBe(true);
+    expect(useAuthStore.getState().bookmarks).toContain("5:1");
+
+    // Once the new session's own request settles, it clears its own busy
+    // state normally.
+    resolveNewFetch({ ok: true });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useAuthStore.getState().isBookmarkBusy("5:1")).toBe(false);
+    expect(useAuthStore.getState().bookmarks).toContain("5:1");
   });
 
   it("loadRemoteBookmarks does nothing when no token", async () => {

--- a/app/bookmarks/page.tsx
+++ b/app/bookmarks/page.tsx
@@ -16,6 +16,7 @@ export default function BookmarksPage() {
   const tCommon = useTranslations("common");
   const bookmarks = useAuthStore((s) => s.bookmarks);
   const bookmarksLoadError = useAuthStore((s) => s.bookmarksLoadError);
+  const bookmarkBusy = useAuthStore((s) => s.bookmarkBusy);
   const toggleBookmark = useAuthStore((s) => s.toggleBookmark);
   const [verses, setVerses] = useState<Map<string, Verse>>(new Map());
   const [loading, setLoading] = useState(bookmarks.length > 0);
@@ -131,6 +132,7 @@ export default function BookmarksPage() {
                           tone="danger"
                           size="xs"
                           onClick={() => toggleBookmark(ref)}
+                          disabled={Boolean(bookmarkBusy[ref])}
                           aria-label={tCommon("removeBookmark")}
                         >
                           <Trash2 />

--- a/app/search/SearchPageClient.tsx
+++ b/app/search/SearchPageClient.tsx
@@ -273,6 +273,7 @@ function ResultCard({ result }: { result: SearchResult }) {
   const tSearch = useTranslations("search");
   const accessToken = useAuthStore((s) => s.accessToken);
   const isBookmarked = useAuthStore((s) => s.isBookmarked(result.ref));
+  const bookmarkBusy = useAuthStore((s) => s.isBookmarkBusy(result.ref));
   const toggleBookmark = useAuthStore((s) => s.toggleBookmark);
 
   return (
@@ -291,6 +292,7 @@ function ResultCard({ result }: { result: SearchResult }) {
                 tone="gold"
                 size="xs"
                 onClick={() => toggleBookmark(result.ref)}
+                disabled={bookmarkBusy}
                 aria-label={isBookmarked ? t("removeBookmark") : t("bookmarkVerse")}
                 className={cn(isBookmarked && "border-gold-muted text-gold")}
               >

--- a/store/auth.ts
+++ b/store/auth.ts
@@ -18,6 +18,10 @@ interface AuthStore {
   // Refs with a POST/DELETE currently in flight — guards toggleBookmark
   // against a second click racing the first before it resolves.
   bookmarkBusy: Record<string, boolean>;
+  // Bumped by clearAuth — lets a toggleBookmark request started in a prior
+  // session detect that it's stale and skip its clearBusy/rollback, so it
+  // can't clobber busy/bookmark state that belongs to a later session.
+  bookmarkGeneration: number;
 
   setTokens: (accessToken: string) => void;
   setSessionLoaded: () => void;
@@ -71,12 +75,19 @@ export const useAuthStore = create<AuthStore>()(
       bookmarks: [],
       bookmarksLoadError: false,
       bookmarkBusy: {},
+      bookmarkGeneration: 0,
 
       setTokens: (accessToken) => set({ accessToken }),
       setSessionLoaded: () => set({ isSessionLoading: false }),
 
       clearAuth: () => {
-        set({ accessToken: null, bookmarks: [], bookmarksLoadError: false });
+        set((s) => ({
+          accessToken: null,
+          bookmarks: [],
+          bookmarksLoadError: false,
+          bookmarkBusy: {},
+          bookmarkGeneration: s.bookmarkGeneration + 1,
+        }));
         useSocialStore.getState().clearSocial();
       },
 
@@ -84,7 +95,7 @@ export const useAuthStore = create<AuthStore>()(
       isBookmarkBusy: (ref) => Boolean(get().bookmarkBusy[ref]),
 
       toggleBookmark: (ref) => {
-        const { bookmarks, accessToken, bookmarkBusy } = get();
+        const { bookmarks, accessToken, bookmarkBusy, bookmarkGeneration: generation } = get();
         if (bookmarkBusy[ref]) return;
 
         const wasBookmarked = bookmarks.includes(ref);
@@ -97,6 +108,7 @@ export const useAuthStore = create<AuthStore>()(
 
         if (!accessToken) {
           set((s) => {
+            if (s.bookmarkGeneration !== generation) return s;
             const nextBusy = { ...s.bookmarkBusy };
             delete nextBusy[ref];
             return { bookmarkBusy: nextBusy };
@@ -106,15 +118,21 @@ export const useAuthStore = create<AuthStore>()(
 
         const clearBusy = () =>
           set((s) => {
+            if (s.bookmarkGeneration !== generation) return s;
             const nextBusy = { ...s.bookmarkBusy };
             delete nextBusy[ref];
             return { bookmarkBusy: nextBusy };
           });
 
         const rollback = () =>
-          set((s) => ({
-            bookmarks: wasBookmarked ? [...s.bookmarks, ref] : s.bookmarks.filter((r) => r !== ref),
-          }));
+          set((s) => {
+            if (s.bookmarkGeneration !== generation) return s;
+            return {
+              bookmarks: wasBookmarked
+                ? [...s.bookmarks, ref]
+                : s.bookmarks.filter((r) => r !== ref),
+            };
+          });
 
         if (wasBookmarked) {
           fetch(`/api/bookmarks/${encodeURIComponent(ref)}`, {

--- a/store/auth.ts
+++ b/store/auth.ts
@@ -15,12 +15,16 @@ interface AuthStore {
   // or non-OK response) — lets the bookmarks page distinguish "really empty"
   // from "failed to load" instead of rendering both identically.
   bookmarksLoadError: boolean;
+  // Refs with a POST/DELETE currently in flight — guards toggleBookmark
+  // against a second click racing the first before it resolves.
+  bookmarkBusy: Record<string, boolean>;
 
   setTokens: (accessToken: string) => void;
   setSessionLoaded: () => void;
   clearAuth: () => void;
   toggleBookmark: (ref: string) => void;
   isBookmarked: (ref: string) => boolean;
+  isBookmarkBusy: (ref: string) => boolean;
   loadRemoteBookmarks: () => Promise<void>;
 }
 
@@ -66,6 +70,7 @@ export const useAuthStore = create<AuthStore>()(
       isSessionLoading: true,
       bookmarks: [],
       bookmarksLoadError: false,
+      bookmarkBusy: {},
 
       setTokens: (accessToken) => set({ accessToken }),
       setSessionLoaded: () => set({ isSessionLoading: false }),
@@ -76,17 +81,35 @@ export const useAuthStore = create<AuthStore>()(
       },
 
       isBookmarked: (ref) => get().bookmarks.includes(ref),
+      isBookmarkBusy: (ref) => Boolean(get().bookmarkBusy[ref]),
 
       toggleBookmark: (ref) => {
-        const { bookmarks, accessToken } = get();
+        const { bookmarks, accessToken, bookmarkBusy } = get();
+        if (bookmarkBusy[ref]) return;
+
         const wasBookmarked = bookmarks.includes(ref);
 
         // Optimistic update
-        set({
+        set((s) => ({
           bookmarks: wasBookmarked ? bookmarks.filter((r) => r !== ref) : [...bookmarks, ref],
-        });
+          bookmarkBusy: { ...s.bookmarkBusy, [ref]: true },
+        }));
 
-        if (!accessToken) return;
+        if (!accessToken) {
+          set((s) => {
+            const nextBusy = { ...s.bookmarkBusy };
+            delete nextBusy[ref];
+            return { bookmarkBusy: nextBusy };
+          });
+          return;
+        }
+
+        const clearBusy = () =>
+          set((s) => {
+            const nextBusy = { ...s.bookmarkBusy };
+            delete nextBusy[ref];
+            return { bookmarkBusy: nextBusy };
+          });
 
         const rollback = () =>
           set((s) => ({
@@ -101,7 +124,8 @@ export const useAuthStore = create<AuthStore>()(
             .then((r) => {
               if (!r.ok) rollback();
             })
-            .catch(rollback);
+            .catch(rollback)
+            .finally(clearBusy);
         } else {
           fetch("/api/bookmarks", {
             method: "POST",
@@ -114,7 +138,8 @@ export const useAuthStore = create<AuthStore>()(
             .then((r) => {
               if (!r.ok) rollback();
             })
-            .catch(rollback);
+            .catch(rollback)
+            .finally(clearBusy);
         }
       },
 


### PR DESCRIPTION
## Summary

Rapidly double-clicking a bookmark toggle could fire overlapping POST and DELETE requests that race each other, leaving the client-displayed bookmark state out of sync with the server.

## Evidence

`store/auth.ts`'s `toggleBookmark`, invoked from unguarded `IconButton`s in `app/search/SearchPageClient.tsx` and `app/bookmarks/page.tsx`. It optimistically flips local state and fires a POST or DELETE based on the bookmark state read at call time, with no debounce, no busy flag, and neither caller passed `disabled` while a request was in flight.

Reproduction: double-click the bookmark icon fast enough that the second click's `wasBookmarked` check reads the pre-first-click-response state — this fires both a POST and a DELETE nearly simultaneously; whichever response lands last determines the final server state.

## Fix

Added a per-ref `bookmarkBusy: Record<string, boolean>` map to the auth store, set on the ref when a request starts and cleared in `.finally()` when it settles. `toggleBookmark` now no-ops if a request for that ref is already in flight. Both callers (`SearchPageClient.tsx`'s `ResultCard`, `bookmarks/page.tsx`) now disable the toggle button while its ref is busy.

## Testing

Added three tests to `__tests__/store/auth.test.ts`: a second toggle for the same ref while one is in flight is a no-op (no second fetch, state unchanged); the busy flag clears once the request settles, allowing a later toggle; the guard is per-ref, not global (two different refs can toggle concurrently). Verified the new tests fail without the fix. `bun run lint`, `bun run typecheck`, `bun run format:check`, and the full unit suite (966 tests) pass.

Closes #386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate bookmark actions while a request is in progress.
  * Bookmark controls now remain disabled only for the affected verse.
  * Busy states clear after successful or failed bookmark operations.
  * Users can continue bookmarking different verses concurrently.
  * Prevented outdated bookmark requests from affecting a new session after sign-out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->