### PR TITLE
fix: add pagination to the admin audit log page

### DIFF
--- a/__tests__/api/admin/audit.test.ts
+++ b/__tests__/api/admin/audit.test.ts
@@ -7,7 +7,8 @@ vi.mock("@/lib/admin/admin-auth", () => ({ requireAdmin: vi.fn() }));
 function makeDbChain(
   resolveWith: unknown = [],
   onLimit?: (n: number) => void,
-  onOffset?: (n: number) => void
+  onOffset?: (n: number) => void,
+  onOrderBy?: (cols: unknown[]) => void
 ) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
@@ -21,6 +22,8 @@ function makeDbChain(
             Promise.resolve(resolveWith).then(res, rej);
         if (prop === "limit" && onLimit) return (n: number) => (onLimit(n), chain);
         if (prop === "offset" && onOffset) return (n: number) => (onOffset(n), chain);
+        if (prop === "orderBy" && onOrderBy)
+          return (...cols: unknown[]) => (onOrderBy(cols), chain);
         return () => chain;
       },
       apply() {
@@ -29,6 +32,18 @@ function makeDbChain(
     }
   );
   return chain;
+}
+
+/** Drizzle's `desc(column)` produces an SQL fragment whose queryChunks include the
+ *  column itself; the column's `name` is the underlying DB column name. */
+function orderedColumnNames(cols: unknown[]): string[] {
+  return cols.map((col) => {
+    const chunks = (col as { queryChunks?: unknown[] }).queryChunks ?? [];
+    const columnChunk = chunks.find(
+      (c): c is { name: string } => typeof c === "object" && c !== null && "name" in c
+    );
+    return columnChunk?.name ?? "";
+  });
 }
 
 const { mockSelect } = vi.hoisted(() => ({
@@ -169,5 +184,14 @@ describe("GET /api/admin/audit", () => {
     const body = await res.json();
     expect(body.entries).toHaveLength(1);
     expect(body.hasMore).toBe(false);
+  });
+
+  it("orders by id after createdAt so rows with equal timestamps have a stable, gap-free page order", async () => {
+    let capturedOrderBy: unknown[] = [];
+    mockSelect.mockReturnValue(
+      makeDbChain([], undefined, undefined, (cols) => (capturedOrderBy = cols))
+    );
+    await GET(req());
+    expect(orderedColumnNames(capturedOrderBy)).toEqual(["created_at", "id"]);
   });
 });

--- a/__tests__/api/admin/audit.test.ts
+++ b/__tests__/api/admin/audit.test.ts
@@ -4,7 +4,11 @@ import type { User } from "@/lib/infra/db/schema";
 
 vi.mock("@/lib/admin/admin-auth", () => ({ requireAdmin: vi.fn() }));
 
-function makeDbChain(resolveWith: unknown = [], onLimit?: (n: number) => void) {
+function makeDbChain(
+  resolveWith: unknown = [],
+  onLimit?: (n: number) => void,
+  onOffset?: (n: number) => void
+) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
     function () {
@@ -16,6 +20,7 @@ function makeDbChain(resolveWith: unknown = [], onLimit?: (n: number) => void) {
           return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
             Promise.resolve(resolveWith).then(res, rej);
         if (prop === "limit" && onLimit) return (n: number) => (onLimit(n), chain);
+        if (prop === "offset" && onOffset) return (n: number) => (onOffset(n), chain);
         return () => chain;
       },
       apply() {
@@ -36,10 +41,12 @@ import { requireAdmin } from "@/lib/admin/admin-auth";
 
 const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
 
-function req(limit?: string) {
-  const url = limit
-    ? `http://localhost/api/admin/audit?limit=${limit}`
-    : "http://localhost/api/admin/audit";
+function req(params?: { limit?: string; offset?: string }) {
+  const search = new URLSearchParams();
+  if (params?.limit !== undefined) search.set("limit", params.limit);
+  if (params?.offset !== undefined) search.set("offset", params.offset);
+  const qs = search.toString();
+  const url = qs ? `http://localhost/api/admin/audit?${qs}` : "http://localhost/api/admin/audit";
   return new NextRequest(url, { headers: { Authorization: "Bearer t" } });
 }
 
@@ -96,29 +103,71 @@ describe("GET /api/admin/audit", () => {
   it("falls back to the default limit of 100 for a non-numeric limit", async () => {
     let capturedLimit: number | undefined;
     mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
-    await GET(req("abc"));
-    expect(capturedLimit).toBe(100);
+    await GET(req({ limit: "abc" }));
+    // Fetches one extra row (limit + 1) to detect hasMore.
+    expect(capturedLimit).toBe(101);
   });
 
   it("falls back to the default limit of 100 for a negative limit", async () => {
     let capturedLimit: number | undefined;
     mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
-    await GET(req("-5"));
-    expect(capturedLimit).toBe(100);
+    await GET(req({ limit: "-5" }));
+    expect(capturedLimit).toBe(101);
   });
 
   it("caps an oversized limit at 500", async () => {
     let capturedLimit: number | undefined;
     mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
-    const res = await GET(req("10000"));
+    const res = await GET(req({ limit: "10000" }));
     expect(res.status).toBe(200);
-    expect(capturedLimit).toBe(500);
+    expect(capturedLimit).toBe(501);
   });
 
   it("honors a valid custom limit within the cap", async () => {
     let capturedLimit: number | undefined;
     mockSelect.mockReturnValue(makeDbChain([], (n) => (capturedLimit = n)));
-    await GET(req("25"));
-    expect(capturedLimit).toBe(25);
+    await GET(req({ limit: "25" }));
+    expect(capturedLimit).toBe(26);
+  });
+
+  it("defaults offset to 0 when not supplied", async () => {
+    let capturedOffset: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], undefined, (n) => (capturedOffset = n)));
+    await GET(req());
+    expect(capturedOffset).toBe(0);
+  });
+
+  it("falls back to offset 0 for a negative or non-numeric offset", async () => {
+    let capturedOffset: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], undefined, (n) => (capturedOffset = n)));
+    await GET(req({ offset: "-5" }));
+    expect(capturedOffset).toBe(0);
+
+    mockSelect.mockReturnValue(makeDbChain([], undefined, (n) => (capturedOffset = n)));
+    await GET(req({ offset: "abc" }));
+    expect(capturedOffset).toBe(0);
+  });
+
+  it("honors a valid custom offset", async () => {
+    let capturedOffset: number | undefined;
+    mockSelect.mockReturnValue(makeDbChain([], undefined, (n) => (capturedOffset = n)));
+    await GET(req({ offset: "50" }));
+    expect(capturedOffset).toBe(50);
+  });
+
+  it("reports hasMore: true when the DB returns more rows than the requested page", async () => {
+    mockSelect.mockReturnValue(makeDbChain([row({ id: 1 }), row({ id: 2 })]));
+    const res = await GET(req({ limit: "1" }));
+    const body = await res.json();
+    expect(body.entries).toHaveLength(1);
+    expect(body.hasMore).toBe(true);
+  });
+
+  it("reports hasMore: false when the DB returns no more than the requested page", async () => {
+    mockSelect.mockReturnValue(makeDbChain([row({ id: 1 })]));
+    const res = await GET(req({ limit: "1" }));
+    const body = await res.json();
+    expect(body.entries).toHaveLength(1);
+    expect(body.hasMore).toBe(false);
   });
 });

--- a/__tests__/app/admin/audit/page.test.tsx
+++ b/__tests__/app/admin/audit/page.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockApi = vi.fn();
+vi.mock("@/components/admin/AdminContext", async () => {
+  const actual = await vi.importActual("@/components/admin/AdminContext");
+  return {
+    ...actual,
+    useAdminFetch: () => mockApi,
+  };
+});
+
+import AuditPage from "@/app/admin/audit/page";
+
+const entry = (id: number) => ({
+  id,
+  adminQfId: "qf-admin",
+  action: "user.disable",
+  targetType: "user",
+  targetId: String(id),
+  meta: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+});
+
+describe("AuditPage — load more pagination", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+  });
+
+  it("renders the initial page and does not show Load more when hasMore is false", async () => {
+    mockApi.mockResolvedValueOnce({ entries: [entry(1)], hasMore: false });
+
+    render(<AuditPage />);
+
+    await waitFor(() => expect(screen.getByText("user.disable")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+  });
+
+  it("appends the next page on Load more, requesting the next offset, and hides the button once exhausted", async () => {
+    mockApi.mockResolvedValueOnce({ entries: [entry(1)], hasMore: true });
+
+    render(<AuditPage />);
+
+    const loadMoreButton = await screen.findByRole("button", { name: /load more/i });
+
+    mockApi.mockResolvedValueOnce({ entries: [entry(2)], hasMore: false });
+    fireEvent.click(loadMoreButton);
+
+    await waitFor(() => expect(mockApi).toHaveBeenLastCalledWith("/audit?offset=1"));
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument()
+    );
+
+    const targets = screen.getAllByText(/user:/);
+    expect(targets).toHaveLength(2);
+  });
+});

--- a/app/admin/audit/page.tsx
+++ b/app/admin/audit/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, StateNote } from "@/components/admin/primitives";
 import { useAdminFetch } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
+import { Button } from "@/components/ui";
 
 interface Entry {
   id: number;
@@ -15,9 +17,41 @@ interface Entry {
   createdAt: string;
 }
 
+interface AuditPageData {
+  entries: Entry[];
+  hasMore: boolean;
+}
+
 export default function AuditPage() {
   const api = useAdminFetch();
-  const { data, error, loading } = useAsync<{ entries: Entry[] }>(() => api("/audit"), "audit");
+  const { data, error, loading } = useAsync<AuditPageData>(() => api("/audit"), "audit");
+
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState(false);
+
+  useEffect(() => {
+    if (!data) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setEntries(data.entries);
+    setHasMore(data.hasMore);
+  }, [data]);
+
+  const loadMore = async () => {
+    if (loadingMore) return;
+    setLoadingMore(true);
+    setLoadMoreError(false);
+    try {
+      const page = await api<AuditPageData>(`/audit?offset=${entries.length}`);
+      setEntries((prev) => [...prev, ...page.entries]);
+      setHasMore(page.hasMore);
+    } catch {
+      setLoadMoreError(true);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
 
   return (
     <>
@@ -25,9 +59,9 @@ export default function AuditPage() {
       <div className="space-y-4 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
         {loading && <StateNote>Loading…</StateNote>}
-        {data && data.entries.length === 0 && <StateNote>No admin actions recorded yet.</StateNote>}
+        {data && entries.length === 0 && <StateNote>No admin actions recorded yet.</StateNote>}
 
-        {data && data.entries.length > 0 && (
+        {data && entries.length > 0 && (
           <Table>
             <thead>
               <tr>
@@ -38,7 +72,7 @@ export default function AuditPage() {
               </tr>
             </thead>
             <tbody>
-              {data.entries.map((e) => (
+              {entries.map((e) => (
                 <tr key={e.id}>
                   <Td className="whitespace-nowrap text-xs text-text-muted">
                     {new Date(e.createdAt).toLocaleString()}
@@ -56,6 +90,15 @@ export default function AuditPage() {
               ))}
             </tbody>
           </Table>
+        )}
+
+        {hasMore && (
+          <div className="flex flex-col items-center gap-2">
+            <Button variant="secondary" size="sm" onClick={loadMore} disabled={loadingMore}>
+              {loadingMore ? "Loading…" : "Load more"}
+            </Button>
+            {loadMoreError && <StateNote tone="error">Couldn&apos;t load more entries.</StateNote>}
+          </div>
         )}
       </div>
     </>

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -5,23 +5,35 @@ import { db } from "@/lib/infra/db";
 import { adminAuditLog } from "@/lib/infra/db/schema";
 import { safeParse } from "@/lib/infra/http";
 
-/** Most-recent admin actions (newest first). `?limit=` caps the page (default 100). */
+/**
+ * Most-recent admin actions (newest first), paginated. `?limit=` caps the
+ * page (default 100, capped at 500 — kept distinct from the project-wide
+ * parsePagination default/cap since the audit log intentionally allows a
+ * larger page). `?offset=` pages further back.
+ */
 export async function GET(req: NextRequest) {
   const auth = await requireAdmin(req);
   if (auth instanceof NextResponse) return auth;
 
   const limitParam = Number(req.nextUrl.searchParams.get("limit"));
   const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 500) : 100;
+  const offsetParam = Number(req.nextUrl.searchParams.get("offset"));
+  const offset = Number.isInteger(offsetParam) && offsetParam > 0 ? offsetParam : 0;
 
   try {
+    // Fetch one extra row to detect whether more entries exist beyond this page.
     const rows = await db
       .select()
       .from(adminAuditLog)
       .orderBy(desc(adminAuditLog.createdAt))
-      .limit(limit);
+      .limit(limit + 1)
+      .offset(offset);
+
+    const hasMore = rows.length > limit;
+    const page = rows.slice(0, limit);
 
     return NextResponse.json({
-      entries: rows.map((r) => ({
+      entries: page.map((r) => ({
         id: r.id,
         adminQfId: r.adminQfId,
         action: r.action,
@@ -30,6 +42,7 @@ export async function GET(req: NextRequest) {
         meta: r.meta ? safeParse(r.meta) : null,
         createdAt: r.createdAt,
       })),
+      hasMore,
     });
   } catch (err) {
     console.error("admin audit GET db error:", err);

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -25,7 +25,7 @@ export async function GET(req: NextRequest) {
     const rows = await db
       .select()
       .from(adminAuditLog)
-      .orderBy(desc(adminAuditLog.createdAt))
+      .orderBy(desc(adminAuditLog.createdAt), desc(adminAuditLog.id))
       .limit(limit + 1)
       .offset(offset);
 


### PR DESCRIPTION
## Summary

The audit log page fetched a single page with no `limit`/`offset` param, no "load more" control, and no signal when the returned set was truncated. The audit log exists specifically so admins can investigate "every mutating admin action, newest first" — once an install accumulates more than 100 entries, anything older became silently invisible with no way to page back, undermining the log's purpose during an incident investigation.

## Changes

- `app/api/admin/audit/route.ts`: now fetches `limit + 1` rows to derive `hasMore`, and accepts an `?offset=` param (parsed the same way as the existing `?limit=`). Kept the route's own 100-default/500-cap rather than switching to the project-wide `parsePagination` helper (50 default/200 cap), since the audit log intentionally allows a larger page and the issue didn't ask to shrink it — the response shape (`limit+1`/`hasMore`) still follows the same convention as `app/api/social/friends` and `app/api/social/leaderboard`.
- `app/admin/audit/page.tsx`: tracks `entries`/`hasMore` locally (seeded from the initial `useAsync` load), and adds a "Load more" button that fetches `/audit?offset=<entries.length>` and appends — mirroring the load-more pattern already used in `app/social/page.tsx`. The button only renders when `hasMore` is true, so no more "was that all of it?" ambiguity.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:ci` (988 tests, full suite)
- [x] Extended `__tests__/api/admin/audit.test.ts`: offset default/clamping, and `hasMore` true/false based on row count.
- [x] New `__tests__/app/admin/audit/page.test.tsx`: initial load, "Load more" click requests the next offset and appends rows, button disappears once `hasMore` is false.

Closes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pagination to the admin audit log with a **Load more** option.
  - Additional entries now appear alongside existing results.
  - Audit results use consistent ordering and indicate when more entries are available.
  - Improved handling of empty results, completed pages, loading states, and errors.

- **Tests**
  - Added coverage for pagination, offsets, page limits, completion detection, ordering, and audit target rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->