### PR TITLE
fix(social): make the streak counter timezone-aware and reliable

### DIFF
--- a/__tests__/api/admin/users.test.ts
+++ b/__tests__/api/admin/users.test.ts
@@ -53,6 +53,7 @@ const targetUser = {
   lastActiveAt: new Date("2026-01-02"),
   currentStreak: 3,
   longestStreak: 10,
+  timezoneOffsetMinutes: null,
   disabledAt: null,
 };
 

--- a/__tests__/api/bookmarks.test.ts
+++ b/__tests__/api/bookmarks.test.ts
@@ -97,6 +97,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };

--- a/__tests__/api/notes.test.ts
+++ b/__tests__/api/notes.test.ts
@@ -62,6 +62,7 @@ function makeUser(): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
   };
 }

--- a/__tests__/api/social/activity.test.ts
+++ b/__tests__/api/social/activity.test.ts
@@ -100,6 +100,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 3,
     longestStreak: 5,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };
@@ -260,6 +261,71 @@ describe("POST /api/social/activity", () => {
     authedAs(makeUser({ currentStreak: 1, lastActivityDate: yesterdayStr() }));
     await POST(makeReq({ type: "verse_added" }));
     expect(mockTransaction).toHaveBeenCalledOnce();
+  });
+
+  it("buckets by the client's local_date, not UTC", async () => {
+    // 23:30 UTC on the 28th — a UTC+3 client is already on the 29th. Activity
+    // was last logged for the client's local day, so this is a same-day no-op.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T23:30:00Z"));
+    try {
+      authedAs(makeUser({ currentStreak: 4, lastActivityDate: "2026-08-29" }));
+      const res = await POST(makeReq({ type: "verse_added", local_date: "2026-08-29" }));
+      const body = await res.json();
+      expect(body.isNewDay).toBe(false);
+      expect(body.streak).toBe(4);
+      expect(body.activityDate).toBe("2026-08-29");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("increments when last activity was the client's local yesterday", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T23:30:00Z"));
+    try {
+      authedAs(makeUser({ currentStreak: 4, lastActivityDate: "2026-08-28" }));
+      const res = await POST(makeReq({ type: "verse_added", local_date: "2026-08-29" }));
+      const body = await res.json();
+      expect(body.isNewDay).toBe(true);
+      expect(body.streak).toBe(5);
+      expect(body.streakBroken).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores a wildly out-of-range local_date and falls back to UTC", async () => {
+    authedAs(makeUser({ currentStreak: 2, lastActivityDate: yesterdayStr() }));
+    const res = await POST(makeReq({ type: "verse_added", local_date: "1999-01-01" }));
+    const body = await res.json();
+    expect(body.activityDate).toBe(todayStr());
+    expect(body.streak).toBe(3);
+  });
+
+  it("persists the client's timezone offset on the user row", async () => {
+    authedAs(makeUser({ currentStreak: 1, lastActivityDate: yesterdayStr() }));
+    let captured: Record<string, unknown> | undefined;
+    mockUpdate.mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c: any = {
+        set: (v: Record<string, unknown>) => {
+          captured = v;
+          return c;
+        },
+        where: () => c,
+        then: (r: (v: unknown) => unknown) => Promise.resolve(undefined).then(r),
+      };
+      return c;
+    });
+    await POST(makeReq({ type: "verse_added", tz_offset_minutes: 180 }));
+    expect(captured?.timezoneOffsetMinutes).toBe(180);
+  });
+
+  it("rejects an out-of-range tz offset without persisting it", async () => {
+    authedAs(makeUser({ currentStreak: 1, lastActivityDate: yesterdayStr() }));
+    const res = await POST(makeReq({ type: "verse_added", tz_offset_minutes: 99999 }));
+    expect(res.status).toBe(400);
   });
 });
 

--- a/__tests__/api/social/activity.test.ts
+++ b/__tests__/api/social/activity.test.ts
@@ -303,6 +303,31 @@ describe("POST /api/social/activity", () => {
     expect(body.streak).toBe(3);
   });
 
+  it("falls back to UTC for a well-formed but non-existent local_date", async () => {
+    authedAs(makeUser({ currentStreak: 2, lastActivityDate: yesterdayStr() }));
+    const res = await POST(makeReq({ type: "verse_added", local_date: "2026-02-30" }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.activityDate).toBe(todayStr());
+  });
+
+  it("falls back when local_date disagrees with the supplied tz offset", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T12:00:00Z"));
+    try {
+      authedAs(makeUser({ currentStreak: 2, lastActivityDate: "2026-08-27" }));
+      // UTC+0 offset => local day is the 28th; a client claiming the 30th is
+      // trying to pre-credit two days ahead.
+      const res = await POST(
+        makeReq({ type: "verse_added", local_date: "2026-08-30", tz_offset_minutes: 0 })
+      );
+      const body = await res.json();
+      expect(body.activityDate).toBe("2026-08-28");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("persists the client's timezone offset on the user row", async () => {
     authedAs(makeUser({ currentStreak: 1, lastActivityDate: yesterdayStr() }));
     let captured: Record<string, unknown> | undefined;

--- a/__tests__/api/social/activity.test.ts
+++ b/__tests__/api/social/activity.test.ts
@@ -328,6 +328,23 @@ describe("POST /api/social/activity", () => {
     }
   });
 
+  it("credits the offset-derived day when local_date is one day ahead of it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T12:00:00Z"));
+    try {
+      authedAs(makeUser({ currentStreak: 2, lastActivityDate: "2026-08-27" }));
+      // UTC+0 => local day is the 28th; a client claiming the 29th can't
+      // pre-credit tomorrow even by a single day.
+      const res = await POST(
+        makeReq({ type: "verse_added", local_date: "2026-08-29", tz_offset_minutes: 0 })
+      );
+      const body = await res.json();
+      expect(body.activityDate).toBe("2026-08-28");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("persists the client's timezone offset on the user row", async () => {
     authedAs(makeUser({ currentStreak: 1, lastActivityDate: yesterdayStr() }));
     let captured: Record<string, unknown> | undefined;

--- a/__tests__/api/social/challenge-suggestions.test.ts
+++ b/__tests__/api/social/challenge-suggestions.test.ts
@@ -57,6 +57,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };

--- a/__tests__/api/social/challenges.test.ts
+++ b/__tests__/api/social/challenges.test.ts
@@ -98,6 +98,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };

--- a/__tests__/api/social/friends-friendId.test.ts
+++ b/__tests__/api/social/friends-friendId.test.ts
@@ -68,6 +68,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };

--- a/__tests__/api/social/friends-pending-count.test.ts
+++ b/__tests__/api/social/friends-pending-count.test.ts
@@ -49,6 +49,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };

--- a/__tests__/api/social/friends.test.ts
+++ b/__tests__/api/social/friends.test.ts
@@ -68,6 +68,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };

--- a/__tests__/api/social/leaderboard.test.ts
+++ b/__tests__/api/social/leaderboard.test.ts
@@ -60,6 +60,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 5,
     longestStreak: 10,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };
@@ -147,6 +148,43 @@ describe("GET /api/social/leaderboard", () => {
       longestStreak: 12,
       isYou: true,
     });
+  });
+
+  it("keeps a friend's streak alive using their stored timezone offset", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T01:00:00Z"));
+    try {
+      authedAs(makeUser({ id: 1 }));
+      mockSelect
+        .mockReturnValueOnce(makeDbChain([{ requesterId: 1, addresseeId: 2 }]))
+        .mockReturnValueOnce(
+          makeDbChain([
+            {
+              id: 2,
+              username: "westcoast",
+              displayName: null,
+              currentStreak: 8,
+              longestStreak: 8,
+              lastActivityDate: "2026-08-27",
+              timezoneOffsetMinutes: -300,
+            },
+            {
+              id: 1,
+              username: "testuser",
+              displayName: null,
+              currentStreak: 2,
+              longestStreak: 2,
+              lastActivityDate: "2026-08-28",
+              timezoneOffsetMinutes: -300,
+            },
+          ])
+        );
+      const res = await GET(makeReq());
+      const body = await res.json();
+      expect(body.items[0]).toMatchObject({ username: "westcoast", streak: 8 });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("decays a broken streak to 0 so it ranks below an active one", async () => {

--- a/__tests__/api/social/me.test.ts
+++ b/__tests__/api/social/me.test.ts
@@ -61,6 +61,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 3,
     longestStreak: 7,
     lastActivityDate: new Date().toISOString().slice(0, 10),
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };
@@ -124,6 +125,28 @@ describe("GET /api/social/me", () => {
     const body = await res.json();
     expect(body.currentStreak).toBe(0);
     expect(body.longestStreak).toBe(30);
+  });
+
+  it("decays against the user's local day using the stored timezone offset", async () => {
+    // 01:00 UTC on the 29th: UTC has rolled over, but a UTC-5 user is still on
+    // the evening of the 28th. Last activity on the 27th is local-yesterday for
+    // them (alive) even though plain UTC math would call it stale.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T01:00:00Z"));
+    try {
+      authedAs(
+        makeUser({
+          currentStreak: 6,
+          lastActivityDate: "2026-08-27",
+          timezoneOffsetMinutes: -300,
+        })
+      );
+      const res = await GET(makeGetReq());
+      const body = await res.json();
+      expect(body.currentStreak).toBe(6);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/__tests__/api/social/mentions.test.ts
+++ b/__tests__/api/social/mentions.test.ts
@@ -45,6 +45,7 @@ function makeUser(): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
   };
 }

--- a/__tests__/api/social/users.test.ts
+++ b/__tests__/api/social/users.test.ts
@@ -49,6 +49,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };

--- a/__tests__/api/workspace.test.ts
+++ b/__tests__/api/workspace.test.ts
@@ -95,6 +95,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
     ...overrides,
   };

--- a/__tests__/app/stories/StoryActivityTracker.test.tsx
+++ b/__tests__/app/stories/StoryActivityTracker.test.tsx
@@ -3,7 +3,7 @@ import { render, waitFor } from "@testing-library/react";
 import { StoryActivityTracker } from "@/app/stories/[slug]/StoryActivityTracker";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
-import { __resetActivityQueue } from "@/lib/social/post-activity";
+import { resetActivityQueue } from "@/lib/social/post-activity";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -15,7 +15,7 @@ function jsonResponse(body: unknown) {
 describe("StoryActivityTracker", () => {
   beforeEach(() => {
     mockFetch.mockReset();
-    __resetActivityQueue();
+    resetActivityQueue();
     useAuthStore.setState({ accessToken: null });
     useSocialStore.setState({ streak: 0, longestStreak: 0, streakAsOf: null });
   });

--- a/__tests__/app/stories/StoryActivityTracker.test.tsx
+++ b/__tests__/app/stories/StoryActivityTracker.test.tsx
@@ -3,19 +3,21 @@ import { render, waitFor } from "@testing-library/react";
 import { StoryActivityTracker } from "@/app/stories/[slug]/StoryActivityTracker";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
+import { __resetActivityQueue } from "@/lib/social/post-activity";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 function jsonResponse(body: unknown) {
-  return { ok: true, json: async () => body };
+  return { ok: true, status: 200, json: async () => body };
 }
 
 describe("StoryActivityTracker", () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    __resetActivityQueue();
     useAuthStore.setState({ accessToken: null });
-    useSocialStore.setState({ streak: 0, longestStreak: 0 });
+    useSocialStore.setState({ streak: 0, longestStreak: 0, streakAsOf: null });
   });
 
   it("does not fetch when there is no access token", () => {
@@ -34,7 +36,7 @@ describe("StoryActivityTracker", () => {
     expect(url).toBe("/api/social/activity");
     expect(init.method).toBe("POST");
     expect(init.headers.Authorization).toBe("Bearer test-token");
-    expect(JSON.parse(init.body)).toEqual({ type: "hadith_read" });
+    expect(JSON.parse(init.body)).toMatchObject({ type: "hadith_read" });
   });
 
   it("bumps the streak store from the response", async () => {
@@ -47,13 +49,20 @@ describe("StoryActivityTracker", () => {
     expect(useSocialStore.getState().longestStreak).toBe(5);
   });
 
-  it("does not throw when the fetch fails", async () => {
-    useAuthStore.setState({ accessToken: "test-token" });
-    mockFetch.mockRejectedValueOnce(new Error("network error"));
+  it("does not throw or move the streak when the fetch keeps failing", async () => {
+    vi.useFakeTimers();
+    try {
+      useAuthStore.setState({ accessToken: "test-token" });
+      mockFetch.mockRejectedValue(new Error("network error"));
 
-    render(<StoryActivityTracker slug="prophet-yusuf" />);
+      render(<StoryActivityTracker slug="prophet-yusuf" />);
 
-    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
-    expect(useSocialStore.getState().streak).toBe(0);
+      await vi.runAllTimersAsync();
+
+      expect(mockFetch).toHaveBeenCalled();
+      expect(useSocialStore.getState().streak).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/__tests__/hooks/useActivityTracker.test.ts
+++ b/__tests__/hooks/useActivityTracker.test.ts
@@ -69,13 +69,13 @@ describe("useActivityTracker restore vs. genuine activity", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("fires an activity POST when a node is genuinely added while mounted", () => {
+  it("fires an activity POST when a node is genuinely added while mounted", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
     vi.stubGlobal("fetch", fetchMock);
 
     renderHook(() => useActivityTracker());
 
-    act(() => {
+    await act(async () => {
       useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
     });
 
@@ -127,7 +127,7 @@ describe("useActivityTracker restore vs. genuine activity", () => {
     );
   });
 
-  it("resumes firing for genuine additions after a restore", () => {
+  it("resumes firing for genuine additions after a restore", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -138,7 +138,7 @@ describe("useActivityTracker restore vs. genuine activity", () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
 
-    act(() => {
+    await act(async () => {
       useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
     });
     expect(fetchMock).toHaveBeenCalledWith(

--- a/__tests__/hooks/useActivityTracker.test.ts
+++ b/__tests__/hooks/useActivityTracker.test.ts
@@ -100,6 +100,33 @@ describe("useActivityTracker restore vs. genuine activity", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("still delivers the first add when it happens before the auth token arrives", async () => {
+    useAuthStore.setState({ accessToken: null });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ streak: 1, longestStreak: 1, activityDate: "2026-08-28" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useActivityTracker());
+
+    act(() => {
+      useCanvasStore.getState().addVerseNode(baseVerse, { x: 0, y: 0 });
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      useAuthStore.setState({ accessToken: "late-token" });
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/social/activity",
+      expect.objectContaining({ body: expect.stringContaining("verse_added") })
+    );
+  });
+
   it("resumes firing for genuine additions after a restore", () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
     vi.stubGlobal("fetch", fetchMock);

--- a/__tests__/integration/user-tz-offset.integration.test.ts
+++ b/__tests__/integration/user-tz-offset.integration.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/lib/infra/db";
+import { users } from "@/lib/infra/db/schema";
+
+async function reset() {
+  await db.execute(sql`TRUNCATE users RESTART IDENTITY CASCADE`);
+}
+
+beforeEach(reset);
+
+describe("users.timezone_offset_minutes (integration, real Postgres)", () => {
+  it("migration 0023 added the column as a nullable integer", async () => {
+    const rows = await db.execute(sql`
+      SELECT data_type, is_nullable
+      FROM information_schema.columns
+      WHERE table_name = 'users' AND column_name = 'timezone_offset_minutes'
+    `);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ data_type: "integer", is_nullable: "YES" });
+  });
+
+  it("defaults to null and round-trips a stored offset", async () => {
+    const [created] = await db
+      .insert(users)
+      .values({ qfId: "qf-tz-1", username: "tzuser" })
+      .returning();
+    expect(created.timezoneOffsetMinutes).toBeNull();
+
+    await db.update(users).set({ timezoneOffsetMinutes: 180 }).where(eq(users.id, created.id));
+
+    const [updated] = await db.select().from(users).where(eq(users.id, created.id));
+    expect(updated.timezoneOffsetMinutes).toBe(180);
+  });
+});

--- a/__tests__/lib/admin/admin-auth.test.ts
+++ b/__tests__/lib/admin/admin-auth.test.ts
@@ -18,6 +18,7 @@ function makeUser(qfId: string): User {
     currentStreak: 0,
     longestStreak: 0,
     lastActivityDate: null,
+    timezoneOffsetMinutes: null,
     disabledAt: null,
   };
 }

--- a/__tests__/lib/social/post-activity.test.ts
+++ b/__tests__/lib/social/post-activity.test.ts
@@ -164,4 +164,20 @@ describe("postActivity", () => {
     await flushQueue("tok-b");
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("a reset while a POST is in flight discards its result and doesn't re-queue it", async () => {
+    let resolveFetch: (v: unknown) => void = () => {};
+    const inFlight = new Promise((resolve) => {
+      resolveFetch = resolve;
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(inFlight));
+
+    const p = postActivity("tok-a", { type: "verse_added", verseRef: "1:1" });
+
+    resetActivityQueue();
+    resolveFetch(okJson({ streak: 7, longestStreak: 7, activityDate: "2026-08-28" }));
+
+    await expect(p).resolves.toBeNull();
+    expect(pendingActivityCount()).toBe(0);
+  });
 });

--- a/__tests__/lib/social/post-activity.test.ts
+++ b/__tests__/lib/social/post-activity.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  postActivity,
+  flushQueue,
+  pendingActivityCount,
+  __resetActivityQueue,
+} from "@/lib/social/post-activity";
+
+function okJson(body: unknown) {
+  return { ok: true, status: 200, json: () => Promise.resolve(body) };
+}
+function errStatus(status: number) {
+  return { ok: false, status, json: () => Promise.resolve({ error: "nope" }) };
+}
+
+describe("postActivity", () => {
+  beforeEach(() => {
+    __resetActivityQueue();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("sends the local calendar day and tz offset in the body", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okJson({ streak: 3, longestStreak: 5, activityDate: "2026-08-28" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await postActivity("tok", { type: "verse_added", verseRef: "2:255" });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.type).toBe("verse_added");
+    expect(body.verse_ref).toBe("2:255");
+    expect(body.local_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(typeof body.tz_offset_minutes).toBe("number");
+  });
+
+  it("returns the parsed result on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(okJson({ streak: 4, longestStreak: 6, activityDate: "2026-08-28" }))
+    );
+    const result = await postActivity("tok", { type: "connection_made" });
+    expect(result).toEqual({ streak: 4, longestStreak: 6, activityDate: "2026-08-28" });
+  });
+
+  it("retries a 500 then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errStatus(500))
+      .mockResolvedValueOnce(okJson({ streak: 1, longestStreak: 1, activityDate: "2026-08-28" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const p = postActivity("tok", { type: "verse_added" });
+    await vi.runAllTimersAsync();
+    const result = await p;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result?.streak).toBe(1);
+    expect(pendingActivityCount()).toBe(0);
+  });
+
+  it("gives up after 3 attempts and enqueues the activity", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(errStatus(503));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const p = postActivity("tok", { type: "verse_added", verseRef: "1:1" });
+    await vi.runAllTimersAsync();
+    const result = await p;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result).toBeNull();
+    expect(pendingActivityCount()).toBe(1);
+  });
+
+  it("does not retry a 400 and does not enqueue it", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(errStatus(400));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await postActivity("tok", { type: "bogus" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+    expect(pendingActivityCount()).toBe(0);
+  });
+
+  it("retries on a network error (fetch rejects)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce(okJson({ streak: 2, longestStreak: 2, activityDate: "2026-08-28" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const p = postActivity("tok", { type: "verse_added" });
+    await vi.runAllTimersAsync();
+    const result = await p;
+
+    expect(result?.streak).toBe(2);
+  });
+
+  it("never rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")));
+    const p = postActivity("tok", { type: "verse_added" });
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toBeNull();
+  });
+
+  it("flushQueue drains an enqueued item after a later success", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(errStatus(500));
+    vi.stubGlobal("fetch", fetchMock);
+    const p = postActivity("tok", { type: "verse_added", verseRef: "1:1" });
+    await vi.runAllTimersAsync();
+    await p;
+    expect(pendingActivityCount()).toBe(1);
+
+    fetchMock.mockResolvedValue(
+      okJson({ streak: 9, longestStreak: 9, activityDate: "2026-08-28" })
+    );
+    await flushQueue("tok");
+    await vi.runAllTimersAsync();
+
+    expect(pendingActivityCount()).toBe(0);
+  });
+});

--- a/__tests__/lib/social/post-activity.test.ts
+++ b/__tests__/lib/social/post-activity.test.ts
@@ -180,4 +180,43 @@ describe("postActivity", () => {
     await expect(p).resolves.toBeNull();
     expect(pendingActivityCount()).toBe(0);
   });
+
+  it("a pre-reset drain that resolves later can't consume or send the new session's queued entry", async () => {
+    // Session A: leave one entry in the queue.
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(errStatus(503)));
+    const pa = postActivity("tok-a", { type: "verse_added", verseRef: "a:1" });
+    await vi.runAllTimersAsync();
+    await pa;
+    expect(pendingActivityCount()).toBe(1);
+
+    // Start a flush for A whose in-flight send hangs mid-drain.
+    let resolveHang: (v: unknown) => void = () => {};
+    const hang = new Promise((resolve) => {
+      resolveHang = resolve;
+    });
+    const fetchA = vi.fn().mockReturnValue(hang);
+    vi.stubGlobal("fetch", fetchA);
+    const flush = flushQueue("tok-a");
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Sign-out, then session B queues its own activity.
+    resetActivityQueue();
+    expect(pendingActivityCount()).toBe(0);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(errStatus(503)));
+    const pb = postActivity("tok-b", { type: "verse_added", verseRef: "b:1" });
+    await vi.runAllTimersAsync();
+    await pb;
+    expect(pendingActivityCount()).toBe(1);
+
+    // A's drain finally resolves — it must not touch B's entry.
+    resolveHang(okJson({ streak: 1, longestStreak: 1, activityDate: "2026-08-28" }));
+    await flush;
+    await vi.runAllTimersAsync();
+
+    expect(pendingActivityCount()).toBe(1);
+    const sentBUnderTokenA = fetchA.mock.calls.some(
+      (c) => JSON.parse(c[1].body).verse_ref === "b:1"
+    );
+    expect(sentBUnderTokenA).toBe(false);
+  });
 });

--- a/__tests__/lib/social/post-activity.test.ts
+++ b/__tests__/lib/social/post-activity.test.ts
@@ -3,7 +3,7 @@ import {
   postActivity,
   flushQueue,
   pendingActivityCount,
-  __resetActivityQueue,
+  resetActivityQueue,
 } from "@/lib/social/post-activity";
 
 function okJson(body: unknown) {
@@ -15,7 +15,7 @@ function errStatus(status: number) {
 
 describe("postActivity", () => {
   beforeEach(() => {
-    __resetActivityQueue();
+    resetActivityQueue();
     vi.useFakeTimers();
   });
   afterEach(() => {
@@ -123,5 +123,45 @@ describe("postActivity", () => {
     await vi.runAllTimersAsync();
 
     expect(pendingActivityCount()).toBe(0);
+  });
+
+  it("sends a queued older event before a newly submitted one", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(errStatus(500));
+    vi.stubGlobal("fetch", fetchMock);
+    const p1 = postActivity("tok", { type: "verse_added", verseRef: "1:1" });
+    await vi.runAllTimersAsync();
+    await p1;
+    expect(pendingActivityCount()).toBe(1);
+
+    const sent: string[] = [];
+    fetchMock.mockImplementation((_url: string, init: { body: string }) => {
+      sent.push(JSON.parse(init.body).verse_ref);
+      return Promise.resolve(okJson({ streak: 1, longestStreak: 1, activityDate: "2026-08-28" }));
+    });
+
+    const p2 = postActivity("tok", { type: "verse_added", verseRef: "2:2" });
+    await vi.runAllTimersAsync();
+    await p2;
+
+    expect(sent).toEqual(["1:1", "2:2"]);
+    expect(pendingActivityCount()).toBe(0);
+  });
+
+  it("resetActivityQueue drops deferred events so they can't flush under a new token", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(errStatus(503)));
+    const p = postActivity("tok-a", { type: "verse_added", verseRef: "1:1" });
+    await vi.runAllTimersAsync();
+    await p;
+    expect(pendingActivityCount()).toBe(1);
+
+    resetActivityQueue();
+    expect(pendingActivityCount()).toBe(0);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okJson({ streak: 1, longestStreak: 1, activityDate: "2026-08-28" }));
+    vi.stubGlobal("fetch", fetchMock);
+    await flushQueue("tok-b");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/lib/social/streak.test.ts
+++ b/__tests__/lib/social/streak.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { effectiveStreak, todayUTC, yesterdayUTC } from "@/lib/social/streak";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  effectiveStreak,
+  todayUTC,
+  yesterdayUTC,
+  previousDay,
+  localDateFromOffset,
+} from "@/lib/social/streak";
 
 describe("effectiveStreak", () => {
   it("keeps the streak when last activity was today", () => {
@@ -16,5 +22,81 @@ describe("effectiveStreak", () => {
 
   it("is 0 when there is no recorded activity", () => {
     expect(effectiveStreak(5, null)).toBe(0);
+  });
+});
+
+describe("previousDay", () => {
+  it("subtracts one calendar day", () => {
+    expect(previousDay("2026-03-15")).toBe("2026-03-14");
+  });
+
+  it("rolls back across a month boundary", () => {
+    expect(previousDay("2026-03-01")).toBe("2026-02-28");
+  });
+
+  it("rolls back across a year boundary", () => {
+    expect(previousDay("2026-01-01")).toBe("2025-12-31");
+  });
+
+  it("handles a leap day", () => {
+    expect(previousDay("2028-03-01")).toBe("2028-02-29");
+  });
+});
+
+describe("localDateFromOffset", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("returns the UTC date for a zero offset", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T23:30:00Z"));
+    expect(localDateFromOffset(0)).toBe("2026-08-28");
+  });
+
+  it("returns tomorrow for UTC+3 just before UTC midnight", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T22:30:00Z"));
+    expect(localDateFromOffset(180)).toBe("2026-08-29");
+  });
+
+  it("returns yesterday for UTC-5 just after UTC midnight", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T02:00:00Z"));
+    expect(localDateFromOffset(-300)).toBe("2026-08-28");
+  });
+
+  it("treats a null offset as UTC", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T12:00:00Z"));
+    expect(localDateFromOffset(null)).toBe("2026-08-28");
+  });
+});
+
+describe("effectiveStreak with a timezone offset", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("keeps a streak alive that UTC would already have decayed", () => {
+    // 01:00 local on the 29th for a UTC+3 user is 22:00 UTC on the 28th.
+    // Their last activity was the 28th (local yesterday) — still alive.
+    // Plain UTC math: today=28th, yesterday=27th, lastActivity 28th >= 27th — also alive here,
+    // so pick a sharper case: last activity two UTC-days ago but one local-day ago.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T22:30:00Z")); // 01:30 on the 30th, UTC+3
+    // local today = 30th, local yesterday = 29th
+    expect(effectiveStreak(6, "2026-08-29", 180)).toBe(6);
+    // UTC would say: today 29th, yesterday 28th, lastActivity 29th >= 28th -> still 6 too.
+  });
+
+  it("decays a streak whose last activity is before local yesterday", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T21:00:00Z")); // 00:00 on the 31st, UTC+3
+    // local today = 31st, local yesterday = 30th; last activity 29th -> decayed
+    expect(effectiveStreak(6, "2026-08-29", 180)).toBe(0);
+  });
+
+  it("defaults to UTC when no offset is given", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T12:00:00Z"));
+    expect(effectiveStreak(4, "2026-08-27")).toBe(4);
+    expect(effectiveStreak(4, "2026-08-26")).toBe(0);
   });
 });

--- a/__tests__/store/social.test.ts
+++ b/__tests__/store/social.test.ts
@@ -107,14 +107,45 @@ describe("social store", () => {
     expect(useSocialStore.getState().longestStreak).toBe(5);
   });
 
-  it("applyActivityResult always wins and records the day it was computed for", () => {
-    useSocialStore.getState().bumpStreak(9, 9, "2026-08-28");
+  it("applyActivityResult wins over a hydration read and records the day it was computed for", () => {
+    useSocialStore.getState().bumpStreak(2, 2, "2026-08-28");
     useSocialStore.getState().applyActivityResult({
       streak: 3,
       longestStreak: 9,
       activityDate: "2026-08-28",
     });
     expect(useSocialStore.getState().streak).toBe(3);
+    expect(useSocialStore.getState().streakAsOf).toBe("2026-08-28");
+  });
+
+  it("applyActivityResult ignores an out-of-order response that regresses the same day", () => {
+    useSocialStore.getState().applyActivityResult({
+      streak: 6,
+      longestStreak: 6,
+      activityDate: "2026-08-28",
+    });
+    // An earlier POST resolving late with a lower same-day streak.
+    useSocialStore.getState().applyActivityResult({
+      streak: 5,
+      longestStreak: 6,
+      activityDate: "2026-08-28",
+    });
+    expect(useSocialStore.getState().streak).toBe(6);
+  });
+
+  it("applyActivityResult ignores a response older than the day already applied", () => {
+    useSocialStore.getState().applyActivityResult({
+      streak: 4,
+      longestStreak: 4,
+      activityDate: "2026-08-29",
+    });
+    useSocialStore.getState().applyActivityResult({
+      streak: 3,
+      longestStreak: 4,
+      activityDate: "2026-08-28",
+    });
+    expect(useSocialStore.getState().streak).toBe(4);
+    expect(useSocialStore.getState().streakAsOf).toBe("2026-08-29");
   });
 
   it("longestStreak never decreases", () => {

--- a/__tests__/store/social.test.ts
+++ b/__tests__/store/social.test.ts
@@ -6,6 +6,7 @@ const INITIAL = {
   username: null,
   streak: 0,
   longestStreak: 0,
+  streakAsOf: null,
   pendingFriendCount: 0,
   pendingChallengeCount: 0,
   pendingMentionCount: 0,
@@ -73,6 +74,70 @@ describe("social store", () => {
     expect(useSocialStore.getState()).toMatchObject({ streak: 5, longestStreak: 99 });
   });
 
+  it("bumpStreak ignores a hydration read older than the value already applied", () => {
+    useSocialStore.getState().applyActivityResult({
+      streak: 5,
+      longestStreak: 5,
+      activityDate: "2026-08-28",
+    });
+    // A slow GET from an earlier day resolves late.
+    useSocialStore.getState().bumpStreak(3, 3, "2026-08-27");
+    expect(useSocialStore.getState().streak).toBe(5);
+  });
+
+  it("bumpStreak ignores a same-day hydration read that regresses the streak", () => {
+    useSocialStore.getState().applyActivityResult({
+      streak: 5,
+      longestStreak: 5,
+      activityDate: "2026-08-28",
+    });
+    // A stale in-flight GET (pre-increment) lands after the POST result.
+    useSocialStore.getState().bumpStreak(4, 5, "2026-08-28");
+    expect(useSocialStore.getState().streak).toBe(5);
+  });
+
+  it("bumpStreak applies a newer hydration read, including a legitimate decay to 0", () => {
+    useSocialStore.getState().applyActivityResult({
+      streak: 5,
+      longestStreak: 5,
+      activityDate: "2026-08-28",
+    });
+    useSocialStore.getState().bumpStreak(0, 5, "2026-08-30");
+    expect(useSocialStore.getState().streak).toBe(0);
+    expect(useSocialStore.getState().longestStreak).toBe(5);
+  });
+
+  it("applyActivityResult always wins and records the day it was computed for", () => {
+    useSocialStore.getState().bumpStreak(9, 9, "2026-08-28");
+    useSocialStore.getState().applyActivityResult({
+      streak: 3,
+      longestStreak: 9,
+      activityDate: "2026-08-28",
+    });
+    expect(useSocialStore.getState().streak).toBe(3);
+  });
+
+  it("longestStreak never decreases", () => {
+    useSocialStore.getState().applyActivityResult({
+      streak: 10,
+      longestStreak: 10,
+      activityDate: "2026-08-28",
+    });
+    useSocialStore.getState().bumpStreak(1, 1, "2026-08-29");
+    expect(useSocialStore.getState().longestStreak).toBe(10);
+  });
+
+  it("clearSocial resets streakAsOf so a stale guard can't block the next user", () => {
+    useSocialStore.getState().applyActivityResult({
+      streak: 7,
+      longestStreak: 7,
+      activityDate: "2026-08-28",
+    });
+    useSocialStore.getState().clearSocial();
+    useSocialStore.getState().bumpStreak(2, 2, "2026-01-01");
+    expect(useSocialStore.getState().streak).toBe(2);
+  });
+
   it("setPendingFriendCount/setPendingChallengeCount/setPendingMentionCount each set their own field independently", () => {
     useSocialStore.getState().setPendingFriendCount(3);
     useSocialStore.getState().setPendingChallengeCount(2);
@@ -96,12 +161,19 @@ describe("social store", () => {
       pendingMentionCount: 1,
     });
 
+    useSocialStore.getState().applyActivityResult({
+      streak: 5,
+      longestStreak: 10,
+      activityDate: "2026-08-28",
+    });
+
     const stored = JSON.parse(localStorage.getItem("open-hikmah-social")!);
     expect(stored.state).toMatchObject({
       userId: 42,
       username: "hikmah_seeker",
       streak: 5,
       longestStreak: 10,
+      streakAsOf: "2026-08-28",
     });
     expect(stored.state.pendingFriendCount).toBeUndefined();
     expect(stored.state.pendingChallengeCount).toBeUndefined();

--- a/app/api/social/activity/route.ts
+++ b/app/api/social/activity/route.ts
@@ -3,7 +3,13 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { activityLog, users } from "@/lib/infra/db/schema";
 import { requireUser, invalidateTokenCache } from "@/lib/auth/social-auth";
-import { todayUTC, yesterdayUTC, previousDay, effectiveStreak } from "@/lib/social/streak";
+import {
+  todayUTC,
+  yesterdayUTC,
+  previousDay,
+  effectiveStreak,
+  localDateFromOffset,
+} from "@/lib/social/streak";
 import { rateLimitOrNull, MUTATION_WINDOW_SECONDS } from "@/lib/infra/rate-limit";
 
 // Activity pings fire on ordinary reading (each verse/connection), so a genuinely
@@ -24,13 +30,24 @@ const MAX_TZ_OFFSET_MIN = 840;
  * date if the client's date is more than ~26h away (a broken clock), so it can't
  * jump the streak forward or drop a day.
  */
-function resolveActivityDate(localDate: string | undefined): string {
+function resolveActivityDate(localDate: string | undefined, offsetMinutes: number | null): string {
   const utc = todayUTC();
   if (!localDate || !DATE_RE.test(localDate)) return utc;
-  const diffDays = Math.abs(
-    (Date.parse(`${localDate}T00:00:00Z`) - Date.parse(`${utc}T00:00:00Z`)) / 86_400_000
-  );
-  return diffDays > 1 ? utc : localDate;
+
+  // Reject a well-formed but non-existent calendar date ("2026-99-99",
+  // "2026-02-30"): Date.parse gives NaN or silently rolls over, and the raw
+  // string would otherwise hit the Postgres `date` column as a 500.
+  const parsedMs = Date.parse(`${localDate}T00:00:00Z`);
+  if (!Number.isFinite(parsedMs) || new Date(parsedMs).toISOString().slice(0, 10) !== localDate) {
+    return utc;
+  }
+
+  // When the client sent its offset too, trust the offset: the reported local
+  // day has to be the one that offset actually yields now (± a day of clock
+  // slack), so a signed-in client can't pre-credit an arbitrary tomorrow.
+  const reference = offsetMinutes !== null ? localDateFromOffset(offsetMinutes) : utc;
+  const diffDays = Math.abs((parsedMs - Date.parse(`${reference}T00:00:00Z`)) / 86_400_000);
+  return diffDays > 1 ? reference : localDate;
 }
 
 export async function POST(req: NextRequest) {
@@ -79,7 +96,7 @@ export async function POST(req: NextRequest) {
   const verseRef = body.verse_ref ?? null;
 
   const { userId } = authed;
-  const today = resolveActivityDate(body.local_date);
+  const today = resolveActivityDate(body.local_date, tzOffsetMinutes);
   const yesterday = today === todayUTC() ? yesterdayUTC() : previousDay(today);
 
   try {

--- a/app/api/social/activity/route.ts
+++ b/app/api/social/activity/route.ts
@@ -3,7 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { activityLog, users } from "@/lib/infra/db/schema";
 import { requireUser, invalidateTokenCache } from "@/lib/auth/social-auth";
-import { todayUTC, yesterdayUTC, effectiveStreak } from "@/lib/social/streak";
+import { todayUTC, yesterdayUTC, previousDay, effectiveStreak } from "@/lib/social/streak";
 import { rateLimitOrNull, MUTATION_WINDOW_SECONDS } from "@/lib/infra/rate-limit";
 
 // Activity pings fire on ordinary reading (each verse/connection), so a genuinely
@@ -12,6 +12,26 @@ import { rateLimitOrNull, MUTATION_WINDOW_SECONDS } from "@/lib/infra/rate-limit
 const ACTIVITY_LIMIT = 300;
 
 const VALID_TYPES = new Set(["verse_added", "connection_made", "hadith_read"]);
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+// Widest real UTC offset is ±14h; allow a little slack for a client clock that's
+// a bit off without letting a wildly-wrong clock fabricate consecutive days.
+const MAX_TZ_OFFSET_MIN = 840;
+
+/**
+ * The day to credit this activity to. Prefer the client's local calendar day so
+ * streaks bucket by the user's midnight, not UTC — but clamp to the server's UTC
+ * date if the client's date is more than ~26h away (a broken clock), so it can't
+ * jump the streak forward or drop a day.
+ */
+function resolveActivityDate(localDate: string | undefined): string {
+  const utc = todayUTC();
+  if (!localDate || !DATE_RE.test(localDate)) return utc;
+  const diffDays = Math.abs(
+    (Date.parse(`${localDate}T00:00:00Z`) - Date.parse(`${utc}T00:00:00Z`)) / 86_400_000
+  );
+  return diffDays > 1 ? utc : localDate;
+}
 
 export async function POST(req: NextRequest) {
   const authed = await requireUser(req);
@@ -25,7 +45,12 @@ export async function POST(req: NextRequest) {
   );
   if (limited) return limited;
 
-  let body: { type?: string; verse_ref?: string };
+  let body: {
+    type?: string;
+    verse_ref?: string;
+    local_date?: string;
+    tz_offset_minutes?: number;
+  };
   try {
     body = await req.json();
   } catch {
@@ -35,6 +60,18 @@ export async function POST(req: NextRequest) {
   if (!body.type || !VALID_TYPES.has(body.type)) {
     return NextResponse.json({ error: "Invalid activity type" }, { status: 400 });
   }
+
+  let tzOffsetMinutes: number | null = null;
+  if (body.tz_offset_minutes !== undefined) {
+    if (
+      !Number.isInteger(body.tz_offset_minutes) ||
+      Math.abs(body.tz_offset_minutes) > MAX_TZ_OFFSET_MIN
+    ) {
+      return NextResponse.json({ error: "Invalid timezone offset" }, { status: 400 });
+    }
+    tzOffsetMinutes = body.tz_offset_minutes;
+  }
+
   // Narrow into locals: `body.type`'s non-undefined narrowing above doesn't
   // survive into the transaction closure below (TS can't prove `body` is
   // unmutated by the time the closure runs).
@@ -42,8 +79,8 @@ export async function POST(req: NextRequest) {
   const verseRef = body.verse_ref ?? null;
 
   const { userId } = authed;
-  const today = todayUTC();
-  const yesterday = yesterdayUTC();
+  const today = resolveActivityDate(body.local_date);
+  const yesterday = today === todayUTC() ? yesterdayUTC() : previousDay(today);
 
   try {
     // Insert + streak read/compute/write run in one transaction: the activity
@@ -68,9 +105,19 @@ export async function POST(req: NextRequest) {
       let newStreak = freshUser.currentStreak;
       let newLongest = freshUser.longestStreak;
       let isNewDay = false;
+      let didWrite = false;
 
       if (lastDate === today) {
-        // Already counted today — no streak change
+        // Already counted today — no streak change. Still refresh the stored
+        // offset so later offset-only reads (GET /me, leaderboard) decay against
+        // the user's current timezone.
+        if (tzOffsetMinutes !== null && tzOffsetMinutes !== freshUser.timezoneOffsetMinutes) {
+          await tx
+            .update(users)
+            .set({ timezoneOffsetMinutes: tzOffsetMinutes })
+            .where(eq(users.id, userId));
+          didWrite = true;
+        }
       } else {
         isNewDay = true;
         if (lastDate === yesterday) {
@@ -89,15 +136,18 @@ export async function POST(req: NextRequest) {
             longestStreak: newLongest,
             lastActivityDate: today,
             lastActiveAt: sql`now()`,
+            ...(tzOffsetMinutes !== null ? { timezoneOffsetMinutes: tzOffsetMinutes } : {}),
           })
           .where(eq(users.id, userId));
+        didWrite = true;
       }
 
-      return { newStreak, newLongest, isNewDay, lastDate };
+      return { newStreak, newLongest, isNewDay, lastDate, didWrite };
     });
 
-    if (result.isNewDay) {
-      // Invalidate cache so next request re-reads fresh streak from DB. Kept
+    if (result.didWrite) {
+      // Invalidate cache so next request re-reads the fresh streak/offset from
+      // DB. Kept
       // outside the transaction — it's a best-effort cache flush, not part of
       // the consistency boundary.
       const rawAuth = req.headers.get("authorization");
@@ -110,6 +160,7 @@ export async function POST(req: NextRequest) {
       longestStreak: result.newLongest,
       isNewDay: result.isNewDay,
       streakBroken: result.isNewDay && result.lastDate !== null && result.lastDate !== yesterday,
+      activityDate: today,
     });
   } catch (err) {
     console.error("social/activity POST db error:", err);
@@ -124,7 +175,7 @@ export async function GET(req: NextRequest) {
 
   const { user } = authed;
   return NextResponse.json({
-    streak: effectiveStreak(user.currentStreak, user.lastActivityDate),
+    streak: effectiveStreak(user.currentStreak, user.lastActivityDate, user.timezoneOffsetMinutes),
     longestStreak: user.longestStreak,
     lastActivityDate: user.lastActivityDate,
   });

--- a/app/api/social/activity/route.ts
+++ b/app/api/social/activity/route.ts
@@ -42,12 +42,18 @@ function resolveActivityDate(localDate: string | undefined, offsetMinutes: numbe
     return utc;
   }
 
-  // When the client sent its offset too, trust the offset: the reported local
-  // day has to be the one that offset actually yields now (± a day of clock
-  // slack), so a signed-in client can't pre-credit an arbitrary tomorrow.
-  const reference = offsetMinutes !== null ? localDateFromOffset(offsetMinutes) : utc;
-  const diffDays = Math.abs((parsedMs - Date.parse(`${reference}T00:00:00Z`)) / 86_400_000);
-  return diffDays > 1 ? reference : localDate;
+  // When the client sent its offset too, the offset is authoritative: the day it
+  // yields right now is the only day we credit, so a signed-in client can't
+  // pre-credit tomorrow (or any other day) by sending a mismatched local_date.
+  if (offsetMinutes !== null) {
+    const reference = localDateFromOffset(offsetMinutes);
+    return localDate === reference ? localDate : reference;
+  }
+
+  // No offset — fall back to UTC with ~26h of clock slack so a slightly-off
+  // client clock near midnight still buckets to its own day.
+  const diffDays = Math.abs((parsedMs - Date.parse(`${utc}T00:00:00Z`)) / 86_400_000);
+  return diffDays > 1 ? utc : localDate;
 }
 
 export async function POST(req: NextRequest) {

--- a/app/api/social/leaderboard/route.ts
+++ b/app/api/social/leaderboard/route.ts
@@ -46,6 +46,7 @@ export async function GET(req: NextRequest) {
       currentStreak: users.currentStreak,
       longestStreak: users.longestStreak,
       lastActivityDate: users.lastActivityDate,
+      timezoneOffsetMinutes: users.timezoneOffsetMinutes,
     })
     .from(users)
     .where(or(...allIds.map((id) => eq(users.id, id))));
@@ -55,7 +56,10 @@ export async function GET(req: NextRequest) {
   // Ranking requires the full set (rank depends on every row's position), so
   // pagination is applied to the already-ranked list, not the DB query.
   const ranked = rows
-    .map((u) => ({ ...u, streak: effectiveStreak(u.currentStreak, u.lastActivityDate) }))
+    .map((u) => ({
+      ...u,
+      streak: effectiveStreak(u.currentStreak, u.lastActivityDate, u.timezoneOffsetMinutes),
+    }))
     .sort(
       (a, b) =>
         b.streak - a.streak ||

--- a/app/api/social/me/route.ts
+++ b/app/api/social/me/route.ts
@@ -15,7 +15,11 @@ export async function GET(req: NextRequest) {
     id: user.id,
     username: user.username,
     displayName: user.displayName,
-    currentStreak: effectiveStreak(user.currentStreak, user.lastActivityDate),
+    currentStreak: effectiveStreak(
+      user.currentStreak,
+      user.lastActivityDate,
+      user.timezoneOffsetMinutes
+    ),
     longestStreak: user.longestStreak,
     lastActivityDate: user.lastActivityDate,
     createdAt: user.createdAt,

--- a/app/stories/[slug]/StoryActivityTracker.tsx
+++ b/app/stories/[slug]/StoryActivityTracker.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
+import { postActivity } from "@/lib/social/post-activity";
 
 /**
  * Credits a Story read toward the daily streak. Canvas verse/connection
@@ -12,27 +13,14 @@ import { useSocialStore } from "@/store/social";
  */
 export function StoryActivityTracker({ slug }: { slug: string }) {
   const accessToken = useAuthStore((s) => s.accessToken);
-  const bumpStreak = useSocialStore((s) => s.bumpStreak);
+  const applyActivityResult = useSocialStore((s) => s.applyActivityResult);
 
   useEffect(() => {
     if (!accessToken) return;
-
-    fetch("/api/social/activity", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify({ type: "hadith_read" }),
-    })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data?.streak !== undefined) bumpStreak(data.streak, data.longestStreak);
-      })
-      .catch(() => {
-        // Non-blocking — ignore errors, same as useActivityTracker.
-      });
-  }, [accessToken, slug, bumpStreak]);
+    void postActivity(accessToken, { type: "hadith_read" }).then((result) => {
+      if (result) applyActivityResult(result);
+    });
+  }, [accessToken, slug, applyActivityResult]);
 
   return null;
 }

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -228,7 +228,8 @@ export function Header({ onSearchOpen }: HeaderProps) {
     })
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
-        if (data?.streak !== undefined) bumpStreak(data.streak, data.longestStreak);
+        if (data?.streak !== undefined)
+          bumpStreak(data.streak, data.longestStreak, data.lastActivityDate ?? null);
       })
       .catch((e) => console.error("header: streak hydration failed", e));
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -131,10 +131,12 @@ export function SessionRestorer() {
             username?: string;
             currentStreak?: number;
             longestStreak?: number;
+            lastActivityDate?: string | null;
           };
           if (p.id && p.username) {
             setProfile({ userId: p.id, username: p.username });
-            if (p.currentStreak !== undefined) bumpStreak(p.currentStreak, p.longestStreak);
+            if (p.currentStreak !== undefined)
+              bumpStreak(p.currentStreak, p.longestStreak, p.lastActivityDate ?? null);
           }
         }
       })

--- a/hooks/useActivityTracker.ts
+++ b/hooks/useActivityTracker.ts
@@ -4,10 +4,11 @@ import { useEffect, useRef } from "react";
 import { useCanvasStore } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
+import { postActivity, flushQueue, type ActivityInput } from "@/lib/social/post-activity";
 
 export function useActivityTracker() {
   const accessToken = useAuthStore((s) => s.accessToken);
-  const { bumpStreak } = useSocialStore();
+  const applyActivityResult = useSocialStore((s) => s.applyActivityResult);
 
   // Seeded from the store's current counts (not 0) so a canvas that's already
   // populated by the time this hook first mounts — e.g. "Open on canvas" from
@@ -17,18 +18,22 @@ export function useActivityTracker() {
   const prevEdgeCount = useRef(useCanvasStore.getState().edges.length);
   const prevRestoreToken = useRef(useCanvasStore.getState().restoreToken);
 
+  // Adds detected before the auth token finishes restoring — replayed once it
+  // arrives. Without this the first add of a session (very often the only one)
+  // silently earns no streak credit.
+  const pending = useRef<ActivityInput[]>([]);
+
   const nodeCount = useCanvasStore((s) => s.nodes.length);
   const edgeCount = useCanvasStore((s) => s.edges.length);
   const nodes = useCanvasStore((s) => s.nodes);
   const restoreToken = useCanvasStore((s) => s.restoreToken);
 
   useEffect(() => {
-    if (!accessToken) {
-      prevNodeCount.current = nodeCount;
-      prevEdgeCount.current = edgeCount;
-      prevRestoreToken.current = restoreToken;
-      return;
-    }
+    const deliver = (input: ActivityInput) => {
+      void postActivity(accessToken!, input).then((result) => {
+        if (result) applyActivityResult(result);
+      });
+    };
 
     // A bulk restore (localStorage reload, share link, workspace load) bumps
     // restoreToken atomically with the node/edge counts — treat it as a new
@@ -43,51 +48,29 @@ export function useActivityTracker() {
 
     const nodeAdded = nodeCount > prevNodeCount.current;
     const edgeAdded = edgeCount > prevEdgeCount.current;
-
-    if (!nodeAdded && !edgeAdded) {
-      prevNodeCount.current = nodeCount;
-      prevEdgeCount.current = edgeCount;
-      return;
-    }
-
-    // Determine activity type and verse ref
-    let activityType: string;
-    let verseRef: string | undefined;
-
-    if (nodeAdded) {
-      activityType = "verse_added";
-      // Get the most recently added node's ref
-      const lastNode = nodes[nodes.length - 1];
-      verseRef = (lastNode?.data as { ref?: string })?.ref;
-    } else {
-      activityType = "connection_made";
-    }
-
     prevNodeCount.current = nodeCount;
     prevEdgeCount.current = edgeCount;
 
-    // Fire and forget — activity tracking is non-blocking
-    fetch("/api/social/activity", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify({ type: activityType, verse_ref: verseRef }),
-    })
-      .then((res) => {
-        if (!res.ok) return;
-        return res.json();
-      })
-      .then((data) => {
-        if (data?.streak !== undefined) {
-          bumpStreak(data.streak, data.longestStreak);
-        }
-      })
-      .catch(() => {
-        // Non-blocking — ignore errors
-      });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nodeCount, edgeCount, restoreToken]);
-  // ^ watches counts only — re-fetching accessToken/bumpStreak on every render would re-fire
+    if (nodeAdded || edgeAdded) {
+      const input: ActivityInput = nodeAdded
+        ? {
+            type: "verse_added",
+            verseRef: (nodes[nodes.length - 1]?.data as { ref?: string })?.ref ?? null,
+          }
+        : { type: "connection_made" };
+
+      if (accessToken) deliver(input);
+      else pending.current.push(input);
+      return;
+    }
+
+    // No new activity this tick — if the token just arrived, replay whatever was
+    // buffered while it was missing and drain any earlier failed POSTs.
+    if (accessToken) {
+      const buffered = pending.current;
+      pending.current = [];
+      buffered.forEach(deliver);
+      void flushQueue(accessToken);
+    }
+  }, [nodeCount, edgeCount, restoreToken, accessToken, nodes, applyActivityResult]);
 }

--- a/hooks/useActivityTracker.ts
+++ b/hooks/useActivityTracker.ts
@@ -59,8 +59,18 @@ export function useActivityTracker() {
           }
         : { type: "connection_made" };
 
-      if (accessToken) deliver(input);
-      else pending.current.push(input);
+      if (accessToken) {
+        // Token and a new add can land in the same render batch — drain whatever
+        // was buffered while the token was missing (in order) before this one,
+        // so the first add of the session isn't stranded in `pending.current`.
+        const buffered = pending.current;
+        pending.current = [];
+        buffered.forEach(deliver);
+        deliver(input);
+        void flushQueue(accessToken);
+      } else {
+        pending.current.push(input);
+      }
       return;
     }
 

--- a/lib/infra/db/migrations/0023_user_tz_offset.sql
+++ b/lib/infra/db/migrations/0023_user_tz_offset.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "timezone_offset_minutes" integer;

--- a/lib/infra/db/migrations/meta/0023_snapshot.json
+++ b/lib/infra/db/migrations/meta/0023_snapshot.json
@@ -1,0 +1,2442 @@
+{
+  "id": "976a296e-87ba-4b70-92fa-439d9def1698",
+  "prevId": "b2167d4d-fc2c-4c64-9883-d798ceaeac60",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_date": {
+          "name": "activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_date_idx": {
+          "name": "activity_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_type_date_idx": {
+          "name": "activity_user_type_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_user_id_users_id_fk": {
+          "name": "activity_log_user_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_qf_id": {
+          "name": "admin_qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_created_idx": {
+          "name": "admin_audit_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_generations": {
+      "name": "ai_generations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_generations_created_idx": {
+          "name": "ai_generations_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_idx": {
+          "name": "bookmarks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bookmarks_user_ref_uniq": {
+          "name": "bookmarks_user_ref_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "verse_ref"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_suggestions": {
+      "name": "challenge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_duration": {
+          "name": "suggested_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_suggestions_active_idx": {
+          "name": "challenge_suggestions_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenger_id": {
+          "name": "challenger_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenged_id": {
+          "name": "challenged_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection_made'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_challenger_status_idx": {
+          "name": "challenges_challenger_status_idx",
+          "columns": [
+            {
+              "expression": "challenger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_challenged_status_idx": {
+          "name": "challenges_challenged_status_idx",
+          "columns": [
+            {
+              "expression": "challenged_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_ends_at_idx": {
+          "name": "challenges_ends_at_idx",
+          "columns": [
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_suggestion_id_idx": {
+          "name": "challenges_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_challenger_id_users_id_fk": {
+          "name": "challenges_challenger_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_challenged_id_users_id_fk": {
+          "name": "challenges_challenged_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "challenged_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenges_suggestion_id_challenge_suggestions_id_fk": {
+          "name": "challenges_suggestion_id_challenge_suggestions_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "challenge_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "challenges_winner_id_users_id_fk": {
+          "name": "challenges_winner_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_challenge": {
+          "name": "no_self_challenge",
+          "value": "\"challenges\".\"challenger_id\" != \"challenges\".\"challenged_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection_coverage": {
+      "name": "connection_coverage",
+      "schema": "",
+      "columns": {
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "active_count": {
+          "name": "active_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "exhausted_at": {
+          "name": "exhausted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_coverage_kind_locale_idx": {
+          "name": "connection_coverage_kind_locale_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_coverage_exhausted_idx": {
+          "name": "connection_coverage_exhausted_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connection_coverage\".\"exhausted_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_coverage_from_ref_kind_locale_pk": {
+          "name": "connection_coverage_from_ref_kind_locale_pk",
+          "columns": [
+            "from_ref",
+            "kind",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_ref": {
+          "name": "from_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_ref": {
+          "name": "to_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_from_to_kind_locale_idx": {
+          "name": "connections_from_to_kind_locale_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_from_kind_idx": {
+          "name": "connections_from_kind_idx",
+          "columns": [
+            {
+              "expression": "from_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_reviewed_at_idx": {
+          "name": "connections_reviewed_at_idx",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_votd": {
+      "name": "curated_votd",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reflection": {
+          "name": "reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressee_id": {
+          "name": "addressee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "friendships_pair_idx": {
+          "name": "friendships_pair_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_addressee_status_idx": {
+          "name": "friendships_addressee_status_idx",
+          "columns": [
+            {
+              "expression": "addressee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "friendships_requester_status_idx": {
+          "name": "friendships_requester_status_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_requester_id_users_id_fk": {
+          "name": "friendships_requester_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_addressee_id_users_id_fk": {
+          "name": "friendships_addressee_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addressee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_friendship": {
+          "name": "no_self_friendship",
+          "value": "\"friendships\".\"requester_id\" != \"friendships\".\"addressee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_runs": {
+      "name": "job_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_tail": {
+          "name": "log_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_runs_type_started_idx": {
+          "name": "job_runs_type_started_idx",
+          "columns": [
+            {
+              "expression": "job_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.name_content": {
+      "name": "name_content",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "name_content_slug_kind_locale_pk": {
+          "name": "name_content_slug_kind_locale_pk",
+          "columns": [
+            "slug",
+            "kind",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.name_verse_reasons": {
+      "name": "name_verse_reasons",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "name_verse_reasons_slug_ref_locale_pk": {
+          "name": "name_verse_reasons_slug_ref_locale_pk",
+          "columns": [
+            "slug",
+            "ref",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_mentions": {
+      "name": "note_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioning_user_id": {
+          "name": "mentioning_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_id": {
+          "name": "mentioned_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_mentions_mentioned_user_read_idx": {
+          "name": "note_mentions_mentioned_user_read_idx",
+          "columns": [
+            {
+              "expression": "mentioned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_mentions_note_id_verse_notes_id_fk": {
+          "name": "note_mentions_note_id_verse_notes_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "verse_notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_mentions_mentioning_user_id_users_id_fk": {
+          "name": "note_mentions_mentioning_user_id_users_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentioning_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_mentions_mentioned_user_id_users_id_fk": {
+          "name": "note_mentions_mentioned_user_id_users_id_fk",
+          "tableFrom": "note_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentioned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_versions": {
+      "name": "prompt_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "prompt_versions_key_idx": {
+          "name": "prompt_versions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_key_active_idx": {
+          "name": "prompt_versions_key_active_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_versions_one_active_per_key_uidx": {
+          "name": "prompt_versions_one_active_per_key_uidx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_versions\".\"active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_workspaces": {
+      "name": "saved_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_workspaces_user_idx": {
+          "name": "saved_workspaces_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_workspaces_user_id_users_id_fk": {
+          "name": "saved_workspaces_user_id_users_id_fk",
+          "tableFrom": "saved_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_log": {
+      "name": "search_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zero_result": {
+          "name": "zero_result",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "search_log_created_idx": {
+          "name": "search_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_log_zero_result_idx": {
+          "name": "search_log_zero_result_idx",
+          "columns": [
+            {
+              "expression": "zero_result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_canvases": {
+      "name": "shared_canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_flags": {
+      "name": "story_flags",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagged_by": {
+          "name": "flagged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagged_at": {
+          "name": "flagged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qf_id": {
+          "name": "qf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_date": {
+          "name": "last_activity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_qf_id_idx": {
+          "name": "users_qf_id_idx",
+          "columns": [
+            {
+              "expression": "qf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_active_idx": {
+          "name": "users_last_active_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_qf_id_unique": {
+          "name": "users_qf_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qf_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_embeddings": {
+      "name": "verse_embeddings",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_embeddings_hnsw_idx": {
+          "name": "verse_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_notes": {
+      "name": "verse_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_ref": {
+          "name": "verse_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_notes_user_ref_idx": {
+          "name": "verse_notes_user_ref_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_notes_user_id_users_id_fk": {
+          "name": "verse_notes_user_id_users_id_fk",
+          "tableFrom": "verse_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_translations": {
+      "name": "verse_translations",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edition": {
+          "name": "edition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_translations_edition_idx": {
+          "name": "verse_translations_edition_idx",
+          "columns": [
+            {
+              "expression": "edition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_translations_ref_verses_ref_fk": {
+          "name": "verse_translations_ref_verses_ref_fk",
+          "tableFrom": "verse_translations",
+          "tableTo": "verses",
+          "columnsFrom": [
+            "ref"
+          ],
+          "columnsTo": [
+            "ref"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "verse_translations_ref_edition_pk": {
+          "name": "verse_translations_ref_edition_pk",
+          "columns": [
+            "ref",
+            "edition"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verses": {
+      "name": "verses",
+      "schema": "",
+      "columns": {
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "surah": {
+          "name": "surah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ayah": {
+          "name": "ayah",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arabic_text": {
+          "name": "arabic_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transliteration": {
+          "name": "transliteration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verses_surah_ayah_idx": {
+          "name": "verses_surah_ayah_idx",
+          "columns": [
+            {
+              "expression": "surah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ayah",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.word_morphology": {
+      "name": "word_morphology",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "word_morphology_ref_pos_idx": {
+          "name": "word_morphology_ref_pos_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_ref_idx": {
+          "name": "word_morphology_ref_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "word_morphology_root_idx": {
+          "name": "word_morphology_root_idx",
+          "columns": [
+            {
+              "expression": "root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/infra/db/migrations/meta/_journal.json
+++ b/lib/infra/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1787815919869,
       "tag": "0022_connection_coverage",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1787939592251,
+      "tag": "0023_user_tz_offset",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/infra/db/schema.ts
+++ b/lib/infra/db/schema.ts
@@ -30,6 +30,12 @@ export const users = pgTable(
     currentStreak: integer("current_streak").notNull().default(0),
     longestStreak: integer("longest_streak").notNull().default(0),
     lastActivityDate: date("last_activity_date"),
+    // Minutes east of UTC for the user's timezone (UTC+3 → 180), refreshed on
+    // each activity POST. Streaks bucket by the user's local calendar day, and
+    // reads (GET /me, leaderboard) that have no client offset decay against this
+    // stored value. Null for rows written before the offset was ever recorded —
+    // readers fall back to UTC.
+    timezoneOffsetMinutes: integer("timezone_offset_minutes"),
     // Soft-disable seam for admin moderation. Null = active; a timestamp marks
     // when an admin disabled the account. Disabled users keep their data but are
     // rejected at the auth boundary (see requireUser / lib/admin-auth.ts).

--- a/lib/social/post-activity.ts
+++ b/lib/social/post-activity.ts
@@ -1,0 +1,141 @@
+/**
+ * Client-side activity POSTs with retry + an in-memory failure queue.
+ *
+ * Activity tracking is non-blocking, but a dropped POST silently breaks the
+ * user's streak the next day, so a transient failure (network blip, a 429 from
+ * the per-user bucket, a 5xx) is retried a few times and, if it still fails,
+ * queued and flushed on the next successful POST or when the tab becomes
+ * visible again. The queue is in-memory only — a full reload before a flush
+ * loses it, which is rare and acceptable.
+ */
+
+export interface ActivityInput {
+  type: string;
+  verseRef?: string | null;
+}
+
+export interface ActivityResult {
+  streak: number;
+  longestStreak: number;
+  activityDate: string;
+}
+
+interface QueuedActivity extends ActivityInput {
+  localDate: string;
+}
+
+const RETRY_BACKOFF_MS = [0, 1000, 3000];
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+
+const queue: QueuedActivity[] = [];
+let lastToken: string | null = null;
+
+/** The client's current local calendar day, "YYYY-MM-DD". */
+export function clientLocalDate(now: Date = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/** Minutes east of UTC for the client's timezone (UTC+3 → 180). */
+export function clientTzOffsetMinutes(now: Date = new Date()): number {
+  return -now.getTimezoneOffset();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function sendOnce(
+  accessToken: string,
+  input: QueuedActivity
+): Promise<{ result: ActivityResult | null; retryable: boolean }> {
+  try {
+    const res = await fetch("/api/social/activity", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        type: input.type,
+        verse_ref: input.verseRef ?? undefined,
+        local_date: input.localDate,
+        tz_offset_minutes: clientTzOffsetMinutes(),
+      }),
+    });
+    if (res.ok) {
+      const data = (await res.json()) as ActivityResult;
+      return { result: data, retryable: false };
+    }
+    return { result: null, retryable: RETRYABLE_STATUS.has(res.status) };
+  } catch {
+    return { result: null, retryable: true };
+  }
+}
+
+async function sendWithRetry(
+  accessToken: string,
+  input: QueuedActivity
+): Promise<{ result: ActivityResult | null; exhausted: boolean }> {
+  for (let attempt = 0; attempt < RETRY_BACKOFF_MS.length; attempt++) {
+    if (attempt > 0) {
+      await delay(RETRY_BACKOFF_MS[attempt] + Math.random() * 250);
+    }
+    const { result, retryable } = await sendOnce(accessToken, input);
+    if (result) return { result, exhausted: false };
+    if (!retryable) return { result: null, exhausted: false };
+  }
+  return { result: null, exhausted: true };
+}
+
+/**
+ * POST an activity event. Resolves with the server's streak result, or null if
+ * it could not be delivered (a non-retryable rejection, or exhausted retries —
+ * in which case the event is queued for a later flush). Never rejects.
+ */
+export async function postActivity(
+  accessToken: string,
+  input: ActivityInput
+): Promise<ActivityResult | null> {
+  lastToken = accessToken;
+  const queued: QueuedActivity = { ...input, localDate: clientLocalDate() };
+
+  const { result, exhausted } = await sendWithRetry(accessToken, queued);
+  if (result) {
+    void flushQueue(accessToken);
+    return result;
+  }
+
+  if (exhausted) queue.push(queued);
+  return null;
+}
+
+/** Attempt to deliver every queued activity, FIFO, stopping at the first failure. */
+export async function flushQueue(accessToken: string): Promise<void> {
+  lastToken = accessToken;
+  while (queue.length > 0) {
+    const next = queue[0];
+    const { result } = await sendWithRetry(accessToken, next);
+    if (!result) return;
+    queue.shift();
+  }
+}
+
+export function pendingActivityCount(): number {
+  return queue.length;
+}
+
+export function __resetActivityQueue(): void {
+  queue.length = 0;
+  lastToken = null;
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible" && lastToken && queue.length > 0) {
+      void flushQueue(lastToken);
+    }
+  });
+}

--- a/lib/social/post-activity.ts
+++ b/lib/social/post-activity.ts
@@ -30,6 +30,13 @@ const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
 const queue: QueuedActivity[] = [];
 let lastToken: string | null = null;
 
+// Bumped by resetActivityQueue (sign-out). A dispatch task that was already
+// in flight when the reset happened captures the pre-reset value and checks it
+// before mutating the queue or returning its result, so a stale event from the
+// previous account can't be re-queued and a stale streak result can't be
+// applied under the new session.
+let generation = 0;
+
 // Every send — a fresh event or a queue flush — runs through this one chain, so
 // there is never a concurrent drain (which could submit the same queue head
 // twice) and a new event never overtakes an older queued one (which would let
@@ -125,6 +132,7 @@ export async function postActivity(
   input: ActivityInput
 ): Promise<ActivityResult | null> {
   const queued: QueuedActivity = { ...input, localDate: clientLocalDate() };
+  const gen = generation;
   let outcome: ActivityResult | null = null;
 
   await enqueueDispatch(async () => {
@@ -132,12 +140,16 @@ export async function postActivity(
     // Older queued events go first. If the backlog can't clear, this event joins
     // the tail rather than jumping ahead of it.
     await drainQueue(accessToken);
+    // A sign-out landed while this task was in flight — the token and any queued
+    // events belong to a session that no longer exists; drop this one silently.
+    if (generation !== gen) return;
     if (queue.length > 0) {
       queue.push(queued);
       return;
     }
 
     const { result, exhausted } = await sendWithRetry(accessToken, queued);
+    if (generation !== gen) return;
     if (result) {
       outcome = result;
       return;
@@ -172,6 +184,7 @@ export function resetActivityQueue(): void {
   queue.length = 0;
   lastToken = null;
   dispatch = Promise.resolve();
+  generation++;
 }
 
 if (typeof document !== "undefined") {

--- a/lib/social/post-activity.ts
+++ b/lib/social/post-activity.ts
@@ -30,6 +30,28 @@ const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
 const queue: QueuedActivity[] = [];
 let lastToken: string | null = null;
 
+// Every send — a fresh event or a queue flush — runs through this one chain, so
+// there is never a concurrent drain (which could submit the same queue head
+// twice) and a new event never overtakes an older queued one (which would let
+// the server overwrite lastActivityDate with the earlier day and break the
+// streak).
+let dispatch: Promise<void> = Promise.resolve();
+
+function enqueueDispatch(task: () => Promise<void>): Promise<void> {
+  const run = dispatch.then(task, task);
+  dispatch = run.catch(() => {});
+  return run;
+}
+
+/** Deliver queued activities in FIFO order, stopping at the first failure. */
+async function drainQueue(accessToken: string): Promise<void> {
+  while (queue.length > 0) {
+    const { result } = await sendWithRetry(accessToken, queue[0]);
+    if (!result) return;
+    queue.shift();
+  }
+}
+
 /** The client's current local calendar day, "YYYY-MM-DD". */
 export function clientLocalDate(now: Date = new Date()): string {
   const y = now.getFullYear();
@@ -70,7 +92,10 @@ async function sendOnce(
       return { result: data, retryable: false };
     }
     return { result: null, retryable: RETRYABLE_STATUS.has(res.status) };
-  } catch {
+  } catch (err) {
+    // A network-level failure is retryable, but it must not vanish: a fully
+    // exhausted event only lives in the in-memory queue and is lost on reload.
+    console.error("postActivity: request failed", err);
     return { result: null, retryable: true };
   }
 }
@@ -99,37 +124,54 @@ export async function postActivity(
   accessToken: string,
   input: ActivityInput
 ): Promise<ActivityResult | null> {
-  lastToken = accessToken;
   const queued: QueuedActivity = { ...input, localDate: clientLocalDate() };
+  let outcome: ActivityResult | null = null;
 
-  const { result, exhausted } = await sendWithRetry(accessToken, queued);
-  if (result) {
-    void flushQueue(accessToken);
-    return result;
-  }
+  await enqueueDispatch(async () => {
+    lastToken = accessToken;
+    // Older queued events go first. If the backlog can't clear, this event joins
+    // the tail rather than jumping ahead of it.
+    await drainQueue(accessToken);
+    if (queue.length > 0) {
+      queue.push(queued);
+      return;
+    }
 
-  if (exhausted) queue.push(queued);
-  return null;
+    const { result, exhausted } = await sendWithRetry(accessToken, queued);
+    if (result) {
+      outcome = result;
+      return;
+    }
+    if (exhausted) {
+      console.error("postActivity: retries exhausted, queued for later flush", queued.type);
+      queue.push(queued);
+    }
+  });
+
+  return outcome;
 }
 
 /** Attempt to deliver every queued activity, FIFO, stopping at the first failure. */
 export async function flushQueue(accessToken: string): Promise<void> {
-  lastToken = accessToken;
-  while (queue.length > 0) {
-    const next = queue[0];
-    const { result } = await sendWithRetry(accessToken, next);
-    if (!result) return;
-    queue.shift();
-  }
+  await enqueueDispatch(async () => {
+    lastToken = accessToken;
+    await drainQueue(accessToken);
+  });
 }
 
 export function pendingActivityCount(): number {
   return queue.length;
 }
 
-export function __resetActivityQueue(): void {
+/**
+ * Drop every deferred activity and forget the last token. Called on sign-out
+ * (see `store/auth.ts` `clearAuth`) so a queued event from one account can never
+ * be flushed later with a different account's bearer token.
+ */
+export function resetActivityQueue(): void {
   queue.length = 0;
   lastToken = null;
+  dispatch = Promise.resolve();
 }
 
 if (typeof document !== "undefined") {

--- a/lib/social/post-activity.ts
+++ b/lib/social/post-activity.ts
@@ -50,11 +50,16 @@ function enqueueDispatch(task: () => Promise<void>): Promise<void> {
   return run;
 }
 
-/** Deliver queued activities in FIFO order, stopping at the first failure. */
-async function drainQueue(accessToken: string): Promise<void> {
-  while (queue.length > 0) {
+/**
+ * Deliver queued activities in FIFO order, stopping at the first failure. `gen`
+ * is the caller's captured generation: if a sign-out bumps it mid-drain, this
+ * stops immediately without sending or shifting — the entries now in `queue`
+ * belong to a different session and must not go out under this token.
+ */
+async function drainQueue(accessToken: string, gen: number): Promise<void> {
+  while (queue.length > 0 && generation === gen) {
     const { result } = await sendWithRetry(accessToken, queue[0]);
-    if (!result) return;
+    if (generation !== gen || !result) return;
     queue.shift();
   }
 }
@@ -139,7 +144,7 @@ export async function postActivity(
     lastToken = accessToken;
     // Older queued events go first. If the backlog can't clear, this event joins
     // the tail rather than jumping ahead of it.
-    await drainQueue(accessToken);
+    await drainQueue(accessToken, gen);
     // A sign-out landed while this task was in flight — the token and any queued
     // events belong to a session that no longer exists; drop this one silently.
     if (generation !== gen) return;
@@ -165,9 +170,10 @@ export async function postActivity(
 
 /** Attempt to deliver every queued activity, FIFO, stopping at the first failure. */
 export async function flushQueue(accessToken: string): Promise<void> {
+  const gen = generation;
   await enqueueDispatch(async () => {
     lastToken = accessToken;
-    await drainQueue(accessToken);
+    await drainQueue(accessToken, gen);
   });
 }
 

--- a/lib/social/streak.ts
+++ b/lib/social/streak.ts
@@ -1,9 +1,15 @@
 /**
- * Streak helpers. Streaks are tracked in UTC days: a streak is "alive" only while
- * the user's last activity was today or yesterday. Because the stored
- * `currentStreak` is reset lazily (only on the user's next activity), a broken
- * streak stays stale in the DB — so every place that *reads* a streak for display
- * or ranking must apply `effectiveStreak` to show the real value.
+ * Streak helpers. A streak is "alive" only while the user's last activity was
+ * their local today or local yesterday. The day boundary is the user's own
+ * calendar day, not UTC: `activityDate` / `lastActivityDate` are the local
+ * `YYYY-MM-DD` the client reported (see `app/api/social/activity` POST), and
+ * every reader decays a stale streak against the same local calendar using the
+ * user's stored `timezoneOffsetMinutes` (null → UTC, for rows written before the
+ * offset was ever recorded).
+ *
+ * Because the stored `currentStreak` is reset lazily (only on the user's next
+ * activity), a broken streak stays stale in the DB — so every place that *reads*
+ * a streak for display or ranking must apply `effectiveStreak`.
  */
 
 export function todayUTC(): string {
@@ -16,12 +22,33 @@ export function yesterdayUTC(): string {
   return d.toISOString().slice(0, 10);
 }
 
+/** The calendar day before `dateStr` ("YYYY-MM-DD" → "YYYY-MM-DD"). */
+export function previousDay(dateStr: string): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * The calendar date right now in a timezone `offsetMinutes` east of UTC
+ * (UTC+3 → `180`). A null offset falls back to UTC.
+ */
+export function localDateFromOffset(offsetMinutes: number | null, now: Date = new Date()): string {
+  const shifted = new Date(now.getTime() + (offsetMinutes ?? 0) * 60_000);
+  return shifted.toISOString().slice(0, 10);
+}
+
 /**
  * The streak as it should be shown right now: the stored value while still alive
- * (last activity today or yesterday), otherwise 0 (the stored value is stale and
- * the run is broken until the next activity resets it to 1).
+ * (last activity on the user's local today or local yesterday), otherwise 0 (the
+ * stored value is stale and the run is broken until the next activity resets it).
  */
-export function effectiveStreak(currentStreak: number, lastActivityDate: string | null): number {
+export function effectiveStreak(
+  currentStreak: number,
+  lastActivityDate: string | null,
+  offsetMinutes: number | null = 0
+): number {
   if (!lastActivityDate) return 0;
-  return lastActivityDate >= yesterdayUTC() ? currentStreak : 0;
+  const localYesterday = previousDay(localDateFromOffset(offsetMinutes));
+  return lastActivityDate >= localYesterday ? currentStreak : 0;
 }

--- a/store/auth.ts
+++ b/store/auth.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { useSocialStore } from "@/store/social";
+import { resetActivityQueue } from "@/lib/social/post-activity";
 
 interface AuthStore {
   // Access token kept in memory — restored on page load via /api/auth/refresh (HttpOnly cookie)
@@ -89,6 +90,7 @@ export const useAuthStore = create<AuthStore>()(
           bookmarkGeneration: s.bookmarkGeneration + 1,
         }));
         useSocialStore.getState().clearSocial();
+        resetActivityQueue();
       },
 
       isBookmarked: (ref) => get().bookmarks.includes(ref),

--- a/store/social.ts
+++ b/store/social.ts
@@ -81,11 +81,19 @@ export const useSocialStore = create<SocialStore>()(
         }),
 
       applyActivityResult: ({ streak, longestStreak, activityDate }) =>
-        set((s) => ({
-          streak,
-          longestStreak: Math.max(s.longestStreak, longestStreak),
-          streakAsOf: activityDate,
-        })),
+        set((s) => {
+          const nextLongest = Math.max(s.longestStreak, longestStreak);
+          // Multiple POSTs can be in flight; an earlier local-date response
+          // landing after a later one must not roll the streak back. Same
+          // date + same-day guard as bumpStreak.
+          if (s.streakAsOf != null) {
+            if (activityDate < s.streakAsOf) return { longestStreak: nextLongest };
+            if (activityDate === s.streakAsOf && streak < s.streak) {
+              return { longestStreak: nextLongest };
+            }
+          }
+          return { streak, longestStreak: nextLongest, streakAsOf: activityDate };
+        }),
 
       setPendingFriendCount: (count) => set({ pendingFriendCount: count }),
 

--- a/store/social.ts
+++ b/store/social.ts
@@ -8,18 +8,30 @@ interface SocialProfile {
   username: string;
 }
 
+interface ActivityResult {
+  streak: number;
+  longestStreak: number;
+  activityDate: string;
+}
+
 interface SocialStore {
   userId: number | null;
   username: string | null;
   streak: number;
   longestStreak: number;
+  // The client-local "YYYY-MM-DD" the current streak/longestStreak were computed
+  // against. Lets a hydration read (GET /me, GET /activity) be ignored when it's
+  // older than — or a same-day regression of — a value already applied, so a
+  // slow in-flight GET can't clobber a fresh POST result back to a stale number.
+  streakAsOf: string | null;
   pendingFriendCount: number;
   pendingChallengeCount: number;
   pendingMentionCount: number;
 
   setProfile: (profile: SocialProfile) => void;
   clearSocial: () => void;
-  bumpStreak: (newStreak: number, newLongest?: number) => void;
+  bumpStreak: (newStreak: number, newLongest?: number, asOf?: string | null) => void;
+  applyActivityResult: (result: ActivityResult) => void;
   setPendingFriendCount: (count: number) => void;
   setPendingChallengeCount: (count: number) => void;
   setPendingMentionCount: (count: number) => void;
@@ -32,6 +44,7 @@ export const useSocialStore = create<SocialStore>()(
       username: null,
       streak: 0,
       longestStreak: 0,
+      streakAsOf: null,
       pendingFriendCount: 0,
       pendingChallengeCount: 0,
       pendingMentionCount: 0,
@@ -44,15 +57,34 @@ export const useSocialStore = create<SocialStore>()(
           username: null,
           streak: 0,
           longestStreak: 0,
+          streakAsOf: null,
           pendingFriendCount: 0,
           pendingChallengeCount: 0,
           pendingMentionCount: 0,
         }),
 
-      bumpStreak: (newStreak, newLongest) =>
+      bumpStreak: (newStreak, newLongest, asOf) =>
+        set((s) => {
+          const longestStreak = Math.max(s.longestStreak, newLongest ?? newStreak);
+          // A hydration read only loses to what's already applied when we can
+          // date both: an older day, or the same day with a lower streak (a
+          // stale pre-increment GET landing after the POST result).
+          if (asOf != null && s.streakAsOf != null) {
+            if (asOf < s.streakAsOf) return { longestStreak };
+            if (asOf === s.streakAsOf && newStreak < s.streak) return { longestStreak };
+          }
+          return {
+            streak: newStreak,
+            longestStreak,
+            streakAsOf: asOf ?? s.streakAsOf,
+          };
+        }),
+
+      applyActivityResult: ({ streak, longestStreak, activityDate }) =>
         set((s) => ({
-          streak: newStreak,
-          longestStreak: newLongest ?? Math.max(s.longestStreak, newStreak),
+          streak,
+          longestStreak: Math.max(s.longestStreak, longestStreak),
+          streakAsOf: activityDate,
         })),
 
       setPendingFriendCount: (count) => set({ pendingFriendCount: count }),
@@ -70,6 +102,7 @@ export const useSocialStore = create<SocialStore>()(
         username: s.username,
         streak: s.streak,
         longestStreak: s.longestStreak,
+        streakAsOf: s.streakAsOf,
       }),
     }
   )


### PR DESCRIPTION
## Why

The streak counter was reported as completely broken. Investigation found **four independent bugs**:

1. **First activity of every session dropped.** `useActivityTracker` excluded `accessToken` from its effect deps, so an add made before the async token restore finished hit the `!accessToken` guard, advanced the baseline, and was never retried.
2. **Stale reads clobbered fresh results.** Three uncoordinated `bumpStreak` callers (`SessionRestorer` → `GET /me`, `Header` → `GET /activity`, POST responses) all did an unconditional `set()`. A slow in-flight GET landing after a POST could knock the number back — including to 0 near a day boundary.
3. **Silent loss on any transient error.** POSTs were fire-and-forget with `.catch(() => {})`; a 429/5xx/network blip lost the whole day (the server does the `activity_log` insert + streak update in one transaction).
4. **UTC day boundary.** `todayUTC`/`yesterdayUTC` bucketed by UTC midnight. For the app's UTC+2–4 audience, late-night activity landed on the wrong calendar day, breaking consecutive-day detection and decaying streaks hours early.

## What

- **`store/social`** — `streakAsOf` freshness guard on `bumpStreak` (ignore an older-dated or same-day-regressing hydration read); new `applyActivityResult` for POST results, which always wins. The three writers are now commutative.
- **`lib/social/post-activity`** (new) — shared POST helper: up to 3 attempts with backoff, retry only on network / 429 / 5xx, never throws. On give-up the event is queued in memory and flushed on the next successful POST or on `visibilitychange` → visible.
- **`lib/social/streak`** — `previousDay`, `localDateFromOffset`; `effectiveStreak` now decays against the user's **local** calendar via a stored offset (defaults to UTC, so existing 2-arg callers/tests are unchanged).
- **`app/api/social/activity`** — accepts `local_date` + `tz_offset_minutes` (validated; a wildly-off `local_date` clamps to UTC), buckets the streak by the client's local day, persists the offset, returns `activityDate`. `GET /me`, `GET /activity`, and the leaderboard all decay with the stored offset.
- **Migration 0023** — `users.timezone_offset_minutes`, nullable (null → UTC fallback). Additive; reverse is a single `DROP COLUMN`.

## AI / Theological changes

None — no prompts, divine-name data, or theological framing touched.

## Tests

- `lib/social/streak`, `lib/social/post-activity` (new), `store/social`, `api/social/activity`, `api/social/me`, `api/social/leaderboard`, `hooks/useActivityTracker`, `app/stories/StoryActivityTracker` — unit.
- `__tests__/integration/user-tz-offset.integration.test.ts` — migration 0023 applied against a real Postgres (Testcontainers); offset column round-trips.
- Full suite: 1368 passing. Typecheck + lint clean.

## Not done here (needs the local stack)

Live browser verification against a running app is still pending — the local dev Postgres (`localhost:5434`) is down and the only Postgres container currently up belongs to another project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaks now follow your local calendar day, including leaderboard and profile streak displays.
  * Activity tracking includes your local date and timezone for more accurate streak updates.
  * Activities are retried and temporarily queued when requests fail or authentication is unavailable.

* **Bug Fixes**
  * Prevented stale activity responses from overwriting newer streak data.
  * Improved streak persistence and handling around midnight, failed requests, and timezone boundaries.

* **Tests**
  * Added coverage for timezone-aware streaks, retries, queued activity, and streak hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->