### PR TITLE
fix(canvas): don't let a pending share-link fetch race the debounced autosave

### DIFF
--- a/__tests__/hooks/useCanvasPersistence.flush.test.ts
+++ b/__tests__/hooks/useCanvasPersistence.flush.test.ts
@@ -105,4 +105,44 @@ describe("useCanvasPersistence flush-on-unload", () => {
     fetchSpy.mockRestore();
     window.history.pushState({}, "", "/canvas");
   });
+
+  it("does not wipe a previously-saved canvas when the debounced autosave timer elapses while a ?share= restore is still in flight", async () => {
+    localStorage.setItem(
+      CANVAS_STORAGE_KEY,
+      JSON.stringify({ v: 1, nodes: [{ id: "existing" }], edges: [] })
+    );
+    window.history.pushState({}, "", "/canvas?share=12345678-1234-1234-1234-123456789abc");
+
+    let resolveFetch: (value: Response) => void;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    renderHook(() => useCanvasPersistence());
+
+    // The share fetch hasn't resolved yet — advance well past the 800ms
+    // autosave debounce while nodes/edges are still the initial empty state.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    const saved = JSON.parse(localStorage.getItem(CANVAS_STORAGE_KEY)!);
+    expect(saved.nodes).toEqual([{ id: "existing" }]);
+
+    await act(async () => {
+      resolveFetch!({ ok: false } as Response);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The fallback restore attempt (triggered once the fetch settles) still
+    // has an intact localStorage entry to read from.
+    const savedAfterSettle = JSON.parse(localStorage.getItem(CANVAS_STORAGE_KEY)!);
+    expect(savedAfterSettle.nodes).toEqual([{ id: "existing" }]);
+
+    fetchSpy.mockRestore();
+    window.history.pushState({}, "", "/canvas");
+  });
 });

--- a/hooks/useCanvasPersistence.ts
+++ b/hooks/useCanvasPersistence.ts
@@ -70,8 +70,15 @@ export function useCanvasPersistence() {
   const nodes = useCanvasStore((s) => s.nodes);
   const edges = useCanvasStore((s) => s.edges);
   const restoreCanvas = useCanvasStore((s) => s.restoreCanvas);
+  // startedRef only guards the mount effect below from running its restore
+  // logic twice (e.g. React StrictMode's double-invoke). hydratedRef is the
+  // real "safe to autosave" signal — it's flipped only once the entire
+  // restore attempt has settled, including any pending ?share= fetch, so the
+  // debounced autosave/unload-flush effects can never see a premature
+  // "hydrated" state and mistake the still-empty initial nodes/edges for an
+  // intentional clear.
+  const startedRef = useRef(false);
   const hydratedRef = useRef(false);
-  const restoringRef = useRef(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestRef = useRef({ nodes, edges });
   useEffect(() => {
@@ -97,18 +104,13 @@ export function useCanvasPersistence() {
 
   // On mount: restore from ?share=<id> first, then localStorage
   useEffect(() => {
-    if (hydratedRef.current) return;
-    hydratedRef.current = true;
+    if (startedRef.current) return;
+    startedRef.current = true;
 
     const params = new URLSearchParams(window.location.search);
     const shareId = params.get("share");
 
     if (shareId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(shareId)) {
-      // While this fetch is in flight, nodes/edges are still their initial
-      // empty state — block the debounced save (and unload flush) from
-      // reading that state as "canvas cleared" and wiping out the real
-      // localStorage fallback this restore might fall back to.
-      restoringRef.current = true;
       fetch(`/api/share/${shareId}`)
         .then((r) => (r.ok ? r.json() : null))
         .then((saved: SavedCanvas | null) => {
@@ -127,18 +129,22 @@ export function useCanvasPersistence() {
           tryRestoreFromLocalStorage();
         })
         .finally(() => {
-          restoringRef.current = false;
+          // Only now — once the share fetch (success, failure, or invalid
+          // data) has fully settled and any fallback restore has run — is it
+          // safe to let the effects below observe nodes/edges as "hydrated".
+          hydratedRef.current = true;
         });
       return;
     }
 
     tryRestoreFromLocalStorage();
+    hydratedRef.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Auto-save to localStorage whenever nodes/edges change (debounced 800ms)
   useEffect(() => {
-    if (!hydratedRef.current || restoringRef.current) return;
+    if (!hydratedRef.current) return;
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
       saveTimerRef.current = null;
@@ -155,7 +161,7 @@ export function useCanvasPersistence() {
   // beforeunload) so the page stays eligible for the back/forward cache.
   useEffect(() => {
     const flush = () => {
-      if (!hydratedRef.current || restoringRef.current || !saveTimerRef.current) return;
+      if (!hydratedRef.current || !saveTimerRef.current) return;
       clearTimeout(saveTimerRef.current);
       saveTimerRef.current = null;
       saveToLocalStorage(latestRef.current.nodes, latestRef.current.edges);


### PR DESCRIPTION
## Summary

Opening a slow or broken `/canvas?share=<id>` link could silently delete a guest user's previously-saved local canvas from `localStorage`, with no error and no way to recover it.

## Root cause

`hooks/useCanvasPersistence.ts`'s mount effect set `hydratedRef.current = true` synchronously, before an in-flight `?share=<id>` fetch resolved. The debounced autosave effect (declared after it, in the same commit) gated only on `hydratedRef`/`restoringRef`, and could observe `nodes`/`edges` still in their empty initial state as "hydrated." Once its 800ms timer elapsed — while the share fetch was still slow/pending, or after it failed — it wiped the guest's real `localStorage` canvas via `saveToLocalStorage([], [])` before the share restore (or its localStorage fallback) ever ran.

## Fix

Split the single overloaded ref into two:
- `startedRef` — guards the mount effect from running its restore logic twice (e.g. React StrictMode double-invoke).
- `hydratedRef` — the real "safe to autosave" signal. It's now only flipped once the *entire* restore attempt has settled: immediately for the plain-localStorage path, or inside `.finally()` (success, invalid-data-fallback, or fetch-failure-fallback) for the `?share=` path.

The debounced autosave and unload-flush effects now gate purely on `hydratedRef`, so they can't observe a premature "hydrated" state regardless of exact promise/render interleaving — no more `restoringRef` needed.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:ci` (982 tests, full suite)
- [x] New regression test in `__tests__/hooks/useCanvasPersistence.flush.test.ts`: pre-seeds `localStorage` with a saved canvas, opens with `?share=<id>`, advances fake timers past the 800ms autosave debounce *while the share fetch is still pending*, and asserts the pre-seeded canvas is untouched — then resolves the fetch with invalid data and asserts the fallback restore still has an intact `localStorage` entry to read from.

Closes #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented autosave from overwriting an existing local canvas while a shared-canvas restoration is still loading.
  * Improved restoration reliability when shared-canvas retrieval fails, allowing the saved local canvas to remain available.
  * Prevented duplicate restoration attempts during initialization, reducing potential data conflicts and preserving canvas content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->