### PR TITLE
fix(canvas): require confirmation before Clear wipes the graph

### DIFF
--- a/__tests__/components/canvas/CanvasToolbar.test.tsx
+++ b/__tests__/components/canvas/CanvasToolbar.test.tsx
@@ -69,6 +69,25 @@ describe("CanvasToolbar export menu", () => {
   });
 });
 
+describe("CanvasToolbar clear confirmation", () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useCanvasStore.setState({ nodes: [verseNode() as any], edges: [] });
+  });
+
+  it("requires a second click before clearing the canvas", () => {
+    render(<CanvasToolbar onSearchOpen={vi.fn()} />);
+    const clearButton = screen.getByRole("button", { name: "Clear" });
+
+    fireEvent.click(clearButton);
+    expect(useCanvasStore.getState().nodes).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Confirm clear?" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm clear?" }));
+    expect(useCanvasStore.getState().nodes).toHaveLength(0);
+  });
+});
+
 describe("CanvasToolbar save workspace name", () => {
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/__tests__/components/canvas/CanvasToolbar.test.tsx
+++ b/__tests__/components/canvas/CanvasToolbar.test.tsx
@@ -4,6 +4,7 @@ import { renderWithIntl as render } from "../../test-utils/render-with-intl";
 import { useCanvasStore } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
 import type { Verse, VerseRef } from "@/types/quran";
+import type { Node } from "@xyflow/react";
 
 vi.mock("@xyflow/react", () => ({
   Panel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -12,7 +13,7 @@ vi.mock("@xyflow/react", () => ({
 
 import { CanvasToolbar } from "@/components/canvas/CanvasToolbar";
 
-function verseNode() {
+function verseNode(): Node {
   const verse: Verse = {
     surah: 1,
     ayah: 1,
@@ -22,13 +23,12 @@ function verseNode() {
     surahName: "Al-Fatihah",
     surahNameArabic: "الفاتحة",
   };
-  return { id: "n1", type: "verse", position: { x: 0, y: 0 }, data: verse };
+  return { id: "n1", type: "verse", position: { x: 0, y: 0 }, data: { ...verse } } as Node;
 }
 
 describe("CanvasToolbar export menu", () => {
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    useCanvasStore.setState({ nodes: [verseNode() as any], edges: [] });
+    useCanvasStore.setState({ nodes: [verseNode()], edges: [] });
   });
 
   it("opens the export menu on click", () => {
@@ -71,8 +71,7 @@ describe("CanvasToolbar export menu", () => {
 
 describe("CanvasToolbar clear confirmation", () => {
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    useCanvasStore.setState({ nodes: [verseNode() as any], edges: [] });
+    useCanvasStore.setState({ nodes: [verseNode()], edges: [] });
   });
 
   it("requires a second click before clearing the canvas", () => {
@@ -95,8 +94,7 @@ describe("CanvasToolbar save workspace name", () => {
   });
 
   it("pluralizes the ICU-formatted verse count in the saved workspace name", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    useCanvasStore.setState({ nodes: [verseNode() as any], edges: [] });
+    useCanvasStore.setState({ nodes: [verseNode()], edges: [] });
     const fetchMock = vi.fn().mockResolvedValue({ ok: true });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -112,8 +110,7 @@ describe("CanvasToolbar save workspace name", () => {
 
   it("uses the plural form for more than one verse", async () => {
     useCanvasStore.setState({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      nodes: [verseNode(), { ...verseNode(), id: "n2" }] as any,
+      nodes: [verseNode(), { ...verseNode(), id: "n2" }],
       edges: [],
     });
     const fetchMock = vi.fn().mockResolvedValue({ ok: true });

--- a/__tests__/components/layout/Header.mobile-bar.test.tsx
+++ b/__tests__/components/layout/Header.mobile-bar.test.tsx
@@ -47,3 +47,17 @@ describe("Header mobile bar — export-failed vs. clear icon", () => {
     expect(failedIconSvg).not.toBe(clearIconSvg);
   });
 });
+
+describe("Header mobile bar — Clear requires confirmation", () => {
+  it("requires a second click before clearing the canvas", () => {
+    renderWithIntl(<Header onSearchOpen={() => {}} />);
+
+    const clearButton = screen.getByRole("button", { name: "Clear" });
+    fireEvent.click(clearButton);
+    expect(useCanvasStore.getState().nodes).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Confirm clear?" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm clear?" }));
+    expect(useCanvasStore.getState().nodes).toHaveLength(0);
+  });
+});

--- a/components/canvas/CanvasToolbar.tsx
+++ b/components/canvas/CanvasToolbar.tsx
@@ -21,6 +21,7 @@ import { useCanvasStore, serializeCanvas } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
 import { useAudioStore } from "@/store/audio";
 import { useCopyFeedback } from "@/hooks/useCopyFeedback";
+import { useArmedConfirm } from "@/hooks/useArmedConfirm";
 import { buildShareUrl } from "@/hooks/useCanvasPersistence";
 import { buildAuthUrl } from "@/lib/auth/pkce";
 import {
@@ -119,6 +120,7 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
   const nodes = useCanvasStore((s) => s.nodes);
   const edges = useCanvasStore((s) => s.edges);
   const reset = useCanvasStore((s) => s.reset);
+  const { armed: clearArmed, trigger: triggerClear } = useArmedConfirm(reset);
 
   const accessToken = useAuthStore((s) => s.accessToken);
 
@@ -332,9 +334,9 @@ export function CanvasToolbar({ onSearchOpen }: { onSearchOpen: () => void }) {
 
         {divider}
 
-        <ToolbarBtn onClick={reset} danger>
+        <ToolbarBtn onClick={triggerClear} danger>
           <RotateCcw className="h-3.5 w-3.5" />
-          {t("clear")}
+          {clearArmed ? t("clearConfirm") : t("clear")}
         </ToolbarBtn>
       </div>
     </Panel>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -26,6 +26,7 @@ import { buildShareUrl } from "@/hooks/useCanvasPersistence";
 import { useState, useEffect, useRef, forwardRef, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { useCopyFeedback } from "@/hooks/useCopyFeedback";
+import { useArmedConfirm } from "@/hooks/useArmedConfirm";
 import {
   exportCanvasToPng,
   exportCanvasToPdf,
@@ -204,6 +205,7 @@ export function Header({ onSearchOpen }: HeaderProps) {
   const moreButtonRef = useRef<HTMLButtonElement>(null);
 
   const reset = useCanvasStore((s) => s.reset);
+  const { armed: clearArmed, trigger: triggerClear } = useArmedConfirm(reset);
   const nodes = useCanvasStore((s) => s.nodes);
   const edges = useCanvasStore((s) => s.edges);
   const requestFit = useCanvasStore((s) => s.requestFit);
@@ -398,7 +400,12 @@ export function Header({ onSearchOpen }: HeaderProps) {
               onClick={() => setMoreOpen((v) => !v)}
               active={moreOpen}
             />
-            <BarButton icon={<RotateCcw />} label={t("clear")} onClick={reset} danger />
+            <BarButton
+              icon={<RotateCcw />}
+              label={clearArmed ? t("clearConfirm") : t("clear")}
+              onClick={triggerClear}
+              danger
+            />
           </div>
           {moreOpen && (
             <MoreSheet

--- a/e2e/canvas.spec.ts
+++ b/e2e/canvas.spec.ts
@@ -11,7 +11,9 @@ test.describe("canvas", () => {
 
     await expect(page.getByText("2:255")).toBeVisible();
 
-    await page.getByRole("button", { name: /clear/i }).click();
+    const clearButton = page.getByRole("button", { name: /clear/i });
+    await clearButton.click();
+    await clearButton.click();
 
     await expect(page.getByRole("button", { name: /search verses/i })).toBeVisible();
     await expect(page.getByText("2:255")).toHaveCount(0);

--- a/messages/az.json
+++ b/messages/az.json
@@ -97,6 +97,7 @@
     "play": "Oxut",
     "playAll": "Hamısını oxut",
     "clear": "Təmizlə",
+    "clearConfirm": "Təmizləməyi təsdiqlə?",
     "workspaceName": "{count, plural, one {# ayə} other {# ayə}} — {date}",
     "noMoreConnections": "Bu növdə başqa əlaqə yoxdur.",
     "connectionsFailed": "Əlaqə tapılmadı. Fərqli növ sınayın.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -97,6 +97,7 @@
     "play": "Play",
     "playAll": "Play all",
     "clear": "Clear",
+    "clearConfirm": "Confirm clear?",
     "workspaceName": "{count, plural, one {# verse} other {# verses}} — {date}",
     "noMoreConnections": "No more connections of this type.",
     "connectionsFailed": "Could not find connections. Try a different type.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -97,6 +97,7 @@
     "play": "Воспроизвести",
     "playAll": "Воспроизвести все",
     "clear": "Очистить",
+    "clearConfirm": "Подтвердить очистку?",
     "workspaceName": "{count, plural, one {# аят} few {# аята} many {# аятов} other {# аята}} — {date}",
     "noMoreConnections": "Больше нет связей этого типа.",
     "connectionsFailed": "Не удалось найти связи. Попробуйте другой тип.",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -97,6 +97,7 @@
     "play": "Oynat",
     "playAll": "Tümünü oynat",
     "clear": "Temizle",
+    "clearConfirm": "Temizlemeyi onayla?",
     "workspaceName": "{count, plural, one {# ayet} other {# ayet}} — {date}",
     "noMoreConnections": "Bu türde başka bağlantı yok.",
     "connectionsFailed": "Bağlantı bulunamadı. Farklı bir tür deneyin.",


### PR DESCRIPTION
## Summary

The canvas toolbar's "Clear" button permanently destroyed the user's entire connection graph on a single click, with no confirmation step and no undo mechanism anywhere in the app.

- `components/canvas/CanvasToolbar.tsx` (desktop toolbar) and `components/layout/Header.tsx` (mobile bottom bar) both wired `onClick` directly to `useCanvasStore().reset()`.
- Both now use the existing `useArmedConfirm` hook (`hooks/useArmedConfirm.ts`) — the same two-click armed-confirm pattern already used for destructive admin actions (`ConfirmButton` in `components/admin/primitives.tsx`). First click arms the button and swaps the label to "Confirm clear?" for 3s; a second click within that window actually clears. `IconButton`/`ToolbarBtn`/`BarButton` aren't built on the `Button` primitive `ConfirmButton` wraps, so `useArmedConfirm` (UI-agnostic) is composed directly instead.
- Added the `clearConfirm` i18n key alongside the existing `clear` key in all four locale files (en/tr/az/ru).

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:ci` (full suite, incl. new tests below)
- [x] New unit tests: `__tests__/components/canvas/CanvasToolbar.test.tsx` and `__tests__/components/layout/Header.mobile-bar.test.tsx` — first click doesn't clear and shows the confirm label; second click clears.
- [x] Manual: verified desktop toolbar and mobile bottom-bar both require two clicks.

Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-step confirmation before clearing the canvas.
  * The canvas remains unchanged after the first click and is cleared only after confirmation.
  * Added localized confirmation text in English, Azerbaijani, Russian, and Turkish.

* **Tests**
  * Added coverage for desktop and mobile canvas-clearing confirmation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->