### PR TITLE
fix(ci): scope main's concurrency group by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,12 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  # Scope by commit SHA for pushes to main so that back-to-back merges (e.g.
+  # several Dependabot auto-merges landing within one CI run's duration) don't
+  # cancel each other's run before it finishes — every merge to main should get
+  # a completed CI record. PR branches keep the ref-scoped group: a superseding
+  # push there really does make the prior run moot.
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: true
 
 # Least privilege by default. Jobs that need to report back to PRs override this explicitly.


### PR DESCRIPTION
## Summary
- `main`'s tip commit (`2696bcf`, PR #512) currently shows `Build`/`E2E`/`Integration`/`Lint · Type-check · Test`/`Docker Build` as **cancelled**, not completed — Dependabot auto-merged 4 PRs to main within ~9 minutes, and CI's concurrency group was scoped only by branch ref, so each new push to `main` cancelled the previous merge's still-running CI before it finished.
- Scopes the concurrency group by commit SHA for pushes to `main`, so back-to-back merges no longer cancel each other's run. PR branches keep the existing ref-scoped behavior (a superseding push there really does make the prior run moot).

## Test plan
- [x] `bun run lint` passes
- [x] Pre-commit/pre-push hooks (typecheck, unit tests, integration tests) passed locally
- [ ] After merge, confirm the next couple of Dependabot auto-merges to `main` each get a completed (not cancelled) CI run via `gh run list --branch main --workflow ci.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration reliability for consecutive changes merged into the main branch.
  * Prevented one merge from unintentionally cancelling another in-progress validation run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->