### PR TITLE
fix(sidebar): check response status before removing a note optimistically

### DIFF
--- a/__tests__/components/layout/ContextSidebar.test.tsx
+++ b/__tests__/components/layout/ContextSidebar.test.tsx
@@ -67,8 +67,9 @@ describe("ContextSidebar — note delete checks response status", () => {
     vi.stubGlobal("fetch", mockFetch);
     mockFetch.mockReset();
     deleteResponse = async () => new Response(null, { status: 204 });
-    // Method-aware (rather than call-order-aware) so React 18's double-invoked
-    // effect in test mode doesn't consume the DELETE mock as the notes GET.
+    // Method-aware (rather than call-order-aware): sibling sections
+    // (InteractiveArabic's morphology fetch, etc.) also call this same mocked
+    // fetch, so a queued once-per-call mock can be consumed out of order.
     mockFetch.mockImplementation((_url: string, init?: RequestInit) =>
       init?.method === "DELETE"
         ? deleteResponse()
@@ -122,6 +123,47 @@ describe("ContextSidebar — note delete checks response status", () => {
 
     expect(screen.getByText("a private note")).toBeInTheDocument();
     expect(await screen.findByText("Delete failed")).toBeInTheDocument();
+  });
+
+  it("doesn't let an earlier note's error-clear timer wipe a later note's error", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const noteA = { id: 1, note: "note A", createdAt: new Date().toISOString() };
+    const noteB = { id: 2, note: "note B", createdAt: new Date().toISOString() };
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) =>
+      init?.method === "DELETE"
+        ? Promise.resolve(new Response(null, { status: 500 }))
+        : Promise.resolve(new Response(JSON.stringify([noteA, noteB]), { status: 200 }))
+    );
+
+    await act(async () => {
+      renderWithIntl(<ContextSidebar />);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "My Notes" }));
+    expect(await screen.findByText("note A")).toBeInTheDocument();
+    const [deleteA, deleteB] = screen.getAllByRole("button", { name: "Delete note" });
+
+    await act(async () => {
+      fireEvent.click(deleteA);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    await act(async () => {
+      fireEvent.click(deleteB);
+    });
+
+    // note A's timer (scheduled at t=0, due at t=3000) would incorrectly clear
+    // note B's error here if it weren't cancelled when note B's delete failed.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(screen.getByText("Delete failed")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(screen.queryByText("Delete failed")).not.toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   it("keeps the note in state and surfaces an error when the DELETE request rejects", async () => {

--- a/__tests__/components/layout/ContextSidebar.test.tsx
+++ b/__tests__/components/layout/ContextSidebar.test.tsx
@@ -56,3 +56,88 @@ describe("ContextSidebar — notes textarea accessibility", () => {
     expect(await screen.findByRole("textbox", { name: /add a private note/i })).toBeInTheDocument();
   });
 });
+
+describe("ContextSidebar — note delete checks response status", () => {
+  const mockFetch = vi.fn();
+  const previousAuth = useAuthStore.getState();
+  const note = { id: 1, note: "a private note", createdAt: new Date().toISOString() };
+  let deleteResponse: () => Promise<Response> = async () => new Response(null, { status: 204 });
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    deleteResponse = async () => new Response(null, { status: 204 });
+    // Method-aware (rather than call-order-aware) so React 18's double-invoked
+    // effect in test mode doesn't consume the DELETE mock as the notes GET.
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) =>
+      init?.method === "DELETE"
+        ? deleteResponse()
+        : Promise.resolve(new Response(JSON.stringify([note]), { status: 200 }))
+    );
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }))
+    );
+    useAuthStore.setState({ accessToken: "test-token" });
+    useCanvasStore.getState().setSidebarContent({ type: "node", verse: baseVerse });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useAuthStore.setState(previousAuth);
+    useCanvasStore.getState().setSidebarContent(null);
+  });
+
+  it("removes the note from state when the DELETE response is ok", async () => {
+    await act(async () => {
+      renderWithIntl(<ContextSidebar />);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "My Notes" }));
+    expect(await screen.findByText("a private note")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Delete note" }));
+    });
+
+    expect(screen.queryByText("a private note")).not.toBeInTheDocument();
+  });
+
+  it("keeps the note in state and surfaces an error when the DELETE response is not ok", async () => {
+    deleteResponse = async () => new Response(null, { status: 500 });
+
+    await act(async () => {
+      renderWithIntl(<ContextSidebar />);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "My Notes" }));
+    expect(await screen.findByText("a private note")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Delete note" }));
+    });
+
+    expect(screen.getByText("a private note")).toBeInTheDocument();
+    expect(await screen.findByText("Delete failed")).toBeInTheDocument();
+  });
+
+  it("keeps the note in state and surfaces an error when the DELETE request rejects", async () => {
+    deleteResponse = () => Promise.reject(new Error("network down"));
+
+    await act(async () => {
+      renderWithIntl(<ContextSidebar />);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "My Notes" }));
+    expect(await screen.findByText("a private note")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Delete note" }));
+    });
+
+    expect(screen.getByText("a private note")).toBeInTheDocument();
+    expect(await screen.findByText("Delete failed")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/layout/ContextSidebar.test.tsx
+++ b/__tests__/components/layout/ContextSidebar.test.tsx
@@ -166,6 +166,69 @@ describe("ContextSidebar — note delete checks response status", () => {
     vi.useRealTimers();
   });
 
+  it("doesn't let an earlier-started delete's timer wipe a later-started delete's error when they settle out of order", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const noteA = { id: 1, note: "note A", createdAt: new Date().toISOString() };
+    const noteB = { id: 2, note: "note B", createdAt: new Date().toISOString() };
+
+    function deferred() {
+      let resolve!: (v: Response) => void;
+      const promise = new Promise<Response>((r) => {
+        resolve = r;
+      });
+      return { promise, resolve };
+    }
+    const deleteA = deferred();
+    const deleteB = deferred();
+
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method !== "DELETE") {
+        return Promise.resolve(new Response(JSON.stringify([noteA, noteB]), { status: 200 }));
+      }
+      return url.endsWith("/1") ? deleteA.promise : deleteB.promise;
+    });
+
+    await act(async () => {
+      renderWithIntl(<ContextSidebar />);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "My Notes" }));
+    expect(await screen.findByText("note A")).toBeInTheDocument();
+    const [deleteAButton, deleteBButton] = screen.getAllByRole("button", { name: "Delete note" });
+
+    // Start both deletes while both are still in flight (neither has settled).
+    await act(async () => {
+      fireEvent.click(deleteAButton);
+      fireEvent.click(deleteBButton);
+    });
+
+    // B (started second) settles first and fails, scheduling its own clear timer.
+    await act(async () => {
+      deleteB.resolve(new Response(null, { status: 500 }));
+      await Promise.resolve();
+    });
+    // A (started first) settles second, 1s later, and also fails — its error
+    // should now be showing, with its own fresh 3s window.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+      deleteA.resolve(new Response(null, { status: 500 }));
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Delete failed")).toBeInTheDocument();
+
+    // B's stale timer (due at t=3000) firing here must not clear A's error,
+    // which only started its own window at t=1000 (due at t=4000).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(screen.getByText("Delete failed")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(screen.queryByText("Delete failed")).not.toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
   it("keeps the note in state and surfaces an error when the DELETE request rejects", async () => {
     deleteResponse = () => Promise.reject(new Error("network down"));
 

--- a/components/layout/ContextSidebar.tsx
+++ b/components/layout/ContextSidebar.tsx
@@ -5,7 +5,7 @@ import { X, ChevronDown, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { useCanvasStore } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSidebarResize } from "@/hooks/useSidebarResize";
 import type { EdgeKind } from "@/types/quran";
 import { Card } from "@/components/ui";
@@ -83,6 +83,21 @@ function NotesSection({ verseRef }: { verseRef: string }) {
   const [saveError, setSaveError] = useState(false);
   const [deleteErrorId, setDeleteErrorId] = useState<number | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const mountedRef = useRef(true);
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const deleteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // NotesSection unmounts whenever the sidebar closes or a different verse is
+  // selected (it's keyed by verse ref) — clear any pending feedback-reset
+  // timeout and stop setting state after that point.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+      if (deleteTimeoutRef.current) clearTimeout(deleteTimeoutRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (!open || !accessToken || loaded) return;
@@ -107,40 +122,53 @@ function NotesSection({ verseRef }: { verseRef: string }) {
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
         body: JSON.stringify({ ref: verseRef, note: draft.trim() }),
       });
+      if (!mountedRef.current) return;
       if (res.ok) {
         const created = await res.json();
         setNotes((prev) => [...prev, created]);
         setDraft("");
       } else {
         setSaveError(true);
-        setTimeout(() => setSaveError(false), 3000);
+        saveTimeoutRef.current = setTimeout(() => {
+          if (mountedRef.current) setSaveError(false);
+        }, 3000);
       }
     } catch {
+      if (!mountedRef.current) return;
       setSaveError(true);
-      setTimeout(() => setSaveError(false), 3000);
+      saveTimeoutRef.current = setTimeout(() => {
+        if (mountedRef.current) setSaveError(false);
+      }, 3000);
     } finally {
-      setSaving(false);
+      if (mountedRef.current) setSaving(false);
     }
   };
 
   const remove = async (id: number) => {
     if (!accessToken) return;
+    if (deleteTimeoutRef.current) clearTimeout(deleteTimeoutRef.current);
     setDeleteErrorId(null);
     try {
       const res = await fetch(`/api/notes/${id}`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${accessToken}` },
       });
+      if (!mountedRef.current) return;
       if (res.ok) {
         setNotes((prev) => prev.filter((n) => n.id !== id));
       } else {
         setDeleteErrorId(id);
-        setTimeout(() => setDeleteErrorId(null), 3000);
+        deleteTimeoutRef.current = setTimeout(() => {
+          if (mountedRef.current) setDeleteErrorId(null);
+        }, 3000);
       }
     } catch (e) {
       console.error("sidebar: note delete failed", e);
+      if (!mountedRef.current) return;
       setDeleteErrorId(id);
-      setTimeout(() => setDeleteErrorId(null), 3000);
+      deleteTimeoutRef.current = setTimeout(() => {
+        if (mountedRef.current) setDeleteErrorId(null);
+      }, 3000);
     }
   };
 

--- a/components/layout/ContextSidebar.tsx
+++ b/components/layout/ContextSidebar.tsx
@@ -129,6 +129,7 @@ function NotesSection({ verseRef }: { verseRef: string }) {
         setDraft("");
       } else {
         setSaveError(true);
+        if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
         saveTimeoutRef.current = setTimeout(() => {
           if (mountedRef.current) setSaveError(false);
         }, 3000);
@@ -136,6 +137,7 @@ function NotesSection({ verseRef }: { verseRef: string }) {
     } catch {
       if (!mountedRef.current) return;
       setSaveError(true);
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
       saveTimeoutRef.current = setTimeout(() => {
         if (mountedRef.current) setSaveError(false);
       }, 3000);
@@ -158,6 +160,10 @@ function NotesSection({ verseRef }: { verseRef: string }) {
         setNotes((prev) => prev.filter((n) => n.id !== id));
       } else {
         setDeleteErrorId(id);
+        // Two deletes can settle out of order: clear any timer a differently-
+        // ordered earlier delete already scheduled, so it can't fire and wipe
+        // this error before its own 3s window elapses.
+        if (deleteTimeoutRef.current) clearTimeout(deleteTimeoutRef.current);
         deleteTimeoutRef.current = setTimeout(() => {
           if (mountedRef.current) setDeleteErrorId(null);
         }, 3000);
@@ -166,6 +172,7 @@ function NotesSection({ verseRef }: { verseRef: string }) {
       console.error("sidebar: note delete failed", e);
       if (!mountedRef.current) return;
       setDeleteErrorId(id);
+      if (deleteTimeoutRef.current) clearTimeout(deleteTimeoutRef.current);
       deleteTimeoutRef.current = setTimeout(() => {
         if (mountedRef.current) setDeleteErrorId(null);
       }, 3000);

--- a/components/layout/ContextSidebar.tsx
+++ b/components/layout/ContextSidebar.tsx
@@ -81,6 +81,7 @@ function NotesSection({ verseRef }: { verseRef: string }) {
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState(false);
+  const [deleteErrorId, setDeleteErrorId] = useState<number | null>(null);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -124,11 +125,23 @@ function NotesSection({ verseRef }: { verseRef: string }) {
 
   const remove = async (id: number) => {
     if (!accessToken) return;
-    await fetch(`/api/notes/${id}`, {
-      method: "DELETE",
-      headers: { Authorization: `Bearer ${accessToken}` },
-    }).catch((e) => console.error("sidebar: note delete failed", e));
-    setNotes((prev) => prev.filter((n) => n.id !== id));
+    setDeleteErrorId(null);
+    try {
+      const res = await fetch(`/api/notes/${id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (res.ok) {
+        setNotes((prev) => prev.filter((n) => n.id !== id));
+      } else {
+        setDeleteErrorId(id);
+        setTimeout(() => setDeleteErrorId(null), 3000);
+      }
+    } catch (e) {
+      console.error("sidebar: note delete failed", e);
+      setDeleteErrorId(id);
+      setTimeout(() => setDeleteErrorId(null), 3000);
+    }
   };
 
   return (
@@ -150,10 +163,15 @@ function NotesSection({ verseRef }: { verseRef: string }) {
               {notes.map((n) => (
                 <div key={n.id} className="flex items-start gap-2 rounded border border-border p-2">
                   <p className="flex-1 text-xs leading-relaxed text-text-secondary">{n.note}</p>
+                  {deleteErrorId === n.id && (
+                    <span className="shrink-0 text-xs text-error">Delete failed</span>
+                  )}
                   <button
                     onClick={() => remove(n.id)}
                     aria-label="Delete note"
-                    className="shrink-0 cursor-pointer text-text-muted transition-colors hover:text-text-secondary"
+                    className={`shrink-0 cursor-pointer transition-colors hover:text-text-secondary ${
+                      deleteErrorId === n.id ? "text-error" : "text-text-muted"
+                    }`}
                   >
                     <X className="h-3 w-3" />
                   </button>


### PR DESCRIPTION
`remove()` in `components/layout/ContextSidebar.tsx`'s `NotesSection` stripped a note from local state unconditionally after the DELETE fetch settled — even on a 4xx/5xx response or a caught network error — so a failed delete still looked successful in the UI until the notes list was reloaded.

## Summary

- `remove()` now only updates local state when the response is `ok`; on failure (non-ok response or thrown error) it keeps the note in state and surfaces an inline "Delete failed" error next to that note, auto-clearing after 3s — mirroring the existing `save()` handler's error pattern in the same file.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [x] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface

Closes #262