### PR TITLE
fix(admin): guard override-winner against non-active/completed challe…

### DIFF
--- a/__tests__/api/admin/challenges.test.ts
+++ b/__tests__/api/admin/challenges.test.ts
@@ -99,6 +99,30 @@ describe("admin challenges [id]", () => {
     expect(res.status).toBe(200);
   });
 
+  it("accepts override-winner on an already-completed challenge (correcting a mistaken result)", async () => {
+    mockSelect.mockReturnValue(makeDbChain([{ ...challenge, status: "completed" }]));
+    const res = await PATCH(
+      req("PATCH", { action: "override-winner", winnerId: challenge.challengerId }),
+      params
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it.each(["pending", "declined", "cancelled"])(
+    "rejects override-winner on a %s challenge",
+    async (status) => {
+      mockSelect.mockReturnValue(makeDbChain([{ ...challenge, status }]));
+      const res = await PATCH(req("PATCH", { action: "override-winner", winnerId: null }), params);
+      expect(res.status).toBe(409);
+    }
+  );
+
+  it("409s when override-winner races a concurrent status change", async () => {
+    mockUpdate.mockReturnValue(makeDbChain([])); // scoped update matched nothing
+    const res = await PATCH(req("PATCH", { action: "override-winner", winnerId: null }), params);
+    expect(res.status).toBe(409);
+  });
+
   it("rejects an unknown action", async () => {
     expect((await PATCH(req("PATCH", { action: "nope" }), params)).status).toBe(400);
   });

--- a/__tests__/api/admin/challenges.test.ts
+++ b/__tests__/api/admin/challenges.test.ts
@@ -123,6 +123,18 @@ describe("admin challenges [id]", () => {
     expect(res.status).toBe(409);
   });
 
+  it("409s when two override-winner corrections race on an already-completed challenge", async () => {
+    // Status alone can't detect this race (it stays "completed" throughout),
+    // so the scoped update must also pin the previously-read winnerId.
+    mockSelect.mockReturnValue(makeDbChain([{ ...challenge, status: "completed", winnerId: 1 }]));
+    mockUpdate.mockReturnValue(makeDbChain([])); // winnerId changed underneath us, scoped update matched nothing
+    const res = await PATCH(
+      req("PATCH", { action: "override-winner", winnerId: challenge.challengedId }),
+      params
+    );
+    expect(res.status).toBe(409);
+  });
+
   it("rejects an unknown action", async () => {
     expect((await PATCH(req("PATCH", { action: "nope" }), params)).status).toBe(400);
   });

--- a/app/api/admin/challenges/[id]/route.ts
+++ b/app/api/admin/challenges/[id]/route.ts
@@ -75,6 +75,15 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   }
 
   if (body.action === "override-winner") {
+    // Matches the statuses the admin UI actually renders the override
+    // control for — a pending/declined/cancelled challenge was never played,
+    // so it has no result to correct.
+    if (challenge.status !== "active" && challenge.status !== "completed") {
+      return NextResponse.json(
+        { error: "Only active or completed challenges can have their winner overridden" },
+        { status: 409 }
+      );
+    }
     const winnerId = body.winnerId ?? null;
     if (
       winnerId !== null &&
@@ -86,13 +95,25 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
         { status: 400 }
       );
     }
+    // Scope the WHERE to the state we just checked, so a concurrent status
+    // change loses the race cleanly instead of silently clobbering it.
     const [updated] = await db
       .update(challenges)
       .set({ status: "completed", winnerId })
-      .where(eq(challenges.id, challengeId))
+      .where(
+        and(
+          eq(challenges.id, challengeId),
+          challenge.status === "active"
+            ? eq(challenges.status, "active")
+            : eq(challenges.status, "completed")
+        )
+      )
       .returning();
     if (!updated) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Challenge status changed by a concurrent request" },
+        { status: 409 }
+      );
     }
     await logAdminAction({
       adminQfId: auth.user.qfId,

--- a/app/api/admin/challenges/[id]/route.ts
+++ b/app/api/admin/challenges/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { requireAdmin, rateLimitAdminMutation } from "@/lib/admin/admin-auth";
 import { logAdminAction } from "@/lib/admin/admin-audit";
 import { db } from "@/lib/infra/db";
@@ -95,8 +95,12 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
         { status: 400 }
       );
     }
-    // Scope the WHERE to the state we just checked, so a concurrent status
-    // change loses the race cleanly instead of silently clobbering it.
+    // Scope the WHERE to the state we just checked. For the active->completed
+    // transition, the status flip itself makes a racing request's WHERE stop
+    // matching. For an already-completed challenge, status never changes, so
+    // also pin the previously-read winnerId — otherwise two concurrent
+    // corrections would both match and the second would silently clobber the
+    // first's winnerId with no 409.
     const [updated] = await db
       .update(challenges)
       .set({ status: "completed", winnerId })
@@ -105,7 +109,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
           eq(challenges.id, challengeId),
           challenge.status === "active"
             ? eq(challenges.status, "active")
-            : eq(challenges.status, "completed")
+            : and(
+                eq(challenges.status, "completed"),
+                sql`${challenges.winnerId} is not distinct from ${challenge.winnerId}`
+              )
         )
       )
       .returning();


### PR DESCRIPTION
The end action already checks challenge.status before mutating; the override-winner action had no equivalent check and could force a pending, declined, or cancelled challenge straight to completed with a fabricated winner, corrupting admin stats and producing a fake result for a match that was never played. Restricts override-winner to the same active/completed statuses the admin UI already scopes the control to, with the same optimistic-concurrency WHERE pattern already used by end.

## Summary

- Guard `override-winner` in `app/api/admin/challenges/[id]/route.ts` to only accept `active`/`completed` challenges (409 otherwise), matching the statuses the admin UI already renders the control for.
- Scope the update's WHERE to the checked status so a concurrent status change loses the race with a 409 instead of clobbering it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [x] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface

Closes #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can override winners for active and completed challenges.
* **Bug Fixes**
  * Winner overrides are now rejected for pending, declined, and cancelled challenges.
  * Conflicting updates are detected and return a conflict response, preventing accidental overwrites when challenge status or winner information changes concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->