### PR TITLE
fix(ci): retry Playwright system-deps install to fix flaky e2e timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
     name: E2E (Playwright)
     runs-on: ubuntu-latest
     needs: [lint-typecheck-test]
-    timeout-minutes: 20
+    timeout-minutes: 25
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -331,11 +331,19 @@ jobs:
 
       - name: Install Playwright browsers (with system deps)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: bunx playwright install --with-deps chromium
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 4
+          max_attempts: 3
+          command: bunx playwright install --with-deps chromium
 
       - name: Install Playwright system dependencies only
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: bunx playwright install-deps chromium
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 4
+          max_attempts: 3
+          command: bunx playwright install-deps chromium
 
       - name: E2E tests
         run: bun run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,7 @@ jobs:
 
       - name: Install Playwright browsers (with system deps)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 4
           max_attempts: 3
@@ -339,7 +339,7 @@ jobs:
 
       - name: Install Playwright system dependencies only
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 4
           max_attempts: 3


### PR DESCRIPTION
## Summary
- The `E2E (Playwright)` CI job intermittently (~1 in 12 runs, per `gh run list` sampling) hangs for the full 20-minute job timeout and gets cancelled, always at the same step: `bunx playwright install-deps chromium` (or `install --with-deps` on the cache-miss path). That step invokes `apt-get update` internally, which occasionally stalls indefinitely on a package-mirror fetch with zero output, no apt-level timeout, and no retry — confirmed via `gh run view --log-failed` on the last 3 cancelled runs, all identical.
- A healthy run completes the whole job, including this step, in ~6 minutes, so this is transient upstream network flakiness on GitHub-hosted runners, not anything in app/test code — nothing downstream (migrations, dev server, actual Playwright tests) is ever reached when it hangs.
- Wraps both apt-invoking install steps with `nick-fields/retry@v3` (4 min per attempt, 3 attempts) so a stalled attempt self-heals within minutes instead of exhausting the job. Bumps the job-level timeout from 20 to 25 minutes to keep headroom for the rest of the job on the retry path.

**New third-party GitHub Action dependency**: `nick-fields/retry@v3`, added to `.github/workflows/ci.yml` only (flagging per repo scope-discipline guardrails). Pinned to major version tag, consistent with how every other action in this workflow file is referenced.

No application code, Playwright config, or test files changed.

fixes: #496

## Test plan
- [x] YAML validated (`yaml.safe_load`)
- [x] `bun run test:ci` / typecheck passed via pre-commit hook
- [x] Integration tests passed via pre-push hook (Testcontainers)
- [ ] Confirm the `E2E (Playwright)` job on this PR completes normally (retry step should be a no-op on a healthy run, duration should stay ~6 min)
- [ ] Watch subsequent CI runs post-merge to confirm a stalled `apt-get` now retries and recovers instead of exhausting the job timeout (can't force-reproduce the upstream stall locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test reliability by adding retries to browser and system-dependency setup.
  * Increased the end-to-end test job timeout from 20 to 25 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->