### PR TITLE
fix(admin): require confirmation before Create & activate on prompts

### DIFF
--- a/__tests__/app/admin/prompts/page.test.tsx
+++ b/__tests__/app/admin/prompts/page.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockApi = vi.fn();
+vi.mock("@/components/admin/AdminContext", async () => {
+  const actual = await vi.importActual("@/components/admin/AdminContext");
+  return {
+    ...actual,
+    useAdminFetch: () => mockApi,
+  };
+});
+
+import PromptsPage from "@/app/admin/prompts/page";
+
+describe("PromptsPage — Create & activate requires confirmation", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+    mockApi.mockResolvedValue({ versions: [] });
+  });
+
+  it("does not create a version on the first click, only after a confirming second click", async () => {
+    render(<PromptsPage />);
+
+    const textarea = await screen.findByPlaceholderText(/Reference: {{fromRef}}/);
+    fireEvent.change(textarea, { target: { value: "New template body" } });
+
+    const createButton = screen.getByRole("button", { name: "Create & activate" });
+    fireEvent.click(createButton);
+
+    expect(mockApi).not.toHaveBeenCalledWith(
+      "/prompts",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(await screen.findByRole("button", { name: "Create & activate?" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create & activate?" }));
+
+    await waitFor(() =>
+      expect(mockApi).toHaveBeenCalledWith("/prompts", {
+        method: "POST",
+        json: { key: "connection.legacy", template: "New template body" },
+      })
+    );
+  });
+});

--- a/__tests__/app/admin/prompts/page.test.tsx
+++ b/__tests__/app/admin/prompts/page.test.tsx
@@ -42,4 +42,25 @@ describe("PromptsPage — Create & activate requires confirmation", () => {
       })
     );
   });
+
+  it("locks the draft textarea while armed so the confirmed content can't change before the second click", async () => {
+    render(<PromptsPage />);
+
+    const textarea = await screen.findByPlaceholderText(/Reference: {{fromRef}}/);
+    fireEvent.change(textarea, { target: { value: "Template A" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create & activate" }));
+    expect(await screen.findByRole("button", { name: "Create & activate?" })).toBeInTheDocument();
+
+    expect(textarea).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create & activate?" }));
+
+    await waitFor(() =>
+      expect(mockApi).toHaveBeenCalledWith("/prompts", {
+        method: "POST",
+        json: { key: "connection.legacy", template: "Template A" },
+      })
+    );
+  });
 });

--- a/__tests__/app/admin/prompts/page.test.tsx
+++ b/__tests__/app/admin/prompts/page.test.tsx
@@ -63,4 +63,27 @@ describe("PromptsPage — Create & activate requires confirmation", () => {
       })
     );
   });
+
+  it("locks the slot selector while armed, so a confirmed create can't land in a different slot", async () => {
+    render(<PromptsPage />);
+
+    const textarea = await screen.findByPlaceholderText(/Reference: {{fromRef}}/);
+    fireEvent.change(textarea, { target: { value: "Template A" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create & activate" }));
+    expect(await screen.findByRole("button", { name: "Create & activate?" })).toBeInTheDocument();
+
+    const otherSlot = screen.getByRole("button", { name: "connection.selection" });
+    expect(otherSlot).toBeDisabled();
+    fireEvent.click(otherSlot);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create & activate?" }));
+
+    await waitFor(() =>
+      expect(mockApi).toHaveBeenCalledWith("/prompts", {
+        method: "POST",
+        json: { key: "connection.legacy", template: "Template A" },
+      })
+    );
+  });
 });

--- a/app/admin/prompts/page.tsx
+++ b/app/admin/prompts/page.tsx
@@ -85,8 +85,12 @@ export default function PromptsPage() {
               <button
                 key={k}
                 onClick={() => setKey(k)}
+                // Locked with the draft/textarea during the armed window — otherwise
+                // a confirmed create could activate the draft in a slot the user
+                // never actually confirmed for.
+                disabled={createArmed || saving}
                 className={cn(
-                  "rounded border px-2 py-1 text-xs transition-colors",
+                  "rounded border px-2 py-1 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50",
                   key === k
                     ? "border-gold-muted bg-gold/10 text-gold"
                     : "border-border text-text-secondary hover:border-gold-muted"

--- a/app/admin/prompts/page.tsx
+++ b/app/admin/prompts/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState } from "react";
+import { Button } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
+import { useArmedConfirm } from "@/hooks/useArmedConfirm";
 import { cn } from "@/lib/utils";
 
 interface PromptVersionRow {
@@ -47,6 +49,12 @@ export default function PromptsPage() {
       setSaving(false);
     }
   };
+
+  // Deliberately not the ConfirmButton primitive: the draft textarea must be
+  // locked for the duration of the armed window, otherwise a user could edit
+  // the template between the arm click and the confirm click and activate
+  // content they never actually confirmed.
+  const { armed: createArmed, trigger: triggerCreate } = useArmedConfirm(createVersion);
 
   const rollback = async (id: number) => {
     setActionError(null);
@@ -105,24 +113,24 @@ export default function PromptsPage() {
           <textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
+            disabled={createArmed || saving}
             placeholder={
               active
                 ? active.template
                 : "e.g. Reference: {{fromRef}}\nArabic: {{arabicText}}\n... Task: {{task}} ..."
             }
             rows={10}
-            className="w-full rounded-md border border-border bg-bg px-3 py-2 font-mono text-xs text-text-primary focus:border-gold-muted"
+            className="w-full rounded-md border border-border bg-bg px-3 py-2 font-mono text-xs text-text-primary focus:border-gold-muted disabled:opacity-60"
           />
           <div className="flex justify-end">
-            <ConfirmButton
+            <Button
               size="sm"
-              variant="primary"
+              variant={createArmed ? "danger" : "primary"}
               disabled={saving || !draft.trim()}
-              onConfirm={createVersion}
-              confirmLabel="Create & activate?"
+              onClick={triggerCreate}
             >
-              {saving ? "Saving…" : "Create & activate"}
-            </ConfirmButton>
+              {saving ? "Saving…" : createArmed ? "Create & activate?" : "Create & activate"}
+            </Button>
           </div>
         </div>
 

--- a/app/admin/prompts/page.tsx
+++ b/app/admin/prompts/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { Button } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
@@ -115,9 +114,15 @@ export default function PromptsPage() {
             className="w-full rounded-md border border-border bg-bg px-3 py-2 font-mono text-xs text-text-primary focus:border-gold-muted"
           />
           <div className="flex justify-end">
-            <Button size="sm" variant="primary" disabled={saving} onClick={createVersion}>
+            <ConfirmButton
+              size="sm"
+              variant="primary"
+              disabled={saving || !draft.trim()}
+              onConfirm={createVersion}
+              confirmLabel="Create & activate?"
+            >
               {saving ? "Saving…" : "Create & activate"}
-            </Button>
+            </ConfirmButton>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Closes #274.

On the admin prompts page, "Create & activate" pushes a brand-new, unreviewed template live for the AI connection-generation flow in one click — the insert transaction atomically deactivates the current active version (`app/api/admin/prompts/route.ts`). "Roll back to this version", which reverts to a *previously working* version, already required confirmation via `ConfirmButton`. The riskier action had no safety gate at all.

## Changes

- Wrapped "Create & activate" in the same `ConfirmButton` component (`components/admin/primitives.tsx`) already used for "Roll back to this version" on the same page.
- Kept the existing "Saving…" label during the in-flight request.
- Removed the now-unused `Button` import.

## AI / Theological changes

- [x] Changes how AI prompt content reaches production — not a change to the prompt *content* or theological framing itself, but this closes a gap where a typo'd/malformed template could go live with zero confirmation, silently affecting every subsequent connection-generation call until noticed. No wording/prompt changes in this PR.

## Test plan

- Added `__tests__/app/admin/prompts/page.test.tsx`: asserts the first click does not call the API, and only a confirming second click issues the `POST /prompts` request.
- `bun run lint`, `bun run typecheck`, `bun run test:ci` pass locally.
- `bun run test:integration` passed via the pre-push hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a two-step confirmation before creating and activating a prompt version.
  - The confirmation state clearly indicates the pending action with a danger-styled button.
  - The draft editor is temporarily disabled while confirmation is active or changes are being saved.

- **Tests**
  - Added coverage for confirmation behavior, request payloads, and editor state during confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->