### PR TITLE
Fix/social friends leaderboard bugs

### DIFF
--- a/__tests__/api/social/friends-friendId.test.ts
+++ b/__tests__/api/social/friends-friendId.test.ts
@@ -144,18 +144,19 @@ describe("PATCH /api/social/friends/[friendId]", () => {
     expect(whereJSON(whereCalls[0])).toContain("2");
   });
 
-  it("the addressee can decline a pending request", async () => {
+  it("the addressee can decline a pending request, deleting the row rather than soft-marking it", async () => {
     const addressee = makeUser({ id: 2 });
     authedAs(addressee);
     mockSelect.mockReturnValue(
       makeDbChain([{ id: 1, requesterId: 1, addresseeId: 2, status: "pending" }])
     );
-    mockUpdate.mockReturnValue(makeDbChain([{ id: 1, status: "declined" }]));
 
     const res = await PATCH(patchReq({ action: "decline" }), params());
 
     expect(res.status).toBe(200);
     expect((await res.json()).status).toBe("declined");
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   it("rejects the requester (or any non-addressee) trying to accept/decline their own outgoing request", async () => {

--- a/__tests__/api/social/friends-friendId.test.ts
+++ b/__tests__/api/social/friends-friendId.test.ts
@@ -150,6 +150,7 @@ describe("PATCH /api/social/friends/[friendId]", () => {
     mockSelect.mockReturnValue(
       makeDbChain([{ id: 1, requesterId: 1, addresseeId: 2, status: "pending" }])
     );
+    mockDelete.mockReturnValue(makeDbChain([{ id: 1 }]));
 
     const res = await PATCH(patchReq({ action: "decline" }), params());
 
@@ -157,6 +158,38 @@ describe("PATCH /api/social/friends/[friendId]", () => {
     expect((await res.json()).status).toBe("declined");
     expect(mockDelete).toHaveBeenCalled();
     expect(mockUpdate).not.toHaveBeenCalled();
+    // The delete itself must be re-scoped to status='pending' (not just the
+    // id looked up above) so a concurrent resolve can't be raced past.
+    expect(whereJSON(whereCalls[1])).toContain('"status"');
+  });
+
+  it("409s an accept that loses a race to a concurrent resolve, without dereferencing an empty update result", async () => {
+    // The initial read sees "pending", but by the time the UPDATE's own
+    // WHERE (id + addresseeId + status='pending') runs, a concurrent
+    // request already resolved it — .returning() comes back empty.
+    const addressee = makeUser({ id: 2 });
+    authedAs(addressee);
+    mockSelect.mockReturnValue(
+      makeDbChain([{ id: 1, requesterId: 1, addresseeId: 2, status: "pending" }])
+    );
+    mockUpdate.mockReturnValue(makeDbChain([]));
+
+    const res = await PATCH(patchReq({ action: "accept" }), params());
+
+    expect(res.status).toBe(409);
+  });
+
+  it("409s a decline that loses a race to a concurrent resolve, without treating zero deleted rows as success", async () => {
+    const addressee = makeUser({ id: 2 });
+    authedAs(addressee);
+    mockSelect.mockReturnValue(
+      makeDbChain([{ id: 1, requesterId: 1, addresseeId: 2, status: "pending" }])
+    );
+    mockDelete.mockReturnValue(makeDbChain([]));
+
+    const res = await PATCH(patchReq({ action: "decline" }), params());
+
+    expect(res.status).toBe(409);
   });
 
   it("rejects the requester (or any non-addressee) trying to accept/decline their own outgoing request", async () => {

--- a/__tests__/api/social/friends-pending-count.test.ts
+++ b/__tests__/api/social/friends-pending-count.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/infra/db/schema";
+
+vi.mock("@/lib/auth/social-auth", () => ({
+  requireUser: vi.fn(),
+}));
+
+function makeDbChain(resolveWith: unknown) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        if (prop === Symbol.toStringTag) return "MockChain";
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockSelect } = vi.hoisted(() => ({
+  mockSelect: vi.fn(),
+}));
+vi.mock("@/lib/infra/db", () => ({
+  db: { select: mockSelect },
+}));
+
+import { GET } from "@/app/api/social/friends/pending-count/route";
+import { requireUser } from "@/lib/auth/social-auth";
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    qfId: "qf-1",
+    username: "testuser",
+    displayName: null,
+    createdAt: new Date(),
+    lastActiveAt: new Date(),
+    currentStreak: 0,
+    longestStreak: 0,
+    lastActivityDate: null,
+    disabledAt: null,
+    ...overrides,
+  };
+}
+
+function authedAs(user: User) {
+  vi.mocked(requireUser).mockResolvedValue({ userId: user.id, user });
+}
+
+function makeReq() {
+  return new NextRequest("http://localhost/api/social/friends/pending-count", {
+    headers: { Authorization: "Bearer valid-token" },
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset();
+  mockSelect.mockReset();
+});
+
+describe("GET /api/social/friends/pending-count", () => {
+  it("401s when unauthorized", async () => {
+    vi.mocked(requireUser).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    );
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the raw DB count, not capped at any pagination limit", async () => {
+    // This is a direct COUNT query, not a fetch-and-filter over a page of
+    // rows — a user with more than one page's worth of pending requests
+    // (the old /api/social/friends?limit=200 approach could undercount past
+    // 200) must still get an accurate badge count.
+    authedAs(makeUser({ id: 1 }));
+    mockSelect.mockReturnValue(makeDbChain([{ count: 250 }]));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.count).toBe(250);
+  });
+
+  it("returns 0 when there are no pending requests", async () => {
+    authedAs(makeUser({ id: 1 }));
+    mockSelect.mockReturnValue(makeDbChain([{ count: 0 }]));
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.count).toBe(0);
+  });
+});

--- a/__tests__/api/social/friends.test.ts
+++ b/__tests__/api/social/friends.test.ts
@@ -32,10 +32,11 @@ function makeDbChain(resolveWith: unknown = []) {
   return chain;
 }
 
-const { mockSelect, mockInsert, mockUpdate, mockRateLimitOrNull } = vi.hoisted(() => ({
+const { mockSelect, mockInsert, mockUpdate, mockDelete, mockRateLimitOrNull } = vi.hoisted(() => ({
   mockSelect: vi.fn(() => makeDbChain([])),
   mockInsert: vi.fn(() => makeDbChain([])),
   mockUpdate: vi.fn(() => makeDbChain([])),
+  mockDelete: vi.fn(() => makeDbChain([])),
   mockRateLimitOrNull: vi.fn(async (): Promise<NextResponse | null> => null),
 }));
 
@@ -44,6 +45,7 @@ vi.mock("@/lib/infra/db", () => ({
     select: mockSelect,
     insert: mockInsert,
     update: mockUpdate,
+    delete: mockDelete,
   },
 }));
 vi.mock("@/lib/infra/rate-limit", () => ({
@@ -179,7 +181,7 @@ describe("GET /api/social/friends", () => {
     expect(body.items[0].friend.streak).toBe(0);
   });
 
-  it("shows the live streak for a friend active today or yesterday", async () => {
+  it("shows the live streak for a friend active today", async () => {
     authedAs(makeUser({ id: 1 }));
     const today = new Date().toISOString().slice(0, 10);
     mockSelect
@@ -195,6 +197,23 @@ describe("GET /api/social/friends", () => {
     const body = await res.json();
     expect(body.items[0].friend.streak).toBe(7);
   });
+
+  it("still shows the live streak for a friend last active yesterday (the decay boundary)", async () => {
+    authedAs(makeUser({ id: 1 }));
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    mockSelect
+      .mockReturnValueOnce(
+        makeDbChain([
+          { id: 1, requesterId: 1, addresseeId: 2, status: "accepted", createdAt: new Date() },
+        ])
+      )
+      .mockReturnValueOnce(
+        makeDbChain([{ id: 2, username: "friend2", currentStreak: 7, lastActivityDate: yesterday }])
+      );
+    const res = await GET(makeGetReq());
+    const body = await res.json();
+    expect(body.items[0].friend.streak).toBe(7);
+  });
 });
 
 describe("POST /api/social/friends", () => {
@@ -205,6 +224,7 @@ describe("POST /api/social/friends", () => {
       makeDbChain([{ id: 10, status: "pending", requesterId: 1, addresseeId: 2 }])
     );
     mockUpdate.mockReturnValue(makeDbChain([]));
+    mockDelete.mockReturnValue(makeDbChain([]));
     mockRateLimitOrNull.mockReset();
     mockRateLimitOrNull.mockResolvedValue(null);
   });
@@ -272,6 +292,24 @@ describe("POST /api/social/friends", () => {
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error).toMatch(/already friends/i);
+  });
+
+  it("re-requesting after a historical declined row deletes it and inserts fresh (not a 409)", async () => {
+    // Declines are deleted going forward (see PATCH .../[friendId]), but a
+    // "declined" row can still exist from before that change shipped. It
+    // must not collide with the unique (requesterId, addresseeId) index.
+    authedAs(makeUser({ id: 1 }));
+    mockSelect
+      .mockReturnValueOnce(makeDbChain([{ id: 2, username: "friend99" }]))
+      .mockReturnValueOnce(makeDbChain([{ id: 10, status: "declined", requesterId: 1 }]));
+    mockInsert.mockReturnValue(
+      makeDbChain([{ id: 11, status: "pending", requesterId: 1, addresseeId: 2 }])
+    );
+    const res = await POST(makePostReq({ username: "friend99" }));
+    expect(mockDelete).toHaveBeenCalled();
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.status).toBe("pending");
   });
 
   it("returns 409 when an outgoing request is already pending", async () => {

--- a/__tests__/api/social/friends.test.ts
+++ b/__tests__/api/social/friends.test.ts
@@ -156,6 +156,45 @@ describe("GET /api/social/friends", () => {
     expect(body.items).toHaveLength(1);
     expect(body.hasMore).toBe(false);
   });
+
+  it("shows the decayed streak (0), not the stale stored value, for a broken streak", async () => {
+    // Same decay rule as the leaderboard route: a friend's currentStreak is
+    // only real while lastActivityDate is today or yesterday. Without
+    // applying effectiveStreak here, this friend would show a stale nonzero
+    // streak in the Friends tab that disagrees with the Leaderboard tab.
+    authedAs(makeUser({ id: 1 }));
+    mockSelect
+      .mockReturnValueOnce(
+        makeDbChain([
+          { id: 1, requesterId: 1, addresseeId: 2, status: "accepted", createdAt: new Date() },
+        ])
+      )
+      .mockReturnValueOnce(
+        makeDbChain([
+          { id: 2, username: "friend2", currentStreak: 7, lastActivityDate: "2000-01-01" },
+        ])
+      );
+    const res = await GET(makeGetReq());
+    const body = await res.json();
+    expect(body.items[0].friend.streak).toBe(0);
+  });
+
+  it("shows the live streak for a friend active today or yesterday", async () => {
+    authedAs(makeUser({ id: 1 }));
+    const today = new Date().toISOString().slice(0, 10);
+    mockSelect
+      .mockReturnValueOnce(
+        makeDbChain([
+          { id: 1, requesterId: 1, addresseeId: 2, status: "accepted", createdAt: new Date() },
+        ])
+      )
+      .mockReturnValueOnce(
+        makeDbChain([{ id: 2, username: "friend2", currentStreak: 7, lastActivityDate: today }])
+      );
+    const res = await GET(makeGetReq());
+    const body = await res.json();
+    expect(body.items[0].friend.streak).toBe(7);
+  });
 });
 
 describe("POST /api/social/friends", () => {

--- a/__tests__/components/layout/Header.polling-failure.test.tsx
+++ b/__tests__/components/layout/Header.polling-failure.test.tsx
@@ -40,17 +40,7 @@ describe("Header — polling badges survive a transient failure", () => {
           mockFetch.mock.calls.filter((c) => String(c[0]).startsWith("/api/social/friends"))
             .length === 1
         ) {
-          return Promise.resolve(
-            new Response(
-              JSON.stringify({
-                items: [
-                  { status: "pending", direction: "received" },
-                  { status: "pending", direction: "received" },
-                ],
-              }),
-              { status: 200 }
-            )
-          );
+          return Promise.resolve(new Response(JSON.stringify({ count: 2 }), { status: 200 }));
         }
         return Promise.resolve(new Response(null, { status: 500 }));
       }

--- a/__tests__/hooks/usePaginatedSocialList.test.ts
+++ b/__tests__/hooks/usePaginatedSocialList.test.ts
@@ -204,4 +204,26 @@ describe("usePaginatedSocialList", () => {
 
     await waitFor(() => expect(onData).toHaveBeenCalledWith(page(0, 2, false).items));
   });
+
+  it("calls onData with the complete combined list after loadMore appends a page", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("offset=2")) {
+        return Promise.resolve(new Response(JSON.stringify(page(2, 2, false)), { status: 200 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify(page(0, 2, true)), { status: 200 }));
+    });
+    const onData = vi.fn();
+
+    const { result } = renderHook(() =>
+      usePaginatedSocialList<Item>({ accessToken: "t", enabled: true, baseUrl: "/api/x", onData })
+    );
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+    onData.mockClear();
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(onData).toHaveBeenCalledWith(page(0, 4, false).items);
+  });
 });

--- a/__tests__/hooks/usePaginatedSocialList.test.ts
+++ b/__tests__/hooks/usePaginatedSocialList.test.ts
@@ -126,6 +126,74 @@ describe("usePaginatedSocialList", () => {
     expect(result.current.items).toEqual([]);
   });
 
+  it("ignores a stale response that lands after a newer overlapping request already resolved", async () => {
+    // The mock fetch below doesn't honor AbortSignal the way a real fetch
+    // does, so calling .abort() on the stale request's controller doesn't
+    // stop its promise from eventually resolving — this exercises the
+    // isCurrent() guard, which is what actually protects state here.
+    let resolveStale!: (r: Response) => void;
+    let resolveFresh!: (r: Response) => void;
+    mockFetch
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveStale = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFresh = resolve;
+          })
+      );
+
+    const { result } = renderHook(() =>
+      usePaginatedSocialList<Item>({ accessToken: "t", enabled: false, baseUrl: "/api/x" })
+    );
+
+    let p1!: Promise<void>;
+    let p2!: Promise<void>;
+    act(() => {
+      p1 = result.current.refresh();
+      p2 = result.current.refresh();
+    });
+
+    // The fresh (second) request resolves first; the stale (first) request's
+    // response lands afterward and must not overwrite it.
+    await act(async () => {
+      resolveFresh(new Response(JSON.stringify(page(0, 1, false)), { status: 200 }));
+      await p2;
+      resolveStale(new Response(JSON.stringify(page(0, 9, false)), { status: 200 }));
+      await p1;
+    });
+
+    expect(result.current.items).toHaveLength(1);
+  });
+
+  it("sets error on a loadMore failure and clears it on a subsequent successful retry", async () => {
+    mockFetch
+      .mockResolvedValueOnce(new Response(JSON.stringify(page(0, 2, true)), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(page(2, 2, false)), { status: 200 }));
+
+    const { result } = renderHook(() =>
+      usePaginatedSocialList<Item>({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+    );
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+    expect(result.current.error).toBe(true);
+    expect(result.current.items).toHaveLength(2);
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+    expect(result.current.error).toBe(false);
+    expect(result.current.items).toHaveLength(4);
+  });
+
   it("calls onData with each successfully replaced page", async () => {
     mockFetch.mockResolvedValue(new Response(JSON.stringify(page(0, 2, false)), { status: 200 }));
     const onData = vi.fn();

--- a/__tests__/hooks/usePaginatedSocialList.test.ts
+++ b/__tests__/hooks/usePaginatedSocialList.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { usePaginatedSocialList } from "@/hooks/usePaginatedSocialList";
+
+interface Item {
+  id: number;
+}
+
+function page(offset: number, count: number, hasMore: boolean) {
+  return {
+    items: Array.from({ length: count }, (_, i): Item => ({ id: offset + i + 1 })),
+    hasMore,
+  };
+}
+
+describe("usePaginatedSocialList", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches the base URL on mount when enabled", async () => {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify(page(0, 2, true)), { status: 200 }));
+
+    const { result } = renderHook(() =>
+      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/x",
+      expect.objectContaining({ headers: { Authorization: "Bearer t" } })
+    );
+    expect(result.current.items).toHaveLength(2);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("does not fetch when disabled or missing a token", () => {
+    renderHook(() =>
+      usePaginatedSocialList({ accessToken: null, enabled: true, baseUrl: "/api/x" })
+    );
+    renderHook(() =>
+      usePaginatedSocialList({ accessToken: "t", enabled: false, baseUrl: "/api/x" })
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("loadMore appends items via an offset query and preserves earlier ones", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("offset=2")) {
+        return Promise.resolve(new Response(JSON.stringify(page(2, 2, false)), { status: 200 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify(page(0, 2, true)), { status: 200 }));
+    });
+
+    const { result } = renderHook(() =>
+      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+    );
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(result.current.items).toHaveLength(4);
+    expect(result.current.items.map((i) => i.id)).toEqual([1, 2, 3, 4]);
+    expect(result.current.hasMore).toBe(false);
+    expect(mockFetch).toHaveBeenCalledWith("/api/x?offset=2", expect.anything());
+  });
+
+  it("refresh re-requests count+1 items (the newest-first buffer) and replaces the list", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("limit=3")) {
+        return Promise.resolve(new Response(JSON.stringify(page(0, 3, false)), { status: 200 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify(page(0, 2, true)), { status: 200 }));
+    });
+
+    const { result } = renderHook(() =>
+      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+    );
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/x?limit=3", expect.anything());
+    expect(result.current.items).toHaveLength(3);
+  });
+
+  it("sets error and clears loading on a non-ok response, without touching items", async () => {
+    mockFetch.mockResolvedValue(new Response(null, { status: 500 }));
+
+    const { result } = renderHook(() =>
+      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+    );
+
+    await waitFor(() => expect(result.current.error).toBe(true));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it("a request cancelled via AbortController does not set an error", async () => {
+    // Simulates what a real `fetch` does when its signal fires: rejects with
+    // a DOMException named "AbortError". A superseded (cancelled) request
+    // must be treated as neither success nor failure — not surfaced as an
+    // error banner just because it lost the race to a newer request.
+    const abortError = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+    });
+    mockFetch.mockRejectedValue(abortError);
+
+    const { result } = renderHook(() =>
+      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe(false);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it("calls onData with each successfully replaced page", async () => {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify(page(0, 2, false)), { status: 200 }));
+    const onData = vi.fn();
+
+    renderHook(() =>
+      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x", onData })
+    );
+
+    await waitFor(() => expect(onData).toHaveBeenCalledWith(page(0, 2, false).items));
+  });
+});

--- a/__tests__/hooks/usePaginatedSocialList.test.ts
+++ b/__tests__/hooks/usePaginatedSocialList.test.ts
@@ -29,7 +29,7 @@ describe("usePaginatedSocialList", () => {
     mockFetch.mockResolvedValue(new Response(JSON.stringify(page(0, 2, true)), { status: 200 }));
 
     const { result } = renderHook(() =>
-      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+      usePaginatedSocialList<Item>({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
     );
 
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -43,10 +43,10 @@ describe("usePaginatedSocialList", () => {
 
   it("does not fetch when disabled or missing a token", () => {
     renderHook(() =>
-      usePaginatedSocialList({ accessToken: null, enabled: true, baseUrl: "/api/x" })
+      usePaginatedSocialList<Item>({ accessToken: null, enabled: true, baseUrl: "/api/x" })
     );
     renderHook(() =>
-      usePaginatedSocialList({ accessToken: "t", enabled: false, baseUrl: "/api/x" })
+      usePaginatedSocialList<Item>({ accessToken: "t", enabled: false, baseUrl: "/api/x" })
     );
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -60,7 +60,7 @@ describe("usePaginatedSocialList", () => {
     });
 
     const { result } = renderHook(() =>
-      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+      usePaginatedSocialList<Item>({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
     );
     await waitFor(() => expect(result.current.items).toHaveLength(2));
 
@@ -83,7 +83,7 @@ describe("usePaginatedSocialList", () => {
     });
 
     const { result } = renderHook(() =>
-      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+      usePaginatedSocialList<Item>({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
     );
     await waitFor(() => expect(result.current.items).toHaveLength(2));
 
@@ -99,7 +99,7 @@ describe("usePaginatedSocialList", () => {
     mockFetch.mockResolvedValue(new Response(null, { status: 500 }));
 
     const { result } = renderHook(() =>
-      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+      usePaginatedSocialList<Item>({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
     );
 
     await waitFor(() => expect(result.current.error).toBe(true));
@@ -118,7 +118,7 @@ describe("usePaginatedSocialList", () => {
     mockFetch.mockRejectedValue(abortError);
 
     const { result } = renderHook(() =>
-      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
+      usePaginatedSocialList<Item>({ accessToken: "t", enabled: true, baseUrl: "/api/x" })
     );
 
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -131,7 +131,7 @@ describe("usePaginatedSocialList", () => {
     const onData = vi.fn();
 
     renderHook(() =>
-      usePaginatedSocialList({ accessToken: "t", enabled: true, baseUrl: "/api/x", onData })
+      usePaginatedSocialList<Item>({ accessToken: "t", enabled: true, baseUrl: "/api/x", onData })
     );
 
     await waitFor(() => expect(onData).toHaveBeenCalledWith(page(0, 2, false).items));

--- a/__tests__/lib/social/friends.test.ts
+++ b/__tests__/lib/social/friends.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { countPendingReceived } from "@/lib/social/friends";
+
+describe("countPendingReceived", () => {
+  it("returns 0 for an empty list", () => {
+    expect(countPendingReceived([])).toBe(0);
+  });
+
+  it("counts only pending+received entries", () => {
+    const friends = [
+      { status: "pending", direction: "received" },
+      { status: "pending", direction: "sent" },
+      { status: "accepted", direction: "received" },
+      { status: "pending", direction: "received" },
+    ];
+    expect(countPendingReceived(friends)).toBe(2);
+  });
+
+  it("ignores entries missing status/direction", () => {
+    expect(countPendingReceived([{}, { status: "pending" }, { direction: "received" }])).toBe(0);
+  });
+});

--- a/app/api/social/friends/[friendId]/route.ts
+++ b/app/api/social/friends/[friendId]/route.ts
@@ -46,9 +46,17 @@ export async function PATCH(
     return NextResponse.json({ error: "Request already resolved" }, { status: 409 });
   }
 
+  if (action === "decline") {
+    // Declines are deleted outright rather than kept as a "declined" row —
+    // a re-request after a decline should look identical to a first-time
+    // request, and nothing reads declined history.
+    await db.delete(friendships).where(eq(friendships.id, friendshipId));
+    return NextResponse.json({ id: friendshipId, status: "declined" });
+  }
+
   const [updated] = await db
     .update(friendships)
-    .set({ status: action === "accept" ? "accepted" : "declined", updatedAt: new Date() })
+    .set({ status: "accepted", updatedAt: new Date() })
     .where(eq(friendships.id, friendshipId))
     .returning();
 

--- a/app/api/social/friends/[friendId]/route.ts
+++ b/app/api/social/friends/[friendId]/route.ts
@@ -46,19 +46,36 @@ export async function PATCH(
     return NextResponse.json({ error: "Request already resolved" }, { status: 409 });
   }
 
+  // Re-check `status = "pending"` in the mutation's own WHERE (not just the
+  // read above) so two concurrent accept/decline calls can't both pass the
+  // read and then both mutate — whichever loses the race affects zero rows
+  // and gets a 409 instead of silently succeeding or throwing on a missing row.
+  const pendingGuard = and(
+    eq(friendships.id, friendshipId),
+    eq(friendships.addresseeId, userId),
+    eq(friendships.status, "pending")
+  );
+
   if (action === "decline") {
     // Declines are deleted outright rather than kept as a "declined" row —
     // a re-request after a decline should look identical to a first-time
     // request, and nothing reads declined history.
-    await db.delete(friendships).where(eq(friendships.id, friendshipId));
+    const deleted = await db.delete(friendships).where(pendingGuard).returning();
+    if (deleted.length === 0) {
+      return NextResponse.json({ error: "Request already resolved" }, { status: 409 });
+    }
     return NextResponse.json({ id: friendshipId, status: "declined" });
   }
 
   const [updated] = await db
     .update(friendships)
     .set({ status: "accepted", updatedAt: new Date() })
-    .where(eq(friendships.id, friendshipId))
+    .where(pendingGuard)
     .returning();
+
+  if (!updated) {
+    return NextResponse.json({ error: "Request already resolved" }, { status: 409 });
+  }
 
   return NextResponse.json({ id: updated.id, status: updated.status });
 }

--- a/app/api/social/friends/pending-count/route.ts
+++ b/app/api/social/friends/pending-count/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/infra/db";
+import { friendships } from "@/lib/infra/db/schema";
+import { requireUser } from "@/lib/auth/social-auth";
+
+export async function GET(req: NextRequest) {
+  const authed = await requireUser(req);
+  if (authed instanceof NextResponse) return authed;
+
+  const { userId } = authed;
+
+  // A direct COUNT, not a fetch-and-filter over a page of friendship rows —
+  // the badge must reflect every pending request, not just however many fit
+  // under a pagination limit.
+  const [{ count }] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(friendships)
+    .where(and(eq(friendships.addresseeId, userId), eq(friendships.status, "pending")));
+
+  return NextResponse.json({ count });
+}

--- a/app/api/social/friends/route.ts
+++ b/app/api/social/friends/route.ts
@@ -153,9 +153,11 @@ export async function POST(req: NextRequest) {
       }
       return NextResponse.json({ error: "Request already sent" }, { status: 409 });
     }
-    // Declined friendships are deleted (see PATCH .../[friendId]), so a
-    // "declined" status here should be unreachable — kept as a defensive
-    // fallthrough to the fresh-insert path below rather than a silent no-op.
+    // A "declined" row here is historical data from before declines were
+    // deleted outright (see PATCH .../[friendId]) — remove it first so it
+    // can't collide with the unique (requesterId, addresseeId) index below;
+    // a fresh request should behave identically to a first-time request.
+    await db.delete(friendships).where(eq(friendships.id, existing.id));
   }
 
   try {

--- a/app/api/social/friends/route.ts
+++ b/app/api/social/friends/route.ts
@@ -5,6 +5,7 @@ import { friendships, users } from "@/lib/infra/db/schema";
 import { requireUser } from "@/lib/auth/social-auth";
 import { rateLimitOrNull } from "@/lib/infra/rate-limit";
 import { isUniqueViolation, parsePagination } from "@/lib/infra/http";
+import { effectiveStreak } from "@/lib/social/streak";
 
 export async function GET(req: NextRequest) {
   const authed = await requireUser(req);
@@ -21,10 +22,8 @@ export async function GET(req: NextRequest) {
       addresseeId: friendships.addresseeId,
       status: friendships.status,
       createdAt: friendships.createdAt,
-      requesterUsername: users.username,
     })
     .from(friendships)
-    .innerJoin(users, eq(users.id, friendships.requesterId))
     .where(or(eq(friendships.requesterId, userId), eq(friendships.addresseeId, userId)))
     .orderBy(desc(friendships.createdAt))
     .limit(limit + 1)
@@ -39,7 +38,12 @@ export async function GET(req: NextRequest) {
   const friendUsers =
     friendIds.length > 0
       ? await db
-          .select({ id: users.id, username: users.username, currentStreak: users.currentStreak })
+          .select({
+            id: users.id,
+            username: users.username,
+            currentStreak: users.currentStreak,
+            lastActivityDate: users.lastActivityDate,
+          })
           .from(users)
           .where(
             friendIds.length === 1
@@ -58,7 +62,11 @@ export async function GET(req: NextRequest) {
       status: r.status,
       direction: r.requesterId === userId ? "sent" : "received",
       friend: friend
-        ? { id: friend.id, username: friend.username, streak: friend.currentStreak }
+        ? {
+            id: friend.id,
+            username: friend.username,
+            streak: effectiveStreak(friend.currentStreak, friend.lastActivityDate),
+          }
         : null,
       createdAt: r.createdAt,
     };
@@ -145,18 +153,9 @@ export async function POST(req: NextRequest) {
       }
       return NextResponse.json({ error: "Request already sent" }, { status: 409 });
     }
-    // A previously declined request — re-open it as a fresh outgoing request.
-    const [reopened] = await db
-      .update(friendships)
-      .set({
-        requesterId: userId,
-        addresseeId: target.id,
-        status: "pending",
-        updatedAt: new Date(),
-      })
-      .where(eq(friendships.id, existing.id))
-      .returning();
-    return NextResponse.json({ id: reopened.id, status: reopened.status, friend }, { status: 201 });
+    // Declined friendships are deleted (see PATCH .../[friendId]), so a
+    // "declined" status here should be unreachable — kept as a defensive
+    // fallthrough to the fresh-insert path below rather than a silent no-op.
   }
 
   try {

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -15,14 +15,27 @@ import type { Suggestion } from "@/components/social/ChallengeSuggestions";
 import { Loader2, Users, Trophy, Swords } from "lucide-react";
 import Link from "next/link";
 import { AuthShell } from "@/components/layout/AuthShell";
+import { usePaginatedSocialList } from "@/hooks/usePaginatedSocialList";
+import { countPendingReceived } from "@/lib/social/friends";
 
 type Tab = "friends" | "leaderboard" | "challenges";
 
-/** Count of incoming pending friend requests — drives the friends badge. */
-function countPendingReceived(friends: unknown[]): number {
-  return (friends as { status?: string; direction?: string }[]).filter(
-    (f) => f.status === "pending" && f.direction === "received"
-  ).length;
+interface FriendEntry {
+  id: number;
+  status: "pending" | "accepted" | "declined";
+  direction: "sent" | "received";
+  friend: { id: number; username: string; streak: number } | null;
+  createdAt: string;
+}
+
+interface LeaderboardEntry {
+  rank: number;
+  id: number;
+  username: string;
+  displayName: string | null;
+  streak: number;
+  longestStreak: number;
+  isYou: boolean;
 }
 
 /** Count of incoming challenges awaiting my response — drives the challenges badge. */
@@ -40,12 +53,6 @@ export default function SocialPage() {
   const pendingChallengeCount = useSocialStore((s) => s.pendingChallengeCount);
 
   const [tab, setTab] = useState<Tab>("leaderboard");
-  const [friends, setFriends] = useState<unknown[]>([]);
-  const [friendsHasMore, setFriendsHasMore] = useState(false);
-  const [loadingMoreFriends, setLoadingMoreFriends] = useState(false);
-  const [leaderboard, setLeaderboard] = useState<unknown[]>([]);
-  const [leaderboardHasMore, setLeaderboardHasMore] = useState(false);
-  const [loadingMoreLeaderboard, setLoadingMoreLeaderboard] = useState(false);
   const [challengesList, setChallengesList] = useState<EnrichedChallenge[]>([]);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [prefill, setPrefill] = useState<ChallengePrefill | null>(null);
@@ -55,17 +62,43 @@ export default function SocialPage() {
   // run (or has just run) and its `finally` always clears these. Defaulting to
   // false let the empty-state UI (e.g. "Add friends to see them here.") flash
   // for one frame before the real data arrived.
-  const [loadingFriends, setLoadingFriends] = useState(true);
-  const [loadingLeaderboard, setLoadingLeaderboard] = useState(true);
   const [loadingChallenges, setLoadingChallenges] = useState(true);
   // Tracked per section (not one shared flag) — otherwise a later-resolving
   // fetch that succeeds would clear the banner even though a different
   // section actually failed and is showing stale/missing data.
-  const [friendsError, setFriendsError] = useState(false);
-  const [leaderboardError, setLeaderboardError] = useState(false);
   const [challengesError, setChallengesError] = useState(false);
-  const loadError = friendsError || leaderboardError || challengesError;
   const [profileTimedOut, setProfileTimedOut] = useState(false);
+
+  const {
+    items: friends,
+    hasMore: friendsHasMore,
+    loading: loadingFriends,
+    loadingMore: loadingMoreFriends,
+    error: friendsError,
+    refresh: fetchFriends,
+    loadMore: loadMoreFriends,
+  } = usePaginatedSocialList<FriendEntry>({
+    accessToken,
+    enabled: !!userId,
+    baseUrl: "/api/social/friends",
+    onData: (items) => setPendingFriendCount(countPendingReceived(items)),
+  });
+
+  const {
+    items: leaderboard,
+    hasMore: leaderboardHasMore,
+    loading: loadingLeaderboard,
+    loadingMore: loadingMoreLeaderboard,
+    error: leaderboardError,
+    refresh: fetchLeaderboard,
+    loadMore: loadMoreLeaderboard,
+  } = usePaginatedSocialList<LeaderboardEntry>({
+    accessToken,
+    enabled: !!userId,
+    baseUrl: "/api/social/leaderboard",
+  });
+
+  const loadError = friendsError || leaderboardError || challengesError;
 
   // Picking a suggestion seeds the create form (remounted via key) and clears on send.
   const pickSuggestion = (s: Suggestion) => {
@@ -81,103 +114,6 @@ export default function SocialPage() {
     setPrefill(null);
     setPrefillKey((k) => k + 1);
   };
-
-  const fetchFriends = useCallback(async () => {
-    if (!accessToken) return;
-    setLoadingFriends(true);
-    try {
-      // Re-fetch the same number of items already loaded (via "Load more")
-      // instead of always resetting to the first page — otherwise an
-      // unrelated friend action (accept/decline/remove) would silently
-      // discard any extra pages the user had loaded. +1 covers a request
-      // just sent (AddFriendForm's onAdded also calls this): rows are
-      // ordered newest-first, so without the buffer the new row would push
-      // the previously-last-visible friend out of the re-fetched count.
-      const url =
-        friends.length > 0
-          ? `/api/social/friends?limit=${friends.length + 1}`
-          : "/api/social/friends";
-      const res = await fetch(url, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      });
-      if (res.ok) {
-        const data: { items: unknown[]; hasMore: boolean } = await res.json();
-        setFriends(data.items);
-        setFriendsHasMore(data.hasMore);
-        // Keep the header badge in sync immediately after any friend action.
-        setPendingFriendCount(countPendingReceived(data.items));
-        setFriendsError(false);
-      } else {
-        setFriendsError(true);
-      }
-    } catch {
-      setFriendsError(true);
-    } finally {
-      setLoadingFriends(false);
-    }
-  }, [accessToken, friends.length, setPendingFriendCount]);
-
-  const loadMoreFriends = useCallback(async () => {
-    if (!accessToken || loadingMoreFriends) return;
-    setLoadingMoreFriends(true);
-    try {
-      const res = await fetch(`/api/social/friends?offset=${friends.length}`, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      });
-      if (res.ok) {
-        const data: { items: unknown[]; hasMore: boolean } = await res.json();
-        setFriends((prev) => [...prev, ...data.items]);
-        setFriendsHasMore(data.hasMore);
-      }
-    } finally {
-      setLoadingMoreFriends(false);
-    }
-  }, [accessToken, friends.length, loadingMoreFriends]);
-
-  const fetchLeaderboard = useCallback(async () => {
-    if (!accessToken) return;
-    setLoadingLeaderboard(true);
-    try {
-      // Same reasoning as fetchFriends (including the +1 buffer — a new
-      // friend also adds a leaderboard entry).
-      const url =
-        leaderboard.length > 0
-          ? `/api/social/leaderboard?limit=${leaderboard.length + 1}`
-          : "/api/social/leaderboard";
-      const res = await fetch(url, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      });
-      if (res.ok) {
-        const data: { items: unknown[]; hasMore: boolean } = await res.json();
-        setLeaderboard(data.items);
-        setLeaderboardHasMore(data.hasMore);
-        setLeaderboardError(false);
-      } else {
-        setLeaderboardError(true);
-      }
-    } catch {
-      setLeaderboardError(true);
-    } finally {
-      setLoadingLeaderboard(false);
-    }
-  }, [accessToken, leaderboard.length]);
-
-  const loadMoreLeaderboard = useCallback(async () => {
-    if (!accessToken || loadingMoreLeaderboard) return;
-    setLoadingMoreLeaderboard(true);
-    try {
-      const res = await fetch(`/api/social/leaderboard?offset=${leaderboard.length}`, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      });
-      if (res.ok) {
-        const data: { items: unknown[]; hasMore: boolean } = await res.json();
-        setLeaderboard((prev) => [...prev, ...data.items]);
-        setLeaderboardHasMore(data.hasMore);
-      }
-    } finally {
-      setLoadingMoreLeaderboard(false);
-    }
-  }, [accessToken, leaderboard.length, loadingMoreLeaderboard]);
 
   const fetchChallenges = useCallback(async () => {
     if (!accessToken) return;
@@ -230,30 +166,6 @@ export default function SocialPage() {
     const { signal } = ctrl;
 
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLoadingFriends(true);
-    fetch("/api/social/friends", { headers: { Authorization: `Bearer ${accessToken}` }, signal })
-      .then((r) => (r.ok ? r.json() : { items: [], hasMore: false }))
-      .then((data: { items: unknown[]; hasMore: boolean }) => {
-        setFriends(data.items);
-        setFriendsHasMore(data.hasMore);
-        setPendingFriendCount(countPendingReceived(data.items));
-      })
-      .catch((e) => console.error("social: friends fetch failed", e))
-      .finally(() => setLoadingFriends(false));
-
-    setLoadingLeaderboard(true);
-    fetch("/api/social/leaderboard", {
-      headers: { Authorization: `Bearer ${accessToken}` },
-      signal,
-    })
-      .then((r) => (r.ok ? r.json() : { items: [], hasMore: false }))
-      .then((data: { items: unknown[]; hasMore: boolean }) => {
-        setLeaderboard(data.items);
-        setLeaderboardHasMore(data.hasMore);
-      })
-      .catch((e) => console.error("social: leaderboard fetch failed", e))
-      .finally(() => setLoadingLeaderboard(false));
-
     setLoadingChallenges(true);
     fetch("/api/social/challenges", { headers: { Authorization: `Bearer ${accessToken}` }, signal })
       .then((r) => (r.ok ? r.json() : []))
@@ -273,7 +185,7 @@ export default function SocialPage() {
       .catch((e) => console.error("social: challenge-suggestions fetch failed", e));
 
     return () => ctrl.abort();
-  }, [accessToken, userId, setPendingFriendCount, setPendingChallengeCount]);
+  }, [accessToken, userId, setPendingChallengeCount]);
 
   return (
     <AuthShell>
@@ -361,7 +273,7 @@ export default function SocialPage() {
                 ) : (
                   <>
                     <FriendList
-                      friends={friends as Parameters<typeof FriendList>[0]["friends"]}
+                      friends={friends}
                       onUpdate={() => {
                         fetchFriends();
                         fetchLeaderboard();
@@ -388,9 +300,7 @@ export default function SocialPage() {
                 <ChallengeSuggestions suggestions={suggestions} onPick={pickSuggestion} />
                 <CreateChallengeForm
                   key={prefillKey}
-                  friends={(
-                    friends as { status: string; friend: { id: number; username: string } | null }[]
-                  )
+                  friends={friends
                     .filter((f) => f.status === "accepted" && f.friend)
                     .map((f) => f.friend!)}
                   loadingFriends={loadingFriends}
@@ -425,9 +335,7 @@ export default function SocialPage() {
                     <Loader2 className="h-4 w-4 animate-spin text-teal" />
                   </div>
                 ) : (
-                  <LeaderboardTable
-                    entries={leaderboard as Parameters<typeof LeaderboardTable>[0]["entries"]}
-                  />
+                  <LeaderboardTable entries={leaderboard} />
                 )}
                 {!loadingLeaderboard && leaderboardHasMore && (
                   <div className="flex justify-center pt-2">

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -20,8 +20,6 @@ import { useCanvasStore, serializeCanvas } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
 import { useAudioStore } from "@/store/audio";
-import { countPendingReceived } from "@/lib/social/friends";
-import { MAX_LIMIT } from "@/lib/infra/http";
 import type { AudioVerse } from "@/store/audio";
 import type { Verse } from "@/types/quran";
 import { buildShareUrl } from "@/hooks/useCanvasPersistence";
@@ -239,20 +237,20 @@ export function Header({ onSearchOpen }: HeaderProps) {
   // Poll for incoming friend requests every 60 s while signed in
   useEffect(() => {
     if (!accessToken || !userId) return;
-    // Use the pagination max rather than the default page size: this poll
-    // only needs an accurate pending-request count, and defaulting to a
-    // small page could undercount for a user with many friends.
+    // A dedicated COUNT endpoint, not a page of friendship rows filtered
+    // client-side — a user with more pending requests than any single page
+    // would otherwise have their badge silently undercount.
     const load = () =>
-      fetch(`/api/social/friends?limit=${MAX_LIMIT}`, {
+      fetch("/api/social/friends/pending-count", {
         headers: { Authorization: `Bearer ${accessToken}` },
       })
         // A failed poll keeps the previously-displayed count rather than
         // resetting it to 0 — a transient 5xx/network hiccup shouldn't make
         // an already-shown badge disappear.
         .then((r) => (r.ok ? r.json() : null))
-        .then((data: { items: { status: string; direction: string }[] } | null) => {
+        .then((data: { count: number } | null) => {
           if (!data) return;
-          setPendingFriendCount(countPendingReceived(data.items));
+          setPendingFriendCount(data.count);
         })
         .catch((e) => console.error("header: friend-request poll failed", e));
     load();

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -20,6 +20,8 @@ import { useCanvasStore, serializeCanvas } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
 import { useAudioStore } from "@/store/audio";
+import { countPendingReceived } from "@/lib/social/friends";
+import { MAX_LIMIT } from "@/lib/infra/http";
 import type { AudioVerse } from "@/store/audio";
 import type { Verse } from "@/types/quran";
 import { buildShareUrl } from "@/hooks/useCanvasPersistence";
@@ -237,11 +239,11 @@ export function Header({ onSearchOpen }: HeaderProps) {
   // Poll for incoming friend requests every 60 s while signed in
   useEffect(() => {
     if (!accessToken || !userId) return;
-    // limit=200 (the pagination max) rather than the default page size: this
-    // poll only needs an accurate pending-request count, and defaulting to a
+    // Use the pagination max rather than the default page size: this poll
+    // only needs an accurate pending-request count, and defaulting to a
     // small page could undercount for a user with many friends.
     const load = () =>
-      fetch("/api/social/friends?limit=200", {
+      fetch(`/api/social/friends?limit=${MAX_LIMIT}`, {
         headers: { Authorization: `Bearer ${accessToken}` },
       })
         // A failed poll keeps the previously-displayed count rather than
@@ -250,10 +252,7 @@ export function Header({ onSearchOpen }: HeaderProps) {
         .then((r) => (r.ok ? r.json() : null))
         .then((data: { items: { status: string; direction: string }[] } | null) => {
           if (!data) return;
-          const count = data.items.filter(
-            (f) => f.status === "pending" && f.direction === "received"
-          ).length;
-          setPendingFriendCount(count);
+          setPendingFriendCount(countPendingReceived(data.items));
         })
         .catch((e) => console.error("header: friend-request poll failed", e));
     load();

--- a/hooks/usePaginatedSocialList.ts
+++ b/hooks/usePaginatedSocialList.ts
@@ -78,7 +78,9 @@ export function usePaginatedSocialList<T>({ accessToken, enabled, baseUrl, onDat
           setItems(data.items);
           onDataRef.current?.(data.items);
         } else {
-          setItems((prev) => [...prev, ...data.items]);
+          const combined = [...itemsRef.current, ...data.items];
+          setItems(combined);
+          onDataRef.current?.(combined);
         }
         setHasMore(data.hasMore);
         setError(false);
@@ -111,8 +113,7 @@ export function usePaginatedSocialList<T>({ accessToken, enabled, baseUrl, onDat
     if (!enabled || !accessToken) return;
     refresh();
     return () => abortRef.current?.abort();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, accessToken, baseUrl]);
+  }, [enabled, accessToken, baseUrl, refresh]);
 
   return { items, hasMore, loading, loadingMore, error, refresh, loadMore };
 }

--- a/hooks/usePaginatedSocialList.ts
+++ b/hooks/usePaginatedSocialList.ts
@@ -37,10 +37,16 @@ export function usePaginatedSocialList<T>({ accessToken, enabled, baseUrl, onDat
   const [error, setError] = useState(false);
 
   const itemsRef = useRef(items);
-  itemsRef.current = items;
   const abortRef = useRef<AbortController | null>(null);
   const onDataRef = useRef(onData);
-  onDataRef.current = onData;
+
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  useEffect(() => {
+    onDataRef.current = onData;
+  }, [onData]);
 
   const runFetch = useCallback(
     async (url: string, mode: "replace" | "append") => {

--- a/hooks/usePaginatedSocialList.ts
+++ b/hooks/usePaginatedSocialList.ts
@@ -54,6 +54,11 @@ export function usePaginatedSocialList<T>({ accessToken, enabled, baseUrl, onDat
       abortRef.current?.abort();
       const ctrl = new AbortController();
       abortRef.current = ctrl;
+      // Aborting the previous controller doesn't retroactively cancel a
+      // request whose response already landed on the wire — only whichever
+      // request is still the current one may apply its result to state,
+      // so an out-of-order resolution can't clobber a newer request's data.
+      const isCurrent = () => abortRef.current === ctrl;
 
       if (mode === "replace") setLoading(true);
       else setLoadingMore(true);
@@ -62,25 +67,30 @@ export function usePaginatedSocialList<T>({ accessToken, enabled, baseUrl, onDat
           headers: { Authorization: `Bearer ${accessToken}` },
           signal: ctrl.signal,
         });
+        if (!isCurrent()) return;
         if (!res.ok) {
-          if (mode === "replace") setError(true);
+          setError(true);
           return;
         }
         const data: PagedResponse<T> = await res.json();
+        if (!isCurrent()) return;
         if (mode === "replace") {
           setItems(data.items);
           onDataRef.current?.(data.items);
-          setError(false);
         } else {
           setItems((prev) => [...prev, ...data.items]);
         }
         setHasMore(data.hasMore);
+        setError(false);
       } catch (e) {
         if ((e as { name?: string }).name === "AbortError") return;
-        if (mode === "replace") setError(true);
+        if (!isCurrent()) return;
+        setError(true);
       } finally {
-        if (mode === "replace") setLoading(false);
-        else setLoadingMore(false);
+        if (isCurrent()) {
+          if (mode === "replace") setLoading(false);
+          else setLoadingMore(false);
+        }
       }
     },
     [accessToken]

--- a/hooks/usePaginatedSocialList.ts
+++ b/hooks/usePaginatedSocialList.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface PagedResponse<T> {
+  items: T[];
+  hasMore: boolean;
+}
+
+interface Options<T> {
+  /** Bearer token; fetching is skipped entirely while this is falsy. */
+  accessToken: string | null;
+  /** Extra gate on top of `accessToken` (e.g. the profile hasn't resolved yet). */
+  enabled: boolean;
+  /** Builds the endpoint URL for a given `limit`/`offset` query string, e.g. `/api/social/friends`. */
+  baseUrl: string;
+  /** Called with each successful page's items — for side effects like updating a badge count. */
+  onData?: (items: T[]) => void;
+}
+
+/**
+ * Shared paginated-list fetching for the Friends and Leaderboard tabs. Both
+ * lists are refetched wholesale (not patched in place) after any mutation, so
+ * `refresh()` re-requests the same number of rows already loaded — plus one,
+ * since rows are ordered newest-first and a just-created row would otherwise
+ * push the previously-last-visible row out of the re-fetched count. There's
+ * no cursor-based "give me back what I had, refreshed" API, so this buffer is
+ * the refresh contract; centralized here instead of duplicated per list.
+ *
+ * All fetches are cancelled via AbortController when superseded, so rapid
+ * mutations (e.g. accepting two requests back to back) can't resolve out of
+ * order and leave stale data in state.
+ */
+export function usePaginatedSocialList<T>({ accessToken, enabled, baseUrl, onData }: Options<T>) {
+  const [items, setItems] = useState<T[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState(false);
+
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const abortRef = useRef<AbortController | null>(null);
+  const onDataRef = useRef(onData);
+  onDataRef.current = onData;
+
+  const runFetch = useCallback(
+    async (url: string, mode: "replace" | "append") => {
+      if (!accessToken) return;
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+
+      if (mode === "replace") setLoading(true);
+      else setLoadingMore(true);
+      try {
+        const res = await fetch(url, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          signal: ctrl.signal,
+        });
+        if (!res.ok) {
+          if (mode === "replace") setError(true);
+          return;
+        }
+        const data: PagedResponse<T> = await res.json();
+        if (mode === "replace") {
+          setItems(data.items);
+          onDataRef.current?.(data.items);
+          setError(false);
+        } else {
+          setItems((prev) => [...prev, ...data.items]);
+        }
+        setHasMore(data.hasMore);
+      } catch (e) {
+        if ((e as { name?: string }).name === "AbortError") return;
+        if (mode === "replace") setError(true);
+      } finally {
+        if (mode === "replace") setLoading(false);
+        else setLoadingMore(false);
+      }
+    },
+    [accessToken]
+  );
+
+  const refresh = useCallback(() => {
+    const count = itemsRef.current.length;
+    const url = count > 0 ? `${baseUrl}?limit=${count + 1}` : baseUrl;
+    return runFetch(url, "replace");
+  }, [baseUrl, runFetch]);
+
+  const loadMore = useCallback(() => {
+    if (loadingMore) return Promise.resolve();
+    return runFetch(`${baseUrl}?offset=${itemsRef.current.length}`, "append");
+  }, [baseUrl, loadingMore, runFetch]);
+
+  useEffect(() => {
+    if (!enabled || !accessToken) return;
+    refresh();
+    return () => abortRef.current?.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, accessToken, baseUrl]);
+
+  return { items, hasMore, loading, loadingMore, error, refresh, loadMore };
+}

--- a/lib/infra/http.ts
+++ b/lib/infra/http.ts
@@ -61,7 +61,7 @@ export interface Pagination {
 }
 
 const DEFAULT_LIMIT = 50;
-export const MAX_LIMIT = 200;
+const MAX_LIMIT = 200;
 
 /**
  * Parses and clamps `limit`/`offset` query params for list endpoints.

--- a/lib/infra/http.ts
+++ b/lib/infra/http.ts
@@ -61,7 +61,7 @@ export interface Pagination {
 }
 
 const DEFAULT_LIMIT = 50;
-const MAX_LIMIT = 200;
+export const MAX_LIMIT = 200;
 
 /**
  * Parses and clamps `limit`/`offset` query params for list endpoints.

--- a/lib/social/friends.ts
+++ b/lib/social/friends.ts
@@ -1,0 +1,9 @@
+interface PendingCountable {
+  status?: string;
+  direction?: string;
+}
+
+/** Count of incoming pending friend requests — drives the friends badge. */
+export function countPendingReceived(friends: PendingCountable[]): number {
+  return friends.filter((f) => f.status === "pending" && f.direction === "received").length;
+}


### PR DESCRIPTION


* **New Features**
  * Added smoother pagination, refresh, loading, and error handling for friends and leaderboard lists.
  * Added accurate pending friend-request counts.
  * Added streak handling that resets inactive friends’ streaks while preserving active streaks.

* **Bug Fixes**
  * Declining a friend request now removes it instead of retaining a declined record.
  * New requests can be sent again after a previous request was declined.

* **Tests**
  * Expanded coverage for friend requests, streak behavior, and pending-request counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smoother pagination, refreshing, and loading states for friends and leaderboard lists.
  * Added accurate pending friend-request counts for notification indicators.
* **Bug Fixes**
  * Friend streaks now preserve activity correctly around daily decay boundaries.
  * Declined requests can be sent again without conflicts.
  * Concurrent accept or decline actions now resolve safely with an appropriate conflict response.
  * Friend-request badges remain accurate during temporary polling failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->