### PR TITLE
chore(admin): render connection confidence in connections table

### DIFF
--- a/__tests__/app/admin/connections/page.test.tsx
+++ b/__tests__/app/admin/connections/page.test.tsx
@@ -48,4 +48,16 @@ describe("ConnectionsPage — confidence column", () => {
     expect(await screen.findByText("2:255 → 24:35")).toBeInTheDocument();
     expect(screen.getByText("—")).toBeInTheDocument();
   });
+
+  it("flags sub-50% confidence for review instead of coloring it as an error", async () => {
+    mockApi.mockResolvedValue({
+      connections: [{ ...baseConnection, confidence: 42 }],
+    });
+
+    render(<ConnectionsPage />);
+
+    const confidence = await screen.findByText("42%");
+    expect(confidence.className).toContain("text-gold");
+    expect(confidence.className).not.toContain("text-error");
+  });
 });

--- a/__tests__/app/admin/connections/page.test.tsx
+++ b/__tests__/app/admin/connections/page.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockApi = vi.fn();
+vi.mock("@/components/admin/AdminContext", async () => {
+  const actual = await vi.importActual("@/components/admin/AdminContext");
+  return {
+    ...actual,
+    useAdminFetch: () => mockApi,
+  };
+});
+
+import ConnectionsPage from "@/app/admin/connections/page";
+
+const baseConnection = {
+  id: 1,
+  fromRef: "2:255",
+  toRef: "24:35",
+  kind: "thematic",
+  reason: "Both describe divine light and knowledge.",
+  model: "claude-opus-4-7",
+  status: "active" as const,
+  reviewedAt: null,
+};
+
+describe("ConnectionsPage — confidence column", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+  });
+
+  it("renders the confidence percentage for a connection that has one", async () => {
+    mockApi.mockResolvedValue({
+      connections: [{ ...baseConnection, confidence: 82 }],
+    });
+
+    render(<ConnectionsPage />);
+
+    expect(await screen.findByText("82%")).toBeInTheDocument();
+  });
+
+  it("renders a placeholder when confidence is null", async () => {
+    mockApi.mockResolvedValue({
+      connections: [{ ...baseConnection, confidence: null }],
+    });
+
+    render(<ConnectionsPage />);
+
+    expect(await screen.findByText("2:255 → 24:35")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/app/admin/connections/page.tsx
+++ b/app/admin/connections/page.tsx
@@ -98,6 +98,7 @@ export default function ConnectionsPage() {
                 <Th>Edge</Th>
                 <Th>Kind</Th>
                 <Th>Why</Th>
+                <Th>Confidence</Th>
                 <Th>Status</Th>
                 <Th>Review</Th>
                 <Th className="text-right">Actions</Th>
@@ -114,6 +115,17 @@ export default function ConnectionsPage() {
                   </Td>
                   <Td className="max-w-md text-xs text-text-secondary">
                     <span className="line-clamp-2">{c.reason}</span>
+                  </Td>
+                  <Td className="whitespace-nowrap text-xs">
+                    {c.confidence === null ? (
+                      <span className="text-text-muted">—</span>
+                    ) : (
+                      <span
+                        className={cn(c.confidence < 50 ? "text-error" : "text-text-secondary")}
+                      >
+                        {c.confidence}%
+                      </span>
+                    )}
                   </Td>
                   <Td>
                     <Pill tone={c.status}>{c.status}</Pill>

--- a/app/admin/connections/page.tsx
+++ b/app/admin/connections/page.tsx
@@ -120,9 +120,7 @@ export default function ConnectionsPage() {
                     {c.confidence === null ? (
                       <span className="text-text-muted">—</span>
                     ) : (
-                      <span
-                        className={cn(c.confidence < 50 ? "text-error" : "text-text-secondary")}
-                      >
+                      <span className={cn(c.confidence < 50 ? "text-gold" : "text-text-secondary")}>
                         {c.confidence}%
                       </span>
                     )}


### PR DESCRIPTION
## Summary

Closes #276.

The admin connections page's `Connection` interface already includes `confidence: number | null`, and `GET /api/admin/connections` already returns it (`db.select().from(connections)` selects all columns) — but the table never rendered it. Moderators had no way to see the AI model's self-reported confidence when deciding whether to approve, flag, or retire a connection.

## Changes

- Added a "Confidence" column to `app/admin/connections/page.tsx`, rendered as a percentage.
- Sub-50% confidence is visually flagged using the existing `text-error` token (same one used elsewhere in this file for error states), so low-confidence edges stand out for triage.
- `null` confidence (not yet backfilled / pre-dates the column) renders as a muted `—` rather than `null%`.
- No API changes needed — the column was already selected, just never rendered.

## AI / Theological changes

- [ ] N/A — no change to prompts, divine-name data, or theological framing. This only renders an existing numeric field already present in the payload.

## Test plan

- Added `__tests__/app/admin/connections/page.test.tsx` (mirrors the existing `__tests__/app/admin/votd/page.test.tsx` pattern) covering: percentage render for a connection with confidence, and the `—` placeholder for `confidence: null`.
- `bun run lint`, `bun run typecheck`, `bun run test:ci` all pass locally.
- `bun run test:integration` passed via the pre-push hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Confidence column to the admin connections table.
  * Confidence values display as percentages, with low-confidence connections highlighted for easier review.
  * Connections without a confidence value now show an em dash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->