### PR TITLE
fix(api): sort root-word concordance results numerically

### DIFF
--- a/__tests__/api/root-concordance.test.ts
+++ b/__tests__/api/root-concordance.test.ts
@@ -22,11 +22,11 @@ function makeDbChain(resolveWith: unknown = []) {
   return chain;
 }
 
-const { mockSelectDistinct, mockGetVerses } = vi.hoisted(() => ({
-  mockSelectDistinct: vi.fn(() => makeDbChain([])),
+const { mockSelect, mockGetVerses } = vi.hoisted(() => ({
+  mockSelect: vi.fn(() => makeDbChain([])),
   mockGetVerses: vi.fn(async () => new Map()),
 }));
-vi.mock("@/lib/infra/db", () => ({ db: { selectDistinct: mockSelectDistinct } }));
+vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect } }));
 vi.mock("@/lib/quran/quran-corpus", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/quran/quran-corpus")>();
   return { ...actual, getVerses: mockGetVerses };
@@ -43,7 +43,7 @@ function params(root: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockSelectDistinct.mockReturnValue(makeDbChain([]));
+  mockSelect.mockReturnValue(makeDbChain([]));
   mockGetVerses.mockResolvedValue(new Map());
 });
 
@@ -54,11 +54,12 @@ describe("GET /api/root/[root]", () => {
   });
 
   it("returns verses for a root in the order the DB query resolved them", async () => {
-    // The route does not re-sort after the query — see issue #360 (lexicographic
-    // vs. numeric ref ordering), which is a separate, already-tracked bug.
-    // This only pins the route's actual passthrough behavior: whatever order
-    // rows come back in is the order returned to the client.
-    mockSelectDistinct.mockReturnValue(makeDbChain([{ ref: "2:255" }, { ref: "10:5" }]));
+    // The route does no application-level re-sorting — ordering is entirely the
+    // DB query's responsibility (see __tests__/integration/root-concordance.integration.test.ts
+    // for the actual numeric-order assertion against real Postgres). This only
+    // pins the route's passthrough behavior: whatever order rows come back in
+    // is the order returned to the client.
+    mockSelect.mockReturnValue(makeDbChain([{ ref: "2:255" }, { ref: "10:5" }]));
     mockGetVerses.mockResolvedValue(
       new Map([
         [
@@ -92,7 +93,7 @@ describe("GET /api/root/[root]", () => {
   });
 
   it("truncates each verse's translation to a short snippet", async () => {
-    mockSelectDistinct.mockReturnValue(makeDbChain([{ ref: "2:255" }]));
+    mockSelect.mockReturnValue(makeDbChain([{ ref: "2:255" }]));
     mockGetVerses.mockResolvedValue(
       new Map([
         [
@@ -114,7 +115,7 @@ describe("GET /api/root/[root]", () => {
   });
 
   it("drops refs the corpus lookup didn't resolve, without failing the request", async () => {
-    mockSelectDistinct.mockReturnValue(makeDbChain([{ ref: "2:255" }, { ref: "114:6" }]));
+    mockSelect.mockReturnValue(makeDbChain([{ ref: "2:255" }, { ref: "114:6" }]));
     mockGetVerses.mockResolvedValue(
       new Map([
         [
@@ -136,7 +137,7 @@ describe("GET /api/root/[root]", () => {
   });
 
   it("degrades to an empty result on a DB error instead of failing the request", async () => {
-    mockSelectDistinct.mockImplementation(() => {
+    mockSelect.mockImplementation(() => {
       throw new Error("connection reset");
     });
 

--- a/__tests__/integration/root-concordance.integration.test.ts
+++ b/__tests__/integration/root-concordance.integration.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { sql } from "drizzle-orm";
+import { NextRequest } from "next/server";
+
+// Real Postgres (Testcontainers). Confirms the route's SQL orderBy actually
+// sorts numerically, not just that a mocked chain was called with the right args.
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => ({ ok: false }))
+);
+
+import { db } from "@/lib/infra/db";
+import { verses, wordMorphology } from "@/lib/infra/db/schema";
+import { GET } from "@/app/api/root/[root]/route";
+
+async function reset() {
+  await db.execute(sql`TRUNCATE verses, word_morphology RESTART IDENTITY CASCADE`);
+}
+
+async function seedVerse(ref: string, root: string) {
+  const [s, a] = ref.split(":");
+  await db.insert(verses).values({
+    ref,
+    surah: Number(s),
+    ayah: Number(a),
+    arabicText: `arabic-${ref}`,
+    translation: `translation-${ref}`,
+  });
+  await db.insert(wordMorphology).values({ ref, position: 1, surface: `w-${ref}`, root });
+}
+
+function req() {
+  return new NextRequest("http://localhost/api/root/رحم");
+}
+function params(root: string) {
+  return { params: Promise.resolve({ root }) };
+}
+
+beforeEach(async () => {
+  await reset();
+});
+
+describe("GET /api/root/[root] — numeric sort (integration, real Postgres)", () => {
+  it("returns results in canonical (surah, ayah) order, not lexicographic", async () => {
+    // Lexicographic order on "surah:ayah" text would be "10:1", "2:10", "2:2".
+    await seedVerse("10:1", "رحم");
+    await seedVerse("2:10", "رحم");
+    await seedVerse("2:2", "رحم");
+
+    const res = await GET(req(), params("رحم"));
+    const body = await res.json();
+
+    expect(body.verses.map((v: { ref: string }) => v.ref)).toEqual(["2:2", "2:10", "10:1"]);
+  });
+});

--- a/app/api/root/[root]/route.ts
+++ b/app/api/root/[root]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { wordMorphology } from "@/lib/infra/db/schema";
 import { getVerses } from "@/lib/quran/quran-corpus";
@@ -22,10 +22,19 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ roo
 
   try {
     const rows = await db
-      .selectDistinct({ ref: wordMorphology.ref })
+      .select({ ref: wordMorphology.ref })
       .from(wordMorphology)
       .where(eq(wordMorphology.root, root))
-      .orderBy(wordMorphology.ref)
+      // GROUP BY instead of SELECT DISTINCT: Postgres requires DISTINCT's ORDER BY
+      // expressions to appear in the select list, but a GROUP BY key has no such
+      // restriction on functions of it. `ref` is "surah:ayah" text, so a plain
+      // orderBy(ref) sorts lexicographically ("10:1" before "2:1") — split and
+      // cast both halves to int for canonical (surah, ayah) order.
+      .groupBy(wordMorphology.ref)
+      .orderBy(
+        sql`split_part(${wordMorphology.ref}, ':', 1)::int`,
+        sql`split_part(${wordMorphology.ref}, ':', 2)::int`
+      )
       .limit(MAX_VERSES);
 
     const refs = rows.map((r) => r.ref);


### PR DESCRIPTION
## Summary

- `app/api/root/[root]/route.ts` sorted `word_morphology.ref` (a `text` column storing unpadded `"surah:ayah"` strings) with a plain `orderBy(wordMorphology.ref)` — a lexicographic string sort, so `"10:1"` sorted before `"2:1"` and, within a surah, `"2:10"` before `"2:2"`. Users browsing the "By Root" word-concordance popover saw verses scrambled out of canonical Quran order.
- Fix: split `ref` on `:` and cast both halves to `int` in the `ORDER BY`, so results come back in true (surah, ayah) order.
- Along the way: Postgres rejects an `ORDER BY` expression that isn't in the select list under `SELECT DISTINCT` (`for SELECT DISTINCT, ORDER BY expressions must appear in select list`) — caught by the new integration test against real Postgres, not by the mocked unit test. Switched the query from `selectDistinct` to `select` + `groupBy(ref)`, which has no such restriction on functions of the grouped column, while still deduplicating refs the same way.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (full suite, 1134 tests)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality
- [x] `bun run test:integration` passes locally (Testcontainers/Docker)

Added `__tests__/integration/root-concordance.integration.test.ts` against real Postgres, seeding refs `"10:1"`, `"2:10"`, `"2:2"` and asserting the response comes back as `["2:2", "2:10", "10:1"]` — this is the test that actually exercises the SQL and caught the `SELECT DISTINCT`/`ORDER BY` restriction, which a mocked unit test couldn't have (the existing `__tests__/api/root-concordance.test.ts` mocks the DB entirely and only pins the route's passthrough behavior, so its stale comment referencing this issue as unfixed was also updated).

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added
- [x] `README.md` updated if the feature changes the public interface

Closes #360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Root concordance results now appear in the correct numerical order by surah and ayah, instead of lexicographic text order.

* **Tests**
  * Added integration coverage to verify canonical verse ordering using a real database.
  * Updated API tests to reflect the revised query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->