### PR TITLE
fix(connections): don't 500 on legitimate empty-generation results

### DIFF
--- a/__tests__/api/connections.test.ts
+++ b/__tests__/api/connections.test.ts
@@ -23,10 +23,11 @@ function makeDbChain(resolveWith: unknown = []) {
   return chain;
 }
 
-const { mockSelect, mockInsert, mockConsume } = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockConsume, mockAnthropicCreate } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])), // no stored edges → cache miss
   mockInsert: vi.fn(() => makeDbChain([])),
   mockConsume: vi.fn(async () => true),
+  mockAnthropicCreate: vi.fn(),
 }));
 
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, insert: mockInsert } }));
@@ -73,18 +74,8 @@ vi.mock("@/lib/infra/rate-limit", () => ({
 }));
 
 vi.mock("@anthropic-ai/sdk", () => {
-  const mockText = JSON.stringify([
-    { ref: "2:255", reason: "The Throne Verse manifests divine sovereignty." },
-    { ref: "3:18", reason: "Allah witnesses His own oneness directly." },
-    { ref: "112:1", reason: "Pure tawhid — the essence of divine singularity." },
-  ]);
-
   class MockAnthropic {
-    messages = {
-      create: vi.fn().mockResolvedValue({
-        content: [{ type: "text", text: mockText }],
-      }),
-    };
+    messages = { create: mockAnthropicCreate };
   }
 
   return { default: MockAnthropic };
@@ -113,6 +104,12 @@ function makeRequest(
   });
 }
 
+const defaultAnthropicText = JSON.stringify([
+  { ref: "2:255", reason: "The Throne Verse manifests divine sovereignty." },
+  { ref: "3:18", reason: "Allah witnesses His own oneness directly." },
+  { ref: "112:1", reason: "Pure tawhid — the essence of divine singularity." },
+]);
+
 describe("POST /api/connections", () => {
   beforeEach(() => {
     mockFetch.mockReset();
@@ -121,6 +118,10 @@ describe("POST /api/connections", () => {
     mockConsume.mockReset();
     mockConsume.mockResolvedValue(true);
     mockSelect.mockReturnValue(makeDbChain([])); // default: cache miss
+    mockAnthropicCreate.mockReset();
+    mockAnthropicCreate.mockResolvedValue({
+      content: [{ type: "text", text: defaultAnthropicText }],
+    });
   });
 
   it("returns 400 when fromRef is missing", async () => {
@@ -286,7 +287,6 @@ describe("POST /api/connections", () => {
   });
 
   it("serves a cache HIT from the DB without generating", async () => {
-    const anthropic = await import("@anthropic-ai/sdk");
     // First select = connections query → returns the stored edge (HIT).
     // Subsequent selects = corpus verse lookup → empty, so resolveVerse falls
     // back to the live fetch. The AI must NOT be called on a hit.
@@ -322,8 +322,8 @@ describe("POST /api/connections", () => {
     expect(res.status).toBe(200);
     expect(body[0]).toMatchObject({ ref: "3:18", reason: "stored" });
     expect(mockInsert).not.toHaveBeenCalled();
-    // The mocked Anthropic client was never constructed/used for a hit.
-    expect(anthropic.default).toBeDefined();
+    // The AI was never called for a hit.
+    expect(mockAnthropicCreate).not.toHaveBeenCalled();
   });
 
   it("returns 400 for a non-array excludeRefs", async () => {
@@ -360,6 +360,24 @@ describe("POST /api/connections", () => {
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with an empty array (not a 500) on a genuine first-time miss with no results", async () => {
+    // No stored edge (miss), and both the grounded-discovery and legacy AI paths
+    // come up empty — a legitimate "nothing found" outcome, not a server error.
+    mockSelect.mockReturnValue(makeDbChain([]));
+    mockAnthropicCreate.mockResolvedValue({ content: [{ type: "text", text: "[]" }] });
+
+    const req = makeRequest({
+      fromRef: "1:1",
+      kind: "thematic",
+      arabicText: "x",
+      translation: "y",
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual([]);
   });
 
   it("returns 200 with an empty array (not a 500) when excludeRefs exhausts a repeat request", async () => {

--- a/__tests__/api/connections.test.ts
+++ b/__tests__/api/connections.test.ts
@@ -378,6 +378,8 @@ describe("POST /api/connections", () => {
     const body = await res.json();
     expect(res.status).toBe(200);
     expect(body).toEqual([]);
+    // Confirms the test actually exercised the generation path, not a vacuous pass.
+    expect(mockAnthropicCreate).toHaveBeenCalled();
   });
 
   it("returns 200 with an empty array (not a 500) when excludeRefs exhausts a repeat request", async () => {

--- a/__tests__/api/names.test.ts
+++ b/__tests__/api/names.test.ts
@@ -190,7 +190,9 @@ describe("GET /api/names/[slug]/verses", () => {
     const req = new NextRequest("http://localhost/api/names/ar-rahman/verses");
     await getNameVerses(req, params("ar-rahman"));
 
-    const searchCall = mockFetch.mock.calls.find(([url]) => String(url).includes("api.quran.com"));
+    const searchCall = mockFetch.mock.calls.find(
+      ([url]) => new URL(String(url)).hostname === "api.quran.com"
+    );
     expect(searchCall).toBeDefined();
     expect(searchCall?.[1]).toEqual(expect.objectContaining({ signal: expect.any(AbortSignal) }));
   });

--- a/__tests__/api/names.test.ts
+++ b/__tests__/api/names.test.ts
@@ -179,6 +179,22 @@ describe("GET /api/names/[slug]/verses", () => {
     }
   });
 
+  it("quran.com search fetch passes an abort signal so a hung upstream fails fast", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url !== "string") return { ok: false };
+      if (url.includes("ar.alafasy")) return arabicResp();
+      if (url.includes("en.sahih")) return transResp();
+      return { ok: false };
+    });
+
+    const req = new NextRequest("http://localhost/api/names/ar-rahman/verses");
+    await getNameVerses(req, params("ar-rahman"));
+
+    const searchCall = mockFetch.mock.calls.find(([url]) => String(url).includes("api.quran.com"));
+    expect(searchCall).toBeDefined();
+    expect(searchCall?.[1]).toEqual(expect.objectContaining({ signal: expect.any(AbortSignal) }));
+  });
+
   it("hydrates verse translation for the requester's edition, not the en.sahih the selection was cached with", async () => {
     mockGetQuranEdition.mockResolvedValue("tr.diyanet");
     mockFetch.mockImplementation(async (url: string) => {

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -28,24 +28,33 @@ const {
   mockInsert,
   mockValues,
   mockOnConflict,
+  mockReturning,
   mockGenerate,
   mockGenerateGrounded,
   mockDiscover,
   mockResolveVerse,
   mockConsume,
+  mockIncr,
 } = vi.hoisted(() => {
-  const mockOnConflict = vi.fn().mockResolvedValue(undefined);
+  // Mirrors the real chain: .values(...).onConflictDoNothing().returning(...) —
+  // `returning` resolves with the rows actually inserted (empty by default here,
+  // matching every existing test's assumption that no row won a genuine
+  // conflict-race; individual tests override this).
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockOnConflict = vi.fn(() => ({ returning: mockReturning }));
   const mockValues = vi.fn((..._args: unknown[]) => ({ onConflictDoNothing: mockOnConflict }));
   return {
     mockSelect: vi.fn(),
     mockInsert: vi.fn(() => ({ values: mockValues })),
     mockValues,
     mockOnConflict,
+    mockReturning,
     mockGenerate: vi.fn(),
     mockGenerateGrounded: vi.fn(),
     mockDiscover: vi.fn(),
     mockResolveVerse: vi.fn(),
     mockConsume: vi.fn(),
+    mockIncr: vi.fn(),
   };
 });
 
@@ -60,6 +69,7 @@ vi.mock("@/lib/infra/rate-limit", () => ({
   consume: mockConsume,
   RateLimitError: class RateLimitError extends Error {},
 }));
+vi.mock("@/lib/infra/metrics", () => ({ incr: mockIncr }));
 
 import { getConnections } from "@/lib/ai/graph-service";
 import { RateLimitError } from "@/lib/infra/rate-limit";
@@ -89,6 +99,8 @@ describe("getConnections", () => {
     mockInsert.mockClear();
     mockValues.mockClear();
     mockOnConflict.mockClear();
+    mockReturning.mockReset().mockResolvedValue([]);
+    mockIncr.mockClear();
     mockGenerate.mockReset();
     mockGenerateGrounded.mockReset();
     mockDiscover.mockReset();
@@ -141,6 +153,17 @@ describe("getConnections", () => {
       locale: "en",
     });
     expect(out).toHaveLength(2);
+  });
+
+  it("on a persist failure, still returns the generated results but counts it — not silent", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    mockGenerate.mockResolvedValue([result("2:255")]);
+    mockReturning.mockRejectedValue(new Error("db down"));
+
+    const out = await getConnections("1:1", "thematic", source);
+
+    expect(out).toHaveLength(1); // caller still gets this request's results
+    expect(mockIncr).toHaveBeenCalledWith("gen_persist_failed");
   });
 
   it("on a miss that generates nothing, does not write to the DB", async () => {
@@ -293,6 +316,8 @@ describe("getConnections — per-locale caching", () => {
     mockInsert.mockClear();
     mockValues.mockClear();
     mockOnConflict.mockClear();
+    mockReturning.mockReset().mockResolvedValue([]);
+    mockIncr.mockClear();
     mockGenerate.mockReset();
     mockGenerateGrounded.mockReset();
     mockDiscover.mockReset();
@@ -338,6 +363,8 @@ describe("getConnections — single-flight de-duplication", () => {
     mockInsert.mockClear();
     mockValues.mockClear();
     mockOnConflict.mockClear();
+    mockReturning.mockReset().mockResolvedValue([]);
+    mockIncr.mockClear();
     mockDiscover.mockReset().mockResolvedValue([]); // no grounding → legacy generate path
     mockResolveVerse.mockReset().mockImplementation(async (ref: string) => verse(ref));
     mockConsume.mockReset().mockResolvedValue(true);

--- a/__tests__/lib/quran/verse-resolver.test.ts
+++ b/__tests__/lib/quran/verse-resolver.test.ts
@@ -125,7 +125,7 @@ describe("resolveVerse", () => {
     expect(result?.translation).toBe("Türkçe metin");
   });
 
-  it("live fallback fetches pass an abort signal so a hung upstream fails fast", async () => {
+  it("both parallel live fallback fetches pass an abort signal so a hung upstream fails fast", async () => {
     mockGetVerse.mockResolvedValue(null);
     vi.mocked(fetch).mockImplementation(async (url: string | URL | Request) => {
       const isArabic = String(url).includes("ar.alafasy");
@@ -135,10 +135,30 @@ describe("resolveVerse", () => {
       } as Response;
     });
     await resolveVerse("2:255");
-    expect(fetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({ signal: expect.any(AbortSignal) })
-    );
+    expect(fetch).toHaveBeenCalledTimes(2);
+    for (const call of vi.mocked(fetch).mock.calls) {
+      expect(call[1]).toEqual(expect.objectContaining({ signal: expect.any(AbortSignal) }));
+    }
+  });
+
+  it("the en.sahih fallback fetch (when the requested edition 404s) also passes an abort signal", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    vi.mocked(fetch).mockImplementation(async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("ar.alafasy")) {
+        return { ok: true, json: async () => ({ data: { text: "نص عربي" } }) } as Response;
+      }
+      if (u.includes("tr.diyanet")) {
+        return { ok: false } as Response;
+      }
+      return { ok: true, json: async () => ({ data: { text: "English fallback" } }) } as Response;
+    });
+    await resolveVerse("2:255", "tr.diyanet");
+    const fallbackCall = vi
+      .mocked(fetch)
+      .mock.calls.find(([url]) => String(url).includes(`/en.sahih`));
+    expect(fallbackCall).toBeDefined();
+    expect(fallbackCall?.[1]).toEqual(expect.objectContaining({ signal: expect.any(AbortSignal) }));
   });
 
   it("live fallback falls back to en.sahih when the requested edition 404s upstream", async () => {

--- a/__tests__/lib/quran/verse-resolver.test.ts
+++ b/__tests__/lib/quran/verse-resolver.test.ts
@@ -125,6 +125,22 @@ describe("resolveVerse", () => {
     expect(result?.translation).toBe("Türkçe metin");
   });
 
+  it("live fallback fetches pass an abort signal so a hung upstream fails fast", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    vi.mocked(fetch).mockImplementation(async (url: string | URL | Request) => {
+      const isArabic = String(url).includes("ar.alafasy");
+      return {
+        ok: true,
+        json: async () => ({ data: { text: isArabic ? "نص عربي" : "English text" } }),
+      } as Response;
+    });
+    await resolveVerse("2:255");
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
   it("live fallback falls back to en.sahih when the requested edition 404s upstream", async () => {
     mockGetVerse.mockResolvedValue(null);
     vi.mocked(fetch).mockImplementation(async (url: string | URL | Request) => {

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -66,12 +66,12 @@ export async function POST(req: NextRequest) {
       { clientKey: clientKey(req), excludeRefs, locale }
     );
 
-    // A "get more" request (excludeRefs non-empty) legitimately can run out of
-    // fresh connections — that's not a server error, just nothing left to give.
-    if (results.length === 0 && excludeRefs.length === 0) {
-      return NextResponse.json({ error: "Could not resolve any verses" }, { status: 500 });
-    }
-
+    // Empty results are not a server error, whether this is a "get more" request
+    // running out of fresh connections, or a genuine first-time miss where the
+    // grounding data isn't seeded for this verse yet and the AI proposed nothing
+    // that survived validation. Either way the client already distinguishes the
+    // two cases (see HikmahCanvas.tsx's runExpansion) and shows an appropriate
+    // notice — the route itself has nothing to treat as an error here.
     return NextResponse.json(results);
   } catch (err) {
     if (err instanceof RateLimitError) {

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -47,6 +47,7 @@ async function searchVerseRefs(arabic: string): Promise<string[]> {
     const res = await fetch(url, {
       headers: { Accept: "application/json" },
       next: { revalidate: 86400 },
+      signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) return [];
     const data = await res.json();

--- a/components/canvas/HikmahCanvas.tsx
+++ b/components/canvas/HikmahCanvas.tsx
@@ -156,9 +156,14 @@ function CanvasInner({ onSearchOpen }: { onSearchOpen: () => void }) {
         const connections: ConnectionResult[] = await res.json();
 
         // A repeat "get more" request can legitimately run dry — that's not a
-        // fetch failure, just nothing further to surface for this kind.
-        if (connections.length === 0 && excludeRefs.length > 0) {
-          throw new ExhaustedExpansionError();
+        // fetch failure, just nothing further to surface for this kind. A
+        // first-time request can also legitimately come back empty (grounding
+        // data not yet seeded for this verse, or the AI proposed nothing that
+        // survived validation) — surface that too, rather than silently doing
+        // nothing.
+        if (connections.length === 0) {
+          if (excludeRefs.length > 0) throw new ExhaustedExpansionError();
+          throw new Error("No connections found for this verse");
         }
 
         for (let i = 0; i < connections.length; i++) {

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -215,7 +215,13 @@ async function generateAndPersist(
         });
       }
     } catch (err) {
+      // A swallowed persist failure would be invisible: the caller still gets
+      // their generated connections this request, but nothing is cached, so
+      // the same (costly) AI generation re-runs on every future request for
+      // this verse — quietly defeating this module's "AI cost trends toward
+      // zero" design. Surface it as a counted metric, not just a log line.
       console.error("Failed to persist connections:", err);
+      incr("gen_persist_failed");
     }
   }
 

--- a/lib/quran/verse-resolver.ts
+++ b/lib/quran/verse-resolver.ts
@@ -37,9 +37,11 @@ async function fetchVerseLive(ref: string, edition: string): Promise<Verse | nul
     const [arabicRes, translationRes] = await Promise.all([
       fetch(`https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/ar.alafasy`, {
         next: { revalidate: 86400 },
+        signal: AbortSignal.timeout(5000),
       }),
       fetch(`https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/${edition}`, {
         next: { revalidate: 86400 },
+        signal: AbortSignal.timeout(5000),
       }),
     ]);
     if (!arabicRes.ok) return null;
@@ -53,7 +55,7 @@ async function fetchVerseLive(ref: string, edition: string): Promise<Verse | nul
     } else if (edition !== DEFAULT_EDITION) {
       const fallbackRes = await fetch(
         `https://api.alquran.cloud/v1/ayah/${surahNum}:${ayahNum}/${DEFAULT_EDITION}`,
-        { next: { revalidate: 86400 } }
+        { next: { revalidate: 86400 }, signal: AbortSignal.timeout(5000) }
       );
       if (!fallbackRes.ok) return null;
       translationData = await fallbackRes.json();


### PR DESCRIPTION
## Summary

- `/api/connections` hard-coded a 500 whenever a genuine first-time generation legitimately found nothing (not a thrown error) — this is why fresh (uncached) verses failed while cached ones worked. It now returns the (possibly empty) result normally; the client already distinguishes "nothing found" from a real fetch failure.
- `generateAndPersist` (`lib/ai/graph-service.ts`) no longer silently swallows a DB-persist failure — it now bumps a `gen_persist_failed` metric (in addition to the existing log), since a silent failure there means the same paid AI generation re-runs on every future request for that verse instead of being cached.
- **Bundled in (originally issue #475, merged here — see below):** added a 5s request timeout (`AbortSignal.timeout(5000)`) to the live Quran verse fetches that had none (`fetchVerseLive` in `lib/quran/verse-resolver.ts`, `searchVerseRefs` in `app/api/names/[slug]/verses/route.ts`), matching the existing pattern in `lib/auth/social-auth.ts`.
- Extended the `runExpansion` empty-result handling in `components/canvas/HikmahCanvas.tsx` so a legitimate first-time "nothing found" result (not just a repeat "get more" exhaustion) surfaces a toast instead of silently doing nothing.

## Why #475 got merged into this PR

While working this issue, CI on `main` was failing because the "E2E (Playwright)" job hits its 20-minute timeout. Investigated via `gh run view --log` on the latest `main` run: the job's log goes completely silent for ~19 minutes right after Playwright browser setup, then gets killed by the timeout — consistent with a genuinely hung network call, not "tests are just slow" (Playwright's own default 30s per-test timeout would otherwise have surfaced a failure).

Root cause: the E2E job's DB setup only runs migrations, never a corpus-seed step, so every verse lookup in that job is a corpus miss. `resolveVerse` then falls back to a **live, previously-unbounded fetch to `api.alquran.cloud`** for every verse rendered across the pages `e2e/a11y.spec.ts` visits (`/today`, `/search`, `/names/*`, `/stories/*`, etc.) — exactly the gap issue #475 already targeted. A slow/unresponsive response from that external API during a given CI run would hang indefinitely with no code-level bound. Fixing #475 directly addresses the observed CI hang, so I did it here instead of as a separate, later PR. Left `timeout-minutes: 20` on the E2E job as-is — the actual fix is bounding the hang, not raising the ceiling further.

(Also checked whether a live AI call could be the culprit instead — `/today` only calls `resolveVerse`, no AI, and no e2e test exercises the AI-backed `/api/connections` "expand" flow — so the missing-timeout live-fetch path is the best-supported explanation for this specific failure.)

## Type of change

- [x] Bug fix

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality

New/updated tests: `__tests__/api/connections.test.ts` (200 with `[]` on a genuine first-time miss), `__tests__/lib/ai/graph-service.test.ts` (persist-failure metric), `__tests__/lib/quran/verse-resolver.test.ts` and `__tests__/api/names.test.ts` (abort-signal assertions on the live fetches).

**Known gap, disclosed:** the deeper "why does generation legitimately return empty so often for uncommon verses" question (possibly related to open issue #152, corpus/embedding backfill coverage) couldn't be live-verified — the project's Anthropic API balance is currently at zero, so I could not exercise the real AI generation path end-to-end. Recommend a spot-check once budget is restored. Separately, whether E2E should depend on live external APIs at all (e.g. seeding the corpus for CI) is a larger, separate change I'm flagging but not doing here.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A, none added
- [x] `README.md` updated if the feature changes the public interface — N/A

Closes #473, Closes #475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty connection searches now return successfully instead of producing an error.
  * Initial expansions with no results now show an appropriate failure notice.
  * Generated results remain available when saving them fails.

* **Reliability**
  * Quran verse lookups now stop waiting after five seconds, improving responsiveness when upstream services are slow.
  * Empty AI search results now return a successful response with an empty list.

* **Monitoring**
  * Save failures for generated connections are now tracked for improved visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->