### PR TITLE
fix(layout): keep header Log in button label on one line at narrow widths

### DIFF
--- a/__tests__/components/layout/AccountMenu.test.tsx
+++ b/__tests__/components/layout/AccountMenu.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
+
+import { AccountMenu } from "@/components/layout/AccountMenu";
+import { useAuthStore } from "@/store/auth";
+
+describe("AccountMenu — logged-out sign-in button", () => {
+  const previousAuth = useAuthStore.getState();
+
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: null, isSessionLoading: false });
+  });
+
+  afterEach(() => {
+    useAuthStore.setState(previousAuth);
+  });
+
+  it("keeps its label on one line instead of wrapping under a squeezed layout", () => {
+    renderWithIntl(<AccountMenu />);
+
+    const button = screen.getByRole("button", { name: /log in/i });
+    expect(button.className).toMatch(/\bwhitespace-nowrap\b/);
+  });
+});

--- a/components/layout/AccountMenu.tsx
+++ b/components/layout/AccountMenu.tsx
@@ -114,7 +114,7 @@ export function AccountMenu() {
         <button
           onClick={signIn}
           disabled={signingIn}
-          className="inline-flex items-center gap-1.5 rounded-md border border-gold px-3.5 py-1.5 text-[13px] font-semibold text-gold transition-colors duration-[120ms] hover:bg-gold/10 disabled:opacity-60"
+          className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-gold px-3.5 py-1.5 text-[13px] font-semibold text-gold transition-colors duration-[120ms] hover:bg-gold/10 disabled:opacity-60"
         >
           {signingIn ? (
             <Loader2 className="size-3.5 animate-spin" />


### PR DESCRIPTION
## Summary

- On narrow mobile viewports the header's "Log in" button wrapped to "Log" / "in" on two lines.
- Root cause: in `AccountMenu.tsx`'s logged-out header row, the sign-in button is the only text-bearing, shrinkable flex item — `LanguagePopover` is a fixed `size-9` icon button and the mobile-only Bookmarks/Settings links are icon-only. Without `whitespace-nowrap`, a flex item's min-content width collapses to its longest unbreakable word once the row is squeezed, so the button's text wraps instead of the button just staying its natural width.
- **Reproduced locally**: at 390px (the reported viewport) it happened to render on one line in this environment (likely font-metric/DPI dependent, right at the edge), but at 320px (iPhone SE) it reliably reproduced exactly as described — "Log" / "in" on two lines. Confirmed the fix holds at both 320px and 390px via screenshot before/after.
- Fix: add `whitespace-nowrap` (keeps the label on one line) and `shrink-0` (so the button isn't compressed at all, rather than shrinking unpredictably) to the button's className.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (994/994)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally — pre-existing unrelated formatting warnings in `.superpowers/sdd/*.md`, not touched by this PR
- [x] New tests added for new functionality — added `__tests__/components/layout/AccountMenu.test.tsx` asserting the logged-out sign-in button carries `whitespace-nowrap`, guarding against the class being removed later. Also manually verified in a real browser at 320px and 390px viewports (screenshots taken before/after the fix).

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — n/a
- [x] `README.md` updated if the feature changes the public interface — n/a

Fixes #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the logged-out sign-in button to keep its label on a single line and prevent unwanted shrinking.

* **Tests**
  * Added coverage for the logged-out account menu and sign-in button layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->