### PR TITLE
fix(a11y): give the verse-notes textarea a programmatic accessible name

### DIFF
--- a/__tests__/components/layout/ContextSidebar.test.tsx
+++ b/__tests__/components/layout/ContextSidebar.test.tsx
@@ -11,8 +11,11 @@ const baseVerse: Verse = {
   surah: 2,
   ayah: 255,
   ref: "2:255",
-  arabicText: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ",
-  translation: "Allah — there is no deity except Him.",
+  // Full verse text + en.sahih (Saheeh International, alquran.cloud) translation — Al-Baqarah 2:255.
+  arabicText:
+    "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ الْحَيُّ الْقَيُّومُ ۚ لَا تَأْخُذُهُ سِنَةٌ وَلَا نَوْمٌ ۚ لَّهُ مَا فِي السَّمَاوَاتِ وَمَا فِي الْأَرْضِ ۗ مَن ذَا الَّذِي يَشْفَعُ عِندَهُ إِلَّا بِإِذْنِهِ ۚ يَعْلَمُ مَا بَيْنَ أَيْدِيهِمْ وَمَا خَلْفَهُمْ ۖ وَلَا يُحِيطُونَ بِشَيْءٍ مِّنْ عِلْمِهِ إِلَّا بِمَا شَاءَ ۚ وَسِعَ كُرْسِيُّهُ السَّمَاوَاتِ وَالْأَرْضَ ۖ وَلَا يَئُودُهُ حِفْظُهُمَا ۚ وَهُوَ الْعَلِيُّ الْعَظِيمُ",
+  translation:
+    "Allah - there is no deity except Him, the Ever-Living, the Self-Sustaining. Neither drowsiness overtakes Him nor sleep. To Him belongs whatever is in the heavens and whatever is on the earth. Who is it that can intercede with Him except by His permission? He knows what is before them and what will be after them, and they encompass not a thing of His knowledge except for what He wills. His Kursi extends over the heavens and the earth, and their preservation tires Him not. And He is the Most High, the Most Great.",
   surahName: "Al-Baqarah",
   surahNameArabic: "البقرة",
 };

--- a/__tests__/components/layout/ContextSidebar.test.tsx
+++ b/__tests__/components/layout/ContextSidebar.test.tsx
@@ -1,0 +1,55 @@
+import { screen, fireEvent, act } from "@testing-library/react";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+
+import { ContextSidebar } from "@/components/layout/ContextSidebar";
+import { useCanvasStore } from "@/store/canvas";
+import { useAuthStore } from "@/store/auth";
+import type { Verse } from "@/types/quran";
+
+const baseVerse: Verse = {
+  surah: 2,
+  ayah: 255,
+  ref: "2:255",
+  arabicText: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ",
+  translation: "Allah — there is no deity except Him.",
+  surahName: "Al-Baqarah",
+  surahNameArabic: "البقرة",
+};
+
+describe("ContextSidebar — notes textarea accessibility", () => {
+  const mockFetch = vi.fn();
+  const previousAuth = useAuthStore.getState();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }))
+    );
+    useAuthStore.setState({ accessToken: "test-token" });
+    useCanvasStore.getState().setSidebarContent({ type: "node", verse: baseVerse });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useAuthStore.setState(previousAuth);
+    useCanvasStore.getState().setSidebarContent(null);
+  });
+
+  it("gives the notes textarea a programmatic accessible name", async () => {
+    await act(async () => {
+      renderWithIntl(<ContextSidebar />);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "My Notes" }));
+
+    expect(await screen.findByRole("textbox", { name: /add a private note/i })).toBeInTheDocument();
+  });
+});

--- a/components/layout/ContextSidebar.tsx
+++ b/components/layout/ContextSidebar.tsx
@@ -163,6 +163,7 @@ function NotesSection({ verseRef }: { verseRef: string }) {
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
                 placeholder="Add a private note…"
+                aria-label="Add a private note"
                 rows={2}
                 className="w-full resize-none rounded border border-border bg-transparent px-2.5 py-2 text-xs text-text-primary transition-colors focus:border-gold-muted"
               />


### PR DESCRIPTION
## Summary

The "Add a private note…" textarea in the canvas sidebar relied solely on placeholder text, with no programmatic label.

## Evidence

`components/layout/ContextSidebar.tsx` (`NotesSection`) — no `<label>`, `aria-label`, or `aria-labelledby` ties the textarea to the "My Notes" section heading. Placeholder text disappears once typing starts and is not a reliable substitute for a programmatic label.

## Fix

Added `aria-label="Add a private note"` to the textarea.

## Testing

Added `__tests__/components/layout/ContextSidebar.test.tsx`, which opens the "My Notes" section and queries the textarea by its accessible name via `getByRole("textbox", { name: /add a private note/i })`. Verified the test fails without the fix. `bun run lint`, `bun run typecheck`, `bun run format:check`, and the full unit suite (969 tests) pass.

Closes #387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved the private notes panel by giving its text area a clear accessible label: “Add a private note.”
  * Screen reader users can now more easily identify the purpose of the notes field.

* **Tests**
  * Added coverage to verify the notes field is correctly announced to assistive technologies and remains accessible when the panel is opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->