### PR TITLE
fix(a11y): add missing main landmarks and h1s

### DIFF
--- a/app/names/[slug]/page.tsx
+++ b/app/names/[slug]/page.tsx
@@ -82,83 +82,92 @@ export default async function NameDetailPage({ params }: Props) {
         </Link>
       </header>
 
-      {/* Name hero */}
-      <div className="mx-auto max-w-3xl border-b border-border-subtle px-6 pt-14 pb-12 text-center">
-        <div className="mb-6 inline-block rounded border border-border bg-surface-raised px-2 py-1 font-mono text-xs text-text-muted">
-          {t("ofNinetyNine", { id: name.id })}
+      <main>
+        {/* Name hero */}
+        <div className="mx-auto max-w-3xl border-b border-border-subtle px-6 pt-14 pb-12 text-center">
+          <div className="mb-6 inline-block rounded border border-border bg-surface-raised px-2 py-1 font-mono text-xs text-text-muted">
+            {t("ofNinetyNine", { id: name.id })}
+          </div>
+
+          <h1 className="mb-3 font-arabic text-7xl" style={{ color: styles.accent }}>
+            {name.arabic}
+          </h1>
+
+          <p className="mb-2 font-mono text-xl text-text-primary">{name.transliteration}</p>
+
+          <p className="mb-6 text-lg text-text-secondary">{name.meaning}</p>
+
+          <div className="mb-6 flex flex-wrap items-center justify-center gap-3">
+            <span className={`rounded px-2.5 py-1 text-xs font-medium ${styles.badge}`}>
+              {t(categoryLabelKey)}
+            </span>
+            <span className="rounded border border-border bg-surface-raised px-2.5 py-1 font-mono text-xs text-text-secondary">
+              {t("root", { root: name.root })}
+            </span>
+          </div>
+
+          <p className="mx-auto max-w-xl text-sm leading-relaxed text-text-secondary">
+            {name.description}
+          </p>
         </div>
 
-        <h1 className="mb-3 font-arabic text-7xl" style={{ color: styles.accent }}>
-          {name.arabic}
-        </h1>
+        {/* Reflection + Pairings + Verses */}
+        <div className="max-w-3xl mx-auto px-6 py-10 space-y-10">
+          {/* Believer's Reflection */}
+          <NameReflection
+            slug={slug}
+            accent={styles.accent}
+            initialReflection={initialReflection}
+          />
 
-        <p className="mb-2 font-mono text-xl text-text-primary">{name.transliteration}</p>
+          {/* Structural Pairings */}
+          <NamePairings slug={slug} accent={styles.accent} initialPairings={initialPairings} />
 
-        <p className="mb-6 text-lg text-text-secondary">{name.meaning}</p>
-
-        <div className="mb-6 flex flex-wrap items-center justify-center gap-3">
-          <span className={`rounded px-2.5 py-1 text-xs font-medium ${styles.badge}`}>
-            {t(categoryLabelKey)}
-          </span>
-          <span className="rounded border border-border bg-surface-raised px-2.5 py-1 font-mono text-xs text-text-secondary">
-            {t("root", { root: name.root })}
-          </span>
+          {/* Verse Feed */}
+          <div>
+            <h2 className="mb-6 font-mono text-xs uppercase tracking-widest text-text-muted">
+              {t("versesHeading")}
+            </h2>
+            <NameVerses slug={slug} accent={styles.accent} />
+          </div>
         </div>
 
-        <p className="mx-auto max-w-xl text-sm leading-relaxed text-text-secondary">
-          {name.description}
-        </p>
-      </div>
+        {/* Name navigation */}
+        <div className="mx-auto flex max-w-3xl items-center justify-between border-t border-border-subtle px-6 py-6">
+          {prevName ? (
+            <Link
+              href={`/names/${prevName.slug}`}
+              className="group flex items-center gap-2 text-xs text-text-secondary transition-opacity hover:opacity-80"
+            >
+              <ArrowLeft className="h-3 w-3" />
+              <span className="font-arabic text-base text-text-muted">{prevName.arabic}</span>
+              <span>{prevName.transliteration}</span>
+            </Link>
+          ) : (
+            <span />
+          )}
 
-      {/* Reflection + Pairings + Verses */}
-      <div className="max-w-3xl mx-auto px-6 py-10 space-y-10">
-        {/* Believer's Reflection */}
-        <NameReflection slug={slug} accent={styles.accent} initialReflection={initialReflection} />
-
-        {/* Structural Pairings */}
-        <NamePairings slug={slug} accent={styles.accent} initialPairings={initialPairings} />
-
-        {/* Verse Feed */}
-        <div>
-          <h2 className="mb-6 font-mono text-xs uppercase tracking-widest text-text-muted">
-            {t("versesHeading")}
-          </h2>
-          <NameVerses slug={slug} accent={styles.accent} />
-        </div>
-      </div>
-
-      {/* Name navigation */}
-      <div className="mx-auto flex max-w-3xl items-center justify-between border-t border-border-subtle px-6 py-6">
-        {prevName ? (
           <Link
-            href={`/names/${prevName.slug}`}
-            className="group flex items-center gap-2 text-xs text-text-secondary transition-opacity hover:opacity-80"
+            href="/names"
+            className="text-xs text-text-muted transition-opacity hover:opacity-80"
           >
-            <ArrowLeft className="h-3 w-3" />
-            <span className="font-arabic text-base text-text-muted">{prevName.arabic}</span>
-            <span>{prevName.transliteration}</span>
+            {t("allNinetyNine")}
           </Link>
-        ) : (
-          <span />
-        )}
 
-        <Link href="/names" className="text-xs text-text-muted transition-opacity hover:opacity-80">
-          {t("allNinetyNine")}
-        </Link>
-
-        {nextName ? (
-          <Link
-            href={`/names/${nextName.slug}`}
-            className="group flex items-center gap-2 text-xs text-text-secondary transition-opacity hover:opacity-80"
-          >
-            <span>{nextName.transliteration}</span>
-            <span className="font-arabic text-base text-text-muted">{nextName.arabic}</span>
-            <ArrowRight className="h-3 w-3" />
-          </Link>
-        ) : (
-          <span />
-        )}
-      </div>
+          {nextName ? (
+            <Link
+              href={`/names/${nextName.slug}`}
+              className="group flex items-center gap-2 text-xs text-text-secondary transition-opacity hover:opacity-80"
+            >
+              <span>{nextName.transliteration}</span>
+              <span className="font-arabic text-base text-text-muted">{nextName.arabic}</span>
+              <ArrowRight className="h-3 w-3" />
+            </Link>
+          ) : (
+            <span />
+          )}
+        </div>
+      </main>
     </div>
   );
 }

--- a/app/names/page.tsx
+++ b/app/names/page.tsx
@@ -49,79 +49,81 @@ export default async function NamesPage() {
       <LandingHeader />
       <MobileNavBar />
 
-      {/* Hero */}
-      <div className="px-6 pt-12 pb-10 text-center border-b border-border-subtle">
-        <p className="text-xs uppercase tracking-[0.2em] font-mono mb-3 text-text-muted">
-          {t("eyebrow")}
-        </p>
-        <h1 className="font-arabic text-5xl mb-2 text-gold">أَسْمَاءُ اللَّه الْحُسْنَى</h1>
-        <p className="text-2xl font-light mb-4 text-text-primary">{t("heroTitle")}</p>
-        <p className="text-sm max-w-xl mx-auto text-text-secondary">{t("heroDescription")}</p>
+      <main>
+        {/* Hero */}
+        <div className="px-6 pt-12 pb-10 text-center border-b border-border-subtle">
+          <p className="text-xs uppercase tracking-[0.2em] font-mono mb-3 text-text-muted">
+            {t("eyebrow")}
+          </p>
+          <h1 className="font-arabic text-5xl mb-2 text-gold">أَسْمَاءُ اللَّه الْحُسْنَى</h1>
+          <p className="text-2xl font-light mb-4 text-text-primary">{t("heroTitle")}</p>
+          <p className="text-sm max-w-xl mx-auto text-text-secondary">{t("heroDescription")}</p>
 
-        {/* Legend */}
-        <div className="flex flex-wrap justify-center gap-4 mt-8">
-          {CATEGORY_ORDER.map((cat) => {
+          {/* Legend */}
+          <div className="flex flex-wrap justify-center gap-4 mt-8">
+            {CATEGORY_ORDER.map((cat) => {
+              const label = CATEGORY_LABELS[cat];
+              const labelKeys = CATEGORY_LABEL_KEYS[cat];
+              const colors = CATEGORY_COLORS[cat];
+              return (
+                <div key={cat} className="flex items-center gap-2 text-xs">
+                  <span className={`w-2 h-2 rounded-full ${colors.dot}`} />
+                  <span className="text-text-secondary">{t(labelKeys.label)}</span>
+                  <span className="font-arabic text-sm text-text-muted">{label.ar}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Names by category */}
+        <div className="max-w-6xl mx-auto px-6 py-12 space-y-16">
+          {byCategory.map(({ cat, names }) => {
             const label = CATEGORY_LABELS[cat];
             const labelKeys = CATEGORY_LABEL_KEYS[cat];
             const colors = CATEGORY_COLORS[cat];
             return (
-              <div key={cat} className="flex items-center gap-2 text-xs">
-                <span className={`w-2 h-2 rounded-full ${colors.dot}`} />
-                <span className="text-text-secondary">{t(labelKeys.label)}</span>
-                <span className="font-arabic text-sm text-text-muted">{label.ar}</span>
-              </div>
+              <section key={cat}>
+                {/* Category header */}
+                <div className="mb-6">
+                  <div className="flex items-center gap-3 mb-2">
+                    <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${colors.dot}`} />
+                    <h2 className="text-lg font-medium text-text-primary">{t(labelKeys.label)}</h2>
+                    <span className="font-arabic text-xl text-text-secondary">{label.ar}</span>
+                  </div>
+                  <p className="text-xs pl-5 text-text-muted">{t(labelKeys.description)}</p>
+                </div>
+
+                {/* Grid */}
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                  {names.map((name) => (
+                    <Link
+                      key={name.id}
+                      href={`/names/${name.slug}`}
+                      className="group rounded-lg border border-border bg-surface p-3 transition-all duration-200 hover:scale-[1.02] hover:border-gold"
+                    >
+                      <div className="font-arabic text-xl text-center mb-2 leading-relaxed text-text-primary">
+                        {name.arabic}
+                      </div>
+                      <div className="text-xs text-center font-mono mb-1 text-text-secondary">
+                        {name.transliteration}
+                      </div>
+                      <div className="text-xs text-center text-text-muted">{name.meaning}</div>
+                      <div className="mt-2 flex justify-center">
+                        <span
+                          className={`text-[10px] px-1.5 py-0.5 rounded font-mono ${colors.badge}`}
+                        >
+                          {name.root}
+                        </span>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </section>
             );
           })}
         </div>
-      </div>
-
-      {/* Names by category */}
-      <div className="max-w-6xl mx-auto px-6 py-12 space-y-16">
-        {byCategory.map(({ cat, names }) => {
-          const label = CATEGORY_LABELS[cat];
-          const labelKeys = CATEGORY_LABEL_KEYS[cat];
-          const colors = CATEGORY_COLORS[cat];
-          return (
-            <section key={cat}>
-              {/* Category header */}
-              <div className="mb-6">
-                <div className="flex items-center gap-3 mb-2">
-                  <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${colors.dot}`} />
-                  <h2 className="text-lg font-medium text-text-primary">{t(labelKeys.label)}</h2>
-                  <span className="font-arabic text-xl text-text-secondary">{label.ar}</span>
-                </div>
-                <p className="text-xs pl-5 text-text-muted">{t(labelKeys.description)}</p>
-              </div>
-
-              {/* Grid */}
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-                {names.map((name) => (
-                  <Link
-                    key={name.id}
-                    href={`/names/${name.slug}`}
-                    className="group rounded-lg border border-border bg-surface p-3 transition-all duration-200 hover:scale-[1.02] hover:border-gold"
-                  >
-                    <div className="font-arabic text-xl text-center mb-2 leading-relaxed text-text-primary">
-                      {name.arabic}
-                    </div>
-                    <div className="text-xs text-center font-mono mb-1 text-text-secondary">
-                      {name.transliteration}
-                    </div>
-                    <div className="text-xs text-center text-text-muted">{name.meaning}</div>
-                    <div className="mt-2 flex justify-center">
-                      <span
-                        className={`text-[10px] px-1.5 py-0.5 rounded font-mono ${colors.badge}`}
-                      >
-                        {name.root}
-                      </span>
-                    </div>
-                  </Link>
-                ))}
-              </div>
-            </section>
-          );
-        })}
-      </div>
+      </main>
 
       {/* Footer */}
       <footer className="text-center py-6 text-xs border-t border-border-subtle text-text-muted">

--- a/app/search/SearchPageClient.tsx
+++ b/app/search/SearchPageClient.tsx
@@ -163,7 +163,8 @@ export function SearchPageClient() {
       <LandingHeader />
       <MobileNavBar />
 
-      <div className="mx-auto w-full max-w-[800px] px-6 py-10">
+      <main className="mx-auto w-full max-w-[800px] px-6 py-10">
+        <h1 className="sr-only">{t("dialogTitle")}</h1>
         {/* Search bar */}
         <div className="mb-4 flex items-center gap-3">
           <Search className="h-4 w-4 shrink-0 text-text-muted" />
@@ -278,7 +279,7 @@ export function SearchPageClient() {
             />
           </>
         )}
-      </div>
+      </main>
     </div>
   );
 }

--- a/app/stories/page.tsx
+++ b/app/stories/page.tsx
@@ -19,37 +19,39 @@ export default async function StoriesPage() {
       <LandingHeader />
       <MobileNavBar />
 
-      <div className="px-6 pb-10 pt-12 text-center border-b border-border-subtle">
-        <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-text-muted">
-          {t("eyebrow")}
-        </p>
-        <h1 className="mb-4 text-2xl font-light text-text-primary">{t("heading")}</h1>
-        <p className="mx-auto max-w-xl text-sm text-text-secondary">{t("description")}</p>
-      </div>
+      <main>
+        <div className="px-6 pb-10 pt-12 text-center border-b border-border-subtle">
+          <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-text-muted">
+            {t("eyebrow")}
+          </p>
+          <h1 className="mb-4 text-2xl font-light text-text-primary">{t("heading")}</h1>
+          <p className="mx-auto max-w-xl text-sm text-text-secondary">{t("description")}</p>
+        </div>
 
-      <div className="mx-auto grid max-w-5xl gap-4 px-6 py-12 sm:grid-cols-2 lg:grid-cols-3">
-        {STORIES.map((story) => {
-          const verseCount = story.chapters.reduce((n, c) => n + c.verseRefs.length, 0);
-          return (
-            <Link
-              key={story.slug}
-              href={`/stories/${story.slug}`}
-              className="group rounded-lg border border-border bg-surface p-5 transition-all duration-200 hover:scale-[1.01] hover:border-gold"
-            >
-              <div className="mb-2 font-arabic text-3xl text-gold">{story.arabicName}</div>
-              <h2 className="text-lg font-medium text-text-primary">
-                {resolveLocalized(story.name, locale)}
-              </h2>
-              <p className="mt-1.5 text-sm text-text-secondary">
-                {resolveLocalized(story.tagline, locale)}
-              </p>
-              <p className="mt-3 text-xs text-text-muted">
-                {t("chapterVerseCount", { chapters: story.chapters.length, verses: verseCount })}
-              </p>
-            </Link>
-          );
-        })}
-      </div>
+        <div className="mx-auto grid max-w-5xl gap-4 px-6 py-12 sm:grid-cols-2 lg:grid-cols-3">
+          {STORIES.map((story) => {
+            const verseCount = story.chapters.reduce((n, c) => n + c.verseRefs.length, 0);
+            return (
+              <Link
+                key={story.slug}
+                href={`/stories/${story.slug}`}
+                className="group rounded-lg border border-border bg-surface p-5 transition-all duration-200 hover:scale-[1.01] hover:border-gold"
+              >
+                <div className="mb-2 font-arabic text-3xl text-gold">{story.arabicName}</div>
+                <h2 className="text-lg font-medium text-text-primary">
+                  {resolveLocalized(story.name, locale)}
+                </h2>
+                <p className="mt-1.5 text-sm text-text-secondary">
+                  {resolveLocalized(story.tagline, locale)}
+                </p>
+                <p className="mt-3 text-xs text-text-muted">
+                  {t("chapterVerseCount", { chapters: story.chapters.length, verses: verseCount })}
+                </p>
+              </Link>
+            );
+          })}
+        </div>
+      </main>
 
       <footer className="border-t border-border-subtle py-6 text-center text-xs text-text-muted">
         {t("footer")}

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -20,6 +20,7 @@ export const dynamic = "force-dynamic";
 
 export default async function TodayPage() {
   const t = await getTranslations("errors");
+  const tToday = await getTranslations("today");
   const edition = await getQuranEdition();
   const today = await getVerseOfDayWithReflection(undefined, edition).catch((err) => {
     console.error("Today: Verse of the Day load failed:", err);
@@ -32,6 +33,7 @@ export default async function TodayPage() {
       <MobileNavBar />
 
       <main className="mx-auto flex w-full max-w-[1180px] flex-1 flex-col items-center justify-center px-6 py-12 md:px-12">
+        <h1 className="sr-only">{tToday("verseOfTheDay")}</h1>
         {today ? (
           <VerseOfDayCard verse={today.verse} reflection={today.reflection ?? undefined} />
         ) : (


### PR DESCRIPTION
## Summary

- `/search`, `/names`, `/names/[slug]`, and `/stories` were missing a `<main>` landmark wrapping primary content — confirmed via `@axe-core/playwright` against production (`landmark-one-main`, `region` violations).
- `/today` was missing a level-one heading (`page-has-heading-one`) — it already has `<main>`, just no `<h1>`.
- Same class of issue as #150 (home page missing `<h1>`, already fixed), on five routes that fix never touched.
- Fix: wrap the existing primary-content JSX in `<main>` on the four landmark-missing routes (no visual/behavior change — pure semantic wrapper around already-existing markup). Add a visually-hidden `<h1>` on `/search` (`search.dialogTitle`) and `/today` (`today.verseOfTheDay`), matching the existing `sr-only` pattern already used in `components/home/AuthLoadingSkeleton.tsx`. `/names`, `/names/[slug]`, and `/stories` already had a visible `<h1>` — only the missing `<main>` needed fixing on those.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (full suite, 1134 tests — no test asserted on the absence of `<main>`, so this is purely additive)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality — n/a; `e2e/a11y.spec.ts` already scans all five affected routes (`landmark-one-main`/`page-has-heading-one` are currently "moderate" advisory-only violations there, not hard-failing), so no new e2e assertions are required per the issue's acceptance criteria — the existing scan should simply stop logging these advisories once this merges.
- [ ] Manually verified in a browser — **could not verify locally**: the dev server's maintenance-mode middleware queries Postgres on every request, and no local DB instance is running (only Testcontainers spin up ephemeral ones for `test:integration`). Verified statically instead: each of the 5 changed files now contains exactly one `<main>` and exactly one `<h1>` (confirmed via grep), and the diff only adds wrapping tags / one `sr-only` heading around already-existing, already-tested markup — no logic changed. Recommend a quick manual spot-check against a preview deploy, or re-running `e2e/a11y.spec.ts` in CI, to confirm the axe violations actually clear.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added
- [x] `README.md` updated if the feature changes the public interface

Closes #476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added semantic main content landmarks across name, search, stories, and daily verse pages.
  * Added visually hidden, localized page headings to improve screen-reader navigation.
  * Added a translated “Verse of the Day” heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->