### PR TITLE
refactor: update api, quran, search for __tests__, app, and lib

### DIFF
--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -411,11 +411,28 @@ describe("GET /api/search", () => {
       expect(mockFetch).toHaveBeenCalled();
     });
 
-    it("lists every surah matching a partial name, in ascending order", async () => {
+    it("lists every surah matching a partial name, in ascending order, alongside verse results", async () => {
+      mockFetch.mockResolvedValueOnce(
+        quranComResponse([{ verse_key: "2:30", translations: [{ text: "..." }] }])
+      );
       const res = await GET(makeSearchReq("ba"));
       const body = await res.json();
       expect(body.matchedSurahs.map((s: { number: number }) => s.number)).toEqual([2, 90, 98]);
-      expect(mockFetch).not.toHaveBeenCalled();
+      expect(body.results).toHaveLength(1);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it("surfaces a partial surah-name prefix match alongside keyword search (regression: 'sa' must not suppress verse results)", async () => {
+      mockFetch.mockResolvedValueOnce(
+        quranComResponse([{ verse_key: "1:1", translations: [{ text: "In the name of Allah" }] }])
+      );
+      const res = await GET(makeSearchReq("sa"));
+      const body = await res.json();
+      expect(body.matchedSurahs.map((s: { number: number }) => s.number)).toEqual([
+        32, 34, 37, 38, 61,
+      ]);
+      expect(body.results).toHaveLength(1);
+      expect(mockFetch).toHaveBeenCalled();
     });
 
     it("passes the caller's UI locale to the localized chapter-name fetch", async () => {

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -435,6 +435,28 @@ describe("GET /api/search", () => {
       expect(mockFetch).toHaveBeenCalled();
     });
 
+    it("returns a matchedSurahs payload with no ayah results for Surah 38 (Sad)'s single-character canonical Arabic name", async () => {
+      const res = await GET(makeSearchReq("ص"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results).toEqual([]);
+      expect(body.matchedSurahs).toEqual([
+        { number: 38, name: "Sad", nameArabic: "ص", ayahCount: 88 },
+      ]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns a matchedSurahs payload with no ayah results for Surah 50 (Qaf)'s single-character canonical Arabic name", async () => {
+      const res = await GET(makeSearchReq("ق"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results).toEqual([]);
+      expect(body.matchedSurahs).toEqual([
+        { number: 50, name: "Qaf", nameArabic: "ق", ayahCount: 45 },
+      ]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it("passes the caller's UI locale to the localized chapter-name fetch", async () => {
       mockGetUiLocale.mockResolvedValue("tr");
       await GET(makeSearchReq("kahf"));

--- a/__tests__/app/search/SearchPageClient.test.tsx
+++ b/__tests__/app/search/SearchPageClient.test.tsx
@@ -340,3 +340,71 @@ describe("SearchPageClient — related-by-meaning results", () => {
     expect(screen.getByText("Related by meaning")).toBeInTheDocument();
   });
 });
+
+describe("SearchPageClient — matched-surah results", () => {
+  const mockFetch = vi.fn();
+  const matchedSurah = { number: 34, name: "Saba", nameArabic: "سبأ", ayahCount: 54 };
+  const verseResult = {
+    ref: "1:1",
+    surahName: "Al-Fatiha",
+    surahNameArabic: "الفاتحة",
+    snippet: "In the name of Allah.",
+    arabicText: "بِسْمِ اللَّهِ",
+    translation: "In the name of Allah.",
+  };
+
+  beforeEach(() => {
+    mockSearchParams = new URLSearchParams({ q: "sa" });
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders both the matched-surah section and verse results when the response has both", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: [verseResult],
+          total: 1,
+          page: 1,
+          pageSize: 20,
+          matchedSurahs: [matchedSurah],
+        }),
+        { status: 200 }
+      )
+    );
+
+    await act(async () => {
+      renderWithIntl(<SearchPageClient />);
+    });
+
+    expect(screen.getByText(matchedSurah.name)).toBeInTheDocument();
+    expect(screen.getByText(verseResult.translation)).toBeInTheDocument();
+    expect(screen.queryByText(/no exact matches/i)).not.toBeInTheDocument();
+  });
+
+  it("renders only the matched-surah section, with no 'no exact matches' empty state, when there are no verse results", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: [],
+          total: 0,
+          page: 1,
+          pageSize: 20,
+          matchedSurahs: [matchedSurah],
+        }),
+        { status: 200 }
+      )
+    );
+
+    await act(async () => {
+      renderWithIntl(<SearchPageClient />);
+    });
+
+    expect(screen.getByText(matchedSurah.name)).toBeInTheDocument();
+    expect(screen.queryByText(/no exact matches/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/quran/surah-names.test.ts
+++ b/__tests__/lib/quran/surah-names.test.ts
@@ -105,6 +105,19 @@ describe("matchSurahsByQuery", () => {
     expect(matchSurahsByQuery("b")).toEqual([]);
   });
 
+  it("matches Surah 38 (Sad) by its single-character canonical Arabic name, below the general minimum length", () => {
+    expect(matchSurahsByQuery("ص")).toEqual([38]);
+  });
+
+  it("matches Surah 50 (Qaf) by its single-character canonical Arabic name, below the general minimum length", () => {
+    expect(matchSurahsByQuery("ق")).toEqual([50]);
+  });
+
+  it("still rejects a single-character query that isn't a canonical single-character Arabic name", () => {
+    expect(matchSurahsByQuery("a")).toEqual([]);
+    expect(matchSurahsByQuery("ا")).toEqual([]);
+  });
+
   it("lists every surah whose name starts with a short partial query, in ascending order", () => {
     // Al-Baqarah (2), Al-Balad (90), Al-Bayyinah (98) — all start with "ba"
     // once their Al-/An- style prefix is stripped.
@@ -161,5 +174,13 @@ describe("isExactSurahNameMatch", () => {
 
   it("is false when matchedNumbers is empty", () => {
     expect(isExactSurahNameMatch("kahf", [])).toBe(false);
+  });
+
+  it("is true for Surah 38 (Sad)'s single-character canonical Arabic name", () => {
+    expect(isExactSurahNameMatch("ص", [38])).toBe(true);
+  });
+
+  it("is true for Surah 50 (Qaf)'s single-character canonical Arabic name", () => {
+    expect(isExactSurahNameMatch("ق", [50])).toBe(true);
   });
 });

--- a/__tests__/lib/quran/surah-names.test.ts
+++ b/__tests__/lib/quran/surah-names.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { SURAH_NAMES, getSurahName, matchSurahsByQuery } from "@/lib/quran/surah-names";
+import {
+  SURAH_NAMES,
+  getSurahName,
+  matchSurahsByQuery,
+  isExactSurahNameMatch,
+} from "@/lib/quran/surah-names";
 
 describe("SURAH_NAMES", () => {
   it("contains exactly 114 entries", () => {
@@ -124,5 +129,37 @@ describe("matchSurahsByQuery", () => {
   it("matches against the localizedNames entry's own surah number, not a hardcoded one", () => {
     const localized = new Map([[5, "Kehf"]]); // deliberately not surah 18
     expect(matchSurahsByQuery("Kehf", localized)).toEqual([5]);
+  });
+});
+
+describe("isExactSurahNameMatch", () => {
+  it("is true for a bare transliteration equal to the full name", () => {
+    expect(isExactSurahNameMatch("kahf", [18])).toBe(true);
+  });
+
+  it("is true for the full hyphenated name", () => {
+    expect(isExactSurahNameMatch("Al-Fatiha", [1])).toBe(true);
+  });
+
+  it("is true for an exact Arabic name match", () => {
+    expect(isExactSurahNameMatch("الكهف", [18])).toBe(true);
+  });
+
+  it("is true for an exact localized name match", () => {
+    const localized = new Map([[18, "Пещера"]]);
+    expect(isExactSurahNameMatch("Пещера", [18], localized)).toBe(true);
+  });
+
+  it("is false for a short prefix that only partially matches several names", () => {
+    // "ba" only starts Al-Baqarah/Al-Balad/Al-Bayyinah, it isn't equal to any of them.
+    expect(isExactSurahNameMatch("ba", [2, 90, 98])).toBe(false);
+  });
+
+  it("is false for a prefix match of a single surah", () => {
+    expect(isExactSurahNameMatch("sa", [34, 37, 38, 61])).toBe(false);
+  });
+
+  it("is false when matchedNumbers is empty", () => {
+    expect(isExactSurahNameMatch("kahf", [])).toBe(false);
   });
 });

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { MatchedSurah, SearchResponse, SearchResult, VerseRef } from "@/types/quran";
-import { getSurahName, matchSurahsByQuery } from "@/lib/quran/surah-names";
+import { getSurahName, isExactSurahNameMatch, matchSurahsByQuery } from "@/lib/quran/surah-names";
 import { fetchLocalizedChapterNames } from "@/lib/quran/chapters";
 import { SURAH_LENGTHS } from "@/lib/quran/audio";
 import { searchByMeaning, type SemanticMatch } from "@/lib/quran/semantic-search";
@@ -170,19 +170,20 @@ export async function GET(req: NextRequest) {
 
   const edition = await getQuranEdition();
 
-  // A query matching a surah name (fully or as a prefix, e.g. "kahf" or "ba")
-  // surfaces the matching surah(s) as their own result — not a list of
-  // individual ayah snippets — so the user can listen to or read one start to
-  // finish. Matches the English name, Arabic name, and (for non-English UI
-  // locales) the localized chapter name. See matchSurahsByQuery.
+  // A query that exactly matches a surah name (e.g. "kahf" or "Al-Fatiha", as
+  // opposed to a short ambiguous prefix like "sa" or "ba") surfaces the
+  // matching surah(s) as their own result — not a list of individual ayah
+  // snippets — so the user can listen to or read one start to finish.
+  // Matches the English name, Arabic name, and (for non-English UI locales)
+  // the localized chapter name. See matchSurahsByQuery/isExactSurahNameMatch.
   const uiLocale = await getUiLocale();
   const localizedNames = await fetchLocalizedChapterNames(uiLocale);
   const matchedSurahNumbers = matchSurahsByQuery(q, localizedNames);
-  if (matchedSurahNumbers.length > 0) {
-    const matchedSurahs: MatchedSurah[] = matchedSurahNumbers.map((num) => {
-      const [name, nameArabic] = getSurahName(num);
-      return { number: num, name, nameArabic, ayahCount: SURAH_LENGTHS[num - 1] };
-    });
+  const matchedSurahs: MatchedSurah[] = matchedSurahNumbers.map((num) => {
+    const [name, nameArabic] = getSurahName(num);
+    return { number: num, name, nameArabic, ayahCount: SURAH_LENGTHS[num - 1] };
+  });
+  if (matchedSurahs.length > 0 && isExactSurahNameMatch(q, matchedSurahNumbers, localizedNames)) {
     const response: SearchResponse = {
       results: [],
       total: 0,
@@ -250,6 +251,7 @@ export async function GET(req: NextRequest) {
     page,
     pageSize,
     ...(related.length > 0 ? { related } : {}),
+    ...(matchedSurahs.length > 0 ? { matchedSurahs } : {}),
   };
   await maybeLogSearchQuery(req, q, "keyword", total);
   if (related.length > 0) {

--- a/app/search/SearchPageClient.tsx
+++ b/app/search/SearchPageClient.tsx
@@ -204,15 +204,8 @@ export function SearchPageClient() {
           <div className="py-20 text-center">
             <p className="text-sm text-text-muted">{t("somethingWentWrong")}</p>
           </div>
-        ) : data?.matchedSurahs && data.matchedSurahs.length === 1 ? (
-          <SurahResultCard surah={data.matchedSurahs[0]} />
-        ) : data?.matchedSurahs && data.matchedSurahs.length > 1 ? (
-          <div className="space-y-2">
-            {data.matchedSurahs.map((surah) => (
-              <SurahListItem key={surah.number} surah={surah} />
-            ))}
-          </div>
-        ) : !data || (data.results.length === 0 && !data.related?.length) ? (
+        ) : !data ||
+          (!data.matchedSurahs?.length && data.results.length === 0 && !data.related?.length) ? (
           <div className="py-20 text-center">
             <BookOpen className="mx-auto mb-4 h-8 w-8 text-text-muted/40" />
             <p className="text-sm text-text-muted">
@@ -234,6 +227,17 @@ export function SearchPageClient() {
           </div>
         ) : (
           <>
+            {data.matchedSurahs && data.matchedSurahs.length === 1 ? (
+              <div className="mb-8">
+                <SurahResultCard surah={data.matchedSurahs[0]} />
+              </div>
+            ) : data.matchedSurahs && data.matchedSurahs.length > 1 ? (
+              <div className="mb-8 space-y-2">
+                {data.matchedSurahs.map((surah) => (
+                  <SurahListItem key={surah.number} surah={surah} />
+                ))}
+              </div>
+            ) : null}
             {data.results.length > 0 ? (
               <>
                 <p className="mb-4 text-sm text-text-muted">

--- a/lib/quran/surah-names.ts
+++ b/lib/quran/surah-names.ts
@@ -151,7 +151,17 @@ const MIN_QUERY_LENGTH = 2;
  */
 export function matchSurahsByQuery(query: string, localizedNames?: Map<number, string>): number[] {
   const genericQuery = normalizeGeneric(query);
-  if (genericQuery.length < MIN_QUERY_LENGTH) return [];
+  if (genericQuery.length < MIN_QUERY_LENGTH) {
+    // Below the general prefix-matching minimum, only allow an exact hit
+    // against a surah's canonical Arabic name — two surahs (Sad "ص", Qaf "ق")
+    // have single-character canonical Arabic names, which the two-character
+    // minimum would otherwise make permanently unsearchable by their own name.
+    const exactSingleCharMatch = Object.entries(SURAH_NAMES).find(
+      ([, [, arabicName]]) =>
+        genericQuery.length > 0 && normalizeGeneric(arabicName) === genericQuery
+    );
+    return exactSingleCharMatch ? [parseInt(exactSingleCharMatch[0], 10)] : [];
+  }
   // Empty when the query is pure non-Latin script (e.g. Arabic/Cyrillic) —
   // skip the English-side check entirely rather than let an empty prefix
   // match every surah.

--- a/lib/quran/surah-names.ts
+++ b/lib/quran/surah-names.ts
@@ -171,3 +171,28 @@ export function matchSurahsByQuery(query: string, localizedNames?: Map<number, s
   }
   return matches;
 }
+
+/**
+ * True if `query` exactly equals (not just prefixes) the English, Arabic, or
+ * localized name of at least one of `matchedNumbers` — the "kahf" / "Al-Fatiha"
+ * case where the user's intent is unambiguous, vs. a short prefix like "sa"
+ * that merely starts several names and shouldn't suppress verse search.
+ */
+export function isExactSurahNameMatch(
+  query: string,
+  matchedNumbers: number[],
+  localizedNames?: Map<number, string>
+): boolean {
+  const genericQuery = normalizeGeneric(query);
+  const englishQuery = normalizeSurahName(query);
+
+  return matchedNumbers.some((num) => {
+    const [englishName, arabicName] = SURAH_NAMES[num] ?? ["", ""];
+    const localizedName = localizedNames?.get(num);
+    return (
+      (englishQuery.length > 0 && normalizeSurahName(englishName) === englishQuery) ||
+      normalizeGeneric(arabicName) === genericQuery ||
+      (!!localizedName && normalizeGeneric(localizedName) === genericQuery)
+    );
+  });
+}


### PR DESCRIPTION
## Summary

<!-- 1–3 bullet points: what changed and why -->

-
-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

<!-- Complete this section if you modified any Claude prompts, divine name data, or verse connection logic. Leave blank otherwise. -->

- [ ] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below
- [ ] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)

**Details** (if applicable):
<!-- Describe any changes to prompts, expected output format, or theological framing. Note any deviations from or additions to the Maturidi/Hanafi tradition. -->

## Testing

- [ ] `bun run test:ci` passes locally
- [ ] `bun run typecheck` passes locally
- [ ] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [ ] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Conventional commits
- [ ] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now show matching surahs alongside relevant verse results and related content.
  * Partial surah-name searches no longer hide keyword verse results.
  * Exact matches are recognized across English, Arabic, transliterated, hyphenated, and localized surah names.
  * Improved handling of single and multiple surah matches in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->