### PR TITLE
fix(docker): ship scripts/seed-translations.mjs in the runner image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,5 +15,6 @@ scripts
 !scripts/seed-quran.mjs
 !scripts/embed-corpus.mjs
 !scripts/seed-morphology.mjs
+!scripts/seed-translations.mjs
 hosting.md
 plan.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ COPY --from=deps /app/node_modules/drizzle-orm ./node_modules/drizzle-orm
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/seed-quran.mjs ./scripts/seed-quran.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/embed-corpus.mjs ./scripts/embed-corpus.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/seed-morphology.mjs ./scripts/seed-morphology.mjs
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/seed-translations.mjs ./scripts/seed-translations.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/data/morphology ./data/morphology
 COPY --from=deps /app/node_modules/@google/generative-ai ./node_modules/@google/generative-ai
 


### PR DESCRIPTION
## Summary
- The admin panel's "Seed verse translations" job fails with `Module not found "scripts/seed-translations.mjs"` because the file was never actually shipped in the production Docker image.
- Two packaging gaps, both from when the script was added in `e691d99` ("feat(i18n): multi-edition Quran translation storage (Phase 1)"): `.dockerignore` blanket-excludes `scripts/` and only allowlists specific files by name, and the `Dockerfile`'s runner stage never had a matching `COPY` for this script (its three sibling backfill scripts — `seed-quran.mjs`, `embed-corpus.mjs`, `seed-morphology.mjs` — do).
- No app-code changes; `seed-translations.mjs` only imports `postgres`, which is already copied into the runner image for `migrate.mjs`, so no new `node_modules` dependency is needed.

## Test plan
- [x] Built the image locally with both fixes applied (`docker build --build-arg NEXT_PUBLIC_APP_URL=... --build-arg NEXT_PUBLIC_QF_CLIENT_ID=... --build-arg NEXT_PUBLIC_QF_AUTH_BASE=...`)
- [x] Confirmed `scripts/seed-translations.mjs` is present in the runner container (`docker run --rm <image> ls scripts/`)
- [x] Ran `bun scripts/seed-translations.mjs` inside the container and confirmed it now reaches the script's own `DATABASE_URL is not set` guard instead of failing with "Module not found"
- [x] `bun run test:integration` passed via the pre-push hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Included the translation backfill script in production Docker images.
  * Ensured the script is available during container deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->