### PR TITLE
fix(admin): require confirmation before names Save overwrites cache

### DIFF
--- a/__tests__/app/admin/names/page.test.tsx
+++ b/__tests__/app/admin/names/page.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockApi = vi.fn();
+vi.mock("@/components/admin/AdminContext", async () => {
+  const actual = await vi.importActual("@/components/admin/AdminContext");
+  return {
+    ...actual,
+    useAdminFetch: () => mockApi,
+  };
+});
+
+import NamesPage from "@/app/admin/names/page";
+
+const row = {
+  slug: "ar-rahman",
+  kind: "pairings",
+  data: { note: "original" },
+  model: "claude-opus-4-7",
+  version: 1,
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("NamesPage — Save requires confirmation", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+    mockApi.mockResolvedValue({ rows: [row] });
+  });
+
+  it("does not overwrite on the first click, locks the textarea while armed, and saves the confirmed content on the second click", async () => {
+    render(<NamesPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
+
+    const textarea = await screen.findByDisplayValue(/"note": "original"/);
+    fireEvent.change(textarea, { target: { value: '{"note": "edited"}' } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mockApi).not.toHaveBeenCalledWith(
+      "/names",
+      expect.objectContaining({ method: "PATCH" })
+    );
+    expect(await screen.findByRole("button", { name: "Save?" })).toBeInTheDocument();
+    expect(textarea).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save?" }));
+
+    await waitFor(() =>
+      expect(mockApi).toHaveBeenCalledWith("/names", {
+        method: "PATCH",
+        json: { slug: "ar-rahman", kind: "pairings", data: { note: "edited" } },
+      })
+    );
+  });
+});

--- a/app/admin/names/page.tsx
+++ b/app/admin/names/page.tsx
@@ -6,6 +6,7 @@ import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
+import { useArmedConfirm } from "@/hooks/useArmedConfirm";
 
 interface Row {
   slug: string;
@@ -127,30 +128,13 @@ export default function NamesPage() {
                     {isEditing && (
                       <tr>
                         <td colSpan={5} className="border-b border-border-subtle bg-bg px-3.5 py-3">
-                          <textarea
-                            value={draft}
-                            onChange={(e) => setDraft(e.target.value)}
-                            rows={10}
-                            className="w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-xs text-text-primary focus:border-gold-muted"
+                          <EditRow
+                            draft={draft}
+                            onDraftChange={setDraft}
+                            disabled={busyId === id}
+                            onSave={() => save(r)}
+                            onCancel={() => setEditing(null)}
                           />
-                          <div className="mt-2 flex items-center gap-2">
-                            <Button
-                              size="sm"
-                              variant="primary"
-                              disabled={busyId === id}
-                              onClick={() => save(r)}
-                            >
-                              Save
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              disabled={busyId === id}
-                              onClick={() => setEditing(null)}
-                            >
-                              Cancel
-                            </Button>
-                          </div>
                         </td>
                       </tr>
                     )}
@@ -160,6 +144,51 @@ export default function NamesPage() {
             </tbody>
           </Table>
         )}
+      </div>
+    </>
+  );
+}
+
+// A "Save" overwrites the cached payload outright with no history to revert
+// to (unlike Prompts, which is versioned) — armed here like Invalidate, and
+// the textarea locks while armed so the confirmed content can't change
+// between the two clicks.
+function EditRow({
+  draft,
+  onDraftChange,
+  disabled,
+  onSave,
+  onCancel,
+}: {
+  draft: string;
+  onDraftChange: (value: string) => void;
+  disabled: boolean;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  const { armed, trigger } = useArmedConfirm(onSave);
+
+  return (
+    <>
+      <textarea
+        value={draft}
+        onChange={(e) => onDraftChange(e.target.value)}
+        disabled={armed || disabled}
+        rows={10}
+        className="w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-xs text-text-primary focus:border-gold-muted disabled:opacity-60"
+      />
+      <div className="mt-2 flex items-center gap-2">
+        <Button
+          size="sm"
+          variant={armed ? "danger" : "primary"}
+          disabled={disabled}
+          onClick={trigger}
+        >
+          {armed ? "Save?" : "Save"}
+        </Button>
+        <Button size="sm" variant="ghost" disabled={disabled} onClick={onCancel}>
+          Cancel
+        </Button>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

Closes #275.

On the admin names page, "Save" (`PATCH`es `/api/admin/names`) overwrites the stored `data` payload for a Divine Name outright, with no confirmation and no history to revert to — unlike "Invalidate" on the same page, which already confirms, and unlike Prompts, which is explicitly versioned with rollback support.

## Changes

- Gated "Save" behind the same two-click confirm pattern already used for "Invalidate" on this page.
- Implemented via `useArmedConfirm` directly (not the shared `ConfirmButton`) so the JSON textarea can be **locked while armed** — otherwise the confirm gate wouldn't actually bind to the content the admin saw when they clicked "Save" the first time (same class of gap caught in review on #274/PR #466 for the Prompts page's Create & activate button, applied proactively here).
- Extracted the editing row into its own `EditRow` component so the armed-confirm hook has per-row scope (can't call a hook conditionally inside `.map()`).
- Scoped to the confirmation gate only, per the issue's "at minimum" framing — did not add a history/versioning table, since none exists for names today and that's a larger feature better suited to a separate issue if wanted.

## AI / Theological changes

- [ ] N/A — this only gates when a save happens, not what content is saved or how it's generated. No prompt, divine-name data, or theological framing change.

## Test plan

- Added `__tests__/app/admin/names/page.test.tsx`: asserts the first click doesn't call the API, the textarea locks and the button relabels to "Save?" while armed, and only the confirming second click issues the `PATCH` with the edited content.
- `bun run lint`, `bun run typecheck`, `bun run test:ci` pass locally.
- `bun run test:integration` passed via the pre-push hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-step save confirmation when editing names.
  * The first click arms the save action and changes the button to “Save?” while temporarily disabling the text field.
  * Cancel remains available before confirmation.

* **Tests**
  * Added coverage for the confirmation flow and verified updates are submitted only after the second click.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->