### PR TITLE
fix(names): use TANZIH_CONSTRAINT in translateReason instead of hardcoded wording

### DIFF
--- a/__tests__/api/names.test.ts
+++ b/__tests__/api/names.test.ts
@@ -12,7 +12,7 @@ vi.mock("next/cache", () => ({
 // so individual tests can override the locale/edition; the defaults below match
 // this suite's pre-existing English-only fixtures/assertions.
 const { mockGetUiLocale, mockGetQuranEdition } = vi.hoisted(() => ({
-  mockGetUiLocale: vi.fn(async () => "en" as const),
+  mockGetUiLocale: vi.fn(async (): Promise<"en" | "tr" | "ru" | "az"> => "en"),
   mockGetQuranEdition: vi.fn(async () => "en.sahih"),
 }));
 vi.mock("@/lib/i18n/request-prefs", () => ({
@@ -55,21 +55,29 @@ vi.mock("@/lib/infra/db", () => ({
   },
 }));
 
-vi.mock("@anthropic-ai/sdk", () => {
-  const mockText = JSON.stringify([
-    { ref: "2:255", reason: "Verse of the Throne manifests Al-Hayy and Al-Qayyum." },
-    { ref: "3:18", reason: "Allah witnesses His own oneness." },
-    { ref: "59:22", reason: "Enumerates divine attributes directly." },
-    { ref: "112:1", reason: "Al-Ahad — pure singularity." },
-    { ref: "24:35", reason: "The Light verse expresses An-Nur." },
-  ]);
+// Shared (not per-instance) so tests can inspect every prompt sent to the AI
+// across the module's several `new Anthropic()` call sites (callAI creates a
+// fresh client per call).
+const { mockCreate } = vi.hoisted(() => ({
+  mockCreate: vi.fn(async (_args: { messages: Array<{ content: string }> }) => ({
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify([
+          { ref: "2:255", reason: "Verse of the Throne manifests Al-Hayy and Al-Qayyum." },
+          { ref: "3:18", reason: "Allah witnesses His own oneness." },
+          { ref: "59:22", reason: "Enumerates divine attributes directly." },
+          { ref: "112:1", reason: "Al-Ahad — pure singularity." },
+          { ref: "24:35", reason: "The Light verse expresses An-Nur." },
+        ]),
+      },
+    ],
+  })),
+}));
 
+vi.mock("@anthropic-ai/sdk", () => {
   class MockAnthropic {
-    messages = {
-      create: vi.fn().mockResolvedValue({
-        content: [{ type: "text", text: mockText }],
-      }),
-    };
+    messages = { create: mockCreate };
   }
 
   return { default: MockAnthropic };
@@ -78,6 +86,7 @@ vi.mock("@anthropic-ai/sdk", () => {
 // Static imports — must come after vi.mock declarations so mocks are active
 import { GET as getAllNames } from "@/app/api/names/route";
 import { GET as getNameVerses } from "@/app/api/names/[slug]/verses/route";
+import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
 
 // Stub fetch AFTER static imports so vi.stubGlobal wins over any fetch patch
 // that next/server applies during module initialization
@@ -187,6 +196,31 @@ describe("GET /api/names/[slug]/verses", () => {
     expect(body.length).toBeGreaterThan(0);
     for (const verse of body) {
       expect(verse.translation).toBe("Türkçe çeviri");
+    }
+  });
+
+  it("translateReason's prompt carries the shared TANZIH_CONSTRAINT text, not a hardcoded duplicate", async () => {
+    mockGetUiLocale.mockResolvedValue("tr");
+    mockGetQuranEdition.mockResolvedValue("tr.diyanet");
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url !== "string") return { ok: false };
+      if (url.includes("ar.alafasy")) return arabicResp();
+      if (url.includes("tr.diyanet")) return transResp("Türkçe çeviri");
+      if (url.includes("en.sahih")) return transResp("English translation");
+      return { ok: false };
+    });
+    mockCreate.mockClear();
+
+    const req = new NextRequest("http://localhost/api/names/as-salam/verses");
+    const res = await getNameVerses(req, params("as-salam"));
+    expect(res.status).toBe(200);
+
+    const translationPrompts = mockCreate.mock.calls
+      .map(([arg]) => arg.messages[0].content as string)
+      .filter((prompt: string) => prompt.startsWith("Translate the following sentence"));
+    expect(translationPrompts.length).toBeGreaterThan(0);
+    for (const prompt of translationPrompts) {
+      expect(prompt).toContain(TANZIH_CONSTRAINT);
     }
   });
 });

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -148,7 +148,7 @@ function stripHtml(text: string): string {
 // target language, so the underlying theological justification stays exactly
 // what was already generated and validated in English.
 async function translateReason(reason: string, language: string): Promise<string> {
-  const prompt = `Translate the following sentence into ${language}. Preserve its meaning exactly — do not add, remove, or alter any theological claim, and maintain strict Tanzih (divine transcendence). Return ONLY the translated sentence, with no quotation marks, labels, or explanation.
+  const prompt = `Translate the following sentence into ${language}. Preserve its meaning exactly — do not add, remove, or alter any theological claim, and maintain ${TANZIH_CONSTRAINT}. Return ONLY the translated sentence, with no quotation marks, labels, or explanation.
 
 Sentence: "${reason}"`;
   const translated = await callAI(prompt);


### PR DESCRIPTION
## Summary

- `translateReason()` in `app/api/names/[slug]/verses/route.ts` hardcoded its own copy of the Tanzih directive instead of importing `TANZIH_CONSTRAINT` from `lib/ai/theological-constraints.ts`, unlike every other prompt-construction call site (`buildReasons`, `fallbackAIVerses` in the same file, and `lib/ai/connection-generator.ts`'s `tanzihDirective()`).
- Interpolates the shared constant instead, so a future edit to `TANZIH_CONSTRAINT` (e.g. tightening wording, fixing a theological nuance) is no longer silently missed by the one prompt that translates AI-generated reasoning text into non-English locales.
- No behavior change today — the hardcoded wording already matched the constant. This is purely about removing the drift risk.

## Type of change

- [ ] Bug fix
- [x] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [ ] No AI or theological changes in this PR
- [x] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below
- [ ] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per AGENTS.md

**Details**: `translateReason()`'s prompt now interpolates `TANZIH_CONSTRAINT` instead of its own hardcoded Tanzih sentence. The resulting prompt text is unchanged (the constant's current value matches what was hardcoded before), so no change to the model's actual instructions or output — this is a source-of-truth fix, not a wording change.

## Testing

- [x] `bun run test:ci` passes locally (994/994)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally — pre-existing unrelated formatting warnings in `.superpowers/sdd/*.md`, not touched by this PR
- [x] New tests added for new functionality — added a regression test in `__tests__/api/names.test.ts` that captures the actual prompt sent to the AI for the non-English translation path and asserts it contains `TANZIH_CONSTRAINT`, so this can't silently regress again.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — n/a
- [x] `README.md` updated if the feature changes the public interface — n/a

Fixes #362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation guidance to consistently preserve important textual constraints.
  * Added validation ensuring generated translation prompts include the required preservation rule.

* **Tests**
  * Expanded automated coverage for translation prompt requirements.
  * Improved test reliability and inspection of translation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->