### PR TITLE
fix(admin): VOTD Preview button now has a busy/disabled state

### DIFF
--- a/__tests__/app/admin/votd/page.test.tsx
+++ b/__tests__/app/admin/votd/page.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/components/admin/AdminContext", async () => {
 
 import VotdPage from "@/app/admin/votd/page";
 
+// en.sahih (Saheeh International, alquran.cloud) — Al-Baqarah 2:255.
 const verse = {
   surah: 2,
   ayah: 255,

--- a/__tests__/app/admin/votd/page.test.tsx
+++ b/__tests__/app/admin/votd/page.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const mockApi = vi.fn();
+vi.mock("@/components/admin/AdminContext", async () => {
+  const actual = await vi.importActual("@/components/admin/AdminContext");
+  return {
+    ...actual,
+    useAdminFetch: () => mockApi,
+  };
+});
+
+import VotdPage from "@/app/admin/votd/page";
+
+const verse = {
+  surah: 2,
+  ayah: 255,
+  ref: "2:255",
+  arabicText: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ",
+  translation: "Allah — there is no deity except Him.",
+  surahName: "Al-Baqarah",
+  surahNameArabic: "البقرة",
+};
+
+describe("VotdPage — Preview button guards against overlapping requests", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    mockApi.mockReset();
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+    mockApi.mockResolvedValue({ entries: [] }); // calendar load for any month
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("disables Preview while a request is in flight and ignores a stale second click's response", async () => {
+    render(<VotdPage />);
+
+    fireEvent.click(screen.getByText("1", { selector: "span.tabular-nums" }));
+
+    const verseInput = await screen.findByPlaceholderText("e.g. 2:255");
+    fireEvent.change(verseInput, { target: { value: "2:255" } });
+
+    const first = deferred<Response>();
+    mockFetch.mockReturnValueOnce(first.promise);
+
+    const previewButton = screen.getByRole("button", { name: "Preview" });
+    fireEvent.click(previewButton);
+
+    expect(previewButton).toBeDisabled();
+
+    // A second click while the first request is in flight must not fire another fetch.
+    fireEvent.click(previewButton);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    first.resolve(new Response(JSON.stringify(verse), { status: 200 }));
+    await waitFor(() => expect(previewButton).not.toBeDisabled());
+    expect(await screen.findByText(verse.translation)).toBeInTheDocument();
+  });
+});

--- a/app/admin/votd/page.tsx
+++ b/app/admin/votd/page.tsx
@@ -156,6 +156,7 @@ function DayEditor({
   const [reflection, setReflection] = useState(existing?.reflection ?? "");
   const [preview, setPreview] = useState<Verse | null>(null);
   const [busy, setBusy] = useState(false);
+  const [previewBusy, setPreviewBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
 
   if (!date) {
@@ -167,6 +168,7 @@ function DayEditor({
   }
 
   const doPreview = async () => {
+    if (previewBusy) return;
     setMsg(null);
     setPreview(null);
     const match = /^(\d+):(\d+)$/.exec(verseRef.trim());
@@ -174,6 +176,7 @@ function DayEditor({
       setMsg("Enter a reference like 2:255.");
       return;
     }
+    setPreviewBusy(true);
     try {
       const v = await fetch(`/api/verse/${match[1]}/${match[2]}`);
       if (!v.ok) {
@@ -183,6 +186,8 @@ function DayEditor({
       setPreview((await v.json()) as Verse);
     } catch {
       setMsg("Preview failed.");
+    } finally {
+      setPreviewBusy(false);
     }
   };
 
@@ -231,8 +236,8 @@ function DayEditor({
             onChange={(e) => setVerseRef(e.target.value)}
             placeholder="e.g. 2:255"
           />
-          <Button size="md" variant="secondary" onClick={doPreview}>
-            Preview
+          <Button size="md" variant="secondary" onClick={doPreview} disabled={previewBusy}>
+            {previewBusy ? "Previewing…" : "Preview"}
           </Button>
         </div>
       </label>


### PR DESCRIPTION
## Summary

The Verse-of-the-Day admin "Preview" button didn't show a busy state or guard against rapid repeated clicks, unlike the adjacent "Update"/"Set verse" button.

## Evidence

`app/admin/votd/page.tsx`'s `doPreview()` is async (fetches `/api/verse/...`) but the "Preview" button was never disabled and showed no spinner while the request was in flight. Rapid clicks could fire overlapping preview fetches with no guard, so a stale response could overwrite a newer one.

## Fix

Added a `previewBusy` flag matching the pattern already used on the "Update" button: set before the fetch, cleared in `finally`, and the button is `disabled` while set (also shows "Previewing…"). `doPreview()` also early-returns if already busy, as a second guard against re-entrancy.

## Testing

Added `__tests__/app/admin/votd/page.test.tsx`: clicking Preview disables the button; a second click while the request is in flight does not fire a second fetch; the button re-enables and shows the result once the request settles. Verified the test fails without the fix. `bun run lint`, `bun run typecheck`, `bun run format:check`, and the full unit suite (974 tests) pass.

Closes #388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the VOTD admin preview experience by disabling the Preview button while a request is in progress.
  * Prevented duplicate preview requests from overlapping.
  * Updated the button label to clearly indicate when a preview is loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->