### PR TITLE
fix(workspaces): require confirmation before deleting a saved canvas

### DIFF
--- a/__tests__/app/workspaces/page.test.tsx
+++ b/__tests__/app/workspaces/page.test.tsx
@@ -1,0 +1,69 @@
+import { screen, act, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/workspaces",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+import WorkspacesPage from "@/app/workspaces/page";
+import { useAuthStore } from "@/store/auth";
+import { TooltipProvider } from "@/components/ui";
+
+describe("WorkspacesPage — delete confirmation", () => {
+  const mockFetch = vi.fn();
+  const previousAuthState = useAuthStore.getState();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    useAuthStore.setState({ accessToken: "test-token", isSessionLoading: false });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useAuthStore.setState(previousAuthState);
+  });
+
+  const workspace = {
+    id: 1,
+    name: "3 verses — Jan 1",
+    nodeCount: 3,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("requires a second click before deleting a saved canvas", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify([workspace]), { status: 200 }));
+
+    await act(async () => {
+      renderWithIntl(
+        <TooltipProvider>
+          <WorkspacesPage />
+        </TooltipProvider>
+      );
+    });
+
+    await waitFor(() => expect(screen.getByText(workspace.name)).toBeInTheDocument());
+
+    const deleteButton = screen.getByRole("button", { name: "Delete canvas" });
+    fireEvent.click(deleteButton);
+
+    // First click only arms the button — no DELETE request, row still present.
+    expect(mockFetch).toHaveBeenCalledTimes(1); // just the initial GET
+    expect(screen.getByText(workspace.name)).toBeInTheDocument();
+    const confirmButton = screen.getByRole("button", { name: "Confirm delete canvas?" });
+
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "/api/workspace/1",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+    await waitFor(() => expect(screen.queryByText(workspace.name)).not.toBeInTheDocument());
+  });
+});

--- a/app/workspaces/page.tsx
+++ b/app/workspaces/page.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from "@/store/auth";
 import { useCanvasStore, type SavedCanvas } from "@/store/canvas";
 import { Card, IconButton, Tooltip } from "@/components/ui";
 import { AuthShell } from "@/components/layout/AuthShell";
+import { useArmedConfirm } from "@/hooks/useArmedConfirm";
 
 interface WorkspaceMeta {
   id: number;
@@ -15,6 +16,75 @@ interface WorkspaceMeta {
   nodeCount: number;
   createdAt: string;
   updatedAt: string;
+}
+
+function WorkspaceRow({
+  ws,
+  loadingId,
+  deletingId,
+  onLoad,
+  onDelete,
+}: {
+  ws: WorkspaceMeta;
+  loadingId: number | null;
+  deletingId: number | null;
+  onLoad: (id: number) => void;
+  onDelete: (id: number) => void;
+}) {
+  const { armed: deleteArmed, trigger: triggerDelete } = useArmedConfirm(() => onDelete(ws.id));
+
+  return (
+    <Card className="flex items-center justify-between gap-4 p-4">
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-text-primary">{ws.name}</p>
+        <div className="mt-1 flex items-center gap-3">
+          <span className="rounded border border-border px-1.5 py-0.5 font-mono text-xs text-text-muted">
+            {ws.nodeCount} verse{ws.nodeCount === 1 ? "" : "s"}
+          </span>
+          <span className="text-xs text-text-muted">
+            {new Date(ws.updatedAt).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+            })}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1.5">
+        <button
+          onClick={() => onLoad(ws.id)}
+          disabled={!!loadingId}
+          className="flex cursor-pointer items-center gap-1.5 rounded border border-teal px-2.5 py-1.5 text-xs text-teal transition-colors hover:bg-teal/10 disabled:opacity-50"
+        >
+          {loadingId === ws.id ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Upload className="h-3.5 w-3.5" />
+          )}
+          <span>Load</span>
+        </button>
+
+        <Tooltip label={deleteArmed ? "Confirm delete canvas?" : "Delete canvas"}>
+          <IconButton
+            tone="danger"
+            size="sm"
+            onClick={triggerDelete}
+            disabled={!!deletingId}
+            aria-label={deleteArmed ? "Confirm delete canvas?" : "Delete canvas"}
+          >
+            {deletingId === ws.id ? (
+              <Loader2 className="animate-spin" />
+            ) : deleteArmed ? (
+              <TriangleAlert />
+            ) : (
+              <Trash2 />
+            )}
+          </IconButton>
+        </Tooltip>
+      </div>
+    </Card>
+  );
 }
 
 export default function WorkspacesPage() {
@@ -135,50 +205,14 @@ export default function WorkspacesPage() {
         ) : (
           <div className="space-y-3">
             {workspaces.map((ws) => (
-              <Card key={ws.id} className="flex items-center justify-between gap-4 p-4">
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-text-primary">{ws.name}</p>
-                  <div className="mt-1 flex items-center gap-3">
-                    <span className="rounded border border-border px-1.5 py-0.5 font-mono text-xs text-text-muted">
-                      {ws.nodeCount} verse{ws.nodeCount === 1 ? "" : "s"}
-                    </span>
-                    <span className="text-xs text-text-muted">
-                      {new Date(ws.updatedAt).toLocaleDateString("en-US", {
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                      })}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="flex shrink-0 items-center gap-1.5">
-                  <button
-                    onClick={() => handleLoad(ws.id)}
-                    disabled={!!loadingId}
-                    className="flex cursor-pointer items-center gap-1.5 rounded border border-teal px-2.5 py-1.5 text-xs text-teal transition-colors hover:bg-teal/10 disabled:opacity-50"
-                  >
-                    {loadingId === ws.id ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Upload className="h-3.5 w-3.5" />
-                    )}
-                    <span>Load</span>
-                  </button>
-
-                  <Tooltip label="Delete canvas">
-                    <IconButton
-                      tone="danger"
-                      size="sm"
-                      onClick={() => handleDelete(ws.id)}
-                      disabled={!!deletingId}
-                      aria-label="Delete canvas"
-                    >
-                      {deletingId === ws.id ? <Loader2 className="animate-spin" /> : <Trash2 />}
-                    </IconButton>
-                  </Tooltip>
-                </div>
-              </Card>
+              <WorkspaceRow
+                key={ws.id}
+                ws={ws}
+                loadingId={loadingId}
+                deletingId={deletingId}
+                onLoad={handleLoad}
+                onDelete={handleDelete}
+              />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary

Deleting a saved canvas from `/workspaces` was a single irreversible click with no confirmation, unlike the app's own established confirm pattern for destructive actions elsewhere.

- `app/workspaces/page.tsx`'s `handleDelete` fired `DELETE /api/workspace/:id` directly on click.
- Extracted a `WorkspaceRow` component (hooks can't be called inside `.map()`) so the delete `IconButton` can use `useArmedConfirm` (`hooks/useArmedConfirm.ts`) — the same two-click confirm pattern used for the canvas Clear button (#367) and `ConfirmButton` in `components/admin/primitives.tsx`. First click arms (icon/label swap to "Confirm delete canvas?"), second click within 3s actually deletes.
- No visual/behavioral changes to the rest of the page — pure extraction plus the confirm wrapper.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:ci` (full suite, incl. new test below)
- [x] New test: `__tests__/app/workspaces/page.test.tsx` — first click doesn't fire the DELETE request and the row stays; second click fires DELETE and the row is removed.

Closes #368