### PR TITLE
fix(admin): validate verse refs before persisting name_content

### DIFF
--- a/__tests__/api/admin/names.test.ts
+++ b/__tests__/api/admin/names.test.ts
@@ -163,6 +163,53 @@ describe("PATCH /api/admin/names", () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
+  it("rejects verses data with a corpus-invalid ref, without persisting it", async () => {
+    const res = await PATCH(
+      patch({
+        slug: "ar-rahman",
+        kind: "verses",
+        data: [
+          {
+            ref: "999:999",
+            surah: 999,
+            ayah: 999,
+            arabicText: "a",
+            translation: "t",
+            surahName: "s",
+            surahNameArabic: "s",
+            reason: "r",
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rejects verses data with a syntactically-plausible but non-existent ayah (ref out of range for a real surah)", async () => {
+    const res = await PATCH(
+      patch({
+        slug: "ar-rahman",
+        kind: "verses",
+        data: [
+          {
+            // Al-Fatiha only has 7 ayahs.
+            ref: "1:8",
+            surah: 1,
+            ayah: 8,
+            arabicText: "a",
+            translation: "t",
+            surahName: "Al-Fatihah",
+            surahNameArabic: "الفاتحة",
+            reason: "r",
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("rejects verses data with a wrong field type (surah as string)", async () => {
     const res = await PATCH(
       patch({

--- a/__tests__/api/admin/names.test.ts
+++ b/__tests__/api/admin/names.test.ts
@@ -232,6 +232,33 @@ describe("PATCH /api/admin/names", () => {
     expect(res.status).toBe(400);
   });
 
+  it("rejects verses data where surah/ayah don't match the parsed ref", async () => {
+    const res = await PATCH(
+      patch({
+        slug: "ar-rahman",
+        kind: "verses",
+        data: [
+          {
+            // Valid ref, but surah/ayah point at a different verse (1:1) —
+            // downstream features that key off surah/ayah (e.g.
+            // InteractiveArabic morphology lookups) would then disagree
+            // with the ref-identified verse.
+            ref: "1:1",
+            surah: 2,
+            ayah: 255,
+            arabicText: "a",
+            translation: "t",
+            surahName: "s",
+            surahNameArabic: "s",
+            reason: "r",
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("accepts a valid reflection (plain string)", async () => {
     mockUpdate.mockReturnValue(makeDbChain([{ slug: "ar-rahman", kind: "reflection" }]));
     const res = await PATCH(

--- a/app/api/admin/names/route.ts
+++ b/app/api/admin/names/route.ts
@@ -5,6 +5,7 @@ import { logAdminAction } from "@/lib/admin/admin-audit";
 import { db } from "@/lib/infra/db";
 import { nameContent } from "@/lib/infra/db/schema";
 import { safeParse } from "@/lib/infra/http";
+import { isValidRef } from "@/lib/quran/quran-corpus";
 
 const KINDS = ["verses", "reflection", "pairings"] as const;
 type Kind = (typeof KINDS)[number];
@@ -45,6 +46,13 @@ function isValidVerses(data: unknown): boolean {
       v as Record<string, unknown>;
     return (
       isNonEmptyString(ref) &&
+      // Every AI-generation path validates refs against the local corpus
+      // before use (lib/ai/connection-generator.ts, fallbackAIVerses in
+      // names/[slug]/verses/route.ts) — this admin override path is the one
+      // place that persists a ref straight to end users, so it must be held
+      // to the same "never fabricate a Quran verse reference" bar, not just
+      // checked for non-empty-string shape.
+      isValidRef(ref) &&
       typeof surah === "number" &&
       typeof ayah === "number" &&
       isNonEmptyString(arabicText) &&

--- a/app/api/admin/names/route.ts
+++ b/app/api/admin/names/route.ts
@@ -44,17 +44,20 @@ function isValidVerses(data: unknown): boolean {
     if (typeof v !== "object" || v === null) return false;
     const { ref, surah, ayah, arabicText, translation, surahName, surahNameArabic, reason } =
       v as Record<string, unknown>;
+    if (!isNonEmptyString(ref) || !isValidRef(ref)) return false;
+    // ref is the identity downstream features (e.g. InteractiveArabic) key
+    // morphology lookups on; surah/ayah must agree with it or a mismatched
+    // payload can present one verse's text under another verse's reference.
+    const [refSurah, refAyah] = ref.split(":").map(Number);
     return (
-      isNonEmptyString(ref) &&
       // Every AI-generation path validates refs against the local corpus
       // before use (lib/ai/connection-generator.ts, fallbackAIVerses in
       // names/[slug]/verses/route.ts) — this admin override path is the one
       // place that persists a ref straight to end users, so it must be held
       // to the same "never fabricate a Quran verse reference" bar, not just
       // checked for non-empty-string shape.
-      isValidRef(ref) &&
-      typeof surah === "number" &&
-      typeof ayah === "number" &&
+      surah === refSurah &&
+      ayah === refAyah &&
       isNonEmptyString(arabicText) &&
       isNonEmptyString(translation) &&
       isNonEmptyString(surahName) &&


### PR DESCRIPTION
## Summary

- `isValidVerses` in `app/api/admin/names/route.ts` only checked shape (non-empty strings, correct field types) — it never checked that a `ref` actually resolves to a real verse in the local corpus.
- An admin `PATCH /api/admin/names` with `kind: "verses"` could persist a fabricated verse reference straight into `name_content`, served directly to end users, bypassing the same "never fabricate a Quran verse reference" bar every AI-generation path (`lib/ai/connection-generator.ts`, `fallbackAIVerses` in `app/api/names/[slug]/verses/route.ts`) already enforces.
- Fix: import `isValidRef` from `lib/quran/quran-corpus.ts` and check every verse's `ref` against it inside `isValidVerses`. A payload containing any corpus-invalid ref (nonexistent surah/ayah, or an in-range surah number but out-of-range ayah) is now rejected with 400 before any DB write.

**CODEOWNERS note:** this PR touches `app/api/admin/` (gated per `AGENTS.md`'s Auth/security-surface guardrail). The change is additive validation only — no change to auth, rate limiting, or the admin gate itself.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [ ] No AI or theological changes in this PR
- [x] Changes to theological framing — described below

**Details:** Not a change to theological framing/content itself, but a tightening of the "never fabricate a Quran verse reference" guardrail (AGENTS.md's theological standards, item 3) to close a gap in the one persistence path that previously let it slip.

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality
- [x] `bun run test:integration` passes locally (Testcontainers/Docker) — touches DB-backed admin logic

Added two tests to `__tests__/api/admin/names.test.ts`:
- a corpus-invalid ref (`"999:999"`, nonexistent surah) is rejected with 400 and never reaches `db.update`
- a syntactically-plausible but out-of-range ref (`"1:8"` — Al-Fatiha only has 7 ayahs) is rejected the same way

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added
- [x] `README.md` updated if the feature changes the public interface

Closes #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Quran verse references.
  * Invalid references and nonexistent ayah numbers are now rejected before updates are saved.
  * Prevented database changes when verse data fails validation.

* **Tests**
  * Added coverage for references outside the supported corpus and invalid ayah numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->