### PR TITLE
fix(names): degrade reflection/pairings gracefully on AI provider failure instead of 500ing

### DIFF
--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -169,6 +169,24 @@ describe("names AI routes — model output validation", () => {
     expect(prompt).toMatch(/strict tanzih/i);
   });
 
+  it("reflection: an AI provider failure returns 200 with empty content, not a 500", async () => {
+    mockCallAI.mockRejectedValue(new Error("Your credit balance is too low to access the API."));
+
+    const res = await getReflection(req("ar-rahman", "reflection"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ reflection: "" });
+  });
+
+  it("pairings: an AI provider failure returns 200 with an empty array, not a 500", async () => {
+    mockCallAI.mockRejectedValue(new Error("Your credit balance is too low to access the API."));
+
+    const res = await getPairings(req("ar-rahman", "pairings"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
   it("reflection: no language directive for the default (English) locale", async () => {
     mockCallAI.mockResolvedValue("A reflection paragraph.");
     await getReflection(req("ar-rahman", "reflection"), params("ar-rahman"));

--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -169,22 +169,34 @@ describe("names AI routes — model output validation", () => {
     expect(prompt).toMatch(/strict tanzih/i);
   });
 
-  it("reflection: an AI provider failure returns 200 with empty content, not a 500", async () => {
+  it("reflection: an AI provider failure returns 200 with empty content, not a 500, and logs it", async () => {
     mockCallAI.mockRejectedValue(new Error("Your credit balance is too low to access the API."));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const res = await getReflection(req("ar-rahman", "reflection"), params("ar-rahman"));
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ reflection: "" });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Reflection: AI call failed"),
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
   });
 
-  it("pairings: an AI provider failure returns 200 with an empty array, not a 500", async () => {
+  it("pairings: an AI provider failure returns 200 with an empty array, not a 500, and logs it", async () => {
     mockCallAI.mockRejectedValue(new Error("Your credit balance is too low to access the API."));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const res = await getPairings(req("ar-rahman", "pairings"), params("ar-rahman"));
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Pairings: AI call failed"),
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
   });
 
   it("reflection: no language directive for the default (English) locale", async () => {

--- a/__tests__/app/names/NameReflection.test.tsx
+++ b/__tests__/app/names/NameReflection.test.tsx
@@ -45,4 +45,18 @@ describe("NameReflection", () => {
     );
     expect(container).not.toBeEmptyDOMElement();
   });
+
+  it("shows the error message, not a perpetual skeleton, when the API returns 200 with an empty reflection", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ reflection: "" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithIntl(<NameReflection slug="ar-rahman" accent="#000" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Could not load the reflection at this time.")).toBeInTheDocument()
+    );
+  });
 });

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -7,6 +7,7 @@ import { clientKey } from "@/lib/infra/http";
 import { getUiLocale } from "@/lib/i18n/request-prefs";
 import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
+import { incr } from "@/lib/infra/metrics";
 
 // Bump to force regeneration after a prompt change. Exported so page.tsx can
 // use the same version when checking the cache for a server-side prefetch.
@@ -69,6 +70,7 @@ async function getPairings(
         // buildReasons/fallbackAIVerses in verses/route.ts tolerate a provider
         // failure instead of 500ing the whole page section.
         console.error(`Pairings: AI call failed for ${slug}:`, err);
+        incr("names_ai_call_error");
         return [];
       }
 

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -61,9 +61,16 @@ async function getPairings(
     locale,
     PAIRINGS_VERSION,
     async () => {
-      const text = await callAI(
-        buildPrompt(name.transliteration, name.arabic, name.meaning, locale)
-      );
+      let text: string;
+      try {
+        text = await callAI(buildPrompt(name.transliteration, name.arabic, name.meaning, locale));
+      } catch (err) {
+        // Not cached (empty result), so the next request retries — mirrors how
+        // buildReasons/fallbackAIVerses in verses/route.ts tolerate a provider
+        // failure instead of 500ing the whole page section.
+        console.error(`Pairings: AI call failed for ${slug}:`, err);
+        return [];
+      }
 
       let raw: unknown;
       try {

--- a/app/api/names/[slug]/reflection/route.ts
+++ b/app/api/names/[slug]/reflection/route.ts
@@ -53,10 +53,19 @@ async function getReflection(
     "reflection",
     locale,
     REFLECTION_VERSION,
-    () =>
-      callAI(
-        buildPrompt(name.arabic, name.transliteration, name.meaning, name.description, locale)
-      ),
+    async () => {
+      try {
+        return await callAI(
+          buildPrompt(name.arabic, name.transliteration, name.meaning, name.description, locale)
+        );
+      } catch (err) {
+        // Not cached (empty result), so the next request retries — mirrors how
+        // buildReasons/fallbackAIVerses in verses/route.ts tolerate a provider
+        // failure instead of 500ing the whole page section.
+        console.error(`Reflection: AI call failed for ${slug}:`, err);
+        return "";
+      }
+    },
     (s) => s.trim() === "",
     onBeforeGenerate
   );

--- a/app/api/names/[slug]/reflection/route.ts
+++ b/app/api/names/[slug]/reflection/route.ts
@@ -7,6 +7,7 @@ import { clientKey } from "@/lib/infra/http";
 import { getUiLocale } from "@/lib/i18n/request-prefs";
 import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
+import { incr } from "@/lib/infra/metrics";
 
 // Bump to force regeneration after a prompt change. Exported so page.tsx can
 // use the same version when checking the cache for a server-side prefetch.
@@ -63,6 +64,7 @@ async function getReflection(
         // buildReasons/fallbackAIVerses in verses/route.ts tolerate a provider
         // failure instead of 500ing the whole page section.
         console.error(`Reflection: AI call failed for ${slug}:`, err);
+        incr("names_ai_call_error");
         return "";
       }
     },

--- a/app/names/[slug]/NameReflection.tsx
+++ b/app/names/[slug]/NameReflection.tsx
@@ -32,7 +32,11 @@ export function NameReflection({ slug, accent, initialReflection }: Props) {
     };
   }, [slug, initialReflection]);
 
-  if (error) {
+  // A loaded-but-empty reflection (the API degrades to "" rather than 500ing
+  // on an AI-provider failure — see /api/names/[slug]/reflection) is
+  // functionally the same "unavailable" case as a fetch error, not content
+  // still loading — otherwise the skeleton below would spin forever.
+  if (error || reflection === "") {
     return (
       <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
         {t("couldNotLoadReflection")}
@@ -57,7 +61,7 @@ export function NameReflection({ slug, accent, initialReflection }: Props) {
         </span>
       </div>
 
-      {!reflection ? (
+      {reflection === null ? (
         <div className="space-y-2 animate-pulse">
           {[100, 90, 95].map((w, i) => (
             <div


### PR DESCRIPTION
## Summary

- `/api/names/[slug]/reflection` and `/api/names/[slug]/pairings` returned `500 Internal Server Error` on every name in production, while `/api/names/[slug]/verses` on the same page kept working.
- Root cause: `getReflection()` and `getPairings()` called `callAI()` with no local error handling, so any AI-provider failure (rate limit, quota, transient outage) propagated straight to the route's outer `catch` → hard 500. `verses/route.ts`'s `buildReasons()`/`fallbackAIVerses()` already wrap their `callAI()` calls in try/catch and fall back to a default reason — that's why verses stayed up through the same underlying failure while reflection/pairings crashed.
- **Reproduced locally**: pointed dev at a real (but currently zero-credit) Anthropic key. Before the fix: `verses` → 200 (falls back to `"Contains a form of {name}."` reasons), `reflection`/`pairings` → 500 with the exact same underlying `invalid_request_error`. After the fix: all three return 200, with `reflection`/`pairings` degrading to empty content — matching the frontend's existing "Could not load..." fallback UI instead of surfacing a raw 500.
- Fix: wrap the `callAI()` call in both routes' generate function in the same try/catch pattern already used in `verses/route.ts`, logging and returning empty (not persisted, so the next request retries — matches the existing `isEmpty` contract in `lib/names/name-content.ts`).
- **Scope note**: this closes the code-level gap (missing error handling causing 500s instead of graceful degradation). If production's actual AI calls are failing for an account/billing/quota reason rather than a transient blip, that's an ops-side fix outside this repo's code — but it will now be visible via `console.error` logs instead of a raw 500, and once the underlying provider issue clears, the very next request regenerates real content (nothing gets stuck caching an empty result).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

**Details**: No prompt text, model, or theological framing changed — this only adds error handling around the existing `callAI()` calls so a provider failure degrades gracefully instead of crashing the route.

## Testing

- [x] `bun run test:ci` passes locally (995/995)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally — pre-existing unrelated formatting warnings in `.superpowers/sdd/*.md`, not touched by this PR
- [x] New tests added for new functionality — added regression tests in `__tests__/api/names-ai-validation.test.ts` asserting both routes return `200` with empty content (not `500`) when `callAI` rejects.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — n/a
- [x] `README.md` updated if the feature changes the public interface — n/a

Fixes #443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of AI service failures for name reflections and pairings, returning graceful empty results instead of server errors.
  * Added visible error messaging when reflection content is unavailable, preventing the loading state from persisting indefinitely.
  * Added monitoring for AI call failures to improve issue detection.

* **Tests**
  * Added coverage for AI failures, fallback responses, error logging, and unavailable reflection content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->