### PR TITLE
fix(admin): close job-runner start-guard race

### DIFF
--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -98,6 +98,18 @@ describe("startJob", () => {
     await expect(startJob("seed-quran", "qf-admin")).rejects.toThrow("already running");
   });
 
+  it("only lets one of two near-simultaneous (un-awaited) calls succeed", async () => {
+    const first = startJob("seed-morphology", "qf-admin");
+    const second = startJob("seed-quran", "qf-admin");
+    const results = await Promise.allSettled([first, second]);
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason.message).toMatch(/already running/);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+
   it("clears the running guard once the child process closes", async () => {
     await startJob("seed-morphology", "qf-admin");
     lastChild.current?.emit("close", 0);

--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -110,6 +110,15 @@ describe("startJob", () => {
     expect(mockInsert).toHaveBeenCalledTimes(1);
   });
 
+  it("releases the running guard when the insert rejects, allowing a retry to succeed", async () => {
+    mockInsert.mockReturnValueOnce(makeDbChain(Promise.reject(new Error("insert failed"))));
+    await expect(startJob("seed-morphology", "qf-admin")).rejects.toThrow("insert failed");
+
+    const { runId } = await startJob("seed-quran", "qf-admin");
+    expect(runId).toBe(42);
+    expect(mockInsert).toHaveBeenCalledTimes(2);
+  });
+
   it("clears the running guard once the child process closes", async () => {
     await startJob("seed-morphology", "qf-admin");
     lastChild.current?.emit("close", 0);

--- a/lib/admin/job-runner.ts
+++ b/lib/admin/job-runner.ts
@@ -74,13 +74,24 @@ export async function startJob(jobId: string, adminQfId: string): Promise<{ runI
     throw new Error(`Missing required env var(s): ${missingEnv.join(", ")}`);
   }
 
-  const [row] = await db
-    .insert(jobRuns)
-    .values({ jobType: job.id, status: "running", triggeredBy: adminQfId })
-    .returning({ id: jobRuns.id });
-
-  const state: RunningJob = { jobId: job.id, runId: row.id, logTail: [] };
+  // Claim the slot synchronously (no await between the `if (running)` check
+  // above and this assignment) so two near-simultaneous calls can't both pass
+  // the guard — matches lib/names/name-content.ts's inFlight/reasonInFlight
+  // pattern. `runId` is filled in once the insert below resolves.
+  const state: RunningJob = { jobId: job.id, runId: -1, logTail: [] };
   running = state;
+
+  let row: { id: number };
+  try {
+    [row] = await db
+      .insert(jobRuns)
+      .values({ jobType: job.id, status: "running", triggeredBy: adminQfId })
+      .returning({ id: jobRuns.id });
+  } catch (err) {
+    if (running === state) running = null;
+    throw err;
+  }
+  state.runId = row.id;
 
   const child = spawn("bun", [job.script], { cwd: process.cwd(), env: process.env });
 


### PR DESCRIPTION
## Summary

- `startJob` in `lib/admin/job-runner.ts` is meant to enforce "one job at a time," but the `running` guard was checked synchronously and only *set* after an `await db.insert(...)` resolved — a window where two near-simultaneous `POST /api/admin/jobs` requests (double-click, two admin tabs) could both pass the guard and both spawn a script.
- Fix: claim the `running` slot synchronously immediately after the guard check, before any `await`, matching the check-and-set pattern already used in `lib/names/name-content.ts`'s `inFlight`/`reasonInFlight` maps. `runId` is filled in once the DB insert resolves; if the insert throws, the slot is cleared in the catch path so a failed start doesn't permanently wedge the guard.

**CODEOWNERS note:** this PR touches `lib/admin/` (gated per `AGENTS.md`'s Auth/security-surface guardrail). The change only tightens the existing concurrency guard — no change to auth or rate limiting.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality
- [x] `bun run test:integration` passes locally (Testcontainers/Docker) — touches DB-backed admin logic

Added a test firing two un-awaited `startJob()` calls back-to-back for different jobs and asserting exactly one fulfills (the other rejects with "already running"), with `db.insert` called only once.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added
- [x] `README.md` updated if the feature changes the public interface

Closes #359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate job starts when multiple start requests occur nearly simultaneously.
  * Ensured only one job run is created while subsequent attempts are correctly rejected as already running.
  * Improved cleanup when creating a job run fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->