### PR TITLE
feat(admin): paginate the connections, users, challenges, names & audit lists

### DIFF
--- a/__tests__/api/admin/challenges-list.test.ts
+++ b/__tests__/api/admin/challenges-list.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/lib/social/challenges", () => ({
   },
 }));
 
-function makeSelectChain(resolveWith: unknown) {
+function makeSelectChain(resolveWith: unknown, calls?: Array<[string, unknown[]]>) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
     function () {
@@ -39,7 +39,10 @@ function makeSelectChain(resolveWith: unknown) {
         if (prop === "then")
           return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
             Promise.resolve(resolveWith).then(res, rej);
-        return () => chain;
+        return (...args: unknown[]) => {
+          calls?.push([String(prop), args]);
+          return chain;
+        };
       },
       apply() {
         return chain;
@@ -57,20 +60,26 @@ import { requireAdmin } from "@/lib/admin/admin-auth";
 
 const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
 
-function req() {
-  return new NextRequest("http://localhost/api/admin/challenges", {
-    headers: { Authorization: "Bearer t" },
-  });
+function req(query?: string) {
+  const url = query
+    ? `http://localhost/api/admin/challenges?${query}`
+    : "http://localhost/api/admin/challenges";
+  return new NextRequest(url, { headers: { Authorization: "Bearer t" } });
 }
 
 /** Order matches route.ts: ended, expiredPending, statusCounts, fromSuggestions, rows, users. */
-function queueSelects(ended: unknown[], expiredPending: unknown[], rows: unknown[] = []) {
+function queueSelects(
+  ended: unknown[],
+  expiredPending: unknown[],
+  rows: unknown[] = [],
+  listCalls?: Array<[string, unknown[]]>
+) {
   mockSelect
     .mockReturnValueOnce(makeSelectChain(ended))
     .mockReturnValueOnce(makeSelectChain(expiredPending))
     .mockReturnValueOnce(makeSelectChain([]))
     .mockReturnValueOnce(makeSelectChain([{ fromSuggestions: 0 }]))
-    .mockReturnValueOnce(makeSelectChain(rows))
+    .mockReturnValueOnce(makeSelectChain(rows, listCalls))
     .mockReturnValueOnce(makeSelectChain([]));
 }
 
@@ -145,5 +154,12 @@ describe("GET /api/admin/challenges", () => {
     const body = await (await GET(req())).json();
     expect(body.challenges).toHaveLength(50);
     expect(body.hasMore).toBe(true);
+  });
+
+  it("passes the requested offset through to the list query", async () => {
+    const listCalls: Array<[string, unknown[]]> = [];
+    queueSelects([], [], [], listCalls);
+    await GET(req("offset=50"));
+    expect(listCalls).toContainEqual(["offset", [50]]);
   });
 });

--- a/__tests__/api/admin/challenges-list.test.ts
+++ b/__tests__/api/admin/challenges-list.test.ts
@@ -132,4 +132,18 @@ describe("GET /api/admin/challenges", () => {
     expect(res.status).toBe(200);
     expect(mockRateLimitAdminMutation).toHaveBeenCalledTimes(1);
   });
+
+  it("caps the list page and reports hasMore when an extra row is returned", async () => {
+    const many = Array.from({ length: 51 }, (_, i) => ({
+      id: i + 1,
+      status: "pending",
+      challengerId: 1,
+      challengedId: 2,
+      endsAt: new Date(Date.now() + 1000),
+    }));
+    queueSelects([], [], many);
+    const body = await (await GET(req())).json();
+    expect(body.challenges).toHaveLength(50);
+    expect(body.hasMore).toBe(true);
+  });
 });

--- a/__tests__/api/admin/connections.test.ts
+++ b/__tests__/api/admin/connections.test.ts
@@ -110,6 +110,20 @@ describe("GET /api/admin/connections", () => {
     expect((await GET(get("reviewed=pending"))).status).toBe(200);
     expect((await GET(get("reviewed=reviewed"))).status).toBe(200);
   });
+
+  it("reports hasMore and caps the page when an extra row comes back", async () => {
+    const many = Array.from({ length: 51 }, (_, i) => ({ ...connectionRow, id: i + 1 }));
+    mockSelect.mockReturnValue(makeDbChain(many));
+    const body = await (await GET(get())).json();
+    expect(body.connections).toHaveLength(50);
+    expect(body.hasMore).toBe(true);
+  });
+
+  it("reports hasMore=false when the page isn't full", async () => {
+    mockSelect.mockReturnValue(makeDbChain([connectionRow]));
+    const body = await (await GET(get())).json();
+    expect(body.hasMore).toBe(false);
+  });
 });
 
 describe("PATCH /api/admin/connections", () => {

--- a/__tests__/api/admin/connections.test.ts
+++ b/__tests__/api/admin/connections.test.ts
@@ -8,7 +8,7 @@ vi.mock("@/lib/admin/admin-auth", () => ({
 }));
 vi.mock("@/lib/admin/admin-audit", () => ({ logAdminAction: vi.fn() }));
 
-function makeDbChain(resolveWith: unknown = []) {
+function makeDbChain(resolveWith: unknown = [], calls?: Array<[string, unknown[]]>) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
     function () {
@@ -19,7 +19,10 @@ function makeDbChain(resolveWith: unknown = []) {
         if (prop === "then")
           return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
             Promise.resolve(resolveWith).then(res, rej);
-        return () => chain;
+        return (...args: unknown[]) => {
+          calls?.push([String(prop), args]);
+          return chain;
+        };
       },
       apply() {
         return chain;
@@ -117,6 +120,13 @@ describe("GET /api/admin/connections", () => {
     const body = await (await GET(get())).json();
     expect(body.connections).toHaveLength(50);
     expect(body.hasMore).toBe(true);
+  });
+
+  it("passes the requested offset through to the query", async () => {
+    const calls: Array<[string, unknown[]]> = [];
+    mockSelect.mockReturnValue(makeDbChain([], calls));
+    await GET(get("offset=50"));
+    expect(calls).toContainEqual(["offset", [50]]);
   });
 
   it("reports hasMore=false when the page isn't full", async () => {

--- a/__tests__/api/admin/names.test.ts
+++ b/__tests__/api/admin/names.test.ts
@@ -105,6 +105,22 @@ describe("GET /api/admin/names", () => {
     const body = await res.json();
     expect(body.rows[0].data).toEqual({ text: "hi" });
     expect(body.rows[1].data).toBe("not-json");
+    expect(body.hasMore).toBe(false);
+  });
+
+  it("caps the page and sets hasMore when an extra row is returned", async () => {
+    const many = Array.from({ length: 51 }, (_, i) => ({
+      slug: `n${i}`,
+      kind: "reflection",
+      data: "x",
+      model: null,
+      version: 1,
+      updatedAt: new Date("2026-01-01"),
+    }));
+    mockSelect.mockReturnValue(makeDbChain(many));
+    const body = await (await GET(get())).json();
+    expect(body.rows).toHaveLength(50);
+    expect(body.hasMore).toBe(true);
   });
 });
 

--- a/__tests__/api/admin/names.test.ts
+++ b/__tests__/api/admin/names.test.ts
@@ -8,7 +8,7 @@ vi.mock("@/lib/admin/admin-auth", () => ({
 }));
 vi.mock("@/lib/admin/admin-audit", () => ({ logAdminAction: vi.fn() }));
 
-function makeDbChain(resolveWith: unknown = []) {
+function makeDbChain(resolveWith: unknown = [], calls?: Array<[string, unknown[]]>) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
     function () {
@@ -19,7 +19,10 @@ function makeDbChain(resolveWith: unknown = []) {
         if (prop === "then")
           return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
             Promise.resolve(resolveWith).then(res, rej);
-        return () => chain;
+        return (...args: unknown[]) => {
+          calls?.push([String(prop), args]);
+          return chain;
+        };
       },
       apply() {
         return chain;
@@ -44,10 +47,11 @@ import { logAdminAction } from "@/lib/admin/admin-audit";
 
 const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
 
-function get() {
-  return new NextRequest("http://localhost/api/admin/names", {
-    headers: { Authorization: "Bearer t" },
-  });
+function get(query?: string) {
+  const url = query
+    ? `http://localhost/api/admin/names?${query}`
+    : "http://localhost/api/admin/names";
+  return new NextRequest(url, { headers: { Authorization: "Bearer t" } });
 }
 function patch(body: unknown) {
   return new NextRequest("http://localhost/api/admin/names", {
@@ -121,6 +125,13 @@ describe("GET /api/admin/names", () => {
     const body = await (await GET(get())).json();
     expect(body.rows).toHaveLength(50);
     expect(body.hasMore).toBe(true);
+  });
+
+  it("passes the requested offset through to the query", async () => {
+    const calls: Array<[string, unknown[]]> = [];
+    mockSelect.mockReturnValue(makeDbChain([], calls));
+    await GET(get("offset=50"));
+    expect(calls).toContainEqual(["offset", [50]]);
   });
 });
 

--- a/__tests__/api/admin/users.test.ts
+++ b/__tests__/api/admin/users.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/lib/admin/admin-auth", () => ({
 vi.mock("@/lib/admin/admin-audit", () => ({ logAdminAction: vi.fn() }));
 vi.mock("@/lib/auth/social-auth", () => ({ broadcastUserCacheInvalidation: vi.fn() }));
 
-function makeDbChain(resolveWith: unknown = []) {
+function makeDbChain(resolveWith: unknown = [], calls?: Array<[string, unknown[]]>) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
     function () {
@@ -21,7 +21,10 @@ function makeDbChain(resolveWith: unknown = []) {
         if (prop === "then")
           return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
             Promise.resolve(resolveWith).then(res, rej);
-        return () => chain;
+        return (...args: unknown[]) => {
+          calls?.push([String(prop), args]);
+          return chain;
+        };
       },
       apply() {
         return chain;
@@ -107,6 +110,13 @@ describe("GET /api/admin/users", () => {
     const body = await (await GET(get())).json();
     expect(body.users).toHaveLength(50);
     expect(body.hasMore).toBe(true);
+  });
+
+  it("passes the requested offset through to the query", async () => {
+    const calls: Array<[string, unknown[]]> = [];
+    mockSelect.mockReturnValue(makeDbChain([], calls));
+    await GET(get("offset=50"));
+    expect(calls).toContainEqual(["offset", [50]]);
   });
 });
 

--- a/__tests__/api/admin/users.test.ts
+++ b/__tests__/api/admin/users.test.ts
@@ -98,6 +98,15 @@ describe("GET /api/admin/users", () => {
     expect(body.users).toHaveLength(1);
     expect(body.users[0].isAdmin).toBe(true);
     expect(body.users[0].username).toBe("someone");
+    expect(body.hasMore).toBe(false);
+  });
+
+  it("caps the page and sets hasMore when an extra row is returned", async () => {
+    const many = Array.from({ length: 51 }, (_, i) => ({ ...targetUser, id: i + 1 }));
+    mockSelect.mockReturnValue(makeDbChain(many));
+    const body = await (await GET(get())).json();
+    expect(body.users).toHaveLength(50);
+    expect(body.hasMore).toBe(true);
   });
 });
 

--- a/__tests__/app/admin/connections/page.test.tsx
+++ b/__tests__/app/admin/connections/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const mockApi = vi.fn();
@@ -59,5 +59,27 @@ describe("ConnectionsPage — confidence column", () => {
     const confidence = await screen.findByText("42%");
     expect(confidence.className).toContain("text-gold");
     expect(confidence.className).not.toContain("text-error");
+  });
+
+  it("shows Load more only when hasMore, and appends the next page with an offset", async () => {
+    mockApi
+      .mockResolvedValueOnce({
+        connections: [{ ...baseConnection, id: 1, fromRef: "1:1", confidence: 80 }],
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        connections: [{ ...baseConnection, id: 2, fromRef: "2:2", confidence: 70 }],
+        hasMore: false,
+      });
+
+    render(<ConnectionsPage />);
+
+    const loadMore = await screen.findByRole("button", { name: "Load more" });
+    fireEvent.click(loadMore);
+
+    await waitFor(() => expect(screen.getByText("2:2 → 24:35")).toBeInTheDocument());
+    expect(screen.getByText("1:1 → 24:35")).toBeInTheDocument();
+    expect(mockApi.mock.calls[1][0]).toContain("offset=1");
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
   });
 });

--- a/__tests__/app/admin/votd/page.test.tsx
+++ b/__tests__/app/admin/votd/page.test.tsx
@@ -192,6 +192,61 @@ describe("VotdPage — today's live pick on the calendar", () => {
   });
 });
 
+describe("VotdPage — calendar keyboard navigation", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+    mockApi.mockResolvedValue({ entries: [], today: null });
+  });
+
+  const cell = (day: number) =>
+    screen.getByText(String(day), { selector: "span.tabular-nums" }).closest("button")!;
+
+  // The grid opens on the current month; today's cell is the roving target.
+  const todayDay = new Date().getUTCDate();
+  const daysThisMonth = new Date(
+    Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth() + 1, 0)
+  ).getUTCDate();
+
+  it("labels each day and makes today's cell the tab-reachable one (roving tabindex)", async () => {
+    render(<VotdPage />);
+    await screen.findByText("1", { selector: "span.tabular-nums" });
+
+    expect(cell(todayDay)).toHaveAttribute("tabindex", "0");
+    expect(cell(todayDay === 1 ? 2 : 1)).toHaveAttribute("tabindex", "-1");
+    expect(cell(1).getAttribute("aria-label")).toMatch(/no verse set/);
+  });
+
+  it("ArrowRight moves the selection one day and ArrowDown moves a week", async () => {
+    if (todayDay + 8 > daysThisMonth) return; // avoid month-boundary wrap in this test
+    render(<VotdPage />);
+    await screen.findByText("1", { selector: "span.tabular-nums" });
+
+    const grid = screen.getByRole("grid");
+    fireEvent.keyDown(grid, { key: "ArrowRight" });
+    expect(cell(todayDay + 1)).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(grid, { key: "ArrowDown" });
+    expect(cell(todayDay + 8)).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("PageDown moves to the next month", async () => {
+    render(<VotdPage />);
+    await screen.findByText("1", { selector: "span.tabular-nums" });
+
+    const monthNow = new Date().toLocaleString("en", {
+      month: "long",
+      year: "numeric",
+      timeZone: "UTC",
+    });
+    const grid = screen.getByRole("grid");
+    fireEvent.keyDown(grid, { key: "PageDown" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 2 }).textContent).not.toBe(monthNow)
+    );
+  });
+});
+
 describe("VotdPage — Preview button guards against overlapping requests", () => {
   const mockFetch = vi.fn();
 

--- a/__tests__/app/admin/votd/page.test.tsx
+++ b/__tests__/app/admin/votd/page.test.tsx
@@ -200,8 +200,9 @@ describe("VotdPage — calendar keyboard navigation", () => {
 
   const cell = (day: number) =>
     screen.getByText(String(day), { selector: "span.tabular-nums" }).closest("button")!;
+  // aria-selected lives on the gridcell wrapping the day button (APG grid pattern).
+  const gridcell = (day: number) => cell(day).closest('[role="gridcell"]')!;
 
-  // The grid opens on the current month; today's cell is the roving target.
   const todayDay = new Date().getUTCDate();
   const daysThisMonth = new Date(
     Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth() + 1, 0)
@@ -223,13 +224,28 @@ describe("VotdPage — calendar keyboard navigation", () => {
 
     const grid = screen.getByRole("grid");
     fireEvent.keyDown(grid, { key: "ArrowRight" });
-    expect(cell(todayDay + 1)).toHaveAttribute("aria-selected", "true");
+    expect(gridcell(todayDay + 1)).toHaveAttribute("aria-selected", "true");
 
     fireEvent.keyDown(grid, { key: "ArrowDown" });
-    expect(cell(todayDay + 8)).toHaveAttribute("aria-selected", "true");
+    expect(gridcell(todayDay + 8)).toHaveAttribute("aria-selected", "true");
   });
 
-  it("PageDown moves to the next month", async () => {
+  it("Home and End move to the bounds of the active week", async () => {
+    const weekday = new Date().getUTCDay();
+    // Stay within the month so `cell()` can find the target.
+    if (todayDay - weekday < 1 || todayDay + (6 - weekday) > daysThisMonth) return;
+    render(<VotdPage />);
+    await screen.findByText("1", { selector: "span.tabular-nums" });
+    const grid = screen.getByRole("grid");
+
+    fireEvent.keyDown(grid, { key: "Home" });
+    expect(gridcell(todayDay - weekday)).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(grid, { key: "End" });
+    expect(gridcell(todayDay + (6 - weekday))).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("PageDown moves to the next month, keeping the day of the month", async () => {
     render(<VotdPage />);
     await screen.findByText("1", { selector: "span.tabular-nums" });
 
@@ -244,8 +260,20 @@ describe("VotdPage — calendar keyboard navigation", () => {
     await waitFor(() =>
       expect(screen.getByRole("heading", { level: 2 }).textContent).not.toBe(monthNow)
     );
+    const nextMonth = addMonthStr(new Date().toISOString().slice(0, 7), 1);
+    const nextMonthDays = new Date(
+      Date.UTC(Number(nextMonth.slice(0, 4)), Number(nextMonth.slice(5, 7)), 0)
+    ).getUTCDate();
+    const expectedDom = Math.min(todayDay, nextMonthDays);
+    await waitFor(() => expect(gridcell(expectedDom)).toHaveAttribute("aria-selected", "true"));
   });
 });
+
+function addMonthStr(month: string, delta: number): string {
+  const [y, m] = month.split("-").map(Number);
+  const d = new Date(Date.UTC(y, m - 1 + delta, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
 
 describe("VotdPage — Preview button guards against overlapping requests", () => {
   const mockFetch = vi.fn();

--- a/__tests__/components/admin/AdminLiveRegion.test.tsx
+++ b/__tests__/components/admin/AdminLiveRegion.test.tsx
@@ -1,11 +1,15 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { AdminLiveRegion, useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
 
-function Announcer() {
+function Announcer({ message = "Connection 7 set to retired." }: { message?: string }) {
   const announce = useAdminAnnounce();
-  return <button onClick={() => announce("Connection 7 set to retired.")}>go</button>;
+  return <button onClick={() => announce(message)}>go {message}</button>;
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("AdminLiveRegion", () => {
   it("renders a polite status region and fills it when announce() is called", async () => {
@@ -19,13 +23,60 @@ describe("AdminLiveRegion", () => {
     expect(region).toHaveAttribute("aria-live", "polite");
     expect(region).toHaveTextContent("");
 
-    fireEvent.click(screen.getByText("go"));
+    fireEvent.click(screen.getByRole("button"));
     await waitFor(() => expect(region).toHaveTextContent("Connection 7 set to retired."));
   });
 
   it("no-ops safely when used outside a provider", () => {
     render(<Announcer />);
     // Should not throw on click even though there's no live region mounted.
-    fireEvent.click(screen.getByText("go"));
+    fireEvent.click(screen.getByRole("button"));
+  });
+
+  it("a second announcement replaces the first and resets the 5s expiry", async () => {
+    vi.useFakeTimers();
+    function TwoAnnouncers() {
+      const announce = useAdminAnnounce();
+      return (
+        <>
+          <button onClick={() => announce("first")}>a</button>
+          <button onClick={() => announce("second")}>b</button>
+        </>
+      );
+    }
+    render(
+      <AdminLiveRegion>
+        <TwoAnnouncers />
+      </AdminLiveRegion>
+    );
+    const region = screen.getByRole("status");
+
+    fireEvent.click(screen.getByText("a"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(region).toHaveTextContent("first");
+
+    // 4s later — before the first message would expire — announce again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    fireEvent.click(screen.getByText("b"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(region).toHaveTextContent("second");
+
+    // The original 5s timer would have fired by now; the message must still hold.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(region).toHaveTextContent("second");
+
+    // 5s from the second announcement — now it clears.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(region).toHaveTextContent("");
   });
 });

--- a/__tests__/components/admin/AdminLiveRegion.test.tsx
+++ b/__tests__/components/admin/AdminLiveRegion.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { AdminLiveRegion, useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
+
+function Announcer() {
+  const announce = useAdminAnnounce();
+  return <button onClick={() => announce("Connection 7 set to retired.")}>go</button>;
+}
+
+describe("AdminLiveRegion", () => {
+  it("renders a polite status region and fills it when announce() is called", async () => {
+    render(
+      <AdminLiveRegion>
+        <Announcer />
+      </AdminLiveRegion>
+    );
+
+    const region = screen.getByRole("status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveTextContent("");
+
+    fireEvent.click(screen.getByText("go"));
+    await waitFor(() => expect(region).toHaveTextContent("Connection 7 set to retired."));
+  });
+
+  it("no-ops safely when used outside a provider", () => {
+    render(<Announcer />);
+    // Should not throw on click even though there's no live region mounted.
+    fireEvent.click(screen.getByText("go"));
+  });
+});

--- a/__tests__/components/admin/ExpandableText.test.tsx
+++ b/__tests__/components/admin/ExpandableText.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { ExpandableText } from "@/components/admin/ExpandableText";
+
+/**
+ * jsdom has no layout engine, so scrollHeight/clientHeight are always 0. Stub
+ * them to simulate a clamped element that does (or doesn't) overflow.
+ */
+function stubOverflow(overflowing: boolean) {
+  const scroll = vi
+    .spyOn(HTMLElement.prototype, "scrollHeight", "get")
+    .mockReturnValue(overflowing ? 200 : 40);
+  const client = vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(40);
+  return () => {
+    scroll.mockRestore();
+    client.mockRestore();
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("ExpandableText", () => {
+  it("renders the text with no toggle when it fits", () => {
+    const restore = stubOverflow(false);
+    render(<ExpandableText>short reason</ExpandableText>);
+    expect(screen.getByText("short reason")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    restore();
+  });
+
+  it("shows a Show more toggle when the text overflows, and flips it on click", () => {
+    const restore = stubOverflow(true);
+    render(<ExpandableText>a very long reason that would wrap several times</ExpandableText>);
+
+    const toggle = screen.getByRole("button", { name: "Show more" });
+    fireEvent.click(toggle);
+    expect(screen.getByRole("button", { name: "Show less" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Show less" }));
+    expect(screen.getByRole("button", { name: "Show more" })).toBeInTheDocument();
+    restore();
+  });
+});

--- a/__tests__/components/admin/ExpandableText.test.tsx
+++ b/__tests__/components/admin/ExpandableText.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { ExpandableText } from "@/components/admin/ExpandableText";
 
@@ -38,5 +38,29 @@ describe("ExpandableText", () => {
     fireEvent.click(screen.getByRole("button", { name: "Show less" }));
     expect(screen.getByRole("button", { name: "Show more" })).toBeInTheDocument();
     restore();
+  });
+
+  it("re-measures on resize, revealing the toggle when the element starts overflowing", () => {
+    let trigger: (() => void) | undefined;
+    class FakeResizeObserver {
+      constructor(cb: () => void) {
+        trigger = cb;
+      }
+      observe() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+
+    const restore = stubOverflow(false);
+    render(<ExpandableText>a reason that only overflows once the column narrows</ExpandableText>);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    restore();
+
+    // The column narrowed — the element now overflows its clamp.
+    const restore2 = stubOverflow(true);
+    act(() => trigger?.());
+    expect(screen.getByRole("button", { name: "Show more" })).toBeInTheDocument();
+    restore2();
+    vi.unstubAllGlobals();
   });
 });

--- a/__tests__/components/admin/primitives.test.tsx
+++ b/__tests__/components/admin/primitives.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Table, Th } from "@/components/admin/primitives";
+
+describe("Th", () => {
+  it("defaults to scope=col so screen readers associate the column", () => {
+    const { container } = render(
+      <Table>
+        <thead>
+          <tr>
+            <Th>Name</Th>
+          </tr>
+        </thead>
+      </Table>
+    );
+    expect(container.querySelector("th")).toHaveAttribute("scope", "col");
+  });
+
+  it("allows overriding scope (e.g. row headers)", () => {
+    const { container } = render(
+      <Table>
+        <thead>
+          <tr>
+            <Th scope="row">Name</Th>
+          </tr>
+        </thead>
+      </Table>
+    );
+    expect(container.querySelector("th")).toHaveAttribute("scope", "row");
+  });
+});

--- a/__tests__/components/admin/usePaginated.test.tsx
+++ b/__tests__/components/admin/usePaginated.test.tsx
@@ -64,6 +64,32 @@ describe("usePaginated", () => {
     expect(result.current.rows).toEqual([]);
   });
 
+  it("clears loadingMore when a reload supersedes an in-flight append", async () => {
+    let releaseAppend!: () => void;
+    const fetchPage = vi.fn(async ({ offset }: { offset: number }): Promise<Page<number>> => {
+      if (offset === 0) return { rows: [1], hasMore: true };
+      await new Promise<void>((r) => {
+        releaseAppend = r;
+      });
+      return { rows: [2], hasMore: true };
+    });
+    const { result } = renderHook(() => usePaginated(fetchPage, "k"));
+    await waitFor(() => expect(result.current.rows).toEqual([1]));
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.loadingMore).toBe(true));
+
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.rows).toEqual([1]));
+
+    // The stale append resolves after the reload — its finally is guarded out,
+    // so loadingMore must already be false and loadMore() must work again.
+    act(() => releaseAppend());
+    await waitFor(() => expect(result.current.loadingMore).toBe(false));
+    act(() => result.current.loadMore());
+    expect(fetchPage).toHaveBeenLastCalledWith({ offset: 1 });
+  });
+
   it("keeps rows on a failed loadMore and flags loadMoreError", async () => {
     const fetchPage = vi.fn(async ({ offset }: { offset: number }): Promise<Page<number>> => {
       if (offset === 0) return { rows: [1, 2], hasMore: true };

--- a/__tests__/components/admin/usePaginated.test.tsx
+++ b/__tests__/components/admin/usePaginated.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { usePaginated, type Page } from "@/components/admin/usePaginated";
+import { AdminApiError } from "@/components/admin/AdminContext";
+
+describe("usePaginated", () => {
+  it("loads page 0 on mount and exposes rows + hasMore + extra", async () => {
+    const fetchPage = vi.fn(async (): Promise<Page<number, { total: number }>> => ({
+      rows: [1, 2, 3],
+      hasMore: true,
+      extra: { total: 99 },
+    }));
+    const { result } = renderHook(() => usePaginated(fetchPage, "k"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.rows).toEqual([1, 2, 3]);
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.extra).toEqual({ total: 99 });
+    expect(fetchPage).toHaveBeenCalledWith({ offset: 0 });
+  });
+
+  it("loadMore appends the next page keyed by current row count", async () => {
+    const fetchPage = vi.fn(async ({ offset }: { offset: number }): Promise<Page<number>> => {
+      if (offset === 0) return { rows: [1, 2], hasMore: true };
+      return { rows: [3, 4], hasMore: false };
+    });
+    const { result } = renderHook(() => usePaginated(fetchPage, "k"));
+    await waitFor(() => expect(result.current.rows).toEqual([1, 2]));
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.rows).toEqual([1, 2, 3, 4]));
+    expect(fetchPage).toHaveBeenLastCalledWith({ offset: 2 });
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("reload resets to page 0 and drops appended rows", async () => {
+    let call = 0;
+    const fetchPage = vi.fn(async ({ offset }: { offset: number }): Promise<Page<number>> => {
+      if (offset > 0) return { rows: [99], hasMore: false };
+      call += 1;
+      return { rows: [call], hasMore: true };
+    });
+    const { result } = renderHook(() => usePaginated(fetchPage, "k"));
+    await waitFor(() => expect(result.current.rows).toEqual([1]));
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.rows).toEqual([1, 99]));
+
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.rows).toEqual([2]));
+  });
+
+  it("surfaces a page-0 AdminApiError message and clears rows", async () => {
+    const fetchPage = vi
+      .fn<() => Promise<Page<number>>>()
+      .mockResolvedValueOnce({ rows: [1], hasMore: false })
+      .mockRejectedValueOnce(new AdminApiError(500, "boom"));
+    const { result, rerender } = renderHook(({ k }) => usePaginated(fetchPage, k), {
+      initialProps: { k: "a" },
+    });
+    await waitFor(() => expect(result.current.rows).toEqual([1]));
+
+    rerender({ k: "b" });
+    await waitFor(() => expect(result.current.error).toBe("boom"));
+    expect(result.current.rows).toEqual([]);
+  });
+
+  it("keeps rows on a failed loadMore and flags loadMoreError", async () => {
+    const fetchPage = vi.fn(async ({ offset }: { offset: number }): Promise<Page<number>> => {
+      if (offset === 0) return { rows: [1, 2], hasMore: true };
+      throw new AdminApiError(500, "nope");
+    });
+    const { result } = renderHook(() => usePaginated(fetchPage, "k"));
+    await waitFor(() => expect(result.current.rows).toEqual([1, 2]));
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.loadMoreError).toBe(true));
+    expect(result.current.rows).toEqual([1, 2]);
+  });
+});

--- a/__tests__/lib/admin/format.test.ts
+++ b/__tests__/lib/admin/format.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { formatInfraResult } from "@/lib/admin/format";
+
+describe("formatInfraResult", () => {
+  it("summarises flush-tokens with a pluralised count", () => {
+    expect(formatInfraResult({ action: "flush-tokens", cleared: 12 })).toBe(
+      "Cleared 12 cached tokens."
+    );
+    expect(formatInfraResult({ action: "flush-tokens", cleared: 1 })).toBe(
+      "Cleared 1 cached token."
+    );
+    expect(formatInfraResult({ action: "flush-tokens" })).toBe("Cleared 0 cached tokens.");
+  });
+
+  it("summarises flush-jwks", () => {
+    expect(formatInfraResult({ action: "flush-jwks", ok: true })).toBe("JWKS cache flushed.");
+  });
+
+  it("summarises reset-ratelimits with a pluralised count", () => {
+    expect(formatInfraResult({ action: "reset-ratelimits", deleted: 40 })).toBe(
+      "Deleted 40 rate-limit rows."
+    );
+    expect(formatInfraResult({ action: "reset-ratelimits", deleted: 1 })).toBe(
+      "Deleted 1 rate-limit row."
+    );
+  });
+
+  it("falls back to a generic message for an unknown action", () => {
+    expect(formatInfraResult({ action: "something-else" })).toBe("Done.");
+  });
+});

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -4,6 +4,8 @@ import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { StatTile, Table, Th, Td, StateNote } from "@/components/admin/primitives";
 import { useAdminFetch } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
+import { RefreshButton } from "@/components/admin/RefreshButton";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 
 type AnalyticsSectionKey =
   "topVerses" | "connectionsByKind" | "dau" | "popularSearches" | "zeroResultSearches";
@@ -22,7 +24,7 @@ interface AnalyticsResponse {
 
 export default function AnalyticsPage() {
   const api = useAdminFetch();
-  const { data, error, loading } = useAsync<AnalyticsResponse>(
+  const { data, error, loading, reload } = useAsync<AnalyticsResponse>(
     () => api("/analytics"),
     "analytics"
   );
@@ -32,10 +34,11 @@ export default function AnalyticsPage() {
       <AdminPageHeader
         title="Analytics"
         subtitle="Product usage: what people explore, search, and where search comes up empty."
+        actions={<RefreshButton onClick={reload} loading={loading} />}
       />
       <div className="space-y-6 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
-        {loading && <StateNote>Loading…</StateNote>}
+        {loading && !data && <SkeletonRows n={5} />}
 
         {data && (
           <>
@@ -48,15 +51,25 @@ export default function AnalyticsPage() {
               </StateNote>
             )}
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-              <StatTile label="DAU" value={data.dau} hint="Active in the last 24h" />
-              {data.connectionsByKind.map((k) => (
-                <StatTile
-                  key={k.kind}
-                  label={`${k.kind} connections`}
-                  value={k.count}
-                  tone="teal"
-                />
-              ))}
+              <StatTile
+                label="DAU"
+                value={data.errors?.dau ? "—" : data.dau}
+                hint={data.errors?.dau ? "failed to load" : "Active in the last 24h"}
+              />
+              {data.errors?.connectionsByKind ? (
+                <StatTile label="connections" value="—" hint="failed to load" tone="plain" />
+              ) : data.connectionsByKind.length === 0 ? (
+                <StatTile label="connections" value={0} hint="none generated yet" tone="plain" />
+              ) : (
+                data.connectionsByKind.map((k) => (
+                  <StatTile
+                    key={k.kind}
+                    label={`${k.kind} connections`}
+                    value={k.count}
+                    tone="teal"
+                  />
+                ))
+              )}
             </div>
 
             <Section title="Top verses explored" subtitle="By generated-connection volume">

--- a/app/admin/audit/page.tsx
+++ b/app/admin/audit/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, StateNote } from "@/components/admin/primitives";
 import { useAdminFetch } from "@/components/admin/AdminContext";
-import { useAsync } from "@/components/admin/useAsync";
+import { usePaginated } from "@/components/admin/usePaginated";
 import { Button } from "@/components/ui";
 
 interface Entry {
@@ -17,41 +16,15 @@ interface Entry {
   createdAt: string;
 }
 
-interface AuditPageData {
-  entries: Entry[];
-  hasMore: boolean;
-}
-
 export default function AuditPage() {
   const api = useAdminFetch();
-  const { data, error, loading } = useAsync<AuditPageData>(() => api("/audit"), "audit");
-
-  const [entries, setEntries] = useState<Entry[]>([]);
-  const [hasMore, setHasMore] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [loadMoreError, setLoadMoreError] = useState(false);
-
-  useEffect(() => {
-    if (!data) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setEntries(data.entries);
-    setHasMore(data.hasMore);
-  }, [data]);
-
-  const loadMore = async () => {
-    if (loadingMore) return;
-    setLoadingMore(true);
-    setLoadMoreError(false);
-    try {
-      const page = await api<AuditPageData>(`/audit?offset=${entries.length}`);
-      setEntries((prev) => [...prev, ...page.entries]);
-      setHasMore(page.hasMore);
-    } catch {
-      setLoadMoreError(true);
-    } finally {
-      setLoadingMore(false);
-    }
-  };
+  const { rows, hasMore, error, loading, loadingMore, loadMoreError, loadMore } =
+    usePaginated<Entry>(async ({ offset }) => {
+      const d = await api<{ entries: Entry[]; hasMore: boolean }>(
+        `/audit${offset ? `?offset=${offset}` : ""}`
+      );
+      return { rows: d.entries, hasMore: d.hasMore };
+    }, "audit");
 
   return (
     <>
@@ -59,9 +32,11 @@ export default function AuditPage() {
       <div className="space-y-4 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
         {loading && <StateNote>Loading…</StateNote>}
-        {data && entries.length === 0 && <StateNote>No admin actions recorded yet.</StateNote>}
+        {!loading && !error && rows.length === 0 && (
+          <StateNote>No admin actions recorded yet.</StateNote>
+        )}
 
-        {data && entries.length > 0 && (
+        {rows.length > 0 && (
           <Table>
             <thead>
               <tr>
@@ -72,7 +47,7 @@ export default function AuditPage() {
               </tr>
             </thead>
             <tbody>
-              {entries.map((e) => (
+              {rows.map((e) => (
                 <tr key={e.id}>
                   <Td className="whitespace-nowrap text-xs text-text-muted">
                     {new Date(e.createdAt).toLocaleString()}

--- a/app/admin/connections/page.tsx
+++ b/app/admin/connections/page.tsx
@@ -6,6 +6,8 @@ import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
+import { ExpandableText } from "@/components/admin/ExpandableText";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 import { cn } from "@/lib/utils";
 
 interface Connection {
@@ -96,7 +98,7 @@ export default function ConnectionsPage() {
 
         {error && <StateNote tone="error">{error}</StateNote>}
         {actionError && <StateNote tone="error">{actionError}</StateNote>}
-        {loading && <StateNote>Loading…</StateNote>}
+        {loading && <SkeletonRows />}
         {!loading && !error && rows.length === 0 && <StateNote>No connections match.</StateNote>}
 
         {rows.length > 0 && (
@@ -122,7 +124,7 @@ export default function ConnectionsPage() {
                     <span className="text-xs text-text-secondary">{c.kind}</span>
                   </Td>
                   <Td className="max-w-md text-xs text-text-secondary">
-                    <span className="line-clamp-2">{c.reason}</span>
+                    <ExpandableText>{c.reason}</ExpandableText>
                   </Td>
                   <Td className="whitespace-nowrap text-xs">
                     {c.confidence === null ? (

--- a/app/admin/connections/page.tsx
+++ b/app/admin/connections/page.tsx
@@ -8,6 +8,7 @@ import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
 import { ExpandableText } from "@/components/admin/ExpandableText";
 import { SkeletonRows } from "@/components/admin/Skeleton";
+import { useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
 import { cn } from "@/lib/utils";
 
 interface Connection {
@@ -28,6 +29,7 @@ const REVIEWED_FILTERS = ["pending", "reviewed", "all"] as const;
 
 export default function ConnectionsPage() {
   const api = useAdminFetch();
+  const announce = useAdminAnnounce();
   const [status, setStatus] = useState<(typeof STATUS_FILTERS)[number]>("all");
   const [kind, setKind] = useState<(typeof KIND_FILTERS)[number]>("all");
   const [reviewed, setReviewed] = useState<(typeof REVIEWED_FILTERS)[number]>("pending");
@@ -57,9 +59,12 @@ export default function ConnectionsPage() {
     setBusyId(id);
     try {
       await api("/connections", { method: "PATCH", json: { id, status: next } });
+      announce(`Connection ${id} set to ${next}.`);
       reload();
     } catch (e) {
-      setActionError(e instanceof AdminApiError ? e.message : "Failed to update connection.");
+      const msg = e instanceof AdminApiError ? e.message : "Failed to update connection.";
+      setActionError(msg);
+      announce(msg);
     } finally {
       setBusyId(null);
     }
@@ -70,9 +75,12 @@ export default function ConnectionsPage() {
     setBusyId(id);
     try {
       await api("/connections", { method: "PATCH", json: { id, reviewed: true } });
+      announce(`Connection ${id} marked reviewed.`);
       reload();
     } catch (e) {
-      setActionError(e instanceof AdminApiError ? e.message : "Failed to update connection.");
+      const msg = e instanceof AdminApiError ? e.message : "Failed to update connection.";
+      setActionError(msg);
+      announce(msg);
     } finally {
       setBusyId(null);
     }
@@ -229,6 +237,8 @@ function FilterRow<T extends string>({
         {options.map((o) => (
           <button
             key={o}
+            type="button"
+            aria-pressed={value === o}
             onClick={() => onChange(o)}
             className={cn(
               "rounded border px-2 py-1 text-xs capitalize transition-colors",

--- a/app/admin/connections/page.tsx
+++ b/app/admin/connections/page.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
-import { useAsync } from "@/components/admin/useAsync";
+import { usePaginated } from "@/components/admin/usePaginated";
 import { cn } from "@/lib/utils";
 
 interface Connection {
@@ -32,15 +32,23 @@ export default function ConnectionsPage() {
   const [actionError, setActionError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<number | null>(null);
 
-  const qs = new URLSearchParams();
-  if (status !== "all") qs.set("status", status);
-  if (kind !== "all") qs.set("kind", kind);
-  if (reviewed !== "all") qs.set("reviewed", reviewed);
+  const baseParams = () => {
+    const p = new URLSearchParams();
+    if (status !== "all") p.set("status", status);
+    if (kind !== "all") p.set("kind", kind);
+    if (reviewed !== "all") p.set("reviewed", reviewed);
+    return p;
+  };
 
-  const { data, error, loading, reload } = useAsync<{ connections: Connection[] }>(
-    () => api(`/connections?${qs.toString()}`),
-    `connections:${status}:${kind}:${reviewed}`
-  );
+  const { rows, hasMore, error, loading, loadingMore, loadMoreError, reload, loadMore } =
+    usePaginated<Connection>(async ({ offset }) => {
+      const p = baseParams();
+      if (offset) p.set("offset", String(offset));
+      const d = await api<{ connections: Connection[]; hasMore: boolean }>(
+        `/connections?${p.toString()}`
+      );
+      return { rows: d.connections, hasMore: d.hasMore };
+    }, `connections:${status}:${kind}:${reviewed}`);
 
   const setStatusOf = async (id: number, next: Connection["status"]) => {
     setActionError(null);
@@ -89,9 +97,9 @@ export default function ConnectionsPage() {
         {error && <StateNote tone="error">{error}</StateNote>}
         {actionError && <StateNote tone="error">{actionError}</StateNote>}
         {loading && <StateNote>Loading…</StateNote>}
-        {data && data.connections.length === 0 && <StateNote>No connections match.</StateNote>}
+        {!loading && !error && rows.length === 0 && <StateNote>No connections match.</StateNote>}
 
-        {data && data.connections.length > 0 && (
+        {rows.length > 0 && (
           <Table>
             <thead>
               <tr>
@@ -105,7 +113,7 @@ export default function ConnectionsPage() {
               </tr>
             </thead>
             <tbody>
-              {data.connections.map((c) => (
+              {rows.map((c) => (
                 <tr key={c.id}>
                   <Td className="whitespace-nowrap font-mono text-xs text-text-secondary">
                     {c.fromRef} → {c.toRef}
@@ -182,6 +190,17 @@ export default function ConnectionsPage() {
               ))}
             </tbody>
           </Table>
+        )}
+
+        {hasMore && (
+          <div className="flex flex-col items-center gap-2">
+            <Button variant="secondary" size="sm" onClick={loadMore} disabled={loadingMore}>
+              {loadingMore ? "Loading…" : "Load more"}
+            </Button>
+            {loadMoreError && (
+              <StateNote tone="error">Couldn&apos;t load more connections.</StateNote>
+            )}
+          </div>
         )}
       </div>
     </>

--- a/app/admin/infra/page.tsx
+++ b/app/admin/infra/page.tsx
@@ -14,6 +14,9 @@ import {
 import { InfoHint } from "@/components/admin/InfoHint";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
+import { RefreshButton } from "@/components/admin/RefreshButton";
+import { SkeletonRows } from "@/components/admin/Skeleton";
+import { formatInfraResult } from "@/lib/admin/format";
 
 interface Infra {
   redis: "disabled" | "up" | "down";
@@ -40,11 +43,11 @@ export default function InfraPage() {
     setMsg(null);
     setBusy(true);
     try {
-      const res = await api<Record<string, unknown>>("/infra", {
+      const res = await api<Parameters<typeof formatInfraResult>[0]>("/infra", {
         method: "POST",
         json: { action },
       });
-      setMsg(`Done: ${JSON.stringify(res)}`);
+      setMsg(formatInfraResult(res));
       reload();
     } catch (e) {
       setMsg(e instanceof AdminApiError ? e.message : "Action failed.");
@@ -55,10 +58,14 @@ export default function InfraPage() {
 
   return (
     <>
-      <AdminPageHeader title="Infra" subtitle="Process health, caches, and maintenance actions." />
+      <AdminPageHeader
+        title="Infra"
+        subtitle="Process health, caches, and maintenance actions."
+        actions={<RefreshButton onClick={reload} loading={loading} />}
+      />
       <div className="space-y-6 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
-        {loading && <StateNote>Loading…</StateNote>}
+        {loading && !data && <SkeletonRows n={4} />}
 
         {data && (
           <>

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { AdminGate } from "@/components/admin/AdminGate";
 import { AdminShell } from "@/components/admin/AdminShell";
+import { AdminLiveRegion } from "@/components/admin/AdminLiveRegion";
 
 export const metadata: Metadata = {
   title: "Admin — Open Hikmah",
@@ -15,7 +16,9 @@ export const dynamic = "force-dynamic";
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
     <AdminGate>
-      <AdminShell>{children}</AdminShell>
+      <AdminLiveRegion>
+        <AdminShell>{children}</AdminShell>
+      </AdminLiveRegion>
     </AdminGate>
   );
 }

--- a/app/admin/names/page.tsx
+++ b/app/admin/names/page.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
-import { useAsync } from "@/components/admin/useAsync";
+import { usePaginated } from "@/components/admin/usePaginated";
 import { useArmedConfirm } from "@/hooks/useArmedConfirm";
 
 interface Row {
@@ -19,7 +19,13 @@ interface Row {
 
 export default function NamesPage() {
   const api = useAdminFetch();
-  const { data, error, loading, reload } = useAsync<{ rows: Row[] }>(() => api("/names"), "names");
+  const { rows, hasMore, error, loading, loadingMore, loadMoreError, reload, loadMore } =
+    usePaginated<Row>(async ({ offset }) => {
+      const d = await api<{ rows: Row[]; hasMore: boolean }>(
+        `/names${offset ? `?offset=${offset}` : ""}`
+      );
+      return { rows: d.rows, hasMore: d.hasMore };
+    }, "names");
   const [editing, setEditing] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [msg, setMsg] = useState<string | null>(null);
@@ -79,9 +85,11 @@ export default function NamesPage() {
         {error && <StateNote tone="error">{error}</StateNote>}
         {msg && <StateNote tone="error">{msg}</StateNote>}
         {loading && <StateNote>Loading…</StateNote>}
-        {data && data.rows.length === 0 && <StateNote>No cached name content yet.</StateNote>}
+        {!loading && !error && rows.length === 0 && (
+          <StateNote>No cached name content yet.</StateNote>
+        )}
 
-        {data && data.rows.length > 0 && (
+        {rows.length > 0 && (
           <Table>
             <thead>
               <tr>
@@ -93,7 +101,7 @@ export default function NamesPage() {
               </tr>
             </thead>
             <tbody>
-              {data.rows.map((r) => {
+              {rows.map((r) => {
                 const id = `${r.slug}/${r.kind}`;
                 const isEditing = editing === id;
                 return (
@@ -143,6 +151,15 @@ export default function NamesPage() {
               })}
             </tbody>
           </Table>
+        )}
+
+        {hasMore && (
+          <div className="flex flex-col items-center gap-2">
+            <Button variant="secondary" size="sm" onClick={loadMore} disabled={loadingMore}>
+              {loadingMore ? "Loading…" : "Load more"}
+            </Button>
+            {loadMoreError && <StateNote tone="error">Couldn&apos;t load more entries.</StateNote>}
+          </div>
         )}
       </div>
     </>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -7,6 +7,7 @@ import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admi
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
 import { SkeletonRows } from "@/components/admin/Skeleton";
+import { useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
 
 interface AdminUser {
   id: number;
@@ -22,6 +23,7 @@ interface AdminUser {
 
 export default function UsersPage() {
   const api = useAdminFetch();
+  const announce = useAdminAnnounce();
   const [query, setQuery] = useState("");
   const [submitted, setSubmitted] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
@@ -42,9 +44,12 @@ export default function UsersPage() {
     setBusyId(id);
     try {
       await api("/users", { method: "PATCH", json: { id, disabled } });
+      announce(`User ${id} ${disabled ? "disabled" : "re-enabled"}.`);
       reload();
     } catch (e) {
-      setActionError(e instanceof AdminApiError ? e.message : "Failed to update user.");
+      const msg = e instanceof AdminApiError ? e.message : "Failed to update user.";
+      setActionError(msg);
+      announce(msg);
     } finally {
       setBusyId(null);
     }

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -5,7 +5,7 @@ import { Button, Input } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
-import { useAsync } from "@/components/admin/useAsync";
+import { usePaginated } from "@/components/admin/usePaginated";
 
 interface AdminUser {
   id: number;
@@ -26,10 +26,15 @@ export default function UsersPage() {
   const [actionError, setActionError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<number | null>(null);
 
-  const { data, error, loading, reload } = useAsync<{ users: AdminUser[] }>(
-    () => api(`/users${submitted ? `?q=${encodeURIComponent(submitted)}` : ""}`),
-    `users:${submitted}`
-  );
+  const { rows, hasMore, error, loading, loadingMore, loadMoreError, reload, loadMore } =
+    usePaginated<AdminUser>(async ({ offset }) => {
+      const p = new URLSearchParams();
+      if (submitted) p.set("q", submitted);
+      if (offset) p.set("offset", String(offset));
+      const qs = p.toString();
+      const d = await api<{ users: AdminUser[]; hasMore: boolean }>(`/users${qs ? `?${qs}` : ""}`);
+      return { rows: d.users, hasMore: d.hasMore };
+    }, `users:${submitted}`);
 
   const setDisabled = async (id: number, disabled: boolean) => {
     setActionError(null);
@@ -68,9 +73,9 @@ export default function UsersPage() {
         {error && <StateNote tone="error">{error}</StateNote>}
         {actionError && <StateNote tone="error">{actionError}</StateNote>}
         {loading && <StateNote>Loading…</StateNote>}
-        {data && data.users.length === 0 && <StateNote>No users found.</StateNote>}
+        {!loading && !error && rows.length === 0 && <StateNote>No users found.</StateNote>}
 
-        {data && data.users.length > 0 && (
+        {rows.length > 0 && (
           <Table>
             <thead>
               <tr>
@@ -82,7 +87,7 @@ export default function UsersPage() {
               </tr>
             </thead>
             <tbody>
-              {data.users.map((u) => (
+              {rows.map((u) => (
                 <tr key={u.id}>
                   <Td>
                     <div className="flex items-center gap-2">
@@ -135,6 +140,15 @@ export default function UsersPage() {
               ))}
             </tbody>
           </Table>
+        )}
+
+        {hasMore && (
+          <div className="flex flex-col items-center gap-2">
+            <Button variant="secondary" size="sm" onClick={loadMore} disabled={loadingMore}>
+              {loadingMore ? "Loading…" : "Load more"}
+            </Button>
+            {loadMoreError && <StateNote tone="error">Couldn&apos;t load more users.</StateNote>}
+          </div>
         )}
       </div>
     </>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -6,6 +6,7 @@ import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 
 interface AdminUser {
   id: number;
@@ -72,7 +73,7 @@ export default function UsersPage() {
 
         {error && <StateNote tone="error">{error}</StateNote>}
         {actionError && <StateNote tone="error">{actionError}</StateNote>}
-        {loading && <StateNote>Loading…</StateNote>}
+        {loading && <SkeletonRows />}
         {!loading && !error && rows.length === 0 && <StateNote>No users found.</StateNote>}
 
         {rows.length > 0 && (

--- a/app/admin/votd/page.tsx
+++ b/app/admin/votd/page.tsx
@@ -43,7 +43,25 @@ function monthLabel(month: string): string {
   });
 }
 
+/** "12 March 2026" for a `YYYY-MM-DD` date. */
+function longDate(date: string): string {
+  const [dy, dm, dd] = date.split("-").map(Number);
+  return new Date(Date.UTC(dy, dm - 1, dd)).toLocaleString("en", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 const todayStr = () => new Date().toISOString().slice(0, 10);
+
+/** `YYYY-MM-DD` `delta` days away, wrapping across month/year boundaries. */
+function addDays(date: string, delta: number): string {
+  const [dy, dm, dd] = date.split("-").map(Number);
+  const d = new Date(Date.UTC(dy, dm - 1, dd + delta));
+  return d.toISOString().slice(0, 10);
+}
 
 export default function VotdPage() {
   const api = useAdminFetch();
@@ -67,6 +85,73 @@ export default function VotdPage() {
   const firstWeekday = new Date(Date.UTC(y, m - 1, 1)).getUTCDay();
   const daysInMonth = new Date(Date.UTC(y, m, 0)).getUTCDate();
   const today = todayStr();
+
+  const gridRef = useRef<HTMLDivElement>(null);
+  // After an arrow-key move changes the month, focus the target day once its
+  // button has rendered.
+  const pendingFocus = useRef<string | null>(null);
+  useEffect(() => {
+    if (!pendingFocus.current) return;
+    const el = gridRef.current?.querySelector<HTMLButtonElement>(
+      `[data-date="${pendingFocus.current}"]`
+    );
+    el?.focus();
+    pendingFocus.current = null;
+  }, [month, data]);
+
+  // The one day in the grid that's tab-reachable (roving tabindex): the
+  // selection if it's in this month, else today if visible, else day 1.
+  const rovingDate =
+    selected && selected.startsWith(month)
+      ? selected
+      : today.startsWith(month)
+        ? today
+        : `${month}-01`;
+
+  const moveTo = (date: string) => {
+    setSelected(date);
+    if (date.slice(0, 7) !== month) {
+      pendingFocus.current = date;
+      setMonth(date.slice(0, 7));
+    } else {
+      gridRef.current?.querySelector<HTMLButtonElement>(`[data-date="${date}"]`)?.focus();
+    }
+  };
+
+  const onGridKeyDown = (e: React.KeyboardEvent) => {
+    const from = rovingDate;
+    let target: string | null = null;
+    switch (e.key) {
+      case "ArrowRight":
+        target = addDays(from, 1);
+        break;
+      case "ArrowLeft":
+        target = addDays(from, -1);
+        break;
+      case "ArrowDown":
+        target = addDays(from, 7);
+        break;
+      case "ArrowUp":
+        target = addDays(from, -7);
+        break;
+      case "Home":
+        target = `${month}-01`;
+        break;
+      case "End":
+        target = `${month}-${String(daysInMonth).padStart(2, "0")}`;
+        break;
+      case "PageUp":
+        target = addMonth(month, -1) + "-01";
+        break;
+      case "PageDown":
+        target = addMonth(month, 1) + "-01";
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    moveTo(target);
+  };
 
   return (
     <>
@@ -100,7 +185,7 @@ export default function VotdPage() {
 
           {error && <StateNote tone="error">{error}</StateNote>}
 
-          <div className="grid grid-cols-7 gap-1.5">
+          <div className="grid grid-cols-7 gap-1.5" aria-hidden>
             {WEEKDAYS.map((d, i) => (
               <div
                 key={i}
@@ -109,8 +194,16 @@ export default function VotdPage() {
                 {d}
               </div>
             ))}
+          </div>
+          <div
+            ref={gridRef}
+            role="grid"
+            aria-label={`${monthLabel(month)} — set the verse of the day`}
+            onKeyDown={onGridKeyDown}
+            className="grid grid-cols-7 gap-1.5"
+          >
             {Array.from({ length: firstWeekday }).map((_, i) => (
-              <div key={`pad-${i}`} />
+              <div key={`pad-${i}`} role="presentation" />
             ))}
             {Array.from({ length: daysInMonth }).map((_, i) => {
               const day = i + 1;
@@ -121,6 +214,14 @@ export default function VotdPage() {
               return (
                 <button
                   key={date}
+                  data-date={date}
+                  role="gridcell"
+                  tabIndex={date === rovingDate ? 0 : -1}
+                  aria-current={isToday ? "date" : undefined}
+                  aria-selected={isSelected}
+                  aria-label={`${longDate(date)}${
+                    entry ? `, verse ${entry.verseRef}` : ", no verse set"
+                  }${isToday ? ", today" : ""}`}
                   onClick={() => setSelected(date)}
                   className={cn(
                     "flex aspect-square flex-col items-center justify-center rounded-md border text-sm transition-colors",

--- a/app/admin/votd/page.tsx
+++ b/app/admin/votd/page.tsx
@@ -27,6 +27,24 @@ interface TodayInfo {
 }
 
 const WEEKDAYS = ["S", "M", "T", "W", "T", "F", "S"];
+const WEEKDAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+function daysInMonthOf(month: string): number {
+  const [y, m] = month.split("-").map(Number);
+  return new Date(Date.UTC(y, m, 0)).getUTCDate();
+}
+
+function weekdayOf(date: string): number {
+  return new Date(`${date}T00:00:00Z`).getUTCDay();
+}
 
 function addMonth(month: string, delta: number): string {
   const [y, m] = month.split("-").map(Number);
@@ -43,7 +61,6 @@ function monthLabel(month: string): string {
   });
 }
 
-/** "12 March 2026" for a `YYYY-MM-DD` date. */
 function longDate(date: string): string {
   const [dy, dm, dd] = date.split("-").map(Number);
   return new Date(Date.UTC(dy, dm - 1, dd)).toLocaleString("en", {
@@ -56,7 +73,6 @@ function longDate(date: string): string {
 
 const todayStr = () => new Date().toISOString().slice(0, 10);
 
-/** `YYYY-MM-DD` `delta` days away, wrapping across month/year boundaries. */
 function addDays(date: string, delta: number): string {
   const [dy, dm, dd] = date.split("-").map(Number);
   const d = new Date(Date.UTC(dy, dm - 1, dd + delta));
@@ -108,6 +124,16 @@ export default function VotdPage() {
         ? today
         : `${month}-01`;
 
+  // Lay the month out as calendar weeks so the grid can carry `role="row"`
+  // containers — a bare grid of gridcells isn't a valid grid.
+  const cells: (number | null)[] = [
+    ...Array.from({ length: firstWeekday }, () => null),
+    ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+  ];
+  while (cells.length % 7 !== 0) cells.push(null);
+  const weeks: (number | null)[][] = [];
+  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
+
   const moveTo = (date: string) => {
     setSelected(date);
     if (date.slice(0, 7) !== month) {
@@ -135,17 +161,19 @@ export default function VotdPage() {
         target = addDays(from, -7);
         break;
       case "Home":
-        target = `${month}-01`;
+        // Start of the active week (may cross into the previous month).
+        target = addDays(from, -weekdayOf(from));
         break;
       case "End":
-        target = `${month}-${String(daysInMonth).padStart(2, "0")}`;
+        target = addDays(from, 6 - weekdayOf(from));
         break;
       case "PageUp":
-        target = addMonth(month, -1) + "-01";
+      case "PageDown": {
+        const dest = addMonth(month, e.key === "PageUp" ? -1 : 1);
+        const dom = Math.min(Number(from.slice(8, 10)), daysInMonthOf(dest));
+        target = `${dest}-${String(dom).padStart(2, "0")}`;
         break;
-      case "PageDown":
-        target = addMonth(month, 1) + "-01";
-        break;
+      }
       default:
         return;
     }
@@ -185,73 +213,82 @@ export default function VotdPage() {
 
           {error && <StateNote tone="error">{error}</StateNote>}
 
-          <div className="grid grid-cols-7 gap-1.5" aria-hidden>
-            {WEEKDAYS.map((d, i) => (
-              <div
-                key={i}
-                className="pb-1 text-center font-mono text-[10px] uppercase text-text-muted"
-              >
-                {d}
-              </div>
-            ))}
-          </div>
           <div
             ref={gridRef}
             role="grid"
             aria-label={`${monthLabel(month)} — set the verse of the day`}
             onKeyDown={onGridKeyDown}
-            className="grid grid-cols-7 gap-1.5"
+            className="flex flex-col gap-1.5"
           >
-            {Array.from({ length: firstWeekday }).map((_, i) => (
-              <div key={`pad-${i}`} role="presentation" />
-            ))}
-            {Array.from({ length: daysInMonth }).map((_, i) => {
-              const day = i + 1;
-              const date = `${month}-${String(day).padStart(2, "0")}`;
-              const entry = byDate.get(date);
-              const isSelected = selected === date;
-              const isToday = date === today;
-              return (
-                <button
-                  key={date}
-                  data-date={date}
-                  role="gridcell"
-                  tabIndex={date === rovingDate ? 0 : -1}
-                  aria-current={isToday ? "date" : undefined}
-                  aria-selected={isSelected}
-                  aria-label={`${longDate(date)}${
-                    entry ? `, verse ${entry.verseRef}` : ", no verse set"
-                  }${isToday ? ", today" : ""}`}
-                  onClick={() => setSelected(date)}
-                  className={cn(
-                    "flex aspect-square flex-col items-center justify-center rounded-md border text-sm transition-colors",
-                    isSelected
-                      ? "border-gold bg-gold/10 text-gold"
-                      : entry
-                        ? "border-teal/40 bg-teal/5 text-text-primary hover:border-teal"
-                        : "border-border bg-surface text-text-secondary hover:border-gold-muted",
-                    // Marks the live day independent of curated/selected color, so
-                    // it's identifiable even on an uncurated (algorithmic-pick) day.
-                    isToday && !isSelected && "ring-1 ring-inset ring-gold/50"
-                  )}
+            <div role="row" className="grid grid-cols-7 gap-1.5">
+              {WEEKDAYS.map((d, i) => (
+                <div
+                  key={i}
+                  role="columnheader"
+                  aria-label={WEEKDAY_NAMES[i]}
+                  className="pb-1 text-center font-mono text-[10px] uppercase text-text-muted"
                 >
-                  <span className="tabular-nums">{day}</span>
-                  {entry ? (
-                    <span className="mt-0.5 font-mono text-[9px] text-teal">{entry.verseRef}</span>
-                  ) : (
-                    // No curated entry — for today, still surface the live
-                    // algorithmic pick so the admin can see it without leaving
-                    // the calendar, styled distinctly from a curated ref.
-                    isToday &&
-                    data?.today?.ref && (
-                      <span className="mt-0.5 font-mono text-[9px] text-gold">
-                        {data.today.ref}
-                      </span>
-                    )
-                  )}
-                </button>
-              );
-            })}
+                  {d}
+                </div>
+              ))}
+            </div>
+            {weeks.map((week, wi) => (
+              <div key={wi} role="row" className="grid grid-cols-7 gap-1.5">
+                {week.map((day, ci) => {
+                  if (day === null) return <div key={ci} role="gridcell" aria-hidden />;
+                  const date = `${month}-${String(day).padStart(2, "0")}`;
+                  const entry = byDate.get(date);
+                  const isSelected = selected === date;
+                  const isToday = date === today;
+                  return (
+                    <div
+                      key={date}
+                      role="gridcell"
+                      aria-selected={isSelected}
+                      className="aspect-square"
+                    >
+                      <button
+                        data-date={date}
+                        tabIndex={date === rovingDate ? 0 : -1}
+                        aria-current={isToday ? "date" : undefined}
+                        aria-label={`${longDate(date)}${
+                          entry ? `, verse ${entry.verseRef}` : ", no verse set"
+                        }${isToday ? ", today" : ""}`}
+                        onClick={() => setSelected(date)}
+                        className={cn(
+                          "flex h-full w-full flex-col items-center justify-center rounded-md border text-sm transition-colors",
+                          isSelected
+                            ? "border-gold bg-gold/10 text-gold"
+                            : entry
+                              ? "border-teal/40 bg-teal/5 text-text-primary hover:border-teal"
+                              : "border-border bg-surface text-text-secondary hover:border-gold-muted",
+                          // Marks the live day independent of curated/selected color, so
+                          // it's identifiable even on an uncurated (algorithmic-pick) day.
+                          isToday && !isSelected && "ring-1 ring-inset ring-gold/50"
+                        )}
+                      >
+                        <span className="tabular-nums">{day}</span>
+                        {entry ? (
+                          <span className="mt-0.5 font-mono text-[9px] text-teal">
+                            {entry.verseRef}
+                          </span>
+                        ) : (
+                          // No curated entry — for today, still surface the live
+                          // algorithmic pick so the admin can see it without leaving
+                          // the calendar, styled distinctly from a curated ref.
+                          isToday &&
+                          data?.today?.ref && (
+                            <span className="mt-0.5 font-mono text-[9px] text-gold">
+                              {data.today.ref}
+                            </span>
+                          )
+                        )}
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
           </div>
           {loading && <StateNote>Loading…</StateNote>}
         </div>

--- a/app/api/admin/challenges/route.ts
+++ b/app/api/admin/challenges/route.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
 import { requireAdmin, rateLimitAdminMutation } from "@/lib/admin/admin-auth";
 import { db } from "@/lib/infra/db";
 import { challenges, users } from "@/lib/infra/db/schema";
+import { parsePagination } from "@/lib/infra/http";
 import {
   scoreChallenge,
   resolveEndedChallenges,
@@ -28,8 +29,7 @@ export async function GET(req: NextRequest) {
   if (status && !(STATUSES as readonly string[]).includes(status)) {
     return NextResponse.json({ error: "Invalid status filter" }, { status: 400 });
   }
-  const limitParam = Number(sp.get("limit"));
-  const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 50;
+  const { limit, offset } = parsePagination(req);
 
   try {
     // Finalize any ended/expired challenges before the stats aggregation and the
@@ -78,12 +78,16 @@ export async function GET(req: NextRequest) {
     }
 
     // List (filtered, newest first), finalize any ended ones, then enrich.
-    const rows = await db
+    // One extra row to detect a further page; sliced off before any processing.
+    const pageRows = await db
       .select()
       .from(challenges)
       .where(status ? eq(challenges.status, status) : undefined)
-      .orderBy(desc(challenges.createdAt))
-      .limit(limit);
+      .orderBy(desc(challenges.createdAt), desc(challenges.id))
+      .limit(limit + 1)
+      .offset(offset);
+    const hasMore = pageRows.length > limit;
+    const rows = pageRows.slice(0, limit);
 
     // A challenge can flip from active to overdue in the gap between the
     // `ended` select above and this one, so it slips past the earlier gate.
@@ -140,7 +144,7 @@ export async function GET(req: NextRequest) {
       }
     );
 
-    return NextResponse.json({ stats, challenges: list });
+    return NextResponse.json({ stats, challenges: list, hasMore });
   } catch (err) {
     console.error("admin challenges GET db error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/app/api/admin/connections/route.ts
+++ b/app/api/admin/connections/route.ts
@@ -4,6 +4,7 @@ import { requireAdmin, rateLimitAdminMutation } from "@/lib/admin/admin-auth";
 import { logAdminAction } from "@/lib/admin/admin-audit";
 import { db } from "@/lib/infra/db";
 import { connections } from "@/lib/infra/db/schema";
+import { parsePagination } from "@/lib/infra/http";
 
 const STATUSES = ["active", "flagged", "retired"] as const;
 const KINDS = ["thematic", "root", "contrast"] as const;
@@ -19,8 +20,7 @@ export async function GET(req: NextRequest) {
   const status = sp.get("status");
   const kind = sp.get("kind");
   const reviewed = sp.get("reviewed");
-  const limitParam = Number(sp.get("limit"));
-  const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 100;
+  const { limit, offset } = parsePagination(req);
 
   // Reject unknown filter values rather than silently ignoring them, so a
   // typo'd query surfaces as a 400 instead of unfiltered results.
@@ -45,10 +45,12 @@ export async function GET(req: NextRequest) {
       .select()
       .from(connections)
       .where(filters.length ? and(...filters) : undefined)
-      .orderBy(desc(connections.createdAt))
-      .limit(limit);
+      .orderBy(desc(connections.createdAt), desc(connections.id))
+      .limit(limit + 1)
+      .offset(offset);
 
-    return NextResponse.json({ connections: rows });
+    const hasMore = rows.length > limit;
+    return NextResponse.json({ connections: rows.slice(0, limit), hasMore });
   } catch (err) {
     console.error("admin connections GET db error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/app/api/admin/names/route.ts
+++ b/app/api/admin/names/route.ts
@@ -4,7 +4,7 @@ import { requireAdmin, rateLimitAdminMutation } from "@/lib/admin/admin-auth";
 import { logAdminAction } from "@/lib/admin/admin-audit";
 import { db } from "@/lib/infra/db";
 import { nameContent } from "@/lib/infra/db/schema";
-import { safeParse } from "@/lib/infra/http";
+import { safeParse, parsePagination } from "@/lib/infra/http";
 import { isValidRef } from "@/lib/quran/quran-corpus";
 
 const KINDS = ["verses", "reflection", "pairings"] as const;
@@ -78,14 +78,20 @@ export async function GET(req: NextRequest) {
   const auth = await requireAdmin(req);
   if (auth instanceof NextResponse) return auth;
 
+  const { limit, offset } = parsePagination(req);
+
   try {
     const rows = await db
       .select()
       .from(nameContent)
-      .orderBy(asc(nameContent.slug), asc(nameContent.kind));
+      .orderBy(asc(nameContent.slug), asc(nameContent.kind))
+      .limit(limit + 1)
+      .offset(offset);
 
+    const hasMore = rows.length > limit;
     return NextResponse.json({
-      rows: rows.map((r) => ({
+      hasMore,
+      rows: rows.slice(0, limit).map((r) => ({
         slug: r.slug,
         kind: r.kind,
         data: safeParse(r.data),

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -5,6 +5,7 @@ import { logAdminAction } from "@/lib/admin/admin-audit";
 import { broadcastUserCacheInvalidation } from "@/lib/auth/social-auth";
 import { db } from "@/lib/infra/db";
 import { users } from "@/lib/infra/db/schema";
+import { parsePagination } from "@/lib/infra/http";
 
 /** List users (newest-active first) with optional `?q=` username search. */
 export async function GET(req: NextRequest) {
@@ -12,19 +13,21 @@ export async function GET(req: NextRequest) {
   if (auth instanceof NextResponse) return auth;
 
   const q = req.nextUrl.searchParams.get("q")?.trim();
-  const limitParam = Number(req.nextUrl.searchParams.get("limit"));
-  const limit = Number.isInteger(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 100;
+  const { limit, offset } = parsePagination(req);
 
   try {
     const rows = await db
       .select()
       .from(users)
       .where(q ? ilike(users.username, `%${q}%`) : undefined)
-      .orderBy(desc(users.lastActiveAt))
-      .limit(limit);
+      .orderBy(desc(users.lastActiveAt), desc(users.id))
+      .limit(limit + 1)
+      .offset(offset);
 
+    const hasMore = rows.length > limit;
     return NextResponse.json({
-      users: rows.map((u) => ({
+      hasMore,
+      users: rows.slice(0, limit).map((u) => ({
         id: u.id,
         qfId: u.qfId,
         username: u.username,

--- a/components/admin/AdminLiveRegion.tsx
+++ b/components/admin/AdminLiveRegion.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+
+/**
+ * A single polite `role="status"` live region for the whole admin console, so
+ * moderation actions (flag, retire, disable, finalize…) are announced to screen
+ * readers — the visual `StateNote` feedback is otherwise silent to them.
+ *
+ * `announce("")` then the message, on a microtask gap, so re-announcing the
+ * same string (e.g. flagging two rows in a row) still fires an SR update.
+ */
+const AnnounceContext = createContext<(message: string) => void>(() => {});
+
+export function useAdminAnnounce(): (message: string) => void {
+  return useContext(AnnounceContext);
+}
+
+export function AdminLiveRegion({ children }: { children: React.ReactNode }) {
+  const [message, setMessage] = useState("");
+  const clearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const announce = useCallback((next: string) => {
+    setMessage("");
+    // Next microtask: let the empty render commit so a repeated message still
+    // registers as a change.
+    queueMicrotask(() => setMessage(next));
+    if (clearTimer.current) clearTimeout(clearTimer.current);
+    clearTimer.current = setTimeout(() => setMessage(""), 5000);
+  }, []);
+
+  return (
+    <AnnounceContext.Provider value={announce}>
+      {children}
+      <div role="status" aria-live="polite" className="sr-only">
+        {message}
+      </div>
+    </AnnounceContext.Provider>
+  );
+}

--- a/components/admin/ChallengesModeration.tsx
+++ b/components/admin/ChallengesModeration.tsx
@@ -99,10 +99,14 @@ export function ChallengesModeration() {
     setActionError(null);
     try {
       const res = await api<{ resolved: number }>("/challenges/finalize", { method: "POST" });
-      setFinalizeMsg(`Finalized ${res.resolved} ended challenge${res.resolved === 1 ? "" : "s"}.`);
+      const msg = `Finalized ${res.resolved} ended challenge${res.resolved === 1 ? "" : "s"}.`;
+      setFinalizeMsg(msg);
+      announce(msg);
       reload();
     } catch (e) {
-      setActionError(e instanceof AdminApiError ? e.message : "Finalize failed.");
+      const msg = e instanceof AdminApiError ? e.message : "Finalize failed.";
+      setActionError(msg);
+      announce(msg);
     }
   };
 

--- a/components/admin/ChallengesModeration.tsx
+++ b/components/admin/ChallengesModeration.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 import { cn } from "@/lib/utils";
 
 interface AdminChallenge {
@@ -167,7 +168,7 @@ export function ChallengesModeration() {
       {finalizeMsg && <StateNote>{finalizeMsg}</StateNote>}
       {error && <StateNote tone="error">{error}</StateNote>}
       {actionError && <StateNote tone="error">{actionError}</StateNote>}
-      {loading && <StateNote>Loading…</StateNote>}
+      {loading && <SkeletonRows />}
       {!loading && !error && rows.length === 0 && <StateNote>No challenges match.</StateNote>}
 
       {rows.length > 0 && (

--- a/components/admin/ChallengesModeration.tsx
+++ b/components/admin/ChallengesModeration.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui";
 import {
   Table,
   Th,
@@ -11,7 +12,7 @@ import {
   StatTile,
 } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
-import { useAsync } from "@/components/admin/useAsync";
+import { usePaginated } from "@/components/admin/usePaginated";
 import { cn } from "@/lib/utils";
 
 interface AdminChallenge {
@@ -53,10 +54,26 @@ export function ChallengesModeration() {
   const [finalizeMsg, setFinalizeMsg] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<number | null>(null);
 
-  const { data, error, loading, reload } = useAsync<{ stats: Stats; challenges: AdminChallenge[] }>(
-    () => api(`/challenges${status === "all" ? "" : `?status=${status}`}`),
-    `admin-challenges:${status}`
-  );
+  const {
+    rows,
+    extra: stats,
+    hasMore,
+    error,
+    loading,
+    loadingMore,
+    loadMoreError,
+    reload,
+    loadMore,
+  } = usePaginated<AdminChallenge, Stats>(async ({ offset }) => {
+    const p = new URLSearchParams();
+    if (status !== "all") p.set("status", status);
+    if (offset) p.set("offset", String(offset));
+    const qs = p.toString();
+    const d = await api<{ stats: Stats; challenges: AdminChallenge[]; hasMore: boolean }>(
+      `/challenges${qs ? `?${qs}` : ""}`
+    );
+    return { rows: d.challenges, hasMore: d.hasMore, extra: d.stats };
+  }, `admin-challenges:${status}`);
 
   const act = async (id: number, fn: () => Promise<unknown>) => {
     setActionError(null);
@@ -85,40 +102,40 @@ export function ChallengesModeration() {
 
   return (
     <div className="space-y-4">
-      {data && (
+      {stats && (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-6">
           <StatTile
             label="Total"
-            value={data.stats.total}
+            value={stats.total}
             tone="plain"
             info="All 1v1 challenges ever created, across every status."
           />
           <StatTile
             label="Active"
-            value={data.stats.byStatus.active ?? 0}
+            value={stats.byStatus.active ?? 0}
             tone="teal"
             info="Challenges that have been accepted and are currently being competed (within their time window)."
           />
           <StatTile
             label="Pending"
-            value={data.stats.byStatus.pending ?? 0}
+            value={stats.byStatus.pending ?? 0}
             info="Challenges sent but not yet accepted or declined by the recipient."
           />
           <StatTile
             label="Completed"
-            value={data.stats.byStatus.completed ?? 0}
+            value={stats.byStatus.completed ?? 0}
             tone="plain"
             info="Challenges whose window has ended and a winner (or draw) has been resolved."
           />
           <StatTile
             label="Declined"
-            value={data.stats.byStatus.declined ?? 0}
+            value={stats.byStatus.declined ?? 0}
             tone="plain"
             info="Challenges the recipient declined. (Withdrawn ones show as 'cancelled'.)"
           />
           <StatTile
             label="From suggestions"
-            value={data.stats.fromSuggestions}
+            value={stats.fromSuggestions}
             tone="teal"
             info="How many challenges were started from an admin-curated suggestion, rather than created from scratch."
           />
@@ -151,9 +168,9 @@ export function ChallengesModeration() {
       {error && <StateNote tone="error">{error}</StateNote>}
       {actionError && <StateNote tone="error">{actionError}</StateNote>}
       {loading && <StateNote>Loading…</StateNote>}
-      {data && data.challenges.length === 0 && <StateNote>No challenges match.</StateNote>}
+      {!loading && !error && rows.length === 0 && <StateNote>No challenges match.</StateNote>}
 
-      {data && data.challenges.length > 0 && (
+      {rows.length > 0 && (
         <Table>
           <thead>
             <tr>
@@ -164,7 +181,7 @@ export function ChallengesModeration() {
             </tr>
           </thead>
           <tbody>
-            {data.challenges.map((c) => {
+            {rows.map((c) => {
               const a = c.challengerUsername ?? `#${c.challengerId}`;
               const b = c.challengedUsername ?? `#${c.challengedId}`;
               const winLabel =
@@ -270,6 +287,15 @@ export function ChallengesModeration() {
             })}
           </tbody>
         </Table>
+      )}
+
+      {hasMore && (
+        <div className="flex flex-col items-center gap-2">
+          <Button variant="secondary" size="sm" onClick={loadMore} disabled={loadingMore}>
+            {loadingMore ? "Loading…" : "Load more"}
+          </Button>
+          {loadMoreError && <StateNote tone="error">Couldn&apos;t load more challenges.</StateNote>}
+        </div>
       )}
     </div>
   );

--- a/components/admin/ChallengesModeration.tsx
+++ b/components/admin/ChallengesModeration.tsx
@@ -14,6 +14,7 @@ import {
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
 import { SkeletonRows } from "@/components/admin/Skeleton";
+import { useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
 import { cn } from "@/lib/utils";
 
 interface AdminChallenge {
@@ -50,6 +51,7 @@ const statusTone = (s: AdminChallenge["status"]) =>
 
 export function ChallengesModeration() {
   const api = useAdminFetch();
+  const announce = useAdminAnnounce();
   const [status, setStatus] = useState<(typeof FILTERS)[number]>("all");
   const [actionError, setActionError] = useState<string | null>(null);
   const [finalizeMsg, setFinalizeMsg] = useState<string | null>(null);
@@ -81,9 +83,12 @@ export function ChallengesModeration() {
     setBusyId(id);
     try {
       await fn();
+      announce(`Challenge ${id} updated.`);
       reload();
     } catch (e) {
-      setActionError(e instanceof AdminApiError ? e.message : "Action failed.");
+      const msg = e instanceof AdminApiError ? e.message : "Action failed.";
+      setActionError(msg);
+      announce(msg);
     } finally {
       setBusyId(null);
     }
@@ -148,6 +153,8 @@ export function ChallengesModeration() {
           {FILTERS.map((f) => (
             <button
               key={f}
+              type="button"
+              aria-pressed={status === f}
               onClick={() => setStatus(f)}
               className={cn(
                 "rounded border px-2 py-1 text-xs capitalize transition-colors",

--- a/components/admin/CoverageReport.tsx
+++ b/components/admin/CoverageReport.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 import type { CoverageReport as CoverageResponse, CoverageCell } from "@/lib/admin/coverage-report";
 import type { Locale } from "@/lib/i18n/config";
 import type { EdgeKind } from "@/types/quran";
@@ -87,7 +88,7 @@ export function CoverageReport() {
   return (
     <div className="space-y-8">
       {error && <StateNote tone="error">{error}</StateNote>}
-      {loading && !data && <StateNote>Loading…</StateNote>}
+      {loading && !data && <SkeletonRows n={8} />}
 
       {data && (
         <>
@@ -133,19 +134,26 @@ export function CoverageReport() {
                     {LOCALES.map((l) => {
                       const c = cell(data.matrix, k, l);
                       const missing = c?.missing ?? 0;
+                      const covered = c?.covered ?? 0;
                       return (
                         <Td key={l} className="text-right tabular-nums">
                           {missing === 0 ? (
                             <Pill tone="active">complete</Pill>
                           ) : (
-                            <span className={l === "en" ? "text-gold" : "text-text-primary"}>
-                              {missing.toLocaleString()}
-                              {c && c.exhausted > 0 && (
-                                <span className="ml-1 text-[10px] text-text-muted">
-                                  ({c.exhausted} exh)
-                                </span>
-                              )}
-                            </span>
+                            <>
+                              <span className={l === "en" ? "text-gold" : "text-text-primary"}>
+                                {missing.toLocaleString()}
+                                {c && c.exhausted > 0 && (
+                                  <span className="ml-1 text-[10px] text-text-muted">
+                                    ({c.exhausted} exh)
+                                  </span>
+                                )}
+                              </span>
+                              <span className="block text-[10px] text-text-muted">
+                                {covered.toLocaleString()} / {data.totalVerses.toLocaleString()}{" "}
+                                done
+                              </span>
+                            </>
                           )}
                         </Td>
                       );
@@ -155,8 +163,11 @@ export function CoverageReport() {
               </tbody>
             </Table>
             <p className="mt-1.5 text-xs text-text-muted">
-              Non-English rows are translations of the English reason, so they can never exceed the
-              English count. Fill English first.
+              These are <em>missing</em>-verse counts. A verse can&apos;t get a translated
+              connection until its English one exists, and the translation pass lags English
+              generation — so non-English missing counts are always ≥ English. Fill English first;
+              the translation locales close the gap afterward. (Exhausted-cell tracking is
+              English-only.)
             </p>
           </section>
 

--- a/components/admin/ExpandableText.tsx
+++ b/components/admin/ExpandableText.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Clamps long text to `lines` rows and adds a "Show more / Show less" toggle —
+ * but only when the text actually overflows the clamp. Used for admin table
+ * cells (connection reasons, prompt templates, audit meta) that are usually
+ * short but occasionally paragraph-length.
+ */
+export function ExpandableText({
+  children,
+  lines = 2,
+  className,
+}: {
+  children: string;
+  lines?: number;
+  className?: string;
+}) {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [overflows, setOverflows] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    // Measure against the clamped height: scrollHeight > clientHeight means
+    // there's hidden content worth a toggle.
+    setOverflows(el.scrollHeight - el.clientHeight > 1);
+  }, [children, lines]);
+
+  return (
+    <div className={className}>
+      <p
+        ref={ref}
+        className={cn(!expanded && "overflow-hidden")}
+        style={
+          expanded
+            ? undefined
+            : {
+                display: "-webkit-box",
+                WebkitBoxOrient: "vertical",
+                WebkitLineClamp: lines,
+              }
+        }
+      >
+        {children}
+      </p>
+      {overflows && (
+        <button
+          type="button"
+          onClick={() => setExpanded((e) => !e)}
+          className="mt-0.5 font-mono text-[10px] uppercase tracking-wide text-gold hover:underline"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/admin/ExpandableText.tsx
+++ b/components/admin/ExpandableText.tsx
@@ -23,12 +23,19 @@ export function ExpandableText({
   const [expanded, setExpanded] = useState(false);
 
   useLayoutEffect(() => {
+    if (expanded) return;
     const el = ref.current;
     if (!el) return;
     // Measure against the clamped height: scrollHeight > clientHeight means
-    // there's hidden content worth a toggle.
-    setOverflows(el.scrollHeight - el.clientHeight > 1);
-  }, [children, lines]);
+    // there's hidden content worth a toggle. Re-measure on resize too — a table
+    // cell narrowing can push previously-fitting text into overflow.
+    const measure = () => setOverflows(el.scrollHeight - el.clientHeight > 1);
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [children, lines, expanded]);
 
   return (
     <div className={className}>

--- a/components/admin/RefreshButton.tsx
+++ b/components/admin/RefreshButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { RotateCw } from "lucide-react";
+import { Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+/** Re-runs a page's `useAsync`/`usePaginated` loader. Sits in the
+ *  `AdminPageHeader` actions slot. */
+export function RefreshButton({ onClick, loading }: { onClick: () => void; loading?: boolean }) {
+  return (
+    <Button variant="secondary" size="sm" onClick={onClick} disabled={loading}>
+      <RotateCw className={cn("mr-1.5 h-3.5 w-3.5", loading && "animate-spin")} />
+      {loading ? "Refreshing…" : "Refresh"}
+    </Button>
+  );
+}

--- a/components/admin/RefreshButton.tsx
+++ b/components/admin/RefreshButton.tsx
@@ -4,8 +4,6 @@ import { RotateCw } from "lucide-react";
 import { Button } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
-/** Re-runs a page's `useAsync`/`usePaginated` loader. Sits in the
- *  `AdminPageHeader` actions slot. */
 export function RefreshButton({ onClick, loading }: { onClick: () => void; loading?: boolean }) {
   return (
     <Button variant="secondary" size="sm" onClick={onClick} disabled={loading}>

--- a/components/admin/Skeleton.tsx
+++ b/components/admin/Skeleton.tsx
@@ -1,0 +1,15 @@
+/**
+ * Loading placeholders for admin list content. `SkeletonRows` replaces the bare
+ * "Loading…" note on the list pages so the layout doesn't jump when data lands.
+ */
+import { cn } from "@/lib/utils";
+
+export function SkeletonRows({ n = 6, className }: { n?: number; className?: string }) {
+  return (
+    <div className={cn("space-y-2", className)} aria-hidden>
+      {Array.from({ length: n }, (_, i) => (
+        <div key={i} className="h-9 animate-pulse rounded bg-white/5" />
+      ))}
+    </div>
+  );
+}

--- a/components/admin/Skeleton.tsx
+++ b/components/admin/Skeleton.tsx
@@ -6,10 +6,16 @@ import { cn } from "@/lib/utils";
 
 export function SkeletonRows({ n = 6, className }: { n?: number; className?: string }) {
   return (
-    <div className={cn("space-y-2", className)} aria-hidden>
-      {Array.from({ length: n }, (_, i) => (
-        <div key={i} className="h-9 animate-pulse rounded bg-white/5" />
-      ))}
-    </div>
+    <>
+      {/* The pulsing bars are decorative; assistive tech gets a plain status. */}
+      <span role="status" className="sr-only">
+        Loading…
+      </span>
+      <div className={cn("space-y-2", className)} aria-hidden>
+        {Array.from({ length: n }, (_, i) => (
+          <div key={i} className="h-9 animate-pulse rounded bg-white/5" />
+        ))}
+      </div>
+    </>
   );
 }

--- a/components/admin/primitives.tsx
+++ b/components/admin/primitives.tsx
@@ -79,9 +79,18 @@ export function Table({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function Th({ children, className }: { children?: React.ReactNode; className?: string }) {
+export function Th({
+  children,
+  className,
+  scope = "col",
+}: {
+  children?: React.ReactNode;
+  className?: string;
+  scope?: React.ThHTMLAttributes<HTMLTableCellElement>["scope"];
+}) {
   return (
     <th
+      scope={scope}
       className={cn(
         "border-b border-border bg-surface px-3.5 py-2.5 text-left font-mono text-[10px] font-normal uppercase tracking-[0.14em] text-text-muted",
         className

--- a/components/admin/usePaginated.ts
+++ b/components/admin/usePaginated.ts
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AdminApiError } from "./AdminContext";
 
-/** One page of results plus whether more exist, and any non-row payload. */
 export interface Page<Row, Extra = undefined> {
   rows: Row[];
   hasMore: boolean;
@@ -14,13 +13,10 @@ interface PaginatedState<Row, Extra> {
   rows: Row[];
   extra: Extra | null;
   hasMore: boolean;
-  /** Initial load (page 0) in flight. */
   loading: boolean;
-  /** A `loadMore()` append in flight. */
   loadingMore: boolean;
-  /** Initial load failed. */
   error: string | null;
-  /** A `loadMore()` append failed (rows already on screen are kept). */
+  /** A `loadMore()` append failed — rows already on screen are kept. */
   loadMoreError: boolean;
   reload: () => void;
   loadMore: () => void;
@@ -67,6 +63,9 @@ export function usePaginated<Row, Extra = undefined>(
     setLoading(true);
     setError(null);
     setLoadMoreError(false);
+    // A page-0 reload supersedes any in-flight append: its stale `finally` is
+    // guarded out, so clear the flag here or the Load-more button stays disabled.
+    setLoadingMore(false);
 
     fetchRef
       .current({ offset: 0 })

--- a/components/admin/usePaginated.ts
+++ b/components/admin/usePaginated.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AdminApiError } from "./AdminContext";
+
+/** One page of results plus whether more exist, and any non-row payload. */
+export interface Page<Row, Extra = undefined> {
+  rows: Row[];
+  hasMore: boolean;
+  extra?: Extra;
+}
+
+interface PaginatedState<Row, Extra> {
+  rows: Row[];
+  extra: Extra | null;
+  hasMore: boolean;
+  /** Initial load (page 0) in flight. */
+  loading: boolean;
+  /** A `loadMore()` append in flight. */
+  loadingMore: boolean;
+  /** Initial load failed. */
+  error: string | null;
+  /** A `loadMore()` append failed (rows already on screen are kept). */
+  loadMoreError: boolean;
+  reload: () => void;
+  loadMore: () => void;
+}
+
+/**
+ * List pagination for admin pages: runs `fetchPage({ offset: 0 })` on mount and
+ * whenever `cacheKey` changes (encode filters into the key), then appends later
+ * pages via `loadMore()`. Generalises the tail-append logic that was inlined in
+ * the audit page. `fetchPage` should call `useAdminFetch` and may throw
+ * `AdminApiError`.
+ *
+ * Stale-response guard: a `reload()` or `cacheKey` change bumps a generation
+ * counter; a slow page-0 or loadMore response from a superseded generation is
+ * dropped rather than merged into the wrong list.
+ */
+export function usePaginated<Row, Extra = undefined>(
+  fetchPage: (args: { offset: number }) => Promise<Page<Row, Extra>>,
+  cacheKey: string
+): PaginatedState<Row, Extra> {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [extra, setExtra] = useState<Extra | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loadMoreError, setLoadMoreError] = useState(false);
+  const [tick, setTick] = useState(0);
+
+  const fetchRef = useRef(fetchPage);
+  useEffect(() => {
+    fetchRef.current = fetchPage;
+  });
+
+  // Bumped on every reload / cacheKey change so a superseded in-flight request
+  // can detect it's stale and skip applying its result.
+  const generation = useRef(0);
+
+  useEffect(() => {
+    generation.current += 1;
+    const gen = generation.current;
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoading(true);
+    setError(null);
+    setLoadMoreError(false);
+
+    fetchRef
+      .current({ offset: 0 })
+      .then((page) => {
+        if (gen !== generation.current) return;
+        setRows(page.rows);
+        setExtra(page.extra ?? null);
+        setHasMore(page.hasMore);
+      })
+      .catch((e: unknown) => {
+        if (gen !== generation.current) return;
+        setRows([]);
+        setExtra(null);
+        setHasMore(false);
+        setError(e instanceof AdminApiError ? e.message : "Something went wrong");
+      })
+      .finally(() => {
+        if (gen === generation.current) setLoading(false);
+      });
+  }, [cacheKey, tick]);
+
+  const reload = useCallback(() => setTick((t) => t + 1), []);
+
+  const loadMore = useCallback(() => {
+    if (loadingMore) return;
+    const gen = generation.current;
+    setLoadingMore(true);
+    setLoadMoreError(false);
+    fetchRef
+      .current({ offset: rows.length })
+      .then((page) => {
+        if (gen !== generation.current) return;
+        setRows((prev) => [...prev, ...page.rows]);
+        setHasMore(page.hasMore);
+      })
+      .catch(() => {
+        if (gen === generation.current) setLoadMoreError(true);
+      })
+      .finally(() => {
+        if (gen === generation.current) setLoadingMore(false);
+      });
+  }, [loadingMore, rows.length]);
+
+  return {
+    rows,
+    extra,
+    hasMore,
+    loading,
+    loadingMore,
+    error,
+    loadMoreError,
+    reload,
+    loadMore,
+  };
+}

--- a/lib/admin/format.ts
+++ b/lib/admin/format.ts
@@ -1,0 +1,25 @@
+/**
+ * Human-readable summaries of the `/api/admin/infra` maintenance-action
+ * responses, so the operator sees "Cleared 12 cached tokens." instead of a
+ * raw `Done: {"action":"flush-tokens","cleared":12}` JSON dump.
+ */
+
+interface InfraResult {
+  action?: string;
+  cleared?: number;
+  deleted?: number;
+  ok?: boolean;
+}
+
+export function formatInfraResult(res: InfraResult): string {
+  switch (res.action) {
+    case "flush-tokens":
+      return `Cleared ${res.cleared ?? 0} cached token${res.cleared === 1 ? "" : "s"}.`;
+    case "flush-jwks":
+      return "JWKS cache flushed.";
+    case "reset-ratelimits":
+      return `Deleted ${res.deleted ?? 0} rate-limit row${res.deleted === 1 ? "" : "s"}.`;
+    default:
+      return "Done.";
+  }
+}


### PR DESCRIPTION
## Why

Every admin list page fetched exactly one hard-capped page (100–200 rows) and offered no way to see past it. On the `connections` table (6,000+ rows) the overwhelming majority of data was simply unreachable from the UI.

## What

- **New `components/admin/usePaginated.ts`** — runs page 0 on mount / `cacheKey` change, appends later pages via `loadMore()`. A generation counter guards against a slow superseded response (from an old filter or a prior `reload()`) merging into the wrong list. A failed `loadMore()` keeps the rows already on screen and flags `loadMoreError`; a failed page 0 clears rows and surfaces the message. Generalises the tail-append logic that was inlined in `app/admin/audit/page.tsx` — that page is now refactored onto the hook.
- **Routes** — `connections`, `users`, `challenges`, `names` GET now accept `?offset=`, fetch `limit + 1` to derive `hasMore`, and return `hasMore` alongside the rows. All switched to the shared `parsePagination` helper (`lib/infra/http.ts`), replacing four hand-rolled limit parsers. Challenge-list pagination slices the page *before* self-heal / scoring so only the visible page is enriched. Added a stable `desc(id)` tiebreaker to each ordering so offset paging is deterministic.
- **Pages** — `connections`, `users`, `names`, `ChallengesModeration` render audit's `{hasMore && <Load more>}` block. `ChallengesModeration` reads its `stats` tiles from the hook's `extra` passthrough.

## Tests

`usePaginated.test.tsx` (append by offset, `reload` resets the tail, stale-response guard, `loadMoreError` keeps rows). `hasMore` / page-cap assertions added to `connections`, `users`, `names`, `challenges-list` route tests. `connections/page.test.tsx` drives the Load-more button through to a second `?offset=` fetch. Full unit suite (1346) + pre-push integration tests pass; typecheck + lint clean.

## Notes

Stacked conceptually on PR #523 (branched from `main`, not from that branch) — the only overlap is `challenges/route.ts` and `connections/route.ts`, where PR #523 touches the mutation handlers and this PR touches the GET handlers; a merge will need a trivial resolution.

## AI / Theological changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pagination and “Load more” controls to admin lists.
  - Added refresh controls, loading skeletons, expandable text, and clearer empty/error states.
  - Added accessible keyboard navigation for the VOTD calendar.
  - Added screen-reader announcements for moderation actions.
  - Improved infrastructure result messages and analytics refresh behavior.

- **Bug Fixes**
  - Improved list ordering and prevented outdated requests from replacing loaded results.
  - Improved connection coverage updates when statuses change.

- **Tests**
  - Expanded coverage for pagination, accessibility, loading, refresh, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->