### PR TITLE
chore(tests): add coverage for untested stores and routes with real logic

### DIFF
--- a/__tests__/api/admin/prompts.test.ts
+++ b/__tests__/api/admin/prompts.test.ts
@@ -12,6 +12,11 @@ vi.mock("@/lib/ai/prompt-registry", async (importOriginal) => {
   return { ...actual, invalidatePromptCache: vi.fn() };
 });
 
+// Captures each .set() call's argument (in call order) so tests can assert
+// what the transaction actually wrote, not just that some update happened —
+// e.g. that deactivate-old ({ active: false }) and activate-new
+// ({ active: true }) landed in the right order, not swapped.
+let setCalls: unknown[] = [];
 function makeDbChain(resolveWith: unknown = []) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
@@ -23,7 +28,10 @@ function makeDbChain(resolveWith: unknown = []) {
         if (prop === "then")
           return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
             Promise.resolve(resolveWith).then(res, rej);
-        return () => chain;
+        return (...args: unknown[]) => {
+          if (prop === "set") setCalls.push(args[0]);
+          return chain;
+        };
       },
       apply() {
         return chain;
@@ -51,6 +59,7 @@ import { GET, POST } from "@/app/api/admin/prompts/route";
 import { POST as ROLLBACK } from "@/app/api/admin/prompts/rollback/route";
 import { requireAdmin } from "@/lib/admin/admin-auth";
 import { invalidatePromptCache } from "@/lib/ai/prompt-registry";
+import { logAdminAction } from "@/lib/admin/admin-audit";
 
 const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
 
@@ -64,6 +73,7 @@ function req(url: string, method: string, body?: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  setCalls = [];
   vi.mocked(requireAdmin).mockResolvedValue(admin);
   mockSelect.mockReturnValue(makeDbChain([]));
   txUpdate.mockReturnValue(makeDbChain([]));
@@ -157,6 +167,10 @@ describe("POST /api/admin/prompts — create + activate", () => {
     // interleave with a concurrent request.
     expect(txUpdate).toHaveBeenCalledOnce();
     expect(txInsert).toHaveBeenCalledOnce();
+    // The write itself must deactivate, not accidentally reactivate, the
+    // prior version — pins the actual { active: false } payload, not just
+    // that some update happened.
+    expect(setCalls).toEqual([{ active: false }]);
   });
 
   it("invalidates the prompt cache and logs the admin action after a successful create", async () => {
@@ -172,6 +186,15 @@ describe("POST /api/admin/prompts — create + activate", () => {
     );
 
     expect(invalidatePromptCache).toHaveBeenCalledWith("connection.legacy");
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adminQfId: "qf-admin",
+        action: "prompt.version.create",
+        targetType: "prompt_version",
+        targetId: "2",
+        meta: { key: "connection.legacy" },
+      })
+    );
   });
 });
 
@@ -216,8 +239,20 @@ describe("POST /api/admin/prompts/rollback", () => {
     expect(body.version).toEqual(reactivated);
     expect(mockTransaction).toHaveBeenCalledOnce();
     // Two updates happen on the tx: deactivate whatever's currently active,
-    // then reactivate the target row.
+    // *then* reactivate the target row — asserting both the count and the
+    // order/payload rules out the two writes being swapped (which would
+    // deactivate the version this endpoint is supposed to be rolling back to).
     expect(txUpdate).toHaveBeenCalledTimes(2);
+    expect(setCalls).toEqual([{ active: false }, { active: true }]);
     expect(invalidatePromptCache).toHaveBeenCalledWith("connection.legacy");
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adminQfId: "qf-admin",
+        action: "prompt.version.rollback",
+        targetType: "prompt_version",
+        targetId: "1",
+        meta: { key: "connection.legacy" },
+      })
+    );
   });
 });

--- a/__tests__/api/admin/prompts.test.ts
+++ b/__tests__/api/admin/prompts.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/infra/db/schema";
+
+vi.mock("@/lib/admin/admin-auth", () => ({
+  requireAdmin: vi.fn(),
+  rateLimitAdminMutation: vi.fn(() => null),
+}));
+vi.mock("@/lib/admin/admin-audit", () => ({ logAdminAction: vi.fn() }));
+vi.mock("@/lib/ai/prompt-registry", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/ai/prompt-registry")>();
+  return { ...actual, invalidatePromptCache: vi.fn() };
+});
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockTransaction, txUpdate, txInsert, txSelect } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  txUpdate: vi.fn(() => makeDbChain([])),
+  txInsert: vi.fn(() => makeDbChain([])),
+  txSelect: vi.fn(() => makeDbChain([])),
+  mockTransaction: vi.fn(),
+}));
+vi.mock("@/lib/infra/db", () => ({
+  db: {
+    select: mockSelect,
+    transaction: mockTransaction,
+  },
+}));
+
+import { GET, POST } from "@/app/api/admin/prompts/route";
+import { POST as ROLLBACK } from "@/app/api/admin/prompts/rollback/route";
+import { requireAdmin } from "@/lib/admin/admin-auth";
+import { invalidatePromptCache } from "@/lib/ai/prompt-registry";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function req(url: string, method: string, body?: unknown) {
+  return new NextRequest(url, {
+    method,
+    headers: { Authorization: "Bearer t", "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockSelect.mockReturnValue(makeDbChain([]));
+  txUpdate.mockReturnValue(makeDbChain([]));
+  txInsert.mockReturnValue(makeDbChain([]));
+  txSelect.mockReturnValue(makeDbChain([]));
+  // The route calls db.transaction(async (tx) => ...) — the tx object exposes
+  // the same insert/update/select surface as the top-level mocked db.
+  mockTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
+    cb({ update: txUpdate, insert: txInsert, select: txSelect })
+  );
+});
+
+describe("GET /api/admin/prompts", () => {
+  it("404s for a non-admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(req("http://localhost/api/admin/prompts", "GET"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the known prompt keys and stored versions", async () => {
+    const versions = [{ id: 1, key: "connection.legacy", template: "t", active: true }];
+    mockSelect.mockReturnValue(makeDbChain(versions));
+
+    const res = await GET(req("http://localhost/api/admin/prompts", "GET"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.keys).toEqual(["connection.legacy", "connection.selection"]);
+    expect(body.versions).toEqual(versions);
+  });
+
+  it("rejects an unknown ?key= filter", async () => {
+    const res = await GET(req("http://localhost/api/admin/prompts?key=not-a-real-key", "GET"));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/admin/prompts — create + activate", () => {
+  it("404s for a non-admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await POST(
+      req("http://localhost/api/admin/prompts", "POST", {
+        key: "connection.legacy",
+        template: "New template",
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects an invalid prompt key", async () => {
+    const res = await POST(
+      req("http://localhost/api/admin/prompts", "POST", {
+        key: "not-a-real-key",
+        template: "New template",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a missing or blank template", async () => {
+    const res = await POST(
+      req("http://localhost/api/admin/prompts", "POST", {
+        key: "connection.legacy",
+        template: "   ",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("deactivates the old active version and activates the new one inside one transaction", async () => {
+    const created = { id: 2, key: "connection.legacy", template: "New template", active: true };
+    txInsert.mockReturnValue(makeDbChain([created]));
+
+    const res = await POST(
+      req("http://localhost/api/admin/prompts", "POST", {
+        key: "connection.legacy",
+        template: "New template",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.version).toEqual(created);
+
+    expect(mockTransaction).toHaveBeenCalledOnce();
+    // Deactivate-old and the insert both ran on the same tx handle — proves
+    // the two writes share one transaction, not two round trips that could
+    // interleave with a concurrent request.
+    expect(txUpdate).toHaveBeenCalledOnce();
+    expect(txInsert).toHaveBeenCalledOnce();
+  });
+
+  it("invalidates the prompt cache and logs the admin action after a successful create", async () => {
+    txInsert.mockReturnValue(
+      makeDbChain([{ id: 2, key: "connection.legacy", template: "t", active: true }])
+    );
+
+    await POST(
+      req("http://localhost/api/admin/prompts", "POST", {
+        key: "connection.legacy",
+        template: "New template",
+      })
+    );
+
+    expect(invalidatePromptCache).toHaveBeenCalledWith("connection.legacy");
+  });
+});
+
+describe("POST /api/admin/prompts/rollback", () => {
+  it("404s for a non-admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await ROLLBACK(
+      req("http://localhost/api/admin/prompts/rollback", "POST", { id: 1 })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a non-integer id", async () => {
+    const res = await ROLLBACK(
+      req("http://localhost/api/admin/prompts/rollback", "POST", { id: "not-a-number" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("404s when the target version doesn't exist", async () => {
+    txSelect.mockReturnValue(makeDbChain([]));
+    const res = await ROLLBACK(
+      req("http://localhost/api/admin/prompts/rollback", "POST", { id: 999 })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("reactivates the target version and deactivates whatever else was active for that key", async () => {
+    const target = { id: 1, key: "connection.legacy", template: "old", active: false };
+    const reactivated = { ...target, active: true };
+    txSelect.mockReturnValue(makeDbChain([target]));
+    txUpdate.mockReturnValue(makeDbChain([reactivated]));
+
+    const res = await ROLLBACK(
+      req("http://localhost/api/admin/prompts/rollback", "POST", { id: 1 })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.version).toEqual(reactivated);
+    expect(mockTransaction).toHaveBeenCalledOnce();
+    // Two updates happen on the tx: deactivate whatever's currently active,
+    // then reactivate the target row.
+    expect(txUpdate).toHaveBeenCalledTimes(2);
+    expect(invalidatePromptCache).toHaveBeenCalledWith("connection.legacy");
+  });
+});

--- a/__tests__/api/health.test.ts
+++ b/__tests__/api/health.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { GET } from "@/app/api/health/route";
+
+describe("GET /api/health", () => {
+  it("returns 200 with an ok status", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
+});

--- a/__tests__/api/root-concordance.test.ts
+++ b/__tests__/api/root-concordance.test.ts
@@ -101,7 +101,8 @@ describe("GET /api/root/[root]", () => {
             ref: "2:255",
             surahName: "Al-Baqarah",
             surahNameArabic: "البقرة",
-            translation: "x".repeat(200),
+            translation:
+              "Allah - there is no deity except Him, the Ever-Living, the Sustainer of [all] existence. Neither drowsiness overtakes Him nor sleep. To Him belongs whatever is in the heavens and whatever is on the earth. Who is it that can intercede with Him except by His permission? He knows what is [presently] before them and what will be after them, and they encompass not a thing of His knowledge except for what He wills. His Kursi extends over the heavens and the earth, and their preservation tires Him not. And He is the Most High, the Most Great.",
           },
         ],
       ])
@@ -113,7 +114,7 @@ describe("GET /api/root/[root]", () => {
   });
 
   it("drops refs the corpus lookup didn't resolve, without failing the request", async () => {
-    mockSelectDistinct.mockReturnValue(makeDbChain([{ ref: "2:255" }, { ref: "999:999" }]));
+    mockSelectDistinct.mockReturnValue(makeDbChain([{ ref: "2:255" }, { ref: "114:6" }]));
     mockGetVerses.mockResolvedValue(
       new Map([
         [

--- a/__tests__/api/root-concordance.test.ts
+++ b/__tests__/api/root-concordance.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelectDistinct, mockGetVerses } = vi.hoisted(() => ({
+  mockSelectDistinct: vi.fn(() => makeDbChain([])),
+  mockGetVerses: vi.fn(async () => new Map()),
+}));
+vi.mock("@/lib/infra/db", () => ({ db: { selectDistinct: mockSelectDistinct } }));
+vi.mock("@/lib/quran/quran-corpus", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/quran/quran-corpus")>();
+  return { ...actual, getVerses: mockGetVerses };
+});
+
+import { GET } from "@/app/api/root/[root]/route";
+
+function req() {
+  return new NextRequest("http://localhost/api/root/رحم");
+}
+function params(root: string) {
+  return { params: Promise.resolve({ root }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSelectDistinct.mockReturnValue(makeDbChain([]));
+  mockGetVerses.mockResolvedValue(new Map());
+});
+
+describe("GET /api/root/[root]", () => {
+  it("400s on an empty/whitespace-only root", async () => {
+    const res = await GET(req(), params("   "));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns verses for a root in the order the DB query resolved them", async () => {
+    // The route does not re-sort after the query — see issue #360 (lexicographic
+    // vs. numeric ref ordering), which is a separate, already-tracked bug.
+    // This only pins the route's actual passthrough behavior: whatever order
+    // rows come back in is the order returned to the client.
+    mockSelectDistinct.mockReturnValue(makeDbChain([{ ref: "2:255" }, { ref: "10:5" }]));
+    mockGetVerses.mockResolvedValue(
+      new Map([
+        [
+          "2:255",
+          {
+            ref: "2:255",
+            surahName: "Al-Baqarah",
+            surahNameArabic: "البقرة",
+            translation: "Allah - there is no deity except Him.",
+          },
+        ],
+        [
+          "10:5",
+          {
+            ref: "10:5",
+            surahName: "Yunus",
+            surahNameArabic: "يونس",
+            translation: "It is He who made the sun a shining light.",
+          },
+        ],
+      ])
+    );
+
+    const res = await GET(req(), params("رحم"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.root).toBe("رحم");
+    expect(body.count).toBe(2);
+    expect(body.verses.map((v: { ref: string }) => v.ref)).toEqual(["2:255", "10:5"]);
+  });
+
+  it("truncates each verse's translation to a short snippet", async () => {
+    mockSelectDistinct.mockReturnValue(makeDbChain([{ ref: "2:255" }]));
+    mockGetVerses.mockResolvedValue(
+      new Map([
+        [
+          "2:255",
+          {
+            ref: "2:255",
+            surahName: "Al-Baqarah",
+            surahNameArabic: "البقرة",
+            translation: "x".repeat(200),
+          },
+        ],
+      ])
+    );
+
+    const res = await GET(req(), params("رحم"));
+    const body = await res.json();
+    expect(body.verses[0].snippet).toHaveLength(140);
+  });
+
+  it("drops refs the corpus lookup didn't resolve, without failing the request", async () => {
+    mockSelectDistinct.mockReturnValue(makeDbChain([{ ref: "2:255" }, { ref: "999:999" }]));
+    mockGetVerses.mockResolvedValue(
+      new Map([
+        [
+          "2:255",
+          {
+            ref: "2:255",
+            surahName: "Al-Baqarah",
+            surahNameArabic: "البقرة",
+            translation: "Allah - there is no deity except Him.",
+          },
+        ],
+      ])
+    );
+
+    const res = await GET(req(), params("رحم"));
+    const body = await res.json();
+    expect(body.count).toBe(1);
+    expect(body.verses).toHaveLength(1);
+  });
+
+  it("degrades to an empty result on a DB error instead of failing the request", async () => {
+    mockSelectDistinct.mockImplementation(() => {
+      throw new Error("connection reset");
+    });
+
+    const res = await GET(req(), params("رحم"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ root: "رحم", count: 0, verses: [] });
+  });
+});

--- a/__tests__/api/social/challenge-suggestions.test.ts
+++ b/__tests__/api/social/challenge-suggestions.test.ts
@@ -28,7 +28,7 @@ function makeDbChain(resolveWith: unknown = []) {
 }
 
 const { mockSelect } = vi.hoisted(() => ({
-  mockSelect: vi.fn(() => makeDbChain([])),
+  mockSelect: vi.fn((_projection: Record<string, unknown>) => makeDbChain([])),
 }));
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect } }));
 
@@ -87,6 +87,15 @@ describe("GET /api/social/challenge-suggestions", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.suggestions).toEqual([row]);
+    // `db.select({...})`'s projection argument is the actual mechanism that
+    // drops createdBy — inspect it directly (mockSelect is called, not
+    // chained, so its own mock.calls captures the real argument) rather than
+    // relying only on the mocked row already matching the expected shape.
+    const projection = mockSelect.mock.calls[0][0];
+    expect(Object.keys(projection).sort()).toEqual(
+      ["description", "id", "suggestedDuration", "title", "verseRef"].sort()
+    );
+    expect(projection).not.toHaveProperty("createdBy");
   });
 
   it("returns an empty list when there are no active suggestions", async () => {

--- a/__tests__/api/social/challenge-suggestions.test.ts
+++ b/__tests__/api/social/challenge-suggestions.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/infra/db/schema";
+
+vi.mock("@/lib/auth/social-auth", () => ({
+  requireUser: vi.fn(),
+}));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect } }));
+
+import { GET } from "@/app/api/social/challenge-suggestions/route";
+import { requireUser } from "@/lib/auth/social-auth";
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    qfId: "qf-1",
+    username: "testuser",
+    displayName: null,
+    createdAt: new Date(),
+    lastActiveAt: new Date(),
+    currentStreak: 0,
+    longestStreak: 0,
+    lastActivityDate: null,
+    disabledAt: null,
+    ...overrides,
+  };
+}
+
+function req() {
+  return new NextRequest("http://localhost/api/social/challenge-suggestions", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSelect.mockReturnValue(makeDbChain([]));
+});
+
+describe("GET /api/social/challenge-suggestions", () => {
+  it("401s when unauthenticated", async () => {
+    vi.mocked(requireUser).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns only the exposed display fields, dropping admin-only ones like createdBy", async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 1, user: makeUser() });
+    const row = {
+      id: 1,
+      title: "Memorize Al-Fatiha",
+      description: "Recite it daily for a week.",
+      verseRef: "1:1",
+      suggestedDuration: 7,
+    };
+    mockSelect.mockReturnValue(makeDbChain([row]));
+
+    const res = await GET(req());
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.suggestions).toEqual([row]);
+  });
+
+  it("returns an empty list when there are no active suggestions", async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 1, user: makeUser() });
+    mockSelect.mockReturnValue(makeDbChain([]));
+
+    const res = await GET(req());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ suggestions: [] });
+  });
+});

--- a/__tests__/api/social/challenge-suggestions.test.ts
+++ b/__tests__/api/social/challenge-suggestions.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
+import { asc, eq } from "drizzle-orm";
 import type { User } from "@/lib/infra/db/schema";
+import { challengeSuggestions } from "@/lib/infra/db/schema";
 
 vi.mock("@/lib/auth/social-auth", () => ({
   requireUser: vi.fn(),
 }));
 
+// Records every chained call (`where`, `orderBy`, ...) by method name, not just
+// the final resolved rows — a regression that silently drops the `.where(...)`
+// active-filter or `.orderBy(...)` clause wouldn't be caught by asserting on
+// `resolveWith` alone, since the mock returns it regardless of what's called.
 function makeDbChain(resolveWith: unknown = []) {
+  const calls: Record<string, unknown[][]> = {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
     function () {
@@ -17,18 +24,22 @@ function makeDbChain(resolveWith: unknown = []) {
         if (prop === "then")
           return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
             Promise.resolve(resolveWith).then(res, rej);
-        return () => chain;
+        const key = String(prop);
+        return (...args: unknown[]) => {
+          (calls[key] ??= []).push(args);
+          return chain;
+        };
       },
       apply() {
         return chain;
       },
     }
   );
-  return chain;
+  return { chain, calls };
 }
 
 const { mockSelect } = vi.hoisted(() => ({
-  mockSelect: vi.fn((_projection: Record<string, unknown>) => makeDbChain([])),
+  mockSelect: vi.fn((_projection: Record<string, unknown>) => ({}) as unknown),
 }));
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect } }));
 
@@ -59,7 +70,7 @@ function req() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockSelect.mockReturnValue(makeDbChain([]));
+  mockSelect.mockReturnValue(makeDbChain([]).chain);
 });
 
 describe("GET /api/social/challenge-suggestions", () => {
@@ -80,7 +91,8 @@ describe("GET /api/social/challenge-suggestions", () => {
       verseRef: "1:1",
       suggestedDuration: 7,
     };
-    mockSelect.mockReturnValue(makeDbChain([row]));
+    const { chain, calls } = makeDbChain([row]);
+    mockSelect.mockReturnValue(chain);
 
     const res = await GET(req());
 
@@ -96,11 +108,19 @@ describe("GET /api/social/challenge-suggestions", () => {
       ["description", "id", "suggestedDuration", "title", "verseRef"].sort()
     );
     expect(projection).not.toHaveProperty("createdBy");
+    // A regression that drops the active-only filter or display ordering
+    // wouldn't be caught by asserting on the resolved rows alone (the mock
+    // returns them regardless of what `where`/`orderBy` are called with) —
+    // assert the actual query contract instead.
+    expect(calls.where).toEqual([[eq(challengeSuggestions.isActive, true)]]);
+    expect(calls.orderBy).toEqual([
+      [asc(challengeSuggestions.sortOrder), asc(challengeSuggestions.id)],
+    ]);
   });
 
   it("returns an empty list when there are no active suggestions", async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 1, user: makeUser() });
-    mockSelect.mockReturnValue(makeDbChain([]));
+    mockSelect.mockReturnValue(makeDbChain([]).chain);
 
     const res = await GET(req());
 

--- a/__tests__/api/social/friends-friendId.test.ts
+++ b/__tests__/api/social/friends-friendId.test.ts
@@ -6,6 +6,11 @@ vi.mock("@/lib/auth/social-auth", () => ({
   requireUser: vi.fn(),
 }));
 
+// Captures each chained call's method name + arguments (in addition to the
+// usual thenable passthrough) so tests can assert on the actual .where()
+// predicate the route built — not just on the mocked resolved value, which
+// would pass identically even if the route queried by the wrong column.
+let whereCalls: unknown[] = [];
 function makeDbChain(resolveWith: unknown = []) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
@@ -17,7 +22,10 @@ function makeDbChain(resolveWith: unknown = []) {
         if (prop === "then")
           return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
             Promise.resolve(resolveWith).then(res, rej);
-        return () => chain;
+        return (...args: unknown[]) => {
+          if (prop === "where") whereCalls.push(args[0]);
+          return chain;
+        };
       },
       apply() {
         return chain;
@@ -25,6 +33,16 @@ function makeDbChain(resolveWith: unknown = []) {
     }
   );
   return chain;
+}
+
+// drizzle's eq()/and() build a plain, JSON-serializable SQL-chunk tree (once
+// functions are stripped) — stringifying it is a cheap way to assert the
+// built predicate actually references the expected column and value,
+// without coupling to drizzle's exact internal shape.
+function whereJSON(cond: unknown): string {
+  // Drizzle column objects hold a circular back-reference to their table
+  // (column.table.columns[...] === column) — drop it along with functions.
+  return JSON.stringify(cond, (k, v) => (typeof v === "function" || k === "table" ? undefined : v));
 }
 
 const { mockSelect, mockUpdate, mockDelete } = vi.hoisted(() => ({
@@ -80,6 +98,7 @@ function params(friendId = "1") {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  whereCalls = [];
 });
 
 describe("PATCH /api/social/friends/[friendId]", () => {
@@ -117,6 +136,12 @@ describe("PATCH /api/social/friends/[friendId]", () => {
     const body = await res.json();
     expect(body).toEqual({ id: 1, status: "accepted" });
     expect(mockUpdate).toHaveBeenCalled();
+    // The lookup must be scoped by addresseeId (not e.g. requesterId) — this
+    // inspects the actual predicate the route built, not just the mocked
+    // return value, so a route bug that queried the wrong column would fail
+    // this assertion regardless of what mockSelect is told to resolve with.
+    expect(whereJSON(whereCalls[0])).toContain('"addressee_id"');
+    expect(whereJSON(whereCalls[0])).toContain("2");
   });
 
   it("the addressee can decline a pending request", async () => {
@@ -134,8 +159,11 @@ describe("PATCH /api/social/friends/[friendId]", () => {
   });
 
   it("rejects the requester (or any non-addressee) trying to accept/decline their own outgoing request", async () => {
-    // The requester's own id can never match the addresseeId filter the route
-    // queries by, so the DB lookup returns no row for them.
+    // A real DB would return no row here because the requester's id doesn't
+    // match the addresseeId filter — simulate that via an empty mock result,
+    // then separately assert (below) that the route actually queried by
+    // addresseeId=1 (the requester's own id), proving *why* a real lookup
+    // would find nothing: this scopes by addressee, not requester.
     const requester = makeUser({ id: 1 });
     authedAs(requester);
     mockSelect.mockReturnValue(makeDbChain([]));
@@ -144,6 +172,8 @@ describe("PATCH /api/social/friends/[friendId]", () => {
 
     expect(res.status).toBe(404);
     expect(mockUpdate).not.toHaveBeenCalled();
+    expect(whereJSON(whereCalls[0])).toContain('"addressee_id"');
+    expect(whereJSON(whereCalls[0])).not.toContain('"requester_id"');
   });
 
   it("rejects re-resolving a request that's already accepted/declined", async () => {
@@ -184,6 +214,10 @@ describe("DELETE /api/social/friends/[friendId]", () => {
 
     expect(res.status).toBe(200);
     expect(mockDelete).toHaveBeenCalled();
+    // Lookup must be OR'd across both requesterId and addresseeId — this
+    // inspects the actual predicate built, not just the mocked return value.
+    expect(whereJSON(whereCalls[0])).toContain('"requester_id"');
+    expect(whereJSON(whereCalls[0])).toContain('"addressee_id"');
   });
 
   it("the addressee can also remove the friendship", async () => {
@@ -195,11 +229,14 @@ describe("DELETE /api/social/friends/[friendId]", () => {
 
     expect(res.status).toBe(200);
     expect(mockDelete).toHaveBeenCalled();
+    expect(whereJSON(whereCalls[0])).toContain("2");
   });
 
   it("rejects an unrelated third party trying to remove someone else's friendship", async () => {
-    // Neither requesterId nor addresseeId matches this user, so the DB's
-    // OR-filtered lookup returns no row for them.
+    // A real DB would return no row here because this user's id matches
+    // neither requesterId nor addresseeId — simulate that via an empty mock
+    // result, then separately assert the route actually queried by both
+    // columns OR'd together, scoped to this user's id (99).
     const outsider = makeUser({ id: 99 });
     authedAs(outsider);
     mockSelect.mockReturnValue(makeDbChain([]));
@@ -208,5 +245,8 @@ describe("DELETE /api/social/friends/[friendId]", () => {
 
     expect(res.status).toBe(404);
     expect(mockDelete).not.toHaveBeenCalled();
+    expect(whereJSON(whereCalls[0])).toContain('"requester_id"');
+    expect(whereJSON(whereCalls[0])).toContain('"addressee_id"');
+    expect(whereJSON(whereCalls[0])).toContain("99");
   });
 });

--- a/__tests__/api/social/friends-friendId.test.ts
+++ b/__tests__/api/social/friends-friendId.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/infra/db/schema";
+
+vi.mock("@/lib/auth/social-auth", () => ({
+  requireUser: vi.fn(),
+}));
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect, mockUpdate, mockDelete } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+  mockUpdate: vi.fn(() => makeDbChain([])),
+  mockDelete: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/infra/db", () => ({
+  db: { select: mockSelect, update: mockUpdate, delete: mockDelete },
+}));
+
+import { PATCH, DELETE } from "@/app/api/social/friends/[friendId]/route";
+import { requireUser } from "@/lib/auth/social-auth";
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    qfId: "qf-1",
+    username: "testuser",
+    displayName: null,
+    createdAt: new Date(),
+    lastActiveAt: new Date(),
+    currentStreak: 0,
+    longestStreak: 0,
+    lastActivityDate: null,
+    disabledAt: null,
+    ...overrides,
+  };
+}
+
+function authedAs(user: User) {
+  vi.mocked(requireUser).mockResolvedValue({ userId: user.id, user });
+}
+
+function patchReq(body: object) {
+  return new NextRequest("http://localhost/api/social/friends/1", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", Authorization: "Bearer t" },
+    body: JSON.stringify(body),
+  });
+}
+
+function deleteReq() {
+  return new NextRequest("http://localhost/api/social/friends/1", {
+    method: "DELETE",
+    headers: { Authorization: "Bearer t" },
+  });
+}
+
+function params(friendId = "1") {
+  return { params: Promise.resolve({ friendId }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PATCH /api/social/friends/[friendId]", () => {
+  it("401s when unauthenticated", async () => {
+    vi.mocked(requireUser).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    );
+    const res = await PATCH(patchReq({ action: "accept" }), params());
+    expect(res.status).toBe(401);
+  });
+
+  it("400s on a non-numeric friendId", async () => {
+    authedAs(makeUser());
+    const res = await PATCH(patchReq({ action: "accept" }), params("not-a-number"));
+    expect(res.status).toBe(400);
+  });
+
+  it("400s when action isn't 'accept' or 'decline'", async () => {
+    authedAs(makeUser());
+    const res = await PATCH(patchReq({ action: "delete-please" }), params());
+    expect(res.status).toBe(400);
+  });
+
+  it("the addressee can accept a pending request", async () => {
+    const addressee = makeUser({ id: 2 });
+    authedAs(addressee);
+    mockSelect.mockReturnValue(
+      makeDbChain([{ id: 1, requesterId: 1, addresseeId: 2, status: "pending" }])
+    );
+    mockUpdate.mockReturnValue(makeDbChain([{ id: 1, status: "accepted" }]));
+
+    const res = await PATCH(patchReq({ action: "accept" }), params());
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ id: 1, status: "accepted" });
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it("the addressee can decline a pending request", async () => {
+    const addressee = makeUser({ id: 2 });
+    authedAs(addressee);
+    mockSelect.mockReturnValue(
+      makeDbChain([{ id: 1, requesterId: 1, addresseeId: 2, status: "pending" }])
+    );
+    mockUpdate.mockReturnValue(makeDbChain([{ id: 1, status: "declined" }]));
+
+    const res = await PATCH(patchReq({ action: "decline" }), params());
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe("declined");
+  });
+
+  it("rejects the requester (or any non-addressee) trying to accept/decline their own outgoing request", async () => {
+    // The requester's own id can never match the addresseeId filter the route
+    // queries by, so the DB lookup returns no row for them.
+    const requester = makeUser({ id: 1 });
+    authedAs(requester);
+    mockSelect.mockReturnValue(makeDbChain([]));
+
+    const res = await PATCH(patchReq({ action: "accept" }), params());
+
+    expect(res.status).toBe(404);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rejects re-resolving a request that's already accepted/declined", async () => {
+    const addressee = makeUser({ id: 2 });
+    authedAs(addressee);
+    mockSelect.mockReturnValue(
+      makeDbChain([{ id: 1, requesterId: 1, addresseeId: 2, status: "accepted" }])
+    );
+
+    const res = await PATCH(patchReq({ action: "decline" }), params());
+
+    expect(res.status).toBe(409);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/social/friends/[friendId]", () => {
+  it("401s when unauthenticated", async () => {
+    vi.mocked(requireUser).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    );
+    const res = await DELETE(deleteReq(), params());
+    expect(res.status).toBe(401);
+  });
+
+  it("400s on a non-numeric friendId", async () => {
+    authedAs(makeUser());
+    const res = await DELETE(deleteReq(), params("not-a-number"));
+    expect(res.status).toBe(400);
+  });
+
+  it("the requester can remove the friendship", async () => {
+    const requester = makeUser({ id: 1 });
+    authedAs(requester);
+    mockSelect.mockReturnValue(makeDbChain([{ id: 1 }]));
+
+    const res = await DELETE(deleteReq(), params());
+
+    expect(res.status).toBe(200);
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it("the addressee can also remove the friendship", async () => {
+    const addressee = makeUser({ id: 2 });
+    authedAs(addressee);
+    mockSelect.mockReturnValue(makeDbChain([{ id: 1 }]));
+
+    const res = await DELETE(deleteReq(), params());
+
+    expect(res.status).toBe(200);
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it("rejects an unrelated third party trying to remove someone else's friendship", async () => {
+    // Neither requesterId nor addresseeId matches this user, so the DB's
+    // OR-filtered lookup returns no row for them.
+    const outsider = makeUser({ id: 99 });
+    authedAs(outsider);
+    mockSelect.mockReturnValue(makeDbChain([]));
+
+    const res = await DELETE(deleteReq(), params());
+
+    expect(res.status).toBe(404);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/verse-morphology.test.ts
+++ b/__tests__/api/verse-morphology.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+function makeDbChain(resolveWith: unknown = []) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
+}));
+vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect } }));
+
+import { GET } from "@/app/api/verse/[surah]/[ayah]/morphology/route";
+
+function req() {
+  return new NextRequest("http://localhost/api/verse/2/255/morphology");
+}
+function params(surah: string, ayah: string) {
+  return { params: Promise.resolve({ surah, ayah }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSelect.mockReturnValue(makeDbChain([]));
+});
+
+describe("GET /api/verse/[surah]/[ayah]/morphology", () => {
+  it("400s on an invalid verse reference", async () => {
+    const res = await GET(req(), params("999", "1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns the seeded words for a valid, seeded verse", async () => {
+    const words = [
+      { position: 1, surface: "اللَّهُ", root: "أله", lemma: "الله" },
+      { position: 2, surface: "لَا", root: null, lemma: "لا" },
+    ];
+    mockSelect.mockReturnValue(makeDbChain(words));
+
+    const res = await GET(req(), params("2", "255"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ words });
+  });
+
+  it("returns an empty words array (still 200) for a valid but unseeded verse", async () => {
+    mockSelect.mockReturnValue(makeDbChain([]));
+
+    const res = await GET(req(), params("2", "255"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ words: [] });
+  });
+
+  it("degrades to an empty words array on a DB error instead of failing the request", async () => {
+    mockSelect.mockImplementation(() => {
+      throw new Error("connection reset");
+    });
+
+    const res = await GET(req(), params("2", "255"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ words: [] });
+  });
+});

--- a/__tests__/store/audio.test.ts
+++ b/__tests__/store/audio.test.ts
@@ -88,23 +88,52 @@ describe("audio store", () => {
 
   it("a stale play() resolution does not clobber state from a newer play() call (playGen race guard)", async () => {
     // Rapidly switch tracks before the first play() settles — mirrors a user
-    // skipping tracks faster than playback can start.
+    // skipping tracks faster than playback can start. B is still loading when
+    // A's stale promise settles: this is the only ordering where the guard's
+    // effect is observable — if settled in the other order, isLoading would
+    // land on the same value (false) whether or not the guard exists.
     useAudioStore.getState().playVerse(verseA);
     useAudioStore.getState().playVerse(verseB);
     expect(pendingPlays).toHaveLength(2);
+    expect(useAudioStore.getState().isLoading).toBe(true);
 
-    // The newer (B) call settles first, clearing isLoading for B.
+    // The stale (A) call settles first, while B is still loading. Without the
+    // playGen check, A's .then would incorrectly clear isLoading for B's
+    // still-in-flight play().
+    pendingPlays[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState()).toMatchObject({ currentRef: "1:1", isLoading: true });
+
+    // B's own play() now settles — this is what should actually clear isLoading.
     pendingPlays[1].resolve();
     await Promise.resolve();
     await Promise.resolve();
     expect(useAudioStore.getState()).toMatchObject({ currentRef: "1:1", isLoading: false });
+  });
 
-    // The stale (A) call settles after — its .then callback must be a no-op,
-    // not silently flip isLoading back to reflect a track that's no longer current.
+  it("a stale settlement through next() does not clobber state from a newer next() call", async () => {
+    useAudioStore.getState().playGraph([verseA, verseB, verseC]);
     pendingPlays[0].resolve();
     await Promise.resolve();
     await Promise.resolve();
-    expect(useAudioStore.getState()).toMatchObject({ currentRef: "1:1", isLoading: false });
+
+    // Two rapid next() calls before either play() settles.
+    useAudioStore.getState().next(); // -> verseB, token N
+    useAudioStore.getState().next(); // -> verseC, token N+1 (stale: pendingPlays[2])
+    expect(pendingPlays).toHaveLength(3);
+    expect(useAudioStore.getState()).toMatchObject({ currentRef: "112:1", isLoading: true });
+
+    // The stale (verseB) call settles first — must not clear isLoading for verseC.
+    pendingPlays[1].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState()).toMatchObject({ currentRef: "112:1", isLoading: true });
+
+    pendingPlays[2].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState()).toMatchObject({ currentRef: "112:1", isLoading: false });
   });
 
   it("a stale play() rejection does not clobber isPlaying/isLoading from a newer call", async () => {

--- a/__tests__/store/audio.test.ts
+++ b/__tests__/store/audio.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useAudioStore, type AudioVerse } from "@/store/audio";
+
+const verseA: AudioVerse = { ref: "2:255", surah: 2, ayah: 255, surahName: "Al-Baqarah" };
+const verseB: AudioVerse = { ref: "1:1", surah: 1, ayah: 1, surahName: "Al-Fatiha" };
+const verseC: AudioVerse = { ref: "112:1", surah: 112, ayah: 1, surahName: "Al-Ikhlas" };
+
+// jsdom's HTMLMediaElement.play()/pause()/load() are stubs that throw "not
+// implemented" — replace them with controllable mocks so tests can decide
+// exactly when a play() promise settles (needed to exercise the playGen
+// race guard, which depends on settlement order).
+let pendingPlays: Array<{ resolve: () => void; reject: (e: unknown) => void }>;
+
+beforeEach(() => {
+  pendingPlays = [];
+  window.HTMLMediaElement.prototype.play = vi.fn(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        pendingPlays.push({ resolve, reject });
+      })
+  );
+  window.HTMLMediaElement.prototype.pause = vi.fn();
+  window.HTMLMediaElement.prototype.load = vi.fn();
+
+  useAudioStore.setState({
+    currentRef: null,
+    currentSurahName: null,
+    isPlaying: false,
+    isLoading: false,
+    queue: [],
+    queueIndex: 0,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("audio store", () => {
+  it("playVerse synchronously sets the current verse, playing, and loading state", () => {
+    useAudioStore.getState().playVerse(verseA);
+    const s = useAudioStore.getState();
+    expect(s.currentRef).toBe("2:255");
+    expect(s.currentSurahName).toBe("Al-Baqarah");
+    expect(s.isPlaying).toBe(true);
+    expect(s.isLoading).toBe(true);
+    expect(s.queue).toEqual([verseA]);
+    expect(s.queueIndex).toBe(0);
+  });
+
+  it("playVerse clears isLoading once play() resolves", async () => {
+    useAudioStore.getState().playVerse(verseA);
+    pendingPlays[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState().isLoading).toBe(false);
+    expect(useAudioStore.getState().isPlaying).toBe(true);
+  });
+
+  it("playVerse clears isPlaying and isLoading if play() rejects (e.g. autoplay blocked)", async () => {
+    useAudioStore.getState().playVerse(verseA);
+    pendingPlays[0].reject(new Error("NotAllowedError"));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState().isPlaying).toBe(false);
+    expect(useAudioStore.getState().isLoading).toBe(false);
+  });
+
+  it("playGraph queues all verses starting at the first, and clears isLoading on resolve", async () => {
+    useAudioStore.getState().playGraph([verseA, verseB, verseC]);
+    let s = useAudioStore.getState();
+    expect(s.currentRef).toBe("2:255");
+    expect(s.queue).toEqual([verseA, verseB, verseC]);
+    expect(s.queueIndex).toBe(0);
+
+    pendingPlays[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    s = useAudioStore.getState();
+    expect(s.isLoading).toBe(false);
+  });
+
+  it("playGraph is a no-op for an empty verse list", () => {
+    const before = useAudioStore.getState();
+    useAudioStore.getState().playGraph([]);
+    expect(useAudioStore.getState()).toEqual(before);
+  });
+
+  it("a stale play() resolution does not clobber state from a newer play() call (playGen race guard)", async () => {
+    // Rapidly switch tracks before the first play() settles — mirrors a user
+    // skipping tracks faster than playback can start.
+    useAudioStore.getState().playVerse(verseA);
+    useAudioStore.getState().playVerse(verseB);
+    expect(pendingPlays).toHaveLength(2);
+
+    // The newer (B) call settles first, clearing isLoading for B.
+    pendingPlays[1].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState()).toMatchObject({ currentRef: "1:1", isLoading: false });
+
+    // The stale (A) call settles after — its .then callback must be a no-op,
+    // not silently flip isLoading back to reflect a track that's no longer current.
+    pendingPlays[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState()).toMatchObject({ currentRef: "1:1", isLoading: false });
+  });
+
+  it("a stale play() rejection does not clobber isPlaying/isLoading from a newer call", async () => {
+    useAudioStore.getState().playVerse(verseA);
+    useAudioStore.getState().playVerse(verseB);
+
+    // Newer call succeeds and is actively playing.
+    pendingPlays[1].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState()).toMatchObject({ isPlaying: true, isLoading: false });
+
+    // Stale call's play() promise rejects after the fact — must not stop playback.
+    pendingPlays[0].reject(new Error("stale"));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState()).toMatchObject({
+      currentRef: "1:1",
+      isPlaying: true,
+      isLoading: false,
+    });
+  });
+
+  it("next() advances the queue and clears isLoading once settled", async () => {
+    useAudioStore.getState().playGraph([verseA, verseB, verseC]);
+    pendingPlays[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    useAudioStore.getState().next();
+    let s = useAudioStore.getState();
+    expect(s.currentRef).toBe("1:1");
+    expect(s.queueIndex).toBe(1);
+    expect(s.isLoading).toBe(true);
+
+    pendingPlays[1].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    s = useAudioStore.getState();
+    expect(s.isLoading).toBe(false);
+  });
+
+  it("next() at the end of the queue stops playback instead of advancing", async () => {
+    useAudioStore.getState().playVerse(verseA); // single-item queue
+    pendingPlays[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    useAudioStore.getState().next();
+    const s = useAudioStore.getState();
+    expect(s.currentRef).toBeNull();
+    expect(s.isPlaying).toBe(false);
+    expect(s.queue).toEqual([]);
+  });
+
+  it("prev() moves back through the queue", async () => {
+    useAudioStore.getState().playGraph([verseA, verseB, verseC]);
+    pendingPlays[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    useAudioStore.getState().next();
+    pendingPlays[1].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState().currentRef).toBe("1:1");
+
+    useAudioStore.getState().prev();
+    expect(useAudioStore.getState().currentRef).toBe("2:255");
+    expect(useAudioStore.getState().queueIndex).toBe(0);
+  });
+
+  it("prev() at the start of the queue is a no-op", () => {
+    useAudioStore.getState().playVerse(verseA);
+    useAudioStore.getState().prev();
+    expect(useAudioStore.getState().currentRef).toBe("2:255");
+    expect(useAudioStore.getState().queueIndex).toBe(0);
+  });
+
+  it("_onEnded advances to the next track (used as the <audio> onended handler)", async () => {
+    useAudioStore.getState().playGraph([verseA, verseB]);
+    pendingPlays[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    useAudioStore.getState()._onEnded();
+    expect(useAudioStore.getState().currentRef).toBe("1:1");
+  });
+
+  it("resume() sets isPlaying once play() resolves", async () => {
+    useAudioStore.getState().playVerse(verseA); // creates the module-level Audio instance
+    pendingPlays[0].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    useAudioStore.getState().pause();
+    expect(useAudioStore.getState().isPlaying).toBe(false);
+
+    useAudioStore.getState().resume();
+    expect(pendingPlays).toHaveLength(2);
+    pendingPlays[1].resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useAudioStore.getState().isPlaying).toBe(true);
+  });
+
+  it("pause() stops playback state without clearing the queue", () => {
+    useAudioStore.getState().playVerse(verseA);
+    useAudioStore.getState().pause();
+    const s = useAudioStore.getState();
+    expect(s.isPlaying).toBe(false);
+    expect(s.currentRef).toBe("2:255");
+    expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+  });
+
+  it("stop() clears the current track, queue, and playback state", () => {
+    useAudioStore.getState().playVerse(verseA);
+    useAudioStore.getState().stop();
+    const s = useAudioStore.getState();
+    expect(s.currentRef).toBeNull();
+    expect(s.currentSurahName).toBeNull();
+    expect(s.isPlaying).toBe(false);
+    expect(s.isLoading).toBe(false);
+    expect(s.queue).toEqual([]);
+    expect(s.queueIndex).toBe(0);
+  });
+});

--- a/__tests__/store/social.test.ts
+++ b/__tests__/store/social.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useSocialStore } from "@/store/social";
+
+const INITIAL = {
+  userId: null,
+  username: null,
+  streak: 0,
+  longestStreak: 0,
+  pendingFriendCount: 0,
+  pendingChallengeCount: 0,
+  pendingMentionCount: 0,
+};
+
+describe("social store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSocialStore.setState(INITIAL);
+  });
+
+  it("defaults to a logged-out, zeroed-out profile", () => {
+    const s = useSocialStore.getState();
+    expect(s.userId).toBeNull();
+    expect(s.username).toBeNull();
+    expect(s.streak).toBe(0);
+    expect(s.longestStreak).toBe(0);
+    expect(s.pendingFriendCount).toBe(0);
+    expect(s.pendingChallengeCount).toBe(0);
+    expect(s.pendingMentionCount).toBe(0);
+  });
+
+  it("setProfile sets userId and username, leaving other state untouched", () => {
+    useSocialStore.setState({ streak: 5, pendingFriendCount: 2 });
+    useSocialStore.getState().setProfile({ userId: 42, username: "hikmah_seeker" });
+    const s = useSocialStore.getState();
+    expect(s.userId).toBe(42);
+    expect(s.username).toBe("hikmah_seeker");
+    expect(s.streak).toBe(5);
+    expect(s.pendingFriendCount).toBe(2);
+  });
+
+  it("clearSocial resets every field back to its logged-out default", () => {
+    useSocialStore.setState({
+      userId: 42,
+      username: "hikmah_seeker",
+      streak: 10,
+      longestStreak: 20,
+      pendingFriendCount: 3,
+      pendingChallengeCount: 1,
+      pendingMentionCount: 4,
+    });
+
+    useSocialStore.getState().clearSocial();
+
+    expect(useSocialStore.getState()).toMatchObject(INITIAL);
+  });
+
+  it("bumpStreak sets the current streak and raises longestStreak when exceeded", () => {
+    useSocialStore.getState().bumpStreak(3);
+    expect(useSocialStore.getState()).toMatchObject({ streak: 3, longestStreak: 3 });
+
+    useSocialStore.getState().bumpStreak(7);
+    expect(useSocialStore.getState()).toMatchObject({ streak: 7, longestStreak: 7 });
+  });
+
+  it("bumpStreak lowering the current streak (e.g. a missed day) does not lower longestStreak", () => {
+    useSocialStore.getState().bumpStreak(10);
+    useSocialStore.getState().bumpStreak(1);
+    expect(useSocialStore.getState()).toMatchObject({ streak: 1, longestStreak: 10 });
+  });
+
+  it("bumpStreak honors an explicit newLongest instead of deriving it", () => {
+    useSocialStore.getState().bumpStreak(5, 99);
+    expect(useSocialStore.getState()).toMatchObject({ streak: 5, longestStreak: 99 });
+  });
+
+  it("setPendingFriendCount/setPendingChallengeCount/setPendingMentionCount each set their own field independently", () => {
+    useSocialStore.getState().setPendingFriendCount(3);
+    useSocialStore.getState().setPendingChallengeCount(2);
+    useSocialStore.getState().setPendingMentionCount(1);
+
+    expect(useSocialStore.getState()).toMatchObject({
+      pendingFriendCount: 3,
+      pendingChallengeCount: 2,
+      pendingMentionCount: 1,
+    });
+  });
+
+  it("persists userId, username, streak, and longestStreak to localStorage, but not the pending-* counts", () => {
+    useSocialStore.setState({
+      userId: 42,
+      username: "hikmah_seeker",
+      streak: 5,
+      longestStreak: 10,
+      pendingFriendCount: 3,
+      pendingChallengeCount: 2,
+      pendingMentionCount: 1,
+    });
+
+    const stored = JSON.parse(localStorage.getItem("open-hikmah-social")!);
+    expect(stored.state).toMatchObject({
+      userId: 42,
+      username: "hikmah_seeker",
+      streak: 5,
+      longestStreak: 10,
+    });
+    expect(stored.state.pendingFriendCount).toBeUndefined();
+    expect(stored.state.pendingChallengeCount).toBeUndefined();
+    expect(stored.state.pendingMentionCount).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- `store/audio.ts` — direct unit tests, including the `playGen` monotonic-token race guard that discards stale `play()` callbacks when a user skips tracks faster than playback settles. This was the app's only documented race-condition mitigation and previously had no direct test (only indirect coverage via `MiniPlayer.test.tsx`, which never exercises `playVerse`/`next`/`prev`).
- `store/social.ts` — direct unit tests, including which fields (`userId`, `username`, `streak`, `longestStreak`) persist to `localStorage` vs. which don't (`pendingFriendCount` etc.). Previously zero coverage, unlike sibling stores `auth`/`canvas`/`preferences`.
- `app/api/admin/prompts` (create/activate) + `app/api/admin/prompts/rollback` — the deactivate-old/activate-new transaction behavior. This is the one route that pushes new AI prompt templates live to production, and per AGENTS.md is the theological-generation surface treated as highest-scrutiny — previously the only route on that surface with zero automated coverage.
- `app/api/social/friends/[friendId]` PATCH/DELETE — the addressee-only accept/decline authorization check and the requester-or-addressee-only removal check, including that the wrong user is correctly rejected (404, not a silent no-op).
- `app/api/verse/[surah]/[ayah]/morphology`, `app/api/root/[root]`, `app/api/social/challenge-suggestions`, `app/api/health` — happy-path + error-path coverage, following the existing patterns in sibling test files.

**Note on `app/api/root/[root]`**: I initially wrote a test asserting numeric surah:ayah ordering, but the route doesn't actually re-sort after the DB query — issue #360 already tracks that it currently sorts lexicographically, not numerically. Rewrote that test to pin the route's actual passthrough behavior instead of asserting a guarantee the code doesn't provide; fixing #360 itself is out of scope here.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [x] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR
- [x] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per AGENTS.md

**Details**: No prompts, divine-name data, or theological framing changed — this only adds test coverage around the existing `admin/prompts` mutation logic (verifying the transaction shape, not changing prompt content or generation behavior).

## Testing

- [x] `bun run test:ci` passes locally (1053/1053, 132 files)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally — pre-existing unrelated formatting warnings in `.superpowers/sdd/*.md`, not touched by this PR
- [x] New tests added for new functionality — this PR is entirely new tests (8 new files, 0 production code changes)

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — n/a
- [x] `README.md` updated if the feature changes the public interface — n/a

Fixes #364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for administrative prompt management, including authorization, validation, activation, rollback, caching, and transactions.
  * Added API tests for health checks, root searches, challenge suggestions, friend requests, and verse morphology.
  * Expanded audio playback tests covering queues, failures, playback controls, and race conditions.
  * Added social state tests covering profile updates, streaks, resets, pending counts, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->