### PR TITLE
fix(nav): drop AccountMenu's incomplete ARIA menu semantics, add focus management

### DIFF
--- a/__tests__/components/layout/AccountMenu.test.tsx
+++ b/__tests__/components/layout/AccountMenu.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { renderWithIntl } from "../../test-utils/render-with-intl";
 
@@ -61,5 +61,32 @@ describe("AccountMenu — dropdown a11y", () => {
 
     fireEvent.keyDown(document, { key: "Escape" });
     await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it("traps Tab within the open panel, wrapping last to first and first to last", async () => {
+    renderWithIntl(<AccountMenu />);
+    fireEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    const firstLink = await screen.findByRole("link", { name: /saved canvases/i });
+    const signOutButton = screen.getByRole("button", { name: /sign out/i });
+
+    await act(async () => {
+      signOutButton.focus();
+    });
+    fireEvent.keyDown(signOutButton, { key: "Tab" });
+    expect(document.activeElement).toBe(firstLink);
+
+    fireEvent.keyDown(firstLink, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(signOutButton);
+  });
+
+  it("redirects focus to the Sign in button on sign-out, since the trigger unmounts", async () => {
+    renderWithIntl(<AccountMenu />);
+    fireEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    const signOutButton = await screen.findByRole("button", { name: /sign out/i });
+    fireEvent.click(signOutButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /log in/i })).toHaveFocus());
   });
 });

--- a/__tests__/components/layout/AccountMenu.test.tsx
+++ b/__tests__/components/layout/AccountMenu.test.tsx
@@ -1,9 +1,10 @@
-import { screen } from "@testing-library/react";
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { renderWithIntl } from "../../test-utils/render-with-intl";
 
 import { AccountMenu } from "@/components/layout/AccountMenu";
 import { useAuthStore } from "@/store/auth";
+import { useSocialStore } from "@/store/social";
 
 describe("AccountMenu — logged-out sign-in button", () => {
   const previousAuth = useAuthStore.getState();
@@ -21,5 +22,44 @@ describe("AccountMenu — logged-out sign-in button", () => {
 
     const button = screen.getByRole("button", { name: /log in/i });
     expect(button.className).toMatch(/\bwhitespace-nowrap\b/);
+  });
+});
+
+describe("AccountMenu — dropdown a11y", () => {
+  const previousAuth = useAuthStore.getState();
+  const previousSocial = useSocialStore.getState();
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+    useAuthStore.setState({ accessToken: "test-token", isSessionLoading: false });
+    useSocialStore.setState({ username: "shabnam", streak: 3, longestStreak: 10 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useAuthStore.setState(previousAuth);
+    useSocialStore.setState(previousSocial);
+  });
+
+  it("doesn't claim ARIA menu semantics it doesn't implement (no roving focus, no arrow keys)", () => {
+    renderWithIntl(<AccountMenu />);
+    fireEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+  });
+
+  it("moves focus into the panel on open and back to the trigger on close", async () => {
+    renderWithIntl(<AccountMenu />);
+    const trigger = screen.getByRole("button", { name: /account menu/i });
+
+    fireEvent.click(trigger);
+    const firstLink = await screen.findByRole("link", { name: /saved canvases/i });
+    await waitFor(() => expect(firstLink).toHaveFocus());
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(trigger).toHaveFocus());
   });
 });

--- a/components/layout/AccountMenu.tsx
+++ b/components/layout/AccountMenu.tsx
@@ -34,6 +34,9 @@ export function AccountMenu() {
   const [open, setOpen] = useState(false);
   const { signIn, signingIn } = useSignIn();
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const firstItemRef = useRef<HTMLAnchorElement>(null);
+  const wasOpenRef = useRef(false);
   const t = useTranslations("common");
   const tNav = useTranslations("nav");
 
@@ -51,6 +54,20 @@ export function AccountMenu() {
       document.removeEventListener("mousedown", onDown);
       document.removeEventListener("keydown", onKey);
     };
+  }, [open]);
+
+  // This is a plain nav popover (not a true ARIA menu — no roving-tabindex
+  // arrow-key navigation, so role="menu"/"menuitem" would overpromise), but
+  // it still needs standard popup-button focus management: move focus into
+  // it on open, and back to the trigger on close, however that close happens
+  // (Escape, outside click, or picking an item).
+  useEffect(() => {
+    if (open) {
+      firstItemRef.current?.focus();
+    } else if (wasOpenRef.current) {
+      triggerRef.current?.focus();
+    }
+    wasOpenRef.current = open;
   }, [open]);
 
   const signOut = async () => {
@@ -116,9 +133,10 @@ export function AccountMenu() {
   return (
     <div ref={ref} className="relative">
       <button
+        ref={triggerRef}
         onClick={() => setOpen((o) => !o)}
-        aria-haspopup="menu"
         aria-expanded={open}
+        aria-controls="account-menu-panel"
         aria-label={tNav("accountMenu")}
         className={cn(
           "flex items-center gap-2 rounded-full border bg-surface-raised py-[3px] pl-[3px] pr-2 transition-colors sm:pr-3",
@@ -149,7 +167,7 @@ export function AccountMenu() {
 
       {open && (
         <div
-          role="menu"
+          id="account-menu-panel"
           className="absolute right-0 top-[calc(100%+8px)] z-50 w-[268px] overflow-hidden rounded-2xl border border-border bg-surface-overlay shadow-floating"
         >
           <div
@@ -198,7 +216,12 @@ export function AccountMenu() {
           <div className="h-px bg-border" />
 
           <div className="p-1.5">
-            <Link href="/workspaces" onClick={() => setOpen(false)} className={linkRow}>
+            <Link
+              ref={firstItemRef}
+              href="/workspaces"
+              onClick={() => setOpen(false)}
+              className={linkRow}
+            >
               <FolderOpen /> {tNav("savedCanvases")}
             </Link>
             <Link href="/social" onClick={() => setOpen(false)} className={linkRow}>
@@ -235,7 +258,6 @@ export function AccountMenu() {
           <div className="p-1.5">
             <button
               onClick={signOut}
-              role="menuitem"
               className="flex h-11 w-full items-center gap-3 rounded-lg px-3 text-[13.5px] text-text-primary transition-colors hover:bg-error/10 hover:text-error [&_svg]:size-[17px] [&_svg]:text-text-secondary [&:hover_svg]:text-error"
             >
               <LogOut /> {t("signOut")}

--- a/components/layout/AccountMenu.tsx
+++ b/components/layout/AccountMenu.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
+import { FocusScope } from "@radix-ui/react-focus-scope";
 import { useTranslations } from "next-intl";
 import {
   Flame,
@@ -36,7 +37,8 @@ export function AccountMenu() {
   const ref = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const firstItemRef = useRef<HTMLAnchorElement>(null);
-  const wasOpenRef = useRef(false);
+  const signInRef = useRef<HTMLButtonElement>(null);
+  const hadAuthRef = useRef(!!accessToken);
   const t = useTranslations("common");
   const tNav = useTranslations("nav");
 
@@ -56,19 +58,16 @@ export function AccountMenu() {
     };
   }, [open]);
 
-  // This is a plain nav popover (not a true ARIA menu — no roving-tabindex
-  // arrow-key navigation, so role="menu"/"menuitem" would overpromise), but
-  // it still needs standard popup-button focus management: move focus into
-  // it on open, and back to the trigger on close, however that close happens
-  // (Escape, outside click, or picking an item).
   useEffect(() => {
-    if (open) {
-      firstItemRef.current?.focus();
-    } else if (wasOpenRef.current) {
-      triggerRef.current?.focus();
+    // Signing out swaps to an entirely different subtree, unmounting whatever
+    // had focus in the signed-in menu (including the trigger FocusScope would
+    // otherwise return focus to) — land keyboard focus on the persistent
+    // Sign in button instead of letting it fall through to <body>.
+    if (hadAuthRef.current && !accessToken) {
+      signInRef.current?.focus();
     }
-    wasOpenRef.current = open;
-  }, [open]);
+    hadAuthRef.current = !!accessToken;
+  }, [accessToken]);
 
   const signOut = async () => {
     setOpen(false);
@@ -113,6 +112,7 @@ export function AccountMenu() {
           <Settings />
         </Link>
         <button
+          ref={signInRef}
           onClick={signIn}
           disabled={signingIn}
           className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-gold px-3.5 py-1.5 text-[13px] font-semibold text-gold transition-colors duration-[120ms] hover:bg-gold/10 disabled:opacity-60"
@@ -166,104 +166,125 @@ export function AccountMenu() {
       </button>
 
       {open && (
-        <div
-          id="account-menu-panel"
-          className="absolute right-0 top-[calc(100%+8px)] z-50 w-[268px] overflow-hidden rounded-2xl border border-border bg-surface-overlay shadow-floating"
+        <FocusScope
+          asChild
+          trapped
+          loop
+          onMountAutoFocus={(e) => {
+            // Radix's default mount-autofocus explicitly excludes <a> elements
+            // from candidates, which would land focus on the sign-out button
+            // instead of the first (link) item — override to focus it directly.
+            e.preventDefault();
+            firstItemRef.current?.focus();
+          }}
+          onUnmountAutoFocus={(e) => {
+            // Radix's default restores focus to whatever `document.activeElement`
+            // was when the scope mounted — but a plain click doesn't reliably
+            // focus a <button> in every browser (e.g. Safari), so that can be
+            // unset. Target the trigger explicitly instead.
+            e.preventDefault();
+            triggerRef.current?.focus();
+          }}
         >
           <div
-            className="flex items-center gap-3 p-4"
-            style={{
-              background:
-                "radial-gradient(120% 100% at 0% 0%, color-mix(in srgb, var(--color-gold) 12%, transparent), transparent 60%), linear-gradient(180deg, color-mix(in srgb, var(--color-teal) 8%, transparent), transparent)",
-            }}
+            id="account-menu-panel"
+            className="absolute right-0 top-[calc(100%+8px)] z-50 w-[268px] overflow-hidden rounded-2xl border border-border bg-surface-overlay shadow-floating"
           >
-            <span className="grid size-11 shrink-0 place-items-center rounded-full bg-teal text-[17px] font-bold text-bg shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-gold)_30%,transparent)]">
-              {initial}
-            </span>
-            <div className="min-w-0">
-              <p className="truncate text-[15px] font-semibold text-text-primary">
-                {username ?? tNav("signedIn")}
-              </p>
-              <p className="text-xs text-text-secondary">
-                {streak > 0 ? tNav("dayStreak", { count: streak }) : tNav("signedIn")}
-              </p>
-            </div>
-          </div>
-
-          <div className="flex gap-2 px-4 pb-3.5">
-            <div className="flex-1 rounded-[10px] border border-border bg-surface px-2.5 py-2">
-              <div className="flex items-center gap-1.5">
-                <Flame className="size-[15px] text-gold" fill="currentColor" />
-                <span className="text-[18px] font-bold leading-none text-gold">{streak}</span>
+            <div
+              className="flex items-center gap-3 p-4"
+              style={{
+                background:
+                  "radial-gradient(120% 100% at 0% 0%, color-mix(in srgb, var(--color-gold) 12%, transparent), transparent 60%), linear-gradient(180deg, color-mix(in srgb, var(--color-teal) 8%, transparent), transparent)",
+              }}
+            >
+              <span className="grid size-11 shrink-0 place-items-center rounded-full bg-teal text-[17px] font-bold text-bg shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-gold)_30%,transparent)]">
+                {initial}
+              </span>
+              <div className="min-w-0">
+                <p className="truncate text-[15px] font-semibold text-text-primary">
+                  {username ?? tNav("signedIn")}
+                </p>
+                <p className="text-xs text-text-secondary">
+                  {streak > 0 ? tNav("dayStreak", { count: streak }) : tNav("signedIn")}
+                </p>
               </div>
-              <p className="mt-1 text-[10.5px] uppercase tracking-[0.04em] text-text-muted">
-                {tNav("dayStreakLabel")}
-              </p>
             </div>
-            <div className="flex-1 rounded-[10px] border border-border bg-surface px-2.5 py-2">
-              <div className="flex items-center gap-1.5">
-                <Award className="size-[15px] text-gold" />
-                <span className="text-[18px] font-bold leading-none text-text-primary">
-                  {longestStreak}
-                </span>
+
+            <div className="flex gap-2 px-4 pb-3.5">
+              <div className="flex-1 rounded-[10px] border border-border bg-surface px-2.5 py-2">
+                <div className="flex items-center gap-1.5">
+                  <Flame className="size-[15px] text-gold" fill="currentColor" />
+                  <span className="text-[18px] font-bold leading-none text-gold">{streak}</span>
+                </div>
+                <p className="mt-1 text-[10.5px] uppercase tracking-[0.04em] text-text-muted">
+                  {tNav("dayStreakLabel")}
+                </p>
               </div>
-              <p className="mt-1 text-[10.5px] uppercase tracking-[0.04em] text-text-muted">
-                {tNav("longest")}
-              </p>
+              <div className="flex-1 rounded-[10px] border border-border bg-surface px-2.5 py-2">
+                <div className="flex items-center gap-1.5">
+                  <Award className="size-[15px] text-gold" />
+                  <span className="text-[18px] font-bold leading-none text-text-primary">
+                    {longestStreak}
+                  </span>
+                </div>
+                <p className="mt-1 text-[10.5px] uppercase tracking-[0.04em] text-text-muted">
+                  {tNav("longest")}
+                </p>
+              </div>
+            </div>
+
+            <div className="h-px bg-border" />
+
+            <div className="p-1.5">
+              <Link
+                ref={firstItemRef}
+                href="/workspaces"
+                onClick={() => setOpen(false)}
+                className={linkRow}
+              >
+                <FolderOpen /> {tNav("savedCanvases")}
+              </Link>
+              <Link href="/social" onClick={() => setOpen(false)} className={linkRow}>
+                <Trophy /> {tNav("friendsLeaderboard")}
+                {pendingFriendCount > 0 && (
+                  <span className="ml-auto grid h-[18px] min-w-[18px] place-items-center rounded-full bg-gold px-1 text-[10px] font-bold text-bg">
+                    {pendingFriendCount > 9 ? "9+" : pendingFriendCount}
+                  </span>
+                )}
+              </Link>
+              <Link href="/mentions" onClick={() => setOpen(false)} className={linkRow}>
+                <AtSign /> {tNav("mentions")}
+                {pendingMentionCount > 0 && (
+                  <span className="ml-auto grid h-[18px] min-w-[18px] place-items-center rounded-full bg-gold px-1 text-[10px] font-bold text-bg">
+                    {pendingMentionCount > 9 ? "9+" : pendingMentionCount}
+                  </span>
+                )}
+              </Link>
+              {/* Desktop nav already has Bookmarks — this is the mobile-only entry point since the bottom tab bar dropped it for a 4th tab. */}
+              <Link
+                href="/bookmarks"
+                onClick={() => setOpen(false)}
+                className={cn(linkRow, "md:hidden")}
+              >
+                <Bookmark /> {tNav("bookmarks")}
+              </Link>
+              <Link href="/settings" onClick={() => setOpen(false)} className={linkRow}>
+                <Settings /> {t("settings")}
+              </Link>
+            </div>
+
+            <div className="h-px bg-border" />
+
+            <div className="p-1.5">
+              <button
+                onClick={signOut}
+                className="flex h-11 w-full items-center gap-3 rounded-lg px-3 text-[13.5px] text-text-primary transition-colors hover:bg-error/10 hover:text-error [&_svg]:size-[17px] [&_svg]:text-text-secondary [&:hover_svg]:text-error"
+              >
+                <LogOut /> {t("signOut")}
+              </button>
             </div>
           </div>
-
-          <div className="h-px bg-border" />
-
-          <div className="p-1.5">
-            <Link
-              ref={firstItemRef}
-              href="/workspaces"
-              onClick={() => setOpen(false)}
-              className={linkRow}
-            >
-              <FolderOpen /> {tNav("savedCanvases")}
-            </Link>
-            <Link href="/social" onClick={() => setOpen(false)} className={linkRow}>
-              <Trophy /> {tNav("friendsLeaderboard")}
-              {pendingFriendCount > 0 && (
-                <span className="ml-auto grid h-[18px] min-w-[18px] place-items-center rounded-full bg-gold px-1 text-[10px] font-bold text-bg">
-                  {pendingFriendCount > 9 ? "9+" : pendingFriendCount}
-                </span>
-              )}
-            </Link>
-            <Link href="/mentions" onClick={() => setOpen(false)} className={linkRow}>
-              <AtSign /> {tNav("mentions")}
-              {pendingMentionCount > 0 && (
-                <span className="ml-auto grid h-[18px] min-w-[18px] place-items-center rounded-full bg-gold px-1 text-[10px] font-bold text-bg">
-                  {pendingMentionCount > 9 ? "9+" : pendingMentionCount}
-                </span>
-              )}
-            </Link>
-            {/* Desktop nav already has Bookmarks — this is the mobile-only entry point since the bottom tab bar dropped it for a 4th tab. */}
-            <Link
-              href="/bookmarks"
-              onClick={() => setOpen(false)}
-              className={cn(linkRow, "md:hidden")}
-            >
-              <Bookmark /> {tNav("bookmarks")}
-            </Link>
-            <Link href="/settings" onClick={() => setOpen(false)} className={linkRow}>
-              <Settings /> {t("settings")}
-            </Link>
-          </div>
-
-          <div className="h-px bg-border" />
-
-          <div className="p-1.5">
-            <button
-              onClick={signOut}
-              className="flex h-11 w-full items-center gap-3 rounded-lg px-3 text-[13.5px] text-text-primary transition-colors hover:bg-error/10 hover:text-error [&_svg]:size-[17px] [&_svg]:text-text-secondary [&:hover_svg]:text-error"
-            >
-              <LogOut /> {t("signOut")}
-            </button>
-          </div>
-        </div>
+        </FocusScope>
       )}
     </div>
   );

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -80,8 +80,11 @@ test.describe("mobile bottom nav", () => {
 
     await page.getByRole("button", { name: /account menu/i }).click();
     // Exact match: the loose /saved/i regex also matches the adjacent "Saved
-    // canvases" workspaces link in this same menu.
-    const savedLink = page.getByRole("menu").getByRole("link", { name: "Saved", exact: true });
+    // canvases" workspaces link in this same menu. AccountMenu is a plain nav
+    // popover (not role="menu" — see issue #265), so scope by its panel id.
+    const savedLink = page
+      .locator("#account-menu-panel")
+      .getByRole("link", { name: "Saved", exact: true });
     await expect(savedLink).toBeVisible();
     await savedLink.click();
     // 15s: Next dev serves routes with on-demand compilation, and this may be


### PR DESCRIPTION
`AccountMenu`'s dropdown was marked `role="menu"`, but only the sign-out button had `role="menuitem"` — the two `Link` items had none — and none of the roving-tabindex/arrow-key navigation a true ARIA menu implies was implemented. Opening the menu didn't move focus into it, and closing it didn't return focus to the trigger.

**Design choice, called out explicitly per the issue's own suggested options:** there's no existing WAI-ARIA menu implementation elsewhere in the codebase to extend (verified via grep — `AccountMenu.tsx` was the only file using `role="menu"`), so I went with the simpler, correct option: dropped `role="menu"`/`role="menuitem"` in favor of a plain nav popover (regular links/buttons, no artificial menu semantics to get wrong), rather than building out the full ARIA menu pattern (roving tabindex, arrow-key nav) from scratch for a single component.

## Summary

- Removed `role="menu"` from the dropdown panel and `role="menuitem"` from the sign-out button.
- Replaced `aria-haspopup="menu"` with `aria-controls` pointing at the panel, matching the WAI-ARIA APG's "popup button controlling non-menu content" pattern.
- Added standard popup-button focus management: focus moves to the first link when the panel opens, and back to the trigger button when it closes — however the close happens (Escape, outside click, or picking an item).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [x] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface

Closes #265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard focus behavior when opening and closing the account popover.
  * Trapped and looped focus within the open popover.
  * Restored focus to the account trigger after the popover is closed.
  * Moved focus to the sign-in button after signing out.
  * Added accessible labeling relationships and removed misleading menu semantics.
* **Tests**
  * Added coverage for focus movement, authentication changes, and accessibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->