### PR TITLE
Fix/backfill job in process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       ANTHROPIC_API_KEY: sk-ant-placeholder
       AI_PROVIDER: claude
       GEMINI_API_KEY: placeholder-gemini-key
-      GEMINI_MODEL: gemini-2.0-flash
+      GEMINI_MODEL: gemini-3.5-flash-lite
       NEXT_PUBLIC_QF_CLIENT_ID: placeholder-client-id
       QF_API_BASE: https://placeholder.example.com
       QF_AUTH_BASE: https://placeholder.example.com
@@ -290,7 +290,7 @@ jobs:
       ANTHROPIC_API_KEY: sk-ant-placeholder
       AI_PROVIDER: claude
       GEMINI_API_KEY: placeholder-gemini-key
-      GEMINI_MODEL: gemini-2.0-flash
+      GEMINI_MODEL: gemini-3.5-flash-lite
       NEXT_PUBLIC_QF_CLIENT_ID: placeholder-client-id
       QF_API_BASE: https://placeholder.example.com
       QF_AUTH_BASE: https://placeholder.example.com

--- a/__tests__/api/admin/flags.test.ts
+++ b/__tests__/api/admin/flags.test.ts
@@ -170,6 +170,12 @@ describe("PUT /api/admin/flags", () => {
     expect((await PUT(put({ key: "ai_provider_connections", value: 3 }))).status).toBe(400);
     expect((await PUT(put({ key: "ai_provider_names", value: "gemini" }))).status).toBe(200);
   });
+
+  it("validates the per-feature model keys as strings (no enum check, matching ai_provider_*)", async () => {
+    expect((await PUT(put({ key: "ai_model_connections", value: 5 }))).status).toBe(400);
+    expect((await PUT(put({ key: "ai_model_names", value: "gemini-3.7-flash" }))).status).toBe(200);
+    expect((await PUT(put({ key: "ai_model", value: "" }))).status).toBe(200);
+  });
 });
 
 describe("DELETE /api/admin/flags", () => {

--- a/__tests__/api/admin/flags.test.ts
+++ b/__tests__/api/admin/flags.test.ts
@@ -11,7 +11,11 @@ vi.mock("@/lib/admin/feature-flags", async () => {
   const actual = await vi.importActual<typeof import("@/lib/admin/feature-flags")>(
     "@/lib/admin/feature-flags"
   );
-  return { invalidateFlagCache: vi.fn(), validateFlagType: actual.validateFlagType };
+  return {
+    invalidateFlagCache: vi.fn(),
+    validateFlagType: actual.validateFlagType,
+    getFlagString: vi.fn(async (_key: string, fallback: string) => fallback),
+  };
 });
 
 function makeDbChain(resolveWith: unknown = []) {

--- a/__tests__/api/name-content-rate-limit.test.ts
+++ b/__tests__/api/name-content-rate-limit.test.ts
@@ -56,6 +56,7 @@ vi.mock("@/lib/infra/rate-limit", async (importOriginal) => {
 vi.mock("@/lib/ai/ai", () => ({
   callAI: mockCallAI,
   resolveProvider: vi.fn(async () => "claude" as const),
+  resolveModel: vi.fn(async () => "claude-opus-4-7"),
   defaultModelFor: () => "claude-opus-4-7",
 }));
 

--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -56,6 +56,7 @@ vi.mock("@/lib/infra/rate-limit", async (importOriginal) => {
 vi.mock("@/lib/ai/ai", () => ({
   callAI: mockCallAI,
   resolveProvider: vi.fn(async () => "claude" as const),
+  resolveModel: vi.fn(async () => "claude-opus-4-7"),
   defaultModelFor: () => "claude-opus-4-7",
 }));
 

--- a/__tests__/app/admin/flags/page.test.tsx
+++ b/__tests__/app/admin/flags/page.test.tsx
@@ -9,7 +9,13 @@ vi.mock("@/components/admin/AdminContext", async () => {
 
 import FlagsPage from "@/app/admin/flags/page";
 
-function flags(rows: Record<string, unknown>) {
+type Route = { provider: "claude" | "gemini"; model: string };
+
+function response(
+  rows: Record<string, unknown>,
+  resolvedAi?: Partial<Record<"default" | "connections" | "names", Route>>
+) {
+  const claude: Route = { provider: "claude", model: "claude-opus-4-7" };
   return {
     flags: Object.entries(rows).map(([key, value]) => ({
       key,
@@ -17,6 +23,11 @@ function flags(rows: Record<string, unknown>) {
       updatedBy: "qf-admin",
       updatedAt: "2026-08-01T00:00:00Z",
     })),
+    resolvedAi: {
+      default: resolvedAi?.default ?? claude,
+      connections: resolvedAi?.connections ?? claude,
+      names: resolvedAi?.names ?? claude,
+    },
   };
 }
 
@@ -25,18 +36,23 @@ describe("FlagsPage — AI routing grid", () => {
     mockApi.mockReset();
   });
 
-  it("scopes a route's model options to its selected provider and writes the right flag key", async () => {
-    // Names route pinned to Gemini; everything else default.
-    mockApi.mockImplementation((path: string, opts?: { method?: string }) => {
+  it("scopes model options to the route's server-resolved provider and writes the right key", async () => {
+    // Names route resolves to Gemini server-side (flag or env — the client only
+    // sees the resolved result).
+    mockApi.mockImplementation((_path: string, opts?: { method?: string }) => {
       if (!opts || opts.method !== "PUT")
-        return Promise.resolve(flags({ ai_provider_names: "gemini" }));
+        return Promise.resolve(
+          response(
+            { ai_provider_names: "gemini" },
+            { names: { provider: "gemini", model: "gemini-3.5-flash-lite" } }
+          )
+        );
       return Promise.resolve({});
     });
 
     render(<FlagsPage />);
 
     const namesModel = await screen.findByLabelText("Names (Asma-ul-Husna) model");
-    // Gemini models are offered, not Claude ones.
     expect(within(namesModel).queryByText("gemini-3.7-flash")).toBeTruthy();
     expect(within(namesModel).queryByText("claude-opus-4-7")).toBeNull();
 
@@ -52,12 +68,15 @@ describe("FlagsPage — AI routing grid", () => {
     );
   });
 
-  it("offers Claude models for the default route when nothing is configured", async () => {
-    mockApi.mockResolvedValue(flags({}));
+  it("offers the resolved provider's models even when only an env var (no flag) selects it", async () => {
+    // No provider flag set, but the server resolves Default to Gemini via AI_PROVIDER.
+    mockApi.mockResolvedValue(
+      response({}, { default: { provider: "gemini", model: "gemini-3.5-flash-lite" } })
+    );
     render(<FlagsPage />);
 
     const defaultModel = await screen.findByLabelText("Default model");
-    expect(within(defaultModel).queryByText("claude-opus-4-7")).toBeTruthy();
-    expect(within(defaultModel).queryByText("gemini-3.7-flash")).toBeNull();
+    expect(within(defaultModel).queryByText("gemini-3.7-flash")).toBeTruthy();
+    expect(within(defaultModel).queryByText("claude-opus-4-7")).toBeNull();
   });
 });

--- a/__tests__/app/admin/flags/page.test.tsx
+++ b/__tests__/app/admin/flags/page.test.tsx
@@ -68,6 +68,26 @@ describe("FlagsPage — AI routing grid", () => {
     );
   });
 
+  it("shows the resolved default when a stored model belongs to a now-unselected provider", async () => {
+    // Route was switched Claude -> Gemini; the stale ai_model_names (a Claude
+    // model) is still stored but resolveModel() ignores it.
+    mockApi.mockResolvedValue(
+      response(
+        { ai_provider_names: "gemini", ai_model_names: "claude-opus-4-7" },
+        { names: { provider: "gemini", model: "gemini-3.5-flash-lite" } }
+      )
+    );
+    render(<FlagsPage />);
+
+    const namesModel = (await screen.findByLabelText(
+      "Names (Asma-ul-Husna) model"
+    )) as HTMLSelectElement;
+    expect(namesModel.value).toBe("");
+    expect(within(namesModel).getByRole("option", { selected: true }).textContent).toContain(
+      "gemini-3.5-flash-lite"
+    );
+  });
+
   it("offers the resolved provider's models even when only an env var (no flag) selects it", async () => {
     // No provider flag set, but the server resolves Default to Gemini via AI_PROVIDER.
     mockApi.mockResolvedValue(

--- a/__tests__/app/admin/flags/page.test.tsx
+++ b/__tests__/app/admin/flags/page.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockApi = vi.fn();
+vi.mock("@/components/admin/AdminContext", async () => {
+  const actual = await vi.importActual("@/components/admin/AdminContext");
+  return { ...actual, useAdminFetch: () => mockApi };
+});
+
+import FlagsPage from "@/app/admin/flags/page";
+
+function flags(rows: Record<string, unknown>) {
+  return {
+    flags: Object.entries(rows).map(([key, value]) => ({
+      key,
+      value,
+      updatedBy: "qf-admin",
+      updatedAt: "2026-08-01T00:00:00Z",
+    })),
+  };
+}
+
+describe("FlagsPage — AI routing grid", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+  });
+
+  it("scopes a route's model options to its selected provider and writes the right flag key", async () => {
+    // Names route pinned to Gemini; everything else default.
+    mockApi.mockImplementation((path: string, opts?: { method?: string }) => {
+      if (!opts || opts.method !== "PUT")
+        return Promise.resolve(flags({ ai_provider_names: "gemini" }));
+      return Promise.resolve({});
+    });
+
+    render(<FlagsPage />);
+
+    const namesModel = await screen.findByLabelText("Names (Asma-ul-Husna) model");
+    // Gemini models are offered, not Claude ones.
+    expect(within(namesModel).queryByText("gemini-3.7-flash")).toBeTruthy();
+    expect(within(namesModel).queryByText("claude-opus-4-7")).toBeNull();
+
+    fireEvent.change(namesModel, { target: { value: "gemini-3.7-flash" } });
+    await waitFor(() =>
+      expect(mockApi).toHaveBeenCalledWith(
+        "/flags",
+        expect.objectContaining({
+          method: "PUT",
+          json: { key: "ai_model_names", value: "gemini-3.7-flash" },
+        })
+      )
+    );
+  });
+
+  it("offers Claude models for the default route when nothing is configured", async () => {
+    mockApi.mockResolvedValue(flags({}));
+    render(<FlagsPage />);
+
+    const defaultModel = await screen.findByLabelText("Default model");
+    expect(within(defaultModel).queryByText("claude-opus-4-7")).toBeTruthy();
+    expect(within(defaultModel).queryByText("gemini-3.7-flash")).toBeNull();
+  });
+});

--- a/__tests__/integration/graph.integration.test.ts
+++ b/__tests__/integration/graph.integration.test.ts
@@ -13,7 +13,10 @@ vi.mock("@/lib/ai/ai", () => ({
     model: "claude-opus-4-7",
   })),
   resolveProvider: vi.fn(async () => "claude" as const),
-  resolveModel: vi.fn(async () => "claude-opus-4-7"),
+  resolveModel: vi.fn(
+    async (_feature: string, provider: string, override?: string) =>
+      override ?? (provider === "gemini" ? "gemini-3.5-flash-lite" : "claude-opus-4-7")
+  ),
   defaultModelFor: (p: string) => (p === "gemini" ? "gemini-3.5-flash-lite" : "claude-opus-4-7"),
 }));
 // Guard against accidental network in the resolver fallback — everything must

--- a/__tests__/integration/graph.integration.test.ts
+++ b/__tests__/integration/graph.integration.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/ai/ai", () => ({
     model: "claude-opus-4-7",
   })),
   resolveProvider: vi.fn(async () => "claude" as const),
+  resolveModel: vi.fn(async () => "claude-opus-4-7"),
   defaultModelFor: (p: string) => (p === "gemini" ? "gemini-3.5-flash-lite" : "claude-opus-4-7"),
 }));
 // Guard against accidental network in the resolver fallback — everything must

--- a/__tests__/integration/graph.integration.test.ts
+++ b/__tests__/integration/graph.integration.test.ts
@@ -12,7 +12,9 @@ vi.mock("@/lib/ai/ai", () => ({
     provider: "claude" as const,
     model: "claude-opus-4-7",
   })),
-  resolveProvider: vi.fn(async () => "claude" as const),
+  resolveProvider: vi.fn(
+    async (_feature: string, override?: string) => (override ?? "claude") as "claude" | "gemini"
+  ),
   resolveModel: vi.fn(
     async (_feature: string, provider: string, override?: string) =>
       override ?? (provider === "gemini" ? "gemini-3.5-flash-lite" : "claude-opus-4-7")

--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -165,6 +165,30 @@ describe("startJob — backfill-connections params", () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
+  it("rejects a model that isn't valid for the chosen provider, accepts a valid one", async () => {
+    await expect(
+      startJob("backfill-connections", "qf-admin", {
+        ...validParams,
+        provider: "claude",
+        model: "gemini-3.7-flash",
+      })
+    ).rejects.toThrow(/model/);
+    await expect(
+      startJob("backfill-connections", "qf-admin", { ...validParams, model: "not-a-model" })
+    ).rejects.toThrow(/model/);
+
+    mockRunConnectionBatch.mockReturnValueOnce(new Promise(() => {}));
+    await startJob("backfill-connections", "qf-admin", {
+      ...validParams,
+      provider: "gemini",
+      model: "gemini-3.7-flash",
+    });
+    expect(mockRunConnectionBatch).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "gemini", model: "gemini-3.7-flash" }),
+      expect.anything()
+    );
+  });
+
   it("rejects a bad mode / provider / budget / locale", async () => {
     await expect(
       startJob("backfill-connections", "qf-admin", { ...validParams, mode: "sideways" })
@@ -205,6 +229,7 @@ describe("startJob — backfill-connections params", () => {
       {
         mode: "baseline",
         provider: "claude",
+        model: undefined,
         locales: ["tr", "ru"],
         maxCalls: 10,
         maxCostUsd: 2,

--- a/__tests__/lib/ai/connection-generator.test.ts
+++ b/__tests__/lib/ai/connection-generator.test.ts
@@ -216,11 +216,18 @@ Return ONLY a valid JSON array of { "ref": "surah:ayah", "reason": "..." }.`,
       provider: "gemini" as const,
       model: "gemini-3.5-flash-lite",
     });
-    await generateConnections("1:1", "ar", "tr", "thematic", "en", { provider: "gemini" });
+    await generateConnections("1:1", "ar", "tr", "thematic", "en", {
+      provider: "gemini",
+      model: "gemini-3.7-flash",
+    });
 
     expect(mockCallAIDetailed).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ feature: "connections", provider: "gemini" })
+      expect.objectContaining({
+        feature: "connections",
+        provider: "gemini",
+        model: "gemini-3.7-flash",
+      })
     );
     expect(insertedRows).toContainEqual(
       expect.objectContaining({ model: "gemini-3.5-flash-lite", tokens: 1290 })
@@ -317,11 +324,16 @@ describe("generateGroundedConnections", () => {
     });
     await generateGroundedConnections("1:1", "ar", "tr", "root", ["2:255"], "en", {
       provider: "gemini",
+      model: "gemini-3.7-flash",
     });
 
     expect(mockCallAIDetailed).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ feature: "connections", provider: "gemini" })
+      expect.objectContaining({
+        feature: "connections",
+        provider: "gemini",
+        model: "gemini-3.7-flash",
+      })
     );
     expect(insertedRows).toContainEqual(
       expect.objectContaining({ model: "gemini-3.5-flash-lite", tokens: 1000 })

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -94,6 +94,10 @@ function result(ref: string): ConnectionResult {
 const SOURCE_ARABIC = "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ";
 const source = { arabicText: SOURCE_ARABIC, translation: "tr" };
 
+// getConnections resolves the connections provider+model once and threads the
+// pair through to the generator. With no flag/env set it's the Claude default.
+const RESOLVED = { provider: "claude", model: "claude-opus-4-7" };
+
 describe("getConnections", () => {
   beforeEach(() => {
     mockSelect.mockReset();
@@ -142,7 +146,14 @@ describe("getConnections", () => {
     const out = await getConnections("1:1", "thematic", source);
 
     expect(mockGenerate).toHaveBeenCalledTimes(1);
-    expect(mockGenerate).toHaveBeenCalledWith("1:1", SOURCE_ARABIC, "tr", "thematic", "en");
+    expect(mockGenerate).toHaveBeenCalledWith(
+      "1:1",
+      SOURCE_ARABIC,
+      "tr",
+      "thematic",
+      "en",
+      RESOLVED
+    );
     expect(mockInsert).toHaveBeenCalledTimes(1);
     expect(mockValues).toHaveBeenCalledTimes(1);
     const persisted = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
@@ -236,7 +247,8 @@ describe("getConnections", () => {
       "tr",
       "thematic",
       ["2:255", "3:18"],
-      "en"
+      "en",
+      RESOLVED
     );
     expect(mockGenerate).not.toHaveBeenCalled(); // legacy path skipped
     expect(out).toHaveLength(1);
@@ -251,7 +263,7 @@ describe("getConnections", () => {
     const out = await getConnections("1:1", "root", source);
 
     expect(mockGenerateGrounded).not.toHaveBeenCalled();
-    expect(mockGenerate).toHaveBeenCalledWith("1:1", SOURCE_ARABIC, "tr", "root", "en");
+    expect(mockGenerate).toHaveBeenCalledWith("1:1", SOURCE_ARABIC, "tr", "root", "en", RESOLVED);
     expect(out).toHaveLength(1);
   });
 
@@ -335,7 +347,14 @@ describe("getConnections — per-locale caching", () => {
 
     await getConnections("1:1", "thematic", source, { locale: "tr" });
 
-    expect(mockGenerate).toHaveBeenCalledWith("1:1", SOURCE_ARABIC, "tr", "thematic", "tr");
+    expect(mockGenerate).toHaveBeenCalledWith(
+      "1:1",
+      SOURCE_ARABIC,
+      "tr",
+      "thematic",
+      "tr",
+      RESOLVED
+    );
     const persisted = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
     expect(persisted[0]).toMatchObject({ locale: "tr" });
   });
@@ -350,8 +369,22 @@ describe("getConnections — per-locale caching", () => {
     ]);
 
     expect(mockGenerate).toHaveBeenCalledTimes(2);
-    expect(mockGenerate).toHaveBeenCalledWith("1:1", SOURCE_ARABIC, "tr", "thematic", "en");
-    expect(mockGenerate).toHaveBeenCalledWith("1:1", SOURCE_ARABIC, "tr", "thematic", "tr");
+    expect(mockGenerate).toHaveBeenCalledWith(
+      "1:1",
+      SOURCE_ARABIC,
+      "tr",
+      "thematic",
+      "en",
+      RESOLVED
+    );
+    expect(mockGenerate).toHaveBeenCalledWith(
+      "1:1",
+      SOURCE_ARABIC,
+      "tr",
+      "thematic",
+      "tr",
+      RESOLVED
+    );
   });
 });
 

--- a/__tests__/lib/ai/models.test.ts
+++ b/__tests__/lib/ai/models.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { estimateCostUsd } from "@/lib/ai/ai-cost";
+import { SELECTABLE_MODELS, DEFAULT_MODEL, isModelForProvider } from "@/lib/ai/models";
+
+describe("SELECTABLE_MODELS", () => {
+  it("every selectable model has a real (non-fallback) rate in ai-cost", () => {
+    for (const provider of ["claude", "gemini"] as const) {
+      for (const model of SELECTABLE_MODELS[provider]) {
+        const known = estimateCostUsd(model, provider, { inputTokens: 1_000_000, outputTokens: 0 });
+        const unknown = estimateCostUsd("definitely-not-a-model", provider, {
+          inputTokens: 1_000_000,
+          outputTokens: 0,
+        });
+        // A model with its own RATES entry costs less than the conservative
+        // provider fallback (or the guard would over-estimate for it).
+        expect(known).toBeLessThanOrEqual(unknown);
+        expect(known).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("each provider's default is one of its selectable models", () => {
+    expect(SELECTABLE_MODELS.claude).toContain(DEFAULT_MODEL.claude);
+    expect(SELECTABLE_MODELS.gemini).toContain(DEFAULT_MODEL.gemini);
+  });
+
+  it("isModelForProvider rejects a cross-provider model", () => {
+    expect(isModelForProvider("claude-opus-4-7", "claude")).toBe(true);
+    expect(isModelForProvider("claude-opus-4-7", "gemini")).toBe(false);
+    expect(isModelForProvider("gemini-3.5-flash-lite", "gemini")).toBe(true);
+    expect(isModelForProvider("nonsense", "claude")).toBe(false);
+  });
+});

--- a/__tests__/lib/ai/models.test.ts
+++ b/__tests__/lib/ai/models.test.ts
@@ -4,16 +4,15 @@ import { SELECTABLE_MODELS, DEFAULT_MODEL, isModelForProvider } from "@/lib/ai/m
 
 describe("SELECTABLE_MODELS", () => {
   it("every selectable model has a real (non-fallback) rate in ai-cost", () => {
+    const usage = { inputTokens: 1_000_000, outputTokens: 1_000_000 };
     for (const provider of ["claude", "gemini"] as const) {
+      const fallback = estimateCostUsd("definitely-not-a-model", provider, usage);
       for (const model of SELECTABLE_MODELS[provider]) {
-        const known = estimateCostUsd(model, provider, { inputTokens: 1_000_000, outputTokens: 0 });
-        const unknown = estimateCostUsd("definitely-not-a-model", provider, {
-          inputTokens: 1_000_000,
-          outputTokens: 0,
-        });
-        // A model with its own RATES entry costs less than the conservative
-        // provider fallback (or the guard would over-estimate for it).
-        expect(known).toBeLessThanOrEqual(unknown);
+        const known = estimateCostUsd(model, provider, usage);
+        // A model with its own RATES entry is strictly cheaper than the
+        // conservative provider fallback — if it were missing from RATES it
+        // would resolve to the same (fallback) estimate and this would fail.
+        expect(known).toBeLessThan(fallback);
         expect(known).toBeGreaterThan(0);
       }
     }

--- a/__tests__/lib/ai/provider-resolution.test.ts
+++ b/__tests__/lib/ai/provider-resolution.test.ts
@@ -125,3 +125,74 @@ describe("provider resolution", () => {
     expect(noMeta.usage).toBeNull();
   });
 });
+
+describe("model resolution", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    mockClaudeCreate.mockReset().mockResolvedValue(claudeReply("claude-said"));
+    mockGeminiGenerate.mockReset().mockResolvedValue(geminiReply("gemini-said", null));
+    mockGetFlagString.mockReset().mockImplementation((_key: string, fallback: string) => fallback);
+    process.env = { ...savedEnv };
+    delete process.env.AI_PROVIDER;
+    delete process.env.ANTHROPIC_MODEL;
+    delete process.env.AI_MODEL;
+    delete process.env.AI_MODEL_CONNECTIONS;
+    delete process.env.AI_MODEL_NAMES;
+    process.env.GEMINI_API_KEY = "test-gemini-key";
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it("defaults to the provider's built-in model and forwards it to the SDK", async () => {
+    const res = await callAIDetailed("hi");
+    expect(res.model).toBe("claude-opus-4-7");
+    expect(mockClaudeCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "claude-opus-4-7" })
+    );
+  });
+
+  it("uses the ai_model_<feature> flag over the global default", async () => {
+    mockGetFlagString.mockImplementation((key: string, fallback: string) =>
+      key === "ai_model_names" ? "claude-haiku-4-5" : fallback
+    );
+    const res = await callAIDetailed("hi", { feature: "names" });
+    expect(res.model).toBe("claude-haiku-4-5");
+  });
+
+  it("falls back to the AI_MODEL_<FEATURE> env var", async () => {
+    process.env.AI_MODEL_CONNECTIONS = "claude-sonnet-5";
+    const res = await callAIDetailed("hi", { feature: "connections" });
+    expect(res.model).toBe("claude-sonnet-5");
+  });
+
+  it("falls back to the global ai_model flag for an untagged call", async () => {
+    mockGetFlagString.mockImplementation((key: string, fallback: string) =>
+      key === "ai_model" ? "claude-sonnet-5" : fallback
+    );
+    const res = await callAIDetailed("hi");
+    expect(res.model).toBe("claude-sonnet-5");
+  });
+
+  it("honours an explicit model override above every flag/env", async () => {
+    process.env.AI_MODEL_CONNECTIONS = "claude-sonnet-5";
+    const res = await callAIDetailed("hi", { feature: "connections", model: "claude-haiku-4-5" });
+    expect(res.model).toBe("claude-haiku-4-5");
+  });
+
+  it("ignores a model that doesn't belong to the resolved provider", async () => {
+    // provider resolves to claude (nothing configured), but a Gemini model is set.
+    mockGetFlagString.mockImplementation((key: string, fallback: string) =>
+      key === "ai_model_names" ? "gemini-3.7-flash" : fallback
+    );
+    const res = await callAIDetailed("hi", { feature: "names" });
+    expect(res.model).toBe("claude-opus-4-7");
+  });
+
+  it("resolves a model for the Gemini provider and forwards it", async () => {
+    const res = await callAIDetailed("hi", { provider: "gemini", model: "gemini-3.7-flash" });
+    expect(res.model).toBe("gemini-3.7-flash");
+  });
+});

--- a/__tests__/lib/ai/provider-resolution.test.ts
+++ b/__tests__/lib/ai/provider-resolution.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { mockClaudeCreate, mockGeminiGenerate, mockGetFlagString } = vi.hoisted(() => ({
-  mockClaudeCreate: vi.fn(),
-  mockGeminiGenerate: vi.fn(),
-  mockGetFlagString: vi.fn(),
-}));
+const { mockClaudeCreate, mockGeminiGenerate, mockGetGenerativeModel, mockGetFlagString } =
+  vi.hoisted(() => ({
+    mockClaudeCreate: vi.fn(),
+    mockGeminiGenerate: vi.fn(),
+    mockGetGenerativeModel: vi.fn(),
+    mockGetFlagString: vi.fn(),
+  }));
 
 vi.mock("@anthropic-ai/sdk", () => ({
   default: class {
@@ -14,7 +16,8 @@ vi.mock("@anthropic-ai/sdk", () => ({
 
 vi.mock("@google/generative-ai", () => ({
   GoogleGenerativeAI: class {
-    getGenerativeModel() {
+    getGenerativeModel(...args: unknown[]) {
+      mockGetGenerativeModel(...args);
       return { generateContent: mockGeminiGenerate };
     }
   },
@@ -191,8 +194,10 @@ describe("model resolution", () => {
     expect(res.model).toBe("claude-opus-4-7");
   });
 
-  it("resolves a model for the Gemini provider and forwards it", async () => {
+  it("resolves a model for the Gemini provider and forwards it to the SDK", async () => {
+    mockGetGenerativeModel.mockClear();
     const res = await callAIDetailed("hi", { provider: "gemini", model: "gemini-3.7-flash" });
     expect(res.model).toBe("gemini-3.7-flash");
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith({ model: "gemini-3.7-flash" });
   });
 });

--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -87,11 +87,37 @@ describe("getOrGenerateNameContent", () => {
     const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
     expect(values).toMatchObject({ slug: "al-malik", kind: "verses", locale: "en", version: 2 });
     expect(JSON.parse(values.data as string)).toEqual(["a", "b"]);
-    // The model handed to generate() is the one that gets persisted — resolved
-    // once, so a config change mid-flight can't split them.
-    const modelPassedToGenerate = generate.mock.calls[0][0] as string;
-    expect(typeof modelPassedToGenerate).toBe("string");
-    expect(values.model).toBe(modelPassedToGenerate);
+    // The provider+model pair handed to generate() is the one that gets
+    // persisted — resolved once, so a config change mid-flight can't split them.
+    const passedToGenerate = generate.mock.calls[0][0] as { provider: string; model: string };
+    expect(passedToGenerate).toEqual({ provider: expect.any(String), model: expect.any(String) });
+    expect(values.model).toBe(passedToGenerate.model);
+  });
+
+  it("pins the provider+model resolved once, even if config flips during generation", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const ai = await import("@/lib/ai/ai");
+    const providerSpy = vi.spyOn(ai, "resolveProvider").mockResolvedValue("gemini");
+    const modelSpy = vi.spyOn(ai, "resolveModel").mockResolvedValue("gemini-3.7-flash");
+
+    const generate = vi.fn(async (resolved: { provider: string; model: string }) => {
+      // Admin flips the route back to Claude mid-generation.
+      providerSpy.mockResolvedValue("claude");
+      modelSpy.mockResolvedValue("claude-opus-5");
+      return [resolved.provider, resolved.model];
+    });
+
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 9, generate, isEmptyArr);
+
+    expect(out).toEqual(["gemini", "gemini-3.7-flash"]);
+    const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
+    expect(values.model).toBe("gemini-3.7-flash");
+    expect(generate.mock.calls[0][0]).toEqual({
+      provider: "gemini",
+      model: "gemini-3.7-flash",
+    });
+    providerSpy.mockRestore();
+    modelSpy.mockRestore();
   });
 
   it("keys the cache by locale — a Turkish miss doesn't reuse or clobber the English row", async () => {

--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -87,6 +87,11 @@ describe("getOrGenerateNameContent", () => {
     const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
     expect(values).toMatchObject({ slug: "al-malik", kind: "verses", locale: "en", version: 2 });
     expect(JSON.parse(values.data as string)).toEqual(["a", "b"]);
+    // The model handed to generate() is the one that gets persisted — resolved
+    // once, so a config change mid-flight can't split them.
+    const modelPassedToGenerate = generate.mock.calls[0][0] as string;
+    expect(typeof modelPassedToGenerate).toBe("string");
+    expect(values.model).toBe(modelPassedToGenerate);
   });
 
   it("keys the cache by locale — a Turkish miss doesn't reuse or clobber the English row", async () => {

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -7,6 +7,16 @@ import { Table, Th, Td, StateNote, ConfirmButton } from "@/components/admin/prim
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import { KNOWN_OPERATIONAL_FLAG_KEYS } from "@/lib/admin/feature-flag-keys";
+import { SELECTABLE_MODELS, DEFAULT_MODEL } from "@/lib/ai/models";
+
+const SELECT_CLASS =
+  "h-10 w-full rounded-md border border-border bg-surface px-3 text-sm text-text-primary hover:border-border-subtle focus:border-gold-muted";
+
+const AI_ROUTES = [
+  { key: "", label: "Default" },
+  { key: "_connections", label: "Connections" },
+  { key: "_names", label: "Names (Asma-ul-Husna)" },
+] as const;
 
 interface Flag {
   key: string;
@@ -25,9 +35,20 @@ function OperationalSettings({ flags, reload }: { flags: Flag[]; reload: () => v
   const [busy, setBusy] = useState(false);
 
   const byKey = new Map(flags.map((f) => [f.key, f.value]));
-  const aiProviderRaw = byKey.get("ai_provider");
-  const aiProvider = typeof aiProviderRaw === "string" ? aiProviderRaw : "";
+  const strFlag = (key: string): string => {
+    const v = byKey.get(key);
+    return typeof v === "string" ? v : "";
+  };
   const maintenanceOn = byKey.get("maintenance_mode") === true;
+
+  // Provider for a route's model dropdown: the route's own provider flag, else
+  // the Default route's, else "claude" (the built-in default provider).
+  const providerFor = (routeKey: string): "claude" | "gemini" => {
+    const own = strFlag(`ai_provider${routeKey}`);
+    const dflt = strFlag("ai_provider");
+    const p = own || dflt;
+    return p === "gemini" ? "gemini" : "claude";
+  };
 
   // Uncontrolled: each number field reads its live DOM value on save and is
   // reset (via `key`) whenever the flag list is reloaded from the server.
@@ -63,21 +84,55 @@ function OperationalSettings({ flags, reload }: { flags: Flag[]; reload: () => v
     <div className="space-y-4 rounded-lg border border-border bg-surface p-5">
       <h2 className="text-sm font-medium text-text-primary">Operational settings</h2>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <label className="space-y-1.5">
-          <span className="text-xs text-text-secondary">AI provider</span>
-          <select
-            value={aiProvider}
-            onChange={(e) => setFlag("ai_provider", e.target.value)}
-            disabled={busy}
-            className="h-10 w-full rounded-md border border-border bg-surface px-3 text-sm text-text-primary hover:border-border-subtle focus:border-gold-muted"
-          >
-            <option value="">Default (env: AI_PROVIDER)</option>
-            <option value="claude">Claude</option>
-            <option value="gemini">Gemini</option>
-          </select>
-        </label>
+      <div className="space-y-2">
+        <span className="text-xs text-text-secondary">
+          AI routing (provider &amp; model per feature)
+        </span>
+        <div className="space-y-2 rounded-md border border-border p-3">
+          {AI_ROUTES.map((route) => {
+            const provider = providerFor(route.key);
+            const modelKey = `ai_model${route.key}`;
+            return (
+              <div key={route.key} className="grid items-center gap-2 sm:grid-cols-[8rem_1fr_1fr]">
+                <span className="text-xs text-text-secondary">{route.label}</span>
+                <select
+                  aria-label={`${route.label} provider`}
+                  value={strFlag(`ai_provider${route.key}`)}
+                  onChange={(e) => setFlag(`ai_provider${route.key}`, e.target.value)}
+                  disabled={busy}
+                  className={SELECT_CLASS}
+                >
+                  <option value="">{route.key === "" ? "Default (env)" : "Inherit"}</option>
+                  <option value="claude">Claude</option>
+                  <option value="gemini">Gemini</option>
+                </select>
+                <select
+                  aria-label={`${route.label} model`}
+                  value={strFlag(modelKey)}
+                  onChange={(e) => setFlag(modelKey, e.target.value)}
+                  disabled={busy}
+                  className={SELECT_CLASS}
+                >
+                  <option value="">
+                    {route.key === "" ? `Default (${DEFAULT_MODEL[provider]})` : "Inherit"}
+                  </option>
+                  {SELECTABLE_MODELS[provider].map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            );
+          })}
+        </div>
+        <p className="text-[11px] text-text-muted">
+          A model that doesn&apos;t belong to the selected provider is ignored at call time and the
+          provider default is used instead.
+        </p>
+      </div>
 
+      <div className="grid gap-4 sm:grid-cols-2">
         <div className="space-y-1.5">
           <span className="block text-xs text-text-secondary">Maintenance mode</span>
           <Button

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -111,6 +111,13 @@ function OperationalSettings({
           {AI_ROUTES.map((route) => {
             const resolved = routeFor(route.key);
             const modelKey = `ai_model${route.key}`;
+            // A stored model left over from a previous provider isn't in this
+            // provider's option list — show it as "Default" so the control
+            // reflects what resolveModel() actually uses at call time.
+            const storedModel = strFlag(modelKey);
+            const modelValue = SELECTABLE_MODELS[resolved.provider].includes(storedModel)
+              ? storedModel
+              : "";
             return (
               <div key={route.key} className="grid items-center gap-2 sm:grid-cols-[8rem_1fr_1fr]">
                 <span className="text-xs text-text-secondary">{route.label}</span>
@@ -131,7 +138,7 @@ function OperationalSettings({
                 </select>
                 <select
                   aria-label={`${route.label} model`}
-                  value={strFlag(modelKey)}
+                  value={modelValue}
                   onChange={(e) => setFlag(modelKey, e.target.value)}
                   disabled={busy}
                   className={SELECT_CLASS}

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -7,7 +7,7 @@ import { Table, Th, Td, StateNote, ConfirmButton } from "@/components/admin/prim
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import { KNOWN_OPERATIONAL_FLAG_KEYS } from "@/lib/admin/feature-flag-keys";
-import { SELECTABLE_MODELS, DEFAULT_MODEL } from "@/lib/ai/models";
+import { SELECTABLE_MODELS } from "@/lib/ai/models";
 
 const SELECT_CLASS =
   "h-10 w-full rounded-md border border-border bg-surface px-3 text-sm text-text-primary hover:border-border-subtle focus:border-gold-muted";
@@ -25,11 +25,29 @@ interface Flag {
   updatedAt: string;
 }
 
+type Provider = "claude" | "gemini";
+interface ResolvedRoute {
+  provider: Provider;
+  model: string;
+}
+interface FlagsResponse {
+  flags: Flag[];
+  resolvedAi: { default: ResolvedRoute; connections: ResolvedRoute; names: ResolvedRoute };
+}
+
 /** Purpose-built controls for the settings that runtime code actually reads —
  *  everything else stays in the generic key/value editor below. Each control
  *  writes through the same `PUT /flags` route as the generic editor, so
  *  logAdminAction coverage and cache invalidation are free. */
-function OperationalSettings({ flags, reload }: { flags: Flag[]; reload: () => void }) {
+function OperationalSettings({
+  flags,
+  resolvedAi,
+  reload,
+}: {
+  flags: Flag[];
+  resolvedAi: FlagsResponse["resolvedAi"];
+  reload: () => void;
+}) {
   const api = useAdminFetch();
   const [msg, setMsg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -41,14 +59,15 @@ function OperationalSettings({ flags, reload }: { flags: Flag[]; reload: () => v
   };
   const maintenanceOn = byKey.get("maintenance_mode") === true;
 
-  // Provider for a route's model dropdown: the route's own provider flag, else
-  // the Default route's, else "claude" (the built-in default provider).
-  const providerFor = (routeKey: string): "claude" | "gemini" => {
-    const own = strFlag(`ai_provider${routeKey}`);
-    const dflt = strFlag("ai_provider");
-    const p = own || dflt;
-    return p === "gemini" ? "gemini" : "claude";
-  };
+  // What each route actually resolves to server-side (flags AND env, via
+  // resolveProvider/resolveModel), reported by GET /flags — the client can't
+  // read env itself. Drives which model list to offer + the "default" hint.
+  const routeFor = (routeKey: string): ResolvedRoute =>
+    routeKey === "_connections"
+      ? resolvedAi.connections
+      : routeKey === "_names"
+        ? resolvedAi.names
+        : resolvedAi.default;
 
   // Uncontrolled: each number field reads its live DOM value on save and is
   // reset (via `key`) whenever the flag list is reloaded from the server.
@@ -90,7 +109,7 @@ function OperationalSettings({ flags, reload }: { flags: Flag[]; reload: () => v
         </span>
         <div className="space-y-2 rounded-md border border-border p-3">
           {AI_ROUTES.map((route) => {
-            const provider = providerFor(route.key);
+            const resolved = routeFor(route.key);
             const modelKey = `ai_model${route.key}`;
             return (
               <div key={route.key} className="grid items-center gap-2 sm:grid-cols-[8rem_1fr_1fr]">
@@ -102,7 +121,11 @@ function OperationalSettings({ flags, reload }: { flags: Flag[]; reload: () => v
                   disabled={busy}
                   className={SELECT_CLASS}
                 >
-                  <option value="">{route.key === "" ? "Default (env)" : "Inherit"}</option>
+                  <option value="">
+                    {route.key === ""
+                      ? `Default — ${resolved.provider}`
+                      : `Inherit — ${resolved.provider}`}
+                  </option>
                   <option value="claude">Claude</option>
                   <option value="gemini">Gemini</option>
                 </select>
@@ -113,10 +136,8 @@ function OperationalSettings({ flags, reload }: { flags: Flag[]; reload: () => v
                   disabled={busy}
                   className={SELECT_CLASS}
                 >
-                  <option value="">
-                    {route.key === "" ? `Default (${DEFAULT_MODEL[provider]})` : "Inherit"}
-                  </option>
-                  {SELECTABLE_MODELS[provider].map((m) => (
+                  <option value="">Default — {resolved.model}</option>
+                  {SELECTABLE_MODELS[resolved.provider].map((m) => (
                     <option key={m} value={m}>
                       {m}
                     </option>
@@ -232,10 +253,7 @@ function numOrEmpty(v: unknown): string {
 
 export default function FlagsPage() {
   const api = useAdminFetch();
-  const { data, error, loading, reload } = useAsync<{ flags: Flag[] }>(
-    () => api("/flags"),
-    "flags"
-  );
+  const { data, error, loading, reload } = useAsync<FlagsResponse>(() => api("/flags"), "flags");
 
   const [key, setKey] = useState("");
   const [value, setValue] = useState("");
@@ -291,7 +309,9 @@ export default function FlagsPage() {
         subtitle="Runtime config read by subsystems. A missing key falls back to its code default."
       />
       <div className="space-y-6 p-7">
-        {data && <OperationalSettings flags={data.flags} reload={reload} />}
+        {data && (
+          <OperationalSettings flags={data.flags} resolvedAi={data.resolvedAi} reload={reload} />
+        )}
 
         <div className="space-y-3 rounded-lg border border-border bg-surface p-5">
           <div className="grid gap-3 sm:grid-cols-[200px_1fr]">

--- a/app/api/admin/flags/route.ts
+++ b/app/api/admin/flags/route.ts
@@ -5,17 +5,31 @@ import { logAdminAction } from "@/lib/admin/admin-audit";
 import { db } from "@/lib/infra/db";
 import { featureFlags } from "@/lib/infra/db/schema";
 import { invalidateFlagCache, validateFlagType } from "@/lib/admin/feature-flags";
+import { resolveProvider, resolveModel, type AiFeature } from "@/lib/ai/ai";
 import { safeParse } from "@/lib/infra/http";
+
+async function resolveRoute(feature: AiFeature | undefined) {
+  const provider = await resolveProvider(feature);
+  return { provider, model: await resolveModel(feature, provider) };
+}
 
 const KEY_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
 
-/** All feature flags, alphabetical. Values are JSON (parsed for the client). */
+/** All feature flags, alphabetical. Values are JSON (parsed for the client).
+ *  `resolvedAi` is the provider+model each AI route actually resolves to right
+ *  now (flags + env, per `resolveProvider`/`resolveModel`) — the flags UI needs
+ *  it to offer a valid model list, since it can't read server-side env itself. */
 export async function GET(req: NextRequest) {
   const auth = await requireAdmin(req);
   if (auth instanceof NextResponse) return auth;
 
   try {
     const rows = await db.select().from(featureFlags).orderBy(asc(featureFlags.key));
+    const [defaultRoute, connections, names] = await Promise.all([
+      resolveRoute(undefined),
+      resolveRoute("connections"),
+      resolveRoute("names"),
+    ]);
     return NextResponse.json({
       flags: rows.map((r) => ({
         key: r.key,
@@ -23,6 +37,7 @@ export async function GET(req: NextRequest) {
         updatedBy: r.updatedBy,
         updatedAt: r.updatedAt,
       })),
+      resolvedAi: { default: defaultRoute, connections, names },
     });
   } catch (err) {
     console.error("admin flags GET db error:", err);

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -61,12 +61,12 @@ async function getPairings(
     "pairings",
     locale,
     PAIRINGS_VERSION,
-    async (model) => {
+    async (resolved) => {
       let text: string;
       try {
         text = await callAI(buildPrompt(name.transliteration, name.arabic, name.meaning, locale), {
           feature: "names",
-          model,
+          ...resolved,
         });
       } catch (err) {
         // Not cached (empty result), so the next request retries — mirrors how

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -61,11 +61,12 @@ async function getPairings(
     "pairings",
     locale,
     PAIRINGS_VERSION,
-    async () => {
+    async (model) => {
       let text: string;
       try {
         text = await callAI(buildPrompt(name.transliteration, name.arabic, name.meaning, locale), {
           feature: "names",
+          model,
         });
       } catch (err) {
         // Not cached (empty result), so the next request retries — mirrors how

--- a/app/api/names/[slug]/reflection/route.ts
+++ b/app/api/names/[slug]/reflection/route.ts
@@ -54,11 +54,11 @@ async function getReflection(
     "reflection",
     locale,
     REFLECTION_VERSION,
-    async () => {
+    async (model) => {
       try {
         return await callAI(
           buildPrompt(name.arabic, name.transliteration, name.meaning, name.description, locale),
-          { feature: "names" }
+          { feature: "names", model }
         );
       } catch (err) {
         // Not cached (empty result), so the next request retries — mirrors how

--- a/app/api/names/[slug]/reflection/route.ts
+++ b/app/api/names/[slug]/reflection/route.ts
@@ -54,11 +54,11 @@ async function getReflection(
     "reflection",
     locale,
     REFLECTION_VERSION,
-    async (model) => {
+    async (resolved) => {
       try {
         return await callAI(
           buildPrompt(name.arabic, name.transliteration, name.meaning, name.description, locale),
-          { feature: "names", model }
+          { feature: "names", ...resolved }
         );
       } catch (err) {
         // Not cached (empty result), so the next request retries — mirrors how

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -70,7 +70,8 @@ async function searchVerseRefs(arabic: string): Promise<string[]> {
 async function buildReasons(
   refs: string[],
   transliteration: string,
-  meaning: string
+  meaning: string,
+  model: string
 ): Promise<Map<string, string>> {
   if (refs.length === 0) return new Map();
   const prompt = `You are a classical Islamic scholar (Maturidi/Hanafi tradition).
@@ -86,7 +87,7 @@ Output format:
 { "surah:ayah": "one sentence", ... }`;
 
   try {
-    const text = await callAI(prompt, { feature: "names" });
+    const text = await callAI(prompt, { feature: "names", model });
     const match = text.match(/\{[\s\S]*\}/);
     if (!match) return new Map();
     const obj: unknown = JSON.parse(match[0]);
@@ -107,7 +108,8 @@ async function fallbackAIVerses(
   arabic: string,
   transliteration: string,
   meaning: string,
-  description: string
+  description: string,
+  model: string
 ): Promise<Array<{ ref: string; reason: string }>> {
   const prompt = `You are a classical Islamic scholar (Maturidi/Hanafi tradition).
 
@@ -120,7 +122,7 @@ Return ONLY a JSON array:
 [{ "ref": "surah:ayah", "reason": "one sentence" }, ...]`;
 
   try {
-    const text = await callAI(prompt, { feature: "names" });
+    const text = await callAI(prompt, { feature: "names", model });
     const match = text.match(/\[[\s\S]*\]/);
     if (!match) return [];
     const raw: unknown = JSON.parse(match[0]);
@@ -162,7 +164,7 @@ async function getVersesBySlug(
     // requester's locale — see name_verse_reasons below for why.
     "en",
     VERSES_VERSION,
-    async (): Promise<NameVerse[]> => {
+    async (model): Promise<NameVerse[]> => {
       // Try actual quran.com search first
       const refs = await searchVerseRefs(name.arabic);
 
@@ -170,7 +172,7 @@ async function getVersesBySlug(
       if (refs.length > 0) {
         const [verseDataResults, reasonMap] = await Promise.all([
           Promise.all(refs.map((ref) => fetchVerseData(ref))),
-          buildReasons(refs, name.transliteration, name.meaning),
+          buildReasons(refs, name.transliteration, name.meaning, model),
         ]);
 
         const verses: NameVerse[] = refs
@@ -193,7 +195,8 @@ async function getVersesBySlug(
         name.arabic,
         name.transliteration,
         name.meaning,
-        name.description
+        name.description,
+        model
       );
       if (aiItems.length === 0) return [];
 
@@ -272,7 +275,7 @@ async function getVersesBySlug(
         slug,
         v.ref,
         locale,
-        () => translateReason(v.reason, language, { feature: "names" }),
+        (model) => translateReason(v.reason, language, { feature: "names", model }),
         onBeforeGenerateOnce
       );
       // A blank/failed translation must never silently replace an

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -4,7 +4,11 @@ import { translateReason } from "@/lib/ai/translate";
 import { getNameBySlug } from "@/lib/names/divine-names";
 import { isValidRef } from "@/lib/quran/quran-corpus";
 import { resolveVerse } from "@/lib/quran/verse-resolver";
-import { getOrGenerateNameContent, getOrGenerateVerseReason } from "@/lib/names/name-content";
+import {
+  getOrGenerateNameContent,
+  getOrGenerateVerseReason,
+  type ResolvedNamesModel,
+} from "@/lib/names/name-content";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
 import { incr } from "@/lib/infra/metrics";
@@ -71,7 +75,7 @@ async function buildReasons(
   refs: string[],
   transliteration: string,
   meaning: string,
-  model: string
+  resolved: ResolvedNamesModel
 ): Promise<Map<string, string>> {
   if (refs.length === 0) return new Map();
   const prompt = `You are a classical Islamic scholar (Maturidi/Hanafi tradition).
@@ -87,7 +91,7 @@ Output format:
 { "surah:ayah": "one sentence", ... }`;
 
   try {
-    const text = await callAI(prompt, { feature: "names", model });
+    const text = await callAI(prompt, { feature: "names", ...resolved });
     const match = text.match(/\{[\s\S]*\}/);
     if (!match) return new Map();
     const obj: unknown = JSON.parse(match[0]);
@@ -109,7 +113,7 @@ async function fallbackAIVerses(
   transliteration: string,
   meaning: string,
   description: string,
-  model: string
+  resolved: ResolvedNamesModel
 ): Promise<Array<{ ref: string; reason: string }>> {
   const prompt = `You are a classical Islamic scholar (Maturidi/Hanafi tradition).
 
@@ -122,7 +126,7 @@ Return ONLY a JSON array:
 [{ "ref": "surah:ayah", "reason": "one sentence" }, ...]`;
 
   try {
-    const text = await callAI(prompt, { feature: "names", model });
+    const text = await callAI(prompt, { feature: "names", ...resolved });
     const match = text.match(/\[[\s\S]*\]/);
     if (!match) return [];
     const raw: unknown = JSON.parse(match[0]);
@@ -164,7 +168,7 @@ async function getVersesBySlug(
     // requester's locale — see name_verse_reasons below for why.
     "en",
     VERSES_VERSION,
-    async (model): Promise<NameVerse[]> => {
+    async (resolved): Promise<NameVerse[]> => {
       // Try actual quran.com search first
       const refs = await searchVerseRefs(name.arabic);
 
@@ -172,7 +176,7 @@ async function getVersesBySlug(
       if (refs.length > 0) {
         const [verseDataResults, reasonMap] = await Promise.all([
           Promise.all(refs.map((ref) => fetchVerseData(ref))),
-          buildReasons(refs, name.transliteration, name.meaning, model),
+          buildReasons(refs, name.transliteration, name.meaning, resolved),
         ]);
 
         const verses: NameVerse[] = refs
@@ -196,7 +200,7 @@ async function getVersesBySlug(
         name.transliteration,
         name.meaning,
         name.description,
-        model
+        resolved
       );
       if (aiItems.length === 0) return [];
 
@@ -275,7 +279,7 @@ async function getVersesBySlug(
         slug,
         v.ref,
         locale,
-        (model) => translateReason(v.reason, language, { feature: "names", model }),
+        (resolved) => translateReason(v.reason, language, { feature: "names", ...resolved }),
         onBeforeGenerateOnce
       );
       // A blank/failed translation must never silently replace an

--- a/components/admin/CoverageReport.tsx
+++ b/components/admin/CoverageReport.tsx
@@ -16,6 +16,7 @@ import { useAsync } from "@/components/admin/useAsync";
 import type { CoverageReport as CoverageResponse, CoverageCell } from "@/lib/admin/coverage-report";
 import type { Locale } from "@/lib/i18n/config";
 import type { EdgeKind } from "@/types/quran";
+import { SELECTABLE_MODELS } from "@/lib/ai/models";
 
 type Kind = EdgeKind;
 
@@ -38,6 +39,7 @@ export function CoverageReport() {
 
   const [mode, setMode] = useState<"baseline" | "topup">("baseline");
   const [provider, setProvider] = useState<"claude" | "gemini">("gemini");
+  const [model, setModel] = useState("");
   const [runLocales, setRunLocales] = useState<Record<string, boolean>>({
     tr: true,
     ru: true,
@@ -61,6 +63,7 @@ export function CoverageReport() {
           params: {
             mode,
             provider,
+            ...(model ? { model } : {}),
             locales: TARGET_LOCALES.filter((l) => runLocales[l]).join(","),
             maxCalls,
             maxCostUsd,
@@ -267,11 +270,30 @@ export function CoverageReport() {
                 <span className="mb-1 block text-text-muted">Provider</span>
                 <select
                   value={provider}
-                  onChange={(e) => setProvider(e.target.value as "claude" | "gemini")}
+                  onChange={(e) => {
+                    setProvider(e.target.value as "claude" | "gemini");
+                    setModel("");
+                  }}
                   className="w-full rounded border border-border bg-bg px-2 py-1.5"
                 >
                   <option value="gemini">gemini — cheapest</option>
                   <option value="claude">claude — highest fidelity</option>
+                </select>
+              </label>
+
+              <label className="text-xs">
+                <span className="mb-1 block text-text-muted">Model</span>
+                <select
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  className="w-full rounded border border-border bg-bg px-2 py-1.5"
+                >
+                  <option value="">default</option>
+                  {SELECTABLE_MODELS[provider].map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
                 </select>
               </label>
 

--- a/lib/admin/feature-flag-keys.ts
+++ b/lib/admin/feature-flag-keys.ts
@@ -11,6 +11,13 @@ const KNOWN_FLAG_TYPES: Record<string, FlagType> = {
   // lib/ai/ai.ts resolveProvider().
   ai_provider_connections: "string",
   ai_provider_names: "string",
+  // Model overrides (a model id from lib/ai/models.ts SELECTABLE_MODELS).
+  // `ai_model_<feature>` beats `ai_model` beats the <PROVIDER>_MODEL env / built-in
+  // default. A value that doesn't match the resolved provider is ignored. See
+  // lib/ai/ai.ts resolveModel(). Not enum-validated here (same as ai_provider_*).
+  ai_model: "string",
+  ai_model_connections: "string",
+  ai_model_names: "string",
   maintenance_mode: "boolean",
   ai_gen_limit: "number",
   ai_gen_window_seconds: "number",

--- a/lib/admin/job-runner.ts
+++ b/lib/admin/job-runner.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/infra/db";
 import { jobRuns, verses, verseEmbeddings } from "@/lib/infra/db/schema";
 import { runConnectionBatch, type BatchOptions } from "@/lib/ai/connection-batch";
 import type { Provider } from "@/lib/ai/ai";
+import { SELECTABLE_MODELS, isModelForProvider } from "@/lib/ai/models";
 import { LOCALES, type Locale } from "@/lib/i18n/config";
 
 /**
@@ -77,6 +78,11 @@ function parseBackfillParams(raw: Record<string, unknown>): BatchOptions {
     throw new Error("provider must be claude or gemini");
   }
 
+  const model = raw.model === undefined || raw.model === "" ? undefined : raw.model;
+  if (model !== undefined && (typeof model !== "string" || !isModelForProvider(model, provider))) {
+    throw new Error(`model must be one of: ${SELECTABLE_MODELS[provider].join(", ")}`);
+  }
+
   const localeList = String(raw.locales ?? "")
     .split(",")
     .map((s) => s.trim())
@@ -100,6 +106,7 @@ function parseBackfillParams(raw: Record<string, unknown>): BatchOptions {
   return {
     mode,
     provider: provider as Provider,
+    model: model as string | undefined,
     locales: localeList.filter((l): l is Locale => (LOCALES as readonly string[]).includes(l)),
     maxCalls,
     maxCostUsd,

--- a/lib/ai/ai-cost.ts
+++ b/lib/ai/ai-cost.ts
@@ -7,7 +7,9 @@ import type { AiUsage, Provider } from "@/lib/ai/ai";
  * Rates are USD per 1M tokens, current as of 2026-08 (Anthropic first-party API
  * and Google Gemini list pricing). They are deliberately a small hand-maintained
  * table — update when pricing changes or a new model id starts appearing in
- * `ai_generations.model`. An unknown model falls back to its provider's
+ * `ai_generations.model`. Every id an admin can pick in `lib/ai/models.ts`
+ * (`SELECTABLE_MODELS`) must have an entry here, or the spend guard falls back to
+ * the conservative over-estimate. An unknown model falls back to its provider's
  * most-expensive plausible rate so an estimate never silently under-reports.
  */
 

--- a/lib/ai/ai.ts
+++ b/lib/ai/ai.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { getFlagString } from "@/lib/admin/feature-flags";
+import { DEFAULT_MODEL, isModelForProvider } from "@/lib/ai/models";
 
 export type Provider = "claude" | "gemini";
 
@@ -21,22 +22,64 @@ export interface AiResult {
 }
 
 export interface CallAiOptions {
-  /** Which feature is calling — selects a per-feature provider flag/env when set. */
+  /** Which feature is calling — selects a per-feature provider/model flag/env when set. */
   feature?: AiFeature;
   /** Hard provider override (e.g. the admin batch job's per-run pick). Wins over
    *  every flag and env var. */
   provider?: Provider;
+  /** Hard model override (the admin batch job's per-run pick). Applied only when
+   *  it belongs to the resolved provider; otherwise ignored. */
+  model?: string;
 }
 
-/** The model id a provider will use by default (respecting the model env vars). */
+/** The model id a provider will use by default: the `<PROVIDER>_MODEL` env var
+ *  if set (operator escape hatch), else the built-in default. */
 export function defaultModelFor(provider: Provider): string {
   return provider === "gemini"
-    ? (process.env.GEMINI_MODEL ?? "gemini-3.5-flash-lite")
-    : (process.env.ANTHROPIC_MODEL ?? "claude-opus-4-7");
+    ? (process.env.GEMINI_MODEL ?? DEFAULT_MODEL.gemini)
+    : (process.env.ANTHROPIC_MODEL ?? DEFAULT_MODEL.claude);
 }
 
 function asProvider(value: string | undefined): Provider | null {
   return value === "claude" || value === "gemini" ? value : null;
+}
+
+/**
+ * Resolves the model for a call, given its already-resolved provider. Precedence
+ * (first hit that is a valid model for `provider` wins):
+ *   1. `override` argument (the batch job's per-run pick)
+ *   2. `ai_model_<feature>` admin flag
+ *   3. `AI_MODEL_<FEATURE>` env var
+ *   4. `ai_model` admin flag
+ *   5. `defaultModelFor(provider)` — `<PROVIDER>_MODEL` env, else built-in default
+ *
+ * Admin-set candidates (flags/env) are checked against the provider's selectable
+ * set so a leftover Claude model never gets sent to the Gemini API (or vice
+ * versa) when the provider is switched. Step 5 is the operator escape hatch and
+ * is trusted as-is.
+ */
+export async function resolveModel(
+  feature: AiFeature | undefined,
+  provider: Provider,
+  override?: string
+): Promise<string> {
+  const validFor = (m: string | undefined | null): string | null =>
+    m && isModelForProvider(m, provider) ? m : null;
+
+  const fromOverride = validFor(override);
+  if (fromOverride) return fromOverride;
+
+  if (feature) {
+    const fromFeatureFlag = validFor(await getFlagString(`ai_model_${feature}`, ""));
+    if (fromFeatureFlag) return fromFeatureFlag;
+    const fromFeatureEnv = validFor(process.env[`AI_MODEL_${feature.toUpperCase()}`]);
+    if (fromFeatureEnv) return fromFeatureEnv;
+  }
+
+  const fromGlobalFlag = validFor(await getFlagString("ai_model", ""));
+  if (fromGlobalFlag) return fromGlobalFlag;
+
+  return defaultModelFor(provider);
 }
 
 /**
@@ -74,7 +117,8 @@ export async function resolveProvider(feature?: AiFeature, override?: Provider):
  */
 export async function callAIDetailed(prompt: string, opts: CallAiOptions = {}): Promise<AiResult> {
   const provider = await resolveProvider(opts.feature, opts.provider);
-  return provider === "gemini" ? callGemini(prompt) : callClaude(prompt);
+  const model = await resolveModel(opts.feature, provider, opts.model);
+  return provider === "gemini" ? callGemini(prompt, model) : callClaude(prompt, model);
 }
 
 /**
@@ -86,9 +130,8 @@ export async function callAI(prompt: string, opts: CallAiOptions = {}): Promise<
   return (await callAIDetailed(prompt, opts)).text;
 }
 
-async function callClaude(prompt: string): Promise<AiResult> {
+async function callClaude(prompt: string, model: string): Promise<AiResult> {
   const client = new Anthropic();
-  const model = process.env.ANTHROPIC_MODEL ?? "claude-opus-4-7";
   const message = await client.messages.create({
     model,
     max_tokens: 4096,
@@ -110,10 +153,9 @@ async function callClaude(prompt: string): Promise<AiResult> {
   };
 }
 
-async function callGemini(prompt: string): Promise<AiResult> {
+async function callGemini(prompt: string, model: string): Promise<AiResult> {
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) throw new Error("GEMINI_API_KEY is not set");
-  const model = process.env.GEMINI_MODEL ?? "gemini-3.5-flash-lite";
   const ai = new GoogleGenerativeAI(apiKey);
   const genModel = ai.getGenerativeModel({ model });
   const result = await genModel.generateContent(prompt);

--- a/lib/ai/connection-batch.ts
+++ b/lib/ai/connection-batch.ts
@@ -4,7 +4,7 @@ import { verses, connections, connectionCoverage, aiGenerations } from "@/lib/in
 import { generateConnectionsForCell } from "@/lib/ai/graph-service";
 import { translateReason } from "@/lib/ai/translate";
 import { estimateCostUsd } from "@/lib/ai/ai-cost";
-import { defaultModelFor, type Provider } from "@/lib/ai/ai";
+import { resolveModel, type Provider } from "@/lib/ai/ai";
 import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 import { incr } from "@/lib/infra/metrics";
 import type { EdgeKind } from "@/types/quran";
@@ -86,8 +86,8 @@ const cellKey = (ref: string, kind: string) => `${ref}|${kind}`;
 
 /** Cost of one generation call, estimated (the generation path doesn't return
  *  token usage). Deliberately the DEFAULT_TOKENS path so the guard errs early. */
-function perCallCost(provider: Provider, model?: string): number {
-  return estimateCostUsd(model || defaultModelFor(provider), provider, null);
+function perCallCost(provider: Provider, model: string): number {
+  return estimateCostUsd(model, provider, null);
 }
 
 /** Builds the ordered work list from current DB state. */
@@ -185,7 +185,7 @@ async function translateCellReasons(
   kind: EdgeKind,
   locales: Locale[],
   provider: Provider,
-  model: string | undefined,
+  model: string,
   budget: { spend: () => boolean; stoppedReason: StoppedReason | null }
 ): Promise<{ inserted: number; stoppedReason: StoppedReason | null }> {
   if (locales.length === 0) return { inserted: 0, stoppedReason: null };
@@ -203,7 +203,6 @@ async function translateCellReasons(
     );
   if (enRows.length === 0) return { inserted: 0, stoppedReason: null };
 
-  const attributedModel = model || defaultModelFor(provider);
   let inserted = 0;
 
   for (const locale of locales) {
@@ -241,7 +240,7 @@ async function translateCellReasons(
           kind,
           reason: translated,
           locale,
-          model: attributedModel,
+          model,
         })
         .onConflictDoNothing()
         .returning({ toRef: connections.toRef });
@@ -249,9 +248,7 @@ async function translateCellReasons(
 
       // Cost/audit visibility for translation spend (tokens not tracked here).
       try {
-        await db
-          .insert(aiGenerations)
-          .values({ fromRef, kind, model: attributedModel, promptVersion: null });
+        await db.insert(aiGenerations).values({ fromRef, kind, model, promptVersion: null });
       } catch (err) {
         console.error("connection-batch: ai_generations log failed:", err);
       }
@@ -304,6 +301,13 @@ export async function runConnectionBatch(
     exhausted: 0,
   };
 
+  // Resolve the effective model once, up front: with no per-run pick,
+  // `callAIDetailed` inside generation still applies the connections
+  // flag/env/global-model precedence, so the budget estimate, progress line,
+  // and persisted `model` must resolve the same way or they'd disagree with
+  // what actually ran. Passed as an explicit override everywhere below.
+  const model = await resolveModel("connections", opts.provider, opts.model);
+
   let cells: Cell[];
   try {
     cells = await buildWorkList(opts.mode);
@@ -316,12 +320,12 @@ export async function runConnectionBatch(
 
   hooks.onProgress(
     `[${opts.mode}] ${cells.length} cells to consider | provider=${opts.provider} | ` +
-      `model=${opts.model || "default"} | ` +
+      `model=${model} | ` +
       `locales=${opts.locales.join(",") || "none"} | maxCalls=${opts.maxCalls} | ` +
       `maxCost=$${opts.maxCostUsd}`
   );
 
-  const callCost = perCallCost(opts.provider, opts.model);
+  const callCost = perCallCost(opts.provider, model);
 
   // Shared spend guard. `spend()` is called before EVERY LLM request (one
   // generation + one per locale translation per cell); it debits the counters
@@ -374,7 +378,7 @@ export async function runConnectionBatch(
         excludeRefs,
         "en",
         opts.provider,
-        opts.model
+        model
       );
       if (!calledAI) {
         // No grounding data / drained pool — no request was actually made, so
@@ -399,7 +403,7 @@ export async function runConnectionBatch(
           cell.kind,
           opts.locales,
           opts.provider,
-          opts.model,
+          model,
           budget
         );
         summary.translated += xlt.inserted;

--- a/lib/ai/connection-batch.ts
+++ b/lib/ai/connection-batch.ts
@@ -44,6 +44,9 @@ export interface BatchOptions {
   mode: BatchMode;
   /** Which LLM to use for this run — the admin's per-run pick. */
   provider: Provider;
+  /** Which model to use — the admin's per-run pick. Empty/undefined = the
+   *  resolved default for `provider`. Applied only when it belongs to `provider`. */
+  model?: string;
   /** Target locales to translate the English reason into (subset of tr/ru/az). */
   locales: Locale[];
   /** Hard ceiling on LLM calls this run. Always exact. */
@@ -83,8 +86,8 @@ const cellKey = (ref: string, kind: string) => `${ref}|${kind}`;
 
 /** Cost of one generation call, estimated (the generation path doesn't return
  *  token usage). Deliberately the DEFAULT_TOKENS path so the guard errs early. */
-function perCallCost(provider: Provider): number {
-  return estimateCostUsd(defaultModelFor(provider), provider, null);
+function perCallCost(provider: Provider, model?: string): number {
+  return estimateCostUsd(model || defaultModelFor(provider), provider, null);
 }
 
 /** Builds the ordered work list from current DB state. */
@@ -182,6 +185,7 @@ async function translateCellReasons(
   kind: EdgeKind,
   locales: Locale[],
   provider: Provider,
+  model: string | undefined,
   budget: { spend: () => boolean; stoppedReason: StoppedReason | null }
 ): Promise<{ inserted: number; stoppedReason: StoppedReason | null }> {
   if (locales.length === 0) return { inserted: 0, stoppedReason: null };
@@ -199,7 +203,7 @@ async function translateCellReasons(
     );
   if (enRows.length === 0) return { inserted: 0, stoppedReason: null };
 
-  const model = defaultModelFor(provider);
+  const attributedModel = model || defaultModelFor(provider);
   let inserted = 0;
 
   for (const locale of locales) {
@@ -213,6 +217,7 @@ async function translateCellReasons(
         translated = await translateReason(en.reason, LOCALE_LANGUAGE_NAME[locale], {
           feature: "connections",
           provider,
+          model,
         });
       } catch (err) {
         console.error(`connection-batch: translation failed ${fromRef} ${kind} ${locale}:`, err);
@@ -230,14 +235,23 @@ async function translateCellReasons(
 
       const rows = await db
         .insert(connections)
-        .values({ fromRef, toRef: en.toRef, kind, reason: translated, locale, model })
+        .values({
+          fromRef,
+          toRef: en.toRef,
+          kind,
+          reason: translated,
+          locale,
+          model: attributedModel,
+        })
         .onConflictDoNothing()
         .returning({ toRef: connections.toRef });
       if (rows.length > 0) inserted++;
 
       // Cost/audit visibility for translation spend (tokens not tracked here).
       try {
-        await db.insert(aiGenerations).values({ fromRef, kind, model, promptVersion: null });
+        await db
+          .insert(aiGenerations)
+          .values({ fromRef, kind, model: attributedModel, promptVersion: null });
       } catch (err) {
         console.error("connection-batch: ai_generations log failed:", err);
       }
@@ -302,11 +316,12 @@ export async function runConnectionBatch(
 
   hooks.onProgress(
     `[${opts.mode}] ${cells.length} cells to consider | provider=${opts.provider} | ` +
+      `model=${opts.model || "default"} | ` +
       `locales=${opts.locales.join(",") || "none"} | maxCalls=${opts.maxCalls} | ` +
       `maxCost=$${opts.maxCostUsd}`
   );
 
-  const callCost = perCallCost(opts.provider);
+  const callCost = perCallCost(opts.provider, opts.model);
 
   // Shared spend guard. `spend()` is called before EVERY LLM request (one
   // generation + one per locale translation per cell); it debits the counters
@@ -358,7 +373,8 @@ export async function runConnectionBatch(
         { arabicText: cell.arabicText, translation: cell.translation },
         excludeRefs,
         "en",
-        opts.provider
+        opts.provider,
+        opts.model
       );
       if (!calledAI) {
         // No grounding data / drained pool — no request was actually made, so
@@ -383,6 +399,7 @@ export async function runConnectionBatch(
           cell.kind,
           opts.locales,
           opts.provider,
+          opts.model,
           budget
         );
         summary.translated += xlt.inserted;

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -22,11 +22,12 @@ import type { ConnectionResult, EdgeKind, Verse } from "@/types/quran";
  * Both log the generation to `ai_generations`.
  */
 
-/** Optional generation controls. `provider` forces a specific LLM for this
- *  call (the admin batch job's per-run pick), bypassing the feature/global
- *  provider flags. */
+/** Optional generation controls. `provider` / `model` force a specific LLM for
+ *  this call (the admin batch job's per-run pick), bypassing the feature/global
+ *  flags. `model` is applied only when it belongs to the resolved provider. */
 export interface GenerateOpts {
   provider?: Provider;
+  model?: string;
 }
 
 function tokensFromUsage(
@@ -158,7 +159,11 @@ export async function generateConnections(
     kind,
     locale
   );
-  const res = await callAIDetailed(prompt, { feature: "connections", provider: opts.provider });
+  const res = await callAIDetailed(prompt, {
+    feature: "connections",
+    provider: opts.provider,
+    model: opts.model,
+  });
   const text = res.text;
 
   // Best-effort audit log — never fail generation because logging failed.
@@ -296,7 +301,11 @@ export async function generateGroundedConnections(
     candidates,
     locale
   );
-  const res = await callAIDetailed(prompt, { feature: "connections", provider: opts.provider });
+  const res = await callAIDetailed(prompt, {
+    feature: "connections",
+    provider: opts.provider,
+    model: opts.model,
+  });
   const text = res.text;
 
   try {

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -2,7 +2,7 @@ import { and, eq, inArray, notInArray } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { connections, type Connection } from "@/lib/infra/db/schema";
 import { generateConnections, generateGroundedConnections } from "@/lib/ai/connection-generator";
-import { defaultModelFor, resolveProvider, type Provider } from "@/lib/ai/ai";
+import { resolveModel, resolveProvider, type Provider } from "@/lib/ai/ai";
 import { discoverCandidates } from "@/lib/ai/connection-discovery";
 import { resolveVerse } from "@/lib/quran/verse-resolver";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
@@ -57,6 +57,9 @@ interface GetConnectionsOptions {
    *  batch job's per-run pick). Unset for live traffic, which uses the
    *  feature/global provider flags. */
   provider?: Provider;
+  /** Forces a specific model for the miss-path generation (applied only when it
+   *  belongs to the resolved provider). Batch job's per-run pick. */
+  model?: string;
 }
 
 /** Hydrate stored edges (which carry only refs + reason) into full results. */
@@ -129,10 +132,10 @@ export async function getConnections(
   // Single-flight: if an identical generation is already running, join it rather
   // than starting a second AI call. The get→set below MUST stay synchronous (no
   // await between them) or two concurrent callers could both become the leader.
-  // The exclude set, locale, and provider are folded into the key so a "get
-  // more" request, a different-locale request, or a request pinned to a
-  // different provider never coalesces with an unrelated one.
-  const key = `${fromRef}:${kind}:${locale}:${options.provider ?? "default"}:${[...excludeRefs].sort().join(",")}`;
+  // The exclude set, locale, provider, and model are folded into the key so a
+  // "get more" request, a different-locale request, or a request pinned to a
+  // different provider/model never coalesces with an unrelated one.
+  const key = `${fromRef}:${kind}:${locale}:${options.provider ?? "default"}:${options.model ?? "default"}:${[...excludeRefs].sort().join(",")}`;
   const pending = inFlight.get(key);
   if (pending) {
     incr("gen_coalesced");
@@ -146,7 +149,8 @@ export async function getConnections(
     source,
     excludeRefs,
     locale,
-    options.provider
+    options.provider,
+    options.model
   );
   inFlight.set(key, work);
   try {
@@ -174,9 +178,10 @@ export async function generateConnectionsForCell(
   source: SourceVerse,
   excludeRefs: string[] = [],
   locale: Locale = "en",
-  provider?: Provider
+  provider?: Provider,
+  model?: string
 ): Promise<CellGenerationResult> {
-  const genOpts = provider ? ([{ provider }] as const) : ([] as const);
+  const genOpts = provider || model ? ([{ provider, model }] as const) : ([] as const);
   const candidates = await discoverCandidates(fromRef, kind, undefined, excludeRefs);
   const calledAI = candidates.length > 0 || excludeRefs.length === 0;
   // The legacy ungrounded path has no notion of excludeRefs — it would just
@@ -207,10 +212,11 @@ export async function generateConnectionsForCell(
           );
 
   if (generated.length > 0) {
-    // Attribute the row to the model that actually generated it. With no
-    // explicit provider, the generator resolves the connections feature/global
-    // provider flag — which can be Gemini — so ANTHROPIC_MODEL would be wrong.
-    const model = defaultModelFor(provider ?? (await resolveProvider("connections")));
+    // Attribute the row to the model that actually generated it — resolve the
+    // same provider + model the generator used (feature/global flags, or the
+    // batch job's per-run override), not the ANTHROPIC_MODEL default.
+    const resolvedProvider = provider ?? (await resolveProvider("connections"));
+    const attributedModel = await resolveModel("connections", resolvedProvider, model);
     try {
       const inserted = await db
         .insert(connections)
@@ -220,7 +226,7 @@ export async function generateConnectionsForCell(
             toRef: g.ref,
             kind,
             reason: g.reason,
-            model,
+            model: attributedModel,
             locale,
           }))
         )

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -212,9 +212,9 @@ export async function generateConnectionsForCell(
           );
 
   if (generated.length > 0) {
-    // Attribute the row to the model that actually generated it — resolve the
-    // same provider + model the generator used (feature/global flags, or the
-    // batch job's per-run override), not the ANTHROPIC_MODEL default.
+    // Attribute the row to the model that generated it — resolve the same
+    // provider + model the generator used (batch job's per-run override, or the
+    // connections feature/global flags), not the ANTHROPIC_MODEL default.
     const resolvedProvider = provider ?? (await resolveProvider("connections"));
     const attributedModel = await resolveModel("connections", resolvedProvider, model);
     try {

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -129,13 +129,22 @@ export async function getConnections(
     if (!allowed) throw new RateLimitError();
   }
 
+  // Resolve the effective provider+model ONCE for this miss (honouring any
+  // batch-job override), then thread the same concrete pair through the
+  // single-flight key, the generation call, and the persisted attribution — so
+  // an admin flipping `ai_provider_connections` / `ai_model_connections`
+  // between those steps can't make the request use one provider while the row
+  // records a model from another.
+  const provider = await resolveProvider("connections", options.provider);
+  const model = await resolveModel("connections", provider, options.model);
+
   // Single-flight: if an identical generation is already running, join it rather
   // than starting a second AI call. The get→set below MUST stay synchronous (no
   // await between them) or two concurrent callers could both become the leader.
   // The exclude set, locale, provider, and model are folded into the key so a
   // "get more" request, a different-locale request, or a request pinned to a
   // different provider/model never coalesces with an unrelated one.
-  const key = `${fromRef}:${kind}:${locale}:${options.provider ?? "default"}:${options.model ?? "default"}:${[...excludeRefs].sort().join(",")}`;
+  const key = `${fromRef}:${kind}:${locale}:${provider}:${model}:${[...excludeRefs].sort().join(",")}`;
   const pending = inFlight.get(key);
   if (pending) {
     incr("gen_coalesced");
@@ -149,8 +158,8 @@ export async function getConnections(
     source,
     excludeRefs,
     locale,
-    options.provider,
-    options.model
+    provider,
+    model
   );
   inFlight.set(key, work);
   try {
@@ -178,10 +187,10 @@ export async function generateConnectionsForCell(
   source: SourceVerse,
   excludeRefs: string[] = [],
   locale: Locale = "en",
-  provider?: Provider,
-  model?: string
+  provider: Provider,
+  model: string
 ): Promise<CellGenerationResult> {
-  const genOpts = provider || model ? ([{ provider, model }] as const) : ([] as const);
+  const genOpts = [{ provider, model }] as const;
   const candidates = await discoverCandidates(fromRef, kind, undefined, excludeRefs);
   const calledAI = candidates.length > 0 || excludeRefs.length === 0;
   // The legacy ungrounded path has no notion of excludeRefs — it would just
@@ -212,11 +221,9 @@ export async function generateConnectionsForCell(
           );
 
   if (generated.length > 0) {
-    // Attribute the row to the model that generated it — resolve the same
-    // provider + model the generator used (batch job's per-run override, or the
-    // connections feature/global flags), not the ANTHROPIC_MODEL default.
-    const resolvedProvider = provider ?? (await resolveProvider("connections"));
-    const attributedModel = await resolveModel("connections", resolvedProvider, model);
+    // Attribute the row to the exact model that generated it — the caller
+    // resolved the provider+model pair once and passed it straight through, so
+    // there's nothing to re-resolve here.
     try {
       const inserted = await db
         .insert(connections)
@@ -226,7 +233,7 @@ export async function generateConnectionsForCell(
             toRef: g.ref,
             kind,
             reason: g.reason,
-            model: attributedModel,
+            model,
             locale,
           }))
         )

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -1,0 +1,29 @@
+import type { Provider } from "@/lib/ai/ai";
+
+/**
+ * The model ids an admin may pick per provider (the `/admin/flags` dropdowns and
+ * the backfill run panel). Keep in sync with the `RATES` table in
+ * `lib/ai/ai-cost.ts` — every id here needs a rate so the spend guard doesn't
+ * fall back to the conservative over-estimate — and with `defaultModelFor` in
+ * `lib/ai/ai.ts` when a model is retired.
+ */
+export const SELECTABLE_MODELS: Record<Provider, readonly string[]> = {
+  claude: ["claude-opus-4-7", "claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5"],
+  gemini: [
+    "gemini-3.7-flash",
+    "gemini-3.6-flash",
+    "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.1-flash-lite",
+  ],
+} as const;
+
+/** The model each provider falls back to when nothing is configured. */
+export const DEFAULT_MODEL: Record<Provider, string> = {
+  claude: "claude-opus-4-7",
+  gemini: "gemini-3.5-flash-lite",
+};
+
+export function isModelForProvider(model: string, provider: Provider): boolean {
+  return SELECTABLE_MODELS[provider].includes(model);
+}

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -1,14 +1,17 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { nameContent, nameVerseReasons, type NameContentKind } from "@/lib/infra/db/schema";
-import { defaultModelFor, resolveProvider } from "@/lib/ai/ai";
+import { resolveModel, resolveProvider } from "@/lib/ai/ai";
 import type { Locale } from "@/lib/i18n/config";
 
-// The `model` column records which provider produced the row for later cost
-// attribution. The names feature can be pointed at Gemini (see `resolveProvider`
-// / `ai_provider_names`), so read the resolved provider rather than assuming the
-// Anthropic env var.
-const generatedModel = async () => defaultModelFor(await resolveProvider("names"));
+// The `model` column records which model produced the row for later cost
+// attribution. The names feature can be pointed at a different provider/model
+// (see `ai_provider_names` / `ai_model_names`), so resolve the same way the
+// actual `callAI` will rather than assuming the Anthropic env var.
+const generatedModel = async () => {
+  const provider = await resolveProvider("names");
+  return resolveModel("names", provider);
+};
 
 /**
  * Durable, write-once/read-many cache for the AI-generated 99-Names content

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -4,11 +4,11 @@ import { nameContent, nameVerseReasons, type NameContentKind } from "@/lib/infra
 import { resolveModel, resolveProvider } from "@/lib/ai/ai";
 import type { Locale } from "@/lib/i18n/config";
 
-// The `model` column records which model produced the row for later cost
-// attribution. The names feature can be pointed at a different provider/model
-// (see `ai_provider_names` / `ai_model_names`), so resolve the same way the
-// actual `callAI` will rather than assuming the Anthropic env var.
-const generatedModel = async () => {
+// The model to use for (and attribute) one names generation. Resolved ONCE per
+// generation and passed into both the `callAI` request and the persisted `model`
+// column, so a config change (`ai_provider_names` / `ai_model_names`) mid-flight
+// can't make the recorded model disagree with the one that actually ran.
+const resolveNamesModel = async () => {
   const provider = await resolveProvider("names");
   return resolveModel("names", provider);
 };
@@ -53,7 +53,7 @@ export async function getOrGenerateNameContent<T>(
   kind: NameContentKind,
   locale: Locale,
   version: number,
-  generate: () => Promise<T>,
+  generate: (model: string) => Promise<T>,
   isEmpty: (value: T) => boolean,
   onBeforeGenerate?: () => Promise<void>
 ): Promise<T> {
@@ -139,14 +139,16 @@ async function generateAndPersist<T>(
   kind: NameContentKind,
   locale: Locale,
   version: number,
-  generate: () => Promise<T>,
+  generate: (model: string) => Promise<T>,
   isEmpty: (value: T) => boolean
 ): Promise<T> {
-  const result = await generate();
+  // Resolve the model before generation and use the same value for the request
+  // and the persisted attribution.
+  const model = await resolveNamesModel();
+  const result = await generate(model);
 
   if (!isEmpty(result)) {
     const data = JSON.stringify(result);
-    const model = await generatedModel();
     try {
       await db
         .insert(nameContent)
@@ -180,7 +182,7 @@ export async function getOrGenerateVerseReason(
   slug: string,
   ref: string,
   locale: Locale,
-  generate: () => Promise<string>,
+  generate: (model: string) => Promise<string>,
   onBeforeGenerate?: () => Promise<void>
 ): Promise<string> {
   const [row] = await db
@@ -204,10 +206,10 @@ export async function getOrGenerateVerseReason(
   if (pending) return pending;
 
   const work = (async () => {
-    const reason = await generate();
+    const model = await resolveNamesModel();
+    const reason = await generate(model);
     if (reason.trim() === "") return reason;
 
-    const model = await generatedModel();
     try {
       // `reasonInFlight` only coalesces callers within this process — a
       // concurrent request on another instance can win the same (slug, ref,

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -1,16 +1,24 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { nameContent, nameVerseReasons, type NameContentKind } from "@/lib/infra/db/schema";
-import { resolveModel, resolveProvider } from "@/lib/ai/ai";
+import { resolveModel, resolveProvider, type Provider } from "@/lib/ai/ai";
 import type { Locale } from "@/lib/i18n/config";
 
-// The model to use for (and attribute) one names generation. Resolved ONCE per
-// generation and passed into both the `callAI` request and the persisted `model`
+/** The provider+model to use for (and attribute) one names generation. */
+export interface ResolvedNamesModel {
+  provider: Provider;
+  model: string;
+}
+
+// Resolved ONCE per generation and passed as a pinned pair into both the
+// `callAI` request (as provider + model overrides) and the persisted `model`
 // column, so a config change (`ai_provider_names` / `ai_model_names`) mid-flight
-// can't make the recorded model disagree with the one that actually ran.
-const resolveNamesModel = async () => {
+// can't make the request use one provider while the recorded model belongs to
+// another — or make the stored attribution disagree with what actually ran.
+const resolveNamesModel = async (): Promise<ResolvedNamesModel> => {
   const provider = await resolveProvider("names");
-  return resolveModel("names", provider);
+  const model = await resolveModel("names", provider);
+  return { provider, model };
 };
 
 /**
@@ -53,7 +61,7 @@ export async function getOrGenerateNameContent<T>(
   kind: NameContentKind,
   locale: Locale,
   version: number,
-  generate: (model: string) => Promise<T>,
+  generate: (resolved: ResolvedNamesModel) => Promise<T>,
   isEmpty: (value: T) => boolean,
   onBeforeGenerate?: () => Promise<void>
 ): Promise<T> {
@@ -139,13 +147,14 @@ async function generateAndPersist<T>(
   kind: NameContentKind,
   locale: Locale,
   version: number,
-  generate: (model: string) => Promise<T>,
+  generate: (resolved: ResolvedNamesModel) => Promise<T>,
   isEmpty: (value: T) => boolean
 ): Promise<T> {
-  // Resolve the model before generation and use the same value for the request
-  // and the persisted attribution.
-  const model = await resolveNamesModel();
-  const result = await generate(model);
+  // Resolve the provider+model before generation and use the same pair for the
+  // request and the persisted attribution.
+  const resolved = await resolveNamesModel();
+  const result = await generate(resolved);
+  const model = resolved.model;
 
   if (!isEmpty(result)) {
     const data = JSON.stringify(result);
@@ -182,7 +191,7 @@ export async function getOrGenerateVerseReason(
   slug: string,
   ref: string,
   locale: Locale,
-  generate: (model: string) => Promise<string>,
+  generate: (resolved: ResolvedNamesModel) => Promise<string>,
   onBeforeGenerate?: () => Promise<void>
 ): Promise<string> {
   const [row] = await db
@@ -206,8 +215,9 @@ export async function getOrGenerateVerseReason(
   if (pending) return pending;
 
   const work = (async () => {
-    const model = await resolveNamesModel();
-    const reason = await generate(model);
+    const resolved = await resolveNamesModel();
+    const reason = await generate(resolved);
+    const model = resolved.model;
     if (reason.trim() === "") return reason;
 
     try {

--- a/scripts/backfill-connections.ts
+++ b/scripts/backfill-connections.ts
@@ -17,9 +17,11 @@
  *   BACKFILL_LOCALES      csv subset of tr,ru,az (may be empty)
  *   BACKFILL_MAX_CALLS    hard ceiling on LLM calls (exact)
  *   BACKFILL_MAX_COST_USD best-effort USD ceiling
+ *   BACKFILL_MODEL        optional model id (must match BACKFILL_PROVIDER)
  */
 import { runConnectionBatch, type BatchMode } from "@/lib/ai/connection-batch";
 import type { Provider } from "@/lib/ai/ai";
+import { SELECTABLE_MODELS, isModelForProvider } from "@/lib/ai/models";
 import { LOCALES, type Locale } from "@/lib/i18n/config";
 
 function requireEnv(name: string): string {
@@ -70,6 +72,14 @@ const locales = localeInput.filter(
   (l): l is Locale => (LOCALES as readonly string[]).includes(l) && l !== "en"
 );
 
+const model = process.env.BACKFILL_MODEL || undefined;
+if (model !== undefined && !isModelForProvider(model, provider)) {
+  console.error(
+    `backfill-connections: BACKFILL_MODEL "${model}" is not valid for ${provider} — one of: ${SELECTABLE_MODELS[provider].join(", ")}`
+  );
+  process.exit(1);
+}
+
 const maxCalls = Number(requireEnv("BACKFILL_MAX_CALLS"));
 const maxCostUsd = Number(requireEnv("BACKFILL_MAX_COST_USD"));
 if (
@@ -88,6 +98,7 @@ const summary = await runConnectionBatch(
   {
     mode: mode as BatchMode,
     provider: provider as Provider,
+    model,
     locales,
     maxCalls,
     maxCostUsd,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -37,4 +37,4 @@ process.env.NEXT_PUBLIC_QF_AUTH_BASE = "https://auth.test.qf.com";
 process.env.ANTHROPIC_API_KEY ??= "test-anthropic-key";
 process.env.AI_PROVIDER ??= "claude";
 process.env.GEMINI_API_KEY ??= "test-gemini-key-placeholder";
-process.env.GEMINI_MODEL ??= "gemini-2.0-flash";
+process.env.GEMINI_MODEL ??= "gemini-3.5-flash-lite";


### PR DESCRIPTION
## Summary

<!-- 1–3 bullet points: what changed and why -->

-
-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

<!-- Complete this section if you modified any Claude prompts, divine name data, or verse connection logic. Leave blank otherwise. -->

- [ ] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below
- [ ] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)

**Details** (if applicable):
<!-- Describe any changes to prompts, expected output format, or theological framing. Note any deviations from or additions to the Maturidi/Hanafi tradition. -->

## Testing

- [ ] `bun run test:ci` passes locally
- [ ] `bun run typecheck` passes locally
- [ ] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [ ] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Conventional commits
- [ ] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-route AI provider and model settings for default, connection, and name-generation workflows.
  - Added model selection for connection backfill jobs.
  - Added support for choosing compatible Claude and Gemini models.

- **Improvements**
  - AI-generated content now consistently uses the selected model.
  - Admin settings show the currently resolved provider and model.
  - Added validation for incompatible provider/model combinations.

- **Chores**
  - Updated the default Gemini model used by automated workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->