### PR TITLE
chore(e2e): add missing pages to a11y scan

### DIFF
--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,10 +1,12 @@
 import AxeBuilder from "@axe-core/playwright";
 import type { Page } from "@playwright/test";
 import { DIVINE_NAMES } from "../lib/names/divine-names";
+import { STORIES } from "../lib/stories";
 import { test, expect } from "./fixtures/auth";
 
 const BLOCKING_IMPACTS = new Set(["serious", "critical"]);
 const FIRST_DIVINE_NAME_SLUG = DIVINE_NAMES[0].slug;
+const FIRST_STORY_SLUG = STORIES[0].slug;
 
 async function gotoAndSettle(page: Page, path: string): Promise<void> {
   await page.goto(path, { waitUntil: "domcontentloaded" });
@@ -75,6 +77,26 @@ test.describe("accessibility", () => {
     await gotoAndSettle(page, "/onboarding");
     await scanAndAssert(page, "onboarding");
   });
+
+  test("settings page has no serious a11y violations", async ({ page }) => {
+    await gotoAndSettle(page, "/settings");
+    await scanAndAssert(page, "settings");
+  });
+
+  test("mentions page has no serious a11y violations", async ({ authenticatedPage: page }) => {
+    await gotoAndSettle(page, "/mentions");
+    await scanAndAssert(page, "mentions");
+  });
+
+  test("stories index has no serious a11y violations", async ({ page }) => {
+    await gotoAndSettle(page, "/stories");
+    await scanAndAssert(page, "stories index");
+  });
+
+  test("stories detail page has no serious a11y violations", async ({ page }) => {
+    await gotoAndSettle(page, `/stories/${FIRST_STORY_SLUG}`);
+    await scanAndAssert(page, "stories detail");
+  });
 });
 
 // `/admin/*` is gated client-side by AdminGate, which shows an "Authorising…"
@@ -93,6 +115,9 @@ const ADMIN_PAGES = [
   { path: "/admin/names", label: "admin names" },
   { path: "/admin/infra", label: "admin infra" },
   { path: "/admin/audit", label: "admin audit" },
+  { path: "/admin/analytics", label: "admin analytics" },
+  { path: "/admin/jobs", label: "admin jobs" },
+  { path: "/admin/prompts", label: "admin prompts" },
 ];
 
 test.describe("admin accessibility", () => {


### PR DESCRIPTION
## Summary

`e2e/a11y.spec.ts` runs an axe-core scan over a curated list of pages, but the list omitted several pages that exist in the codebase and are otherwise comparable to pages already scanned.

- `ADMIN_PAGES` now includes `/admin/analytics`, `/admin/jobs`, `/admin/prompts`.
- The non-admin suite now includes `/mentions`, `/settings`, `/stories` (index), and `/stories/[slug]` (using the same dynamic-slug pattern already used for divine names — `STORIES[0].slug`).

All new entries pass axe-core with no serious/critical violations (a couple have pre-existing moderate/advisory violations like `landmark-one-main`/`region`, which the suite already treats as non-blocking everywhere else and only warns on).

## Related

Closes #365. Note left on #332 ("Prophetic Stories" epic) explaining that the feature itself is already fully implemented and this PR was the only remaining gap tied to it.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:ci` (981 tests)
- [x] `bunx playwright test e2e/a11y.spec.ts -g "analytics|jobs|prompts|mentions|settings|stories"` — all 7 new entries pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added accessibility coverage for settings, mentions, and story pages.
  * Expanded accessibility checks to include analytics, jobs, and prompts pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->