### PR TITLE
fix(ci): make gitleaks range survive force-pushed branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,21 @@ jobs:
           # are already public and don't need to be re-surfaced on every run.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             RANGE="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
-          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            RANGE="${{ github.event.before }}..${{ github.event.after }}"
           else
-            RANGE="-1"
+            # `before`/`after` from the push event are unreliable across a
+            # force-push (e.g. Dependabot rebasing a branch): `before` can
+            # end up pointing at a commit that's no longer an ancestor of
+            # `after`, and `git log` errors out on the range instead of
+            # scanning anything. The merge-base with the default branch is
+            # unaffected by how the branch's own history was rewritten and
+            # still captures every commit unique to it, so prefer that.
+            git fetch --quiet origin "${{ github.event.repository.default_branch }}"
+            BASE=$(git merge-base "origin/${{ github.event.repository.default_branch }}" HEAD 2>/dev/null || true)
+            if [ -n "$BASE" ]; then
+              RANGE="$BASE..HEAD"
+            else
+              RANGE="-1"
+            fi
           fi
           gitleaks detect --source . --redact --log-opts="$RANGE"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.event.after }}
         run: |
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz \
             | tar -xz -C /usr/local/bin gitleaks
@@ -33,20 +37,28 @@ jobs:
           # are already public and don't need to be re-surfaced on every run.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             RANGE="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+          elif [ "$PUSH_BEFORE" != "0000000000000000000000000000000000000000" ] \
+            && git merge-base --is-ancestor "$PUSH_BEFORE" "$PUSH_AFTER" 2>/dev/null; then
+            RANGE="$PUSH_BEFORE..$PUSH_AFTER"
           else
-            # `before`/`after` from the push event are unreliable across a
-            # force-push (e.g. Dependabot rebasing a branch): `before` can
-            # end up pointing at a commit that's no longer an ancestor of
-            # `after`, and `git log` errors out on the range instead of
-            # scanning anything. The merge-base with the default branch is
-            # unaffected by how the branch's own history was rewritten and
-            # still captures every commit unique to it, so prefer that.
-            git fetch --quiet origin "${{ github.event.repository.default_branch }}"
-            BASE=$(git merge-base "origin/${{ github.event.repository.default_branch }}" HEAD 2>/dev/null || true)
-            if [ -n "$BASE" ]; then
+            # `before`/`after` are unreliable across a force-push (e.g.
+            # Dependabot rebasing a branch) or a branch's first-ever push:
+            # `before` can end up pointing at a commit that's no longer an
+            # ancestor of `after` (or be the all-zero SHA), and `git log`
+            # errors out on the range instead of scanning anything. Fall back
+            # to the merge-base with the default branch, which is unaffected
+            # by how the branch's own history was rewritten and still
+            # captures every commit unique to it. If there's no merge-base to
+            # diff against either (e.g. this push *is* to the default
+            # branch, so the merge-base is just HEAD itself, or the
+            # histories are unrelated), scan everything reachable from HEAD
+            # rather than only the latest commit, so nothing gets skipped.
+            git fetch --quiet origin "$DEFAULT_BRANCH"
+            BASE=$(git merge-base "origin/$DEFAULT_BRANCH" HEAD 2>/dev/null || true)
+            if [ -n "$BASE" ] && [ "$BASE" != "$(git rev-parse HEAD)" ]; then
               RANGE="$BASE..HEAD"
             else
-              RANGE="-1"
+              RANGE="HEAD"
             fi
           fi
           gitleaks detect --source . --redact --log-opts="$RANGE"


### PR DESCRIPTION
## Summary
- The `Secret Scan (gitleaks)` step computes its scan range from `github.event.before`/`after` on push events. Across a force-push (e.g. Dependabot rebasing a branch), `before` can end up pointing at a commit that's no longer an ancestor of `after`, so `git log before..after` fails with "Invalid revision range" and the check fails even though nothing is actually wrong — see PR #435.
- Falls back to the merge-base with the default branch instead of the event SHAs when the range can't be trusted. This is unaffected by how the branch's own history was rewritten and still captures every commit unique to the branch — unlike scanning only the latest commit (`-1`), which would silently under-scan any earlier commits introduced by the same force-push.

## Test plan
- [x] Confirmed the failure mode against PR #435's failing `Secret Scan (gitleaks)` run (push-triggered, `before`/`after` produced an invalid range).
- [x] `bun run lint`, `bun run typecheck`, `bun run test:ci` pass locally (pre-commit hook).
- [ ] Once merged, PR #435 will need a rebase (`@dependabot rebase`) to pick up the fix on its own push-triggered run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret scanning for push events by detecting changes from the default branch merge base.
  * Added a fallback to scan the latest commit when no common base is available.
  * Preserved existing pull-request scanning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->