### PR TITLE
refactor(--tests--): update app, surah, ai, vitest.config for __tests__

### DIFF
--- a/__tests__/app/stories-pages.test.tsx
+++ b/__tests__/app/stories-pages.test.tsx
@@ -106,16 +106,13 @@ describe("Stories pages — locale-aware rendering", () => {
   });
 
   it("index page shows the locale-specific name/tagline when present", async () => {
-    // First dynamic import of this module in the suite — under full-suite
-    // parallel load, first-time module transform/eval can exceed the
-    // default 5s test timeout even though the test itself is fast.
     mockGetUiLocale.mockResolvedValue("tr");
     const { default: StoriesPage } = await import("@/app/stories/page");
     const text = extractText(await StoriesPage());
     expect(text).toContain("Test Hikayesi");
     expect(text).toContain("Türkçe bir slogan");
     expect(text).not.toContain("Test Story");
-  }, 15000);
+  });
 
   it("index page falls back to English when no locale-specific field exists", async () => {
     mockGetUiLocale.mockResolvedValue("az");

--- a/__tests__/app/surah/page.test.tsx
+++ b/__tests__/app/surah/page.test.tsx
@@ -48,6 +48,8 @@ describe("Surah reading page", () => {
   beforeEach(() => {
     mockGetSurahVerses.mockReset();
     mockGetSurahVerses.mockResolvedValue([verse("1:1"), verse("1:2")]);
+    mockGetQuranEdition.mockReset();
+    mockGetQuranEdition.mockResolvedValue("en.sahih");
   });
 
   it("renders the surah name and ayah count", async () => {
@@ -58,7 +60,7 @@ describe("Surah reading page", () => {
   });
 
   it("fetches every ayah for the requested surah with the caller's edition", async () => {
-    mockGetQuranEdition.mockResolvedValueOnce("tr.diyanet");
+    mockGetQuranEdition.mockResolvedValue("tr.diyanet");
     const { default: SurahReaderPage } = await import("@/app/surah/[number]/page");
     await SurahReaderPage({ params: Promise.resolve({ number: "18" }) });
     expect(mockGetSurahVerses).toHaveBeenCalledWith(18, "tr.diyanet");

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -167,6 +167,21 @@ describe("getConnections", () => {
     expect(out).toHaveLength(2);
   });
 
+  it("threads an explicit provider+model override through to generation", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    mockGenerate.mockResolvedValue([result("2:255")]);
+
+    await getConnections("1:1", "thematic", source, {
+      provider: "gemini",
+      model: "gemini-3.5-flash-lite",
+    });
+
+    expect(mockGenerate).toHaveBeenCalledWith("1:1", SOURCE_ARABIC, "tr", "thematic", "en", {
+      provider: "gemini",
+      model: "gemini-3.5-flash-lite",
+    });
+  });
+
   it("on a persist failure, still returns the generated results but counts it — not silent", async () => {
     mockSelect.mockReturnValue(makeSelectChain([])); // miss
     mockGenerate.mockResolvedValue([result("2:255")]);
@@ -448,6 +463,29 @@ describe("getConnections — single-flight de-duplication", () => {
     ]);
     expect(mockGenerate).toHaveBeenCalledTimes(1);
     expect(mockGenerateGrounded).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT coalesce misses resolved to different models (same verse+kind)", async () => {
+    mockGenerate.mockImplementation(async () => [result("2:255")]);
+    await Promise.all([
+      getConnections("1:1", "thematic", source, {
+        provider: "gemini",
+        model: "gemini-3.5-flash",
+      }),
+      getConnections("1:1", "thematic", source, {
+        provider: "gemini",
+        model: "gemini-3.5-flash-lite",
+      }),
+    ]);
+    expect(mockGenerate).toHaveBeenCalledTimes(2);
+    expect(mockGenerate).toHaveBeenCalledWith("1:1", SOURCE_ARABIC, "tr", "thematic", "en", {
+      provider: "gemini",
+      model: "gemini-3.5-flash",
+    });
+    expect(mockGenerate).toHaveBeenCalledWith("1:1", SOURCE_ARABIC, "tr", "thematic", "en", {
+      provider: "gemini",
+      model: "gemini-3.5-flash-lite",
+    });
   });
 
   it("does NOT coalesce different verse+kind keys", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    // The forks pool evaluates many first-time module transforms in parallel
+    // (jsdom + the App Router page modules are heavy). On a loaded machine that
+    // first import can alone approach Vitest's 5s default, timing out tests
+    // whose own logic is fast — a whole-suite flake that shifts files run to
+    // run. Give that headroom globally instead of patching one test at a time
+    // (see the now-removed `, 15000` on stories-pages.test.tsx).
+    testTimeout: 20000,
+    hookTimeout: 20000,
     // Forks pool is more compatible with Bun's runtime on Windows.
     // The prior threads preference was Node.js-specific.
     pool: "forks",


### PR DESCRIPTION
## Summary

<!-- 1–3 bullet points: what changed and why -->

-
-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

<!-- Complete this section if you modified any Claude prompts, divine name data, or verse connection logic. Leave blank otherwise. -->

- [ ] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below
- [ ] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)

**Details** (if applicable):
<!-- Describe any changes to prompts, expected output format, or theological framing. Note any deviations from or additions to the Maturidi/Hanafi tradition. -->

## Testing

- [ ] `bun run test:ci` passes locally
- [ ] `bun run typecheck` passes locally
- [ ] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [ ] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Conventional commits
- [ ] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to ensure AI connection generation respects selected provider and model settings.
  - Added coverage for handling concurrent requests that use different models.
  - Improved test isolation by resetting and consistently configuring mocked Quran edition data.
  - Standardized test timing with a 20-second limit for tests and setup hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->