### PR TITLE
fix(canvas): regenerate edge ids on node-id remap

### DIFF
--- a/__tests__/store/canvas.test.ts
+++ b/__tests__/store/canvas.test.ts
@@ -600,4 +600,68 @@ describe("appendWorkspace", () => {
     expect(s.getExpansionCounts(remappedId)).toEqual({ thematic: 1 });
     expect(s.getExpansionCounts(existingId)).toEqual({});
   });
+
+  it("regenerates edge ids on node-id remap, so a merged canvas never has two edges sharing an id (issue #474)", () => {
+    // Two canvases that both numbered nodes from scratch: both have an edge
+    // literally named "edge-node-1-node-2". Appending one into the other forces
+    // a node-id remap; the incoming edge's id must be regenerated from the new
+    // source/target, not carried forward, or it collides with the existing edge.
+    useCanvasStore.setState({
+      nodes: [
+        { id: "node-1", type: "verse", position: { x: 0, y: 0 }, data: { ...baseVerse } } as Node,
+        {
+          id: "node-2",
+          type: "verse",
+          position: { x: 300, y: 0 },
+          data: { ...baseVerse, ref: "1:1" as const, surah: 1, ayah: 1 },
+        } as Node,
+      ],
+      edges: [
+        {
+          id: "edge-node-1-node-2",
+          source: "node-1",
+          target: "node-2",
+          type: "hikmah",
+          data: { kind: "thematic", label: "", reason: "" },
+        } as Edge,
+      ],
+    });
+
+    useCanvasStore.getState().appendWorkspace({
+      v: 1,
+      nodes: [
+        {
+          id: "node-1",
+          x: 600,
+          y: 0,
+          verse: { ...baseVerse, ref: "112:1" as const, surah: 112, ayah: 1 },
+        },
+        {
+          id: "node-2",
+          x: 900,
+          y: 0,
+          verse: { ...baseVerse, ref: "3:18" as const, surah: 3, ayah: 18 },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-node-1-node-2",
+          source: "node-1",
+          target: "node-2",
+          kind: "root",
+          label: "",
+          reason: "",
+        },
+      ],
+    });
+
+    const s = useCanvasStore.getState();
+    expect(s.edges).toHaveLength(2);
+    const ids = s.edges.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    const incomingEdge = s.edges.find((e) => (e.data as { kind?: string })?.kind === "root")!;
+    expect(incomingEdge.id).not.toBe("edge-node-1-node-2");
+    expect(incomingEdge.id).toBe(`edge-${incomingEdge.source}-${incomingEdge.target}`);
+  });
 });

--- a/store/canvas.ts
+++ b/store/canvas.ts
@@ -358,11 +358,15 @@ export const useCanvasStore = create<CanvasStore>((set, get) => ({
     }
 
     const finalEdges = incomingEdges
-      .map((e) => ({
-        ...e,
-        source: idRemap.get(e.source) ?? e.source,
-        target: idRemap.get(e.target) ?? e.target,
-      }))
+      .map((e) => {
+        const source = idRemap.get(e.source) ?? e.source;
+        const target = idRemap.get(e.target) ?? e.target;
+        // Edge ids are derived from source/target (see buildConnectionEdge in
+        // lib/canvas/canvas-layout.ts) — regenerate on remap, or a remapped edge
+        // can collide with an unrelated edge of the same original id/formula
+        // already present in the destination canvas.
+        return { ...e, id: `edge-${source}-${target}`, source, target };
+      })
       .filter(
         (e) =>
           !get().edges.some(


### PR DESCRIPTION
## Summary

- `appendWorkspace` in `store/canvas.ts` merges a loaded/shared canvas into the current one. When an incoming node's id collides with an existing node, the node gets a fresh id (tracked in `idRemap`), and incoming edges have their `source`/`target` remapped accordingly — but the edge's `id` itself was spread forward unchanged from the pre-remap value.
- Edge ids are derived deterministically as `edge-${sourceNodeId}-${targetNodeId}` (see `buildConnectionEdge` in `lib/canvas/canvas-layout.ts`). Two canvases that both numbered nodes from scratch (both producing an edge literally named `edge-node-1-node-2`) could merge into two edges sharing the same `id` while pointing at different node pairs — violating React Flow's unique-id-per-edge requirement (`applyEdgeChanges` dispatches by `id`), which can cause silently-wrong edge updates/removals or a duplicate-key render bug.
- Fix: regenerate `id` from the (possibly remapped) `source`/`target` using the same formula, instead of carrying the original `id` forward.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (full suite, 1135 tests)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality

Added a test to `__tests__/store/canvas.test.ts` reproducing the exact two-canvas-merge collision scenario from the issue: an existing canvas with `node-1`/`node-2` and edge `edge-node-1-node-2`, merged with an incoming `SavedCanvas` that also has `node-1`/`node-2` and an edge of the same id — asserting all edges end up with unique ids, and that the incoming edge's regenerated id matches its actual (remapped) `source`/`target`.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added
- [x] `README.md` updated if the feature changes the public interface

Closes #474