### PR TITLE
fix(admin): rate-limit self-heal writes in GET /api/admin/challenges

### DIFF
--- a/__tests__/api/admin/challenges-list.test.ts
+++ b/__tests__/api/admin/challenges-list.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/infra/db/schema";
+
+const { mockRateLimitAdminMutation } = vi.hoisted(() => ({
+  mockRateLimitAdminMutation: vi.fn<() => Promise<NextResponse | null>>(async () => null),
+}));
+vi.mock("@/lib/admin/admin-auth", () => ({
+  requireAdmin: vi.fn(),
+  rateLimitAdminMutation: mockRateLimitAdminMutation,
+}));
+
+const { mockResolveEndedChallenges, mockResolveExpiredPending } = vi.hoisted(() => ({
+  mockResolveEndedChallenges: vi.fn(async () => new Map()),
+  mockResolveExpiredPending: vi.fn(async () => 0),
+}));
+vi.mock("@/lib/social/challenges", () => ({
+  scoreChallenge: vi.fn(async () => 0),
+  pickWinner: vi.fn(() => 1),
+  resolveEndedChallenges: mockResolveEndedChallenges,
+  resolveExpiredPending: mockResolveExpiredPending,
+  mapWithConcurrency: async (
+    items: unknown[],
+    _limit: number,
+    fn: (item: unknown) => Promise<void>
+  ) => {
+    for (const item of items) await fn(item);
+  },
+}));
+
+function makeSelectChain(resolveWith: unknown) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect } = vi.hoisted(() => ({ mockSelect: vi.fn() }));
+vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect } }));
+
+import { GET } from "@/app/api/admin/challenges/route";
+import { requireAdmin } from "@/lib/admin/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+
+function req() {
+  return new NextRequest("http://localhost/api/admin/challenges", {
+    headers: { Authorization: "Bearer t" },
+  });
+}
+
+/** Order matches route.ts: ended, expiredPending, statusCounts, fromSuggestions, rows, users. */
+function queueSelects(ended: unknown[], expiredPending: unknown[], rows: unknown[] = []) {
+  mockSelect
+    .mockReturnValueOnce(makeSelectChain(ended))
+    .mockReturnValueOnce(makeSelectChain(expiredPending))
+    .mockReturnValueOnce(makeSelectChain([]))
+    .mockReturnValueOnce(makeSelectChain([{ fromSuggestions: 0 }]))
+    .mockReturnValueOnce(makeSelectChain(rows))
+    .mockReturnValueOnce(makeSelectChain([]));
+}
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockRateLimitAdminMutation.mockReset().mockResolvedValue(null);
+  mockSelect.mockReset();
+  mockResolveEndedChallenges.mockClear();
+  mockResolveExpiredPending.mockClear();
+});
+
+describe("GET /api/admin/challenges", () => {
+  it("does not rate-limit a plain read with nothing to self-heal", async () => {
+    queueSelects([], []);
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    expect(mockRateLimitAdminMutation).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits when there are ended challenges to self-heal", async () => {
+    queueSelects([{ id: 1, status: "active" }], []);
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    expect(mockRateLimitAdminMutation).toHaveBeenCalledWith(admin);
+  });
+
+  it("rate-limits when there are expired pending invites to self-heal", async () => {
+    queueSelects([], [{ id: 2, status: "pending" }]);
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    expect(mockRateLimitAdminMutation).toHaveBeenCalledWith(admin);
+  });
+
+  it("returns the rate-limit response and skips self-heal writes when throttled", async () => {
+    queueSelects([{ id: 1, status: "active" }], []);
+    mockRateLimitAdminMutation.mockResolvedValue(
+      NextResponse.json({ error: "Too many admin actions — try again later" }, { status: 429 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(429);
+    expect(mockResolveEndedChallenges).not.toHaveBeenCalled();
+    expect(mockResolveExpiredPending).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/admin/challenges-list.test.ts
+++ b/__tests__/api/admin/challenges-list.test.ts
@@ -114,4 +114,22 @@ describe("GET /api/admin/challenges", () => {
     expect(mockResolveEndedChallenges).not.toHaveBeenCalled();
     expect(mockResolveExpiredPending).not.toHaveBeenCalled();
   });
+
+  it("rate-limits a challenge that turns overdue between the ended-select and the list-select", async () => {
+    // Nothing in `ended`/`expiredPending`, but a `rows` entry is active and
+    // already past its endsAt — it slipped past the earlier gate.
+    const overdue = { id: 3, status: "active", endsAt: new Date(Date.now() - 1000) };
+    queueSelects([], [], [overdue]);
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    expect(mockRateLimitAdminMutation).toHaveBeenCalledWith(admin);
+  });
+
+  it("does not double rate-limit when the earlier gate already checked", async () => {
+    const overdue = { id: 3, status: "active", endsAt: new Date(Date.now() - 1000) };
+    queueSelects([{ id: 1, status: "active" }], [], [overdue]);
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    expect(mockRateLimitAdminMutation).toHaveBeenCalledTimes(1);
+  });
 });

--- a/app/api/admin/challenges/route.ts
+++ b/app/api/admin/challenges/route.ts
@@ -32,8 +32,8 @@ export async function GET(req: NextRequest) {
   const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 50;
 
   try {
-    // Finalize any ended active challenges FIRST, so both the stats aggregation and
-    // the returned list reflect the same (post-finalization) state.
+    // Finalize any ended/expired challenges before the stats aggregation and the
+    // returned list are queried, so both reflect the same post-finalization state.
     const now = new Date();
     const ended = await db
       .select()
@@ -85,7 +85,16 @@ export async function GET(req: NextRequest) {
       .orderBy(desc(challenges.createdAt))
       .limit(limit);
 
-    const resolved = await resolveEndedChallenges(rows);
+    // A challenge can flip from active to overdue in the gap between the
+    // `ended` select above and this one, so it slips past the earlier gate.
+    // Reuse the same `now` snapshot (rather than resolveEndedChallenges's
+    // internal default) and rate-limit this write too if we haven't already.
+    const staleActive = rows.filter((c) => c.status === "active" && c.endsAt < now);
+    if (staleActive.length > 0 && ended.length === 0 && expiredPending.length === 0) {
+      const limited = await rateLimitAdminMutation(auth);
+      if (limited) return limited;
+    }
+    const resolved = await resolveEndedChallenges(rows, now);
 
     const userIds = [...new Set(rows.flatMap((c) => [c.challengerId, c.challengedId]))];
     const userRows = userIds.length

--- a/app/api/admin/challenges/route.ts
+++ b/app/api/admin/challenges/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
-import { requireAdmin } from "@/lib/admin/admin-auth";
+import { requireAdmin, rateLimitAdminMutation } from "@/lib/admin/admin-auth";
 import { db } from "@/lib/infra/db";
 import { challenges, users } from "@/lib/infra/db/schema";
 import {
@@ -39,13 +39,22 @@ export async function GET(req: NextRequest) {
       .select()
       .from(challenges)
       .where(and(eq(challenges.status, "active"), lt(challenges.endsAt, now)));
-    await resolveEndedChallenges(ended, now);
 
     // Same self-heal for `pending` invites nobody acted on.
     const expiredPending = await db
       .select()
       .from(challenges)
       .where(and(eq(challenges.status, "pending"), lt(challenges.endsAt, now)));
+
+    // This GET is otherwise read-only, but self-healing performs real UPDATEs
+    // as a side effect. Only throttle when there's actually something to
+    // heal, so plain reads (the common case) stay unaffected.
+    if (ended.length > 0 || expiredPending.length > 0) {
+      const limited = await rateLimitAdminMutation(auth);
+      if (limited) return limited;
+    }
+
+    await resolveEndedChallenges(ended, now);
     await resolveExpiredPending(expiredPending, now);
 
     // Stats: counts per status + suggestion-attributed total.


### PR DESCRIPTION
The self-heal writes triggered as a side effect of a plain GET (resolveEndedChallenges / resolveExpiredPending) were the one write path in `app/api/admin/challenges/` with no `rateLimitAdminMutation` guard, unlike every mutating handler in the same directory (`PATCH`/`DELETE` in `[id]/route.ts`, `finalize/route.ts`). The admin challenges page calls this endpoint on every filter change and mount, and it's a GET, so it's easy to hit repeatedly with no throttle.

## Summary

- `GET /api/admin/challenges` (`app/api/admin/challenges/route.ts`) now checks `rateLimitAdminMutation(auth)` before the self-heal writes, but only when there's actually something to heal (`ended.length > 0 || expiredPending.length > 0`) — plain reads with nothing to self-heal stay unaffected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [x] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface

Closes #271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved administrative challenge retrieval by applying throttling only when automatic data repairs are needed.
  * Prevented repair operations when a request is throttled.
  * Kept standard read-only requests available without unnecessary rate limiting.

* **Tests**
  * Added coverage for normal requests, repair scenarios, and throttled responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->