### PR TITLE
feat(admin): accessibility — live region, aria-pressed filters, keyboard calendar, th scope

### DIFF
--- a/__tests__/app/admin/votd/page.test.tsx
+++ b/__tests__/app/admin/votd/page.test.tsx
@@ -192,6 +192,61 @@ describe("VotdPage — today's live pick on the calendar", () => {
   });
 });
 
+describe("VotdPage — calendar keyboard navigation", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+    mockApi.mockResolvedValue({ entries: [], today: null });
+  });
+
+  const cell = (day: number) =>
+    screen.getByText(String(day), { selector: "span.tabular-nums" }).closest("button")!;
+
+  // The grid opens on the current month; today's cell is the roving target.
+  const todayDay = new Date().getUTCDate();
+  const daysThisMonth = new Date(
+    Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth() + 1, 0)
+  ).getUTCDate();
+
+  it("labels each day and makes today's cell the tab-reachable one (roving tabindex)", async () => {
+    render(<VotdPage />);
+    await screen.findByText("1", { selector: "span.tabular-nums" });
+
+    expect(cell(todayDay)).toHaveAttribute("tabindex", "0");
+    expect(cell(todayDay === 1 ? 2 : 1)).toHaveAttribute("tabindex", "-1");
+    expect(cell(1).getAttribute("aria-label")).toMatch(/no verse set/);
+  });
+
+  it("ArrowRight moves the selection one day and ArrowDown moves a week", async () => {
+    if (todayDay + 8 > daysThisMonth) return; // avoid month-boundary wrap in this test
+    render(<VotdPage />);
+    await screen.findByText("1", { selector: "span.tabular-nums" });
+
+    const grid = screen.getByRole("grid");
+    fireEvent.keyDown(grid, { key: "ArrowRight" });
+    expect(cell(todayDay + 1)).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(grid, { key: "ArrowDown" });
+    expect(cell(todayDay + 8)).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("PageDown moves to the next month", async () => {
+    render(<VotdPage />);
+    await screen.findByText("1", { selector: "span.tabular-nums" });
+
+    const monthNow = new Date().toLocaleString("en", {
+      month: "long",
+      year: "numeric",
+      timeZone: "UTC",
+    });
+    const grid = screen.getByRole("grid");
+    fireEvent.keyDown(grid, { key: "PageDown" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 2 }).textContent).not.toBe(monthNow)
+    );
+  });
+});
+
 describe("VotdPage — Preview button guards against overlapping requests", () => {
   const mockFetch = vi.fn();
 

--- a/__tests__/app/admin/votd/page.test.tsx
+++ b/__tests__/app/admin/votd/page.test.tsx
@@ -200,8 +200,9 @@ describe("VotdPage — calendar keyboard navigation", () => {
 
   const cell = (day: number) =>
     screen.getByText(String(day), { selector: "span.tabular-nums" }).closest("button")!;
+  // aria-selected lives on the gridcell wrapping the day button (APG grid pattern).
+  const gridcell = (day: number) => cell(day).closest('[role="gridcell"]')!;
 
-  // The grid opens on the current month; today's cell is the roving target.
   const todayDay = new Date().getUTCDate();
   const daysThisMonth = new Date(
     Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth() + 1, 0)
@@ -223,13 +224,28 @@ describe("VotdPage — calendar keyboard navigation", () => {
 
     const grid = screen.getByRole("grid");
     fireEvent.keyDown(grid, { key: "ArrowRight" });
-    expect(cell(todayDay + 1)).toHaveAttribute("aria-selected", "true");
+    expect(gridcell(todayDay + 1)).toHaveAttribute("aria-selected", "true");
 
     fireEvent.keyDown(grid, { key: "ArrowDown" });
-    expect(cell(todayDay + 8)).toHaveAttribute("aria-selected", "true");
+    expect(gridcell(todayDay + 8)).toHaveAttribute("aria-selected", "true");
   });
 
-  it("PageDown moves to the next month", async () => {
+  it("Home and End move to the bounds of the active week", async () => {
+    const weekday = new Date().getUTCDay();
+    // Stay within the month so `cell()` can find the target.
+    if (todayDay - weekday < 1 || todayDay + (6 - weekday) > daysThisMonth) return;
+    render(<VotdPage />);
+    await screen.findByText("1", { selector: "span.tabular-nums" });
+    const grid = screen.getByRole("grid");
+
+    fireEvent.keyDown(grid, { key: "Home" });
+    expect(gridcell(todayDay - weekday)).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(grid, { key: "End" });
+    expect(gridcell(todayDay + (6 - weekday))).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("PageDown moves to the next month, keeping the day of the month", async () => {
     render(<VotdPage />);
     await screen.findByText("1", { selector: "span.tabular-nums" });
 
@@ -244,8 +260,20 @@ describe("VotdPage — calendar keyboard navigation", () => {
     await waitFor(() =>
       expect(screen.getByRole("heading", { level: 2 }).textContent).not.toBe(monthNow)
     );
+    const nextMonth = addMonthStr(new Date().toISOString().slice(0, 7), 1);
+    const nextMonthDays = new Date(
+      Date.UTC(Number(nextMonth.slice(0, 4)), Number(nextMonth.slice(5, 7)), 0)
+    ).getUTCDate();
+    const expectedDom = Math.min(todayDay, nextMonthDays);
+    await waitFor(() => expect(gridcell(expectedDom)).toHaveAttribute("aria-selected", "true"));
   });
 });
+
+function addMonthStr(month: string, delta: number): string {
+  const [y, m] = month.split("-").map(Number);
+  const d = new Date(Date.UTC(y, m - 1 + delta, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
 
 describe("VotdPage — Preview button guards against overlapping requests", () => {
   const mockFetch = vi.fn();

--- a/__tests__/components/admin/AdminLiveRegion.test.tsx
+++ b/__tests__/components/admin/AdminLiveRegion.test.tsx
@@ -1,11 +1,15 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { AdminLiveRegion, useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
 
-function Announcer() {
+function Announcer({ message = "Connection 7 set to retired." }: { message?: string }) {
   const announce = useAdminAnnounce();
-  return <button onClick={() => announce("Connection 7 set to retired.")}>go</button>;
+  return <button onClick={() => announce(message)}>go {message}</button>;
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("AdminLiveRegion", () => {
   it("renders a polite status region and fills it when announce() is called", async () => {
@@ -19,13 +23,60 @@ describe("AdminLiveRegion", () => {
     expect(region).toHaveAttribute("aria-live", "polite");
     expect(region).toHaveTextContent("");
 
-    fireEvent.click(screen.getByText("go"));
+    fireEvent.click(screen.getByRole("button"));
     await waitFor(() => expect(region).toHaveTextContent("Connection 7 set to retired."));
   });
 
   it("no-ops safely when used outside a provider", () => {
     render(<Announcer />);
     // Should not throw on click even though there's no live region mounted.
-    fireEvent.click(screen.getByText("go"));
+    fireEvent.click(screen.getByRole("button"));
+  });
+
+  it("a second announcement replaces the first and resets the 5s expiry", async () => {
+    vi.useFakeTimers();
+    function TwoAnnouncers() {
+      const announce = useAdminAnnounce();
+      return (
+        <>
+          <button onClick={() => announce("first")}>a</button>
+          <button onClick={() => announce("second")}>b</button>
+        </>
+      );
+    }
+    render(
+      <AdminLiveRegion>
+        <TwoAnnouncers />
+      </AdminLiveRegion>
+    );
+    const region = screen.getByRole("status");
+
+    fireEvent.click(screen.getByText("a"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(region).toHaveTextContent("first");
+
+    // 4s later — before the first message would expire — announce again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    fireEvent.click(screen.getByText("b"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(region).toHaveTextContent("second");
+
+    // The original 5s timer would have fired by now; the message must still hold.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(region).toHaveTextContent("second");
+
+    // 5s from the second announcement — now it clears.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(region).toHaveTextContent("");
   });
 });

--- a/__tests__/components/admin/AdminLiveRegion.test.tsx
+++ b/__tests__/components/admin/AdminLiveRegion.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { AdminLiveRegion, useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
+
+function Announcer() {
+  const announce = useAdminAnnounce();
+  return <button onClick={() => announce("Connection 7 set to retired.")}>go</button>;
+}
+
+describe("AdminLiveRegion", () => {
+  it("renders a polite status region and fills it when announce() is called", async () => {
+    render(
+      <AdminLiveRegion>
+        <Announcer />
+      </AdminLiveRegion>
+    );
+
+    const region = screen.getByRole("status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveTextContent("");
+
+    fireEvent.click(screen.getByText("go"));
+    await waitFor(() => expect(region).toHaveTextContent("Connection 7 set to retired."));
+  });
+
+  it("no-ops safely when used outside a provider", () => {
+    render(<Announcer />);
+    // Should not throw on click even though there's no live region mounted.
+    fireEvent.click(screen.getByText("go"));
+  });
+});

--- a/__tests__/components/admin/primitives.test.tsx
+++ b/__tests__/components/admin/primitives.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Table, Th } from "@/components/admin/primitives";
+
+describe("Th", () => {
+  it("defaults to scope=col so screen readers associate the column", () => {
+    const { container } = render(
+      <Table>
+        <thead>
+          <tr>
+            <Th>Name</Th>
+          </tr>
+        </thead>
+      </Table>
+    );
+    expect(container.querySelector("th")).toHaveAttribute("scope", "col");
+  });
+
+  it("allows overriding scope (e.g. row headers)", () => {
+    const { container } = render(
+      <Table>
+        <thead>
+          <tr>
+            <Th scope="row">Name</Th>
+          </tr>
+        </thead>
+      </Table>
+    );
+    expect(container.querySelector("th")).toHaveAttribute("scope", "row");
+  });
+});

--- a/app/admin/connections/page.tsx
+++ b/app/admin/connections/page.tsx
@@ -8,6 +8,7 @@ import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
 import { ExpandableText } from "@/components/admin/ExpandableText";
 import { SkeletonRows } from "@/components/admin/Skeleton";
+import { useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
 import { cn } from "@/lib/utils";
 
 interface Connection {
@@ -28,6 +29,7 @@ const REVIEWED_FILTERS = ["pending", "reviewed", "all"] as const;
 
 export default function ConnectionsPage() {
   const api = useAdminFetch();
+  const announce = useAdminAnnounce();
   const [status, setStatus] = useState<(typeof STATUS_FILTERS)[number]>("all");
   const [kind, setKind] = useState<(typeof KIND_FILTERS)[number]>("all");
   const [reviewed, setReviewed] = useState<(typeof REVIEWED_FILTERS)[number]>("pending");
@@ -57,9 +59,12 @@ export default function ConnectionsPage() {
     setBusyId(id);
     try {
       await api("/connections", { method: "PATCH", json: { id, status: next } });
+      announce(`Connection ${id} set to ${next}.`);
       reload();
     } catch (e) {
-      setActionError(e instanceof AdminApiError ? e.message : "Failed to update connection.");
+      const msg = e instanceof AdminApiError ? e.message : "Failed to update connection.";
+      setActionError(msg);
+      announce(msg);
     } finally {
       setBusyId(null);
     }
@@ -70,9 +75,12 @@ export default function ConnectionsPage() {
     setBusyId(id);
     try {
       await api("/connections", { method: "PATCH", json: { id, reviewed: true } });
+      announce(`Connection ${id} marked reviewed.`);
       reload();
     } catch (e) {
-      setActionError(e instanceof AdminApiError ? e.message : "Failed to update connection.");
+      const msg = e instanceof AdminApiError ? e.message : "Failed to update connection.";
+      setActionError(msg);
+      announce(msg);
     } finally {
       setBusyId(null);
     }
@@ -229,6 +237,8 @@ function FilterRow<T extends string>({
         {options.map((o) => (
           <button
             key={o}
+            type="button"
+            aria-pressed={value === o}
             onClick={() => onChange(o)}
             className={cn(
               "rounded border px-2 py-1 text-xs capitalize transition-colors",

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { AdminGate } from "@/components/admin/AdminGate";
 import { AdminShell } from "@/components/admin/AdminShell";
+import { AdminLiveRegion } from "@/components/admin/AdminLiveRegion";
 
 export const metadata: Metadata = {
   title: "Admin — Open Hikmah",
@@ -15,7 +16,9 @@ export const dynamic = "force-dynamic";
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
     <AdminGate>
-      <AdminShell>{children}</AdminShell>
+      <AdminLiveRegion>
+        <AdminShell>{children}</AdminShell>
+      </AdminLiveRegion>
     </AdminGate>
   );
 }

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -7,6 +7,7 @@ import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admi
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
 import { SkeletonRows } from "@/components/admin/Skeleton";
+import { useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
 
 interface AdminUser {
   id: number;
@@ -22,6 +23,7 @@ interface AdminUser {
 
 export default function UsersPage() {
   const api = useAdminFetch();
+  const announce = useAdminAnnounce();
   const [query, setQuery] = useState("");
   const [submitted, setSubmitted] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
@@ -42,9 +44,12 @@ export default function UsersPage() {
     setBusyId(id);
     try {
       await api("/users", { method: "PATCH", json: { id, disabled } });
+      announce(`User ${id} ${disabled ? "disabled" : "re-enabled"}.`);
       reload();
     } catch (e) {
-      setActionError(e instanceof AdminApiError ? e.message : "Failed to update user.");
+      const msg = e instanceof AdminApiError ? e.message : "Failed to update user.";
+      setActionError(msg);
+      announce(msg);
     } finally {
       setBusyId(null);
     }

--- a/app/admin/votd/page.tsx
+++ b/app/admin/votd/page.tsx
@@ -43,7 +43,25 @@ function monthLabel(month: string): string {
   });
 }
 
+/** "12 March 2026" for a `YYYY-MM-DD` date. */
+function longDate(date: string): string {
+  const [dy, dm, dd] = date.split("-").map(Number);
+  return new Date(Date.UTC(dy, dm - 1, dd)).toLocaleString("en", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 const todayStr = () => new Date().toISOString().slice(0, 10);
+
+/** `YYYY-MM-DD` `delta` days away, wrapping across month/year boundaries. */
+function addDays(date: string, delta: number): string {
+  const [dy, dm, dd] = date.split("-").map(Number);
+  const d = new Date(Date.UTC(dy, dm - 1, dd + delta));
+  return d.toISOString().slice(0, 10);
+}
 
 export default function VotdPage() {
   const api = useAdminFetch();
@@ -67,6 +85,73 @@ export default function VotdPage() {
   const firstWeekday = new Date(Date.UTC(y, m - 1, 1)).getUTCDay();
   const daysInMonth = new Date(Date.UTC(y, m, 0)).getUTCDate();
   const today = todayStr();
+
+  const gridRef = useRef<HTMLDivElement>(null);
+  // After an arrow-key move changes the month, focus the target day once its
+  // button has rendered.
+  const pendingFocus = useRef<string | null>(null);
+  useEffect(() => {
+    if (!pendingFocus.current) return;
+    const el = gridRef.current?.querySelector<HTMLButtonElement>(
+      `[data-date="${pendingFocus.current}"]`
+    );
+    el?.focus();
+    pendingFocus.current = null;
+  }, [month, data]);
+
+  // The one day in the grid that's tab-reachable (roving tabindex): the
+  // selection if it's in this month, else today if visible, else day 1.
+  const rovingDate =
+    selected && selected.startsWith(month)
+      ? selected
+      : today.startsWith(month)
+        ? today
+        : `${month}-01`;
+
+  const moveTo = (date: string) => {
+    setSelected(date);
+    if (date.slice(0, 7) !== month) {
+      pendingFocus.current = date;
+      setMonth(date.slice(0, 7));
+    } else {
+      gridRef.current?.querySelector<HTMLButtonElement>(`[data-date="${date}"]`)?.focus();
+    }
+  };
+
+  const onGridKeyDown = (e: React.KeyboardEvent) => {
+    const from = rovingDate;
+    let target: string | null = null;
+    switch (e.key) {
+      case "ArrowRight":
+        target = addDays(from, 1);
+        break;
+      case "ArrowLeft":
+        target = addDays(from, -1);
+        break;
+      case "ArrowDown":
+        target = addDays(from, 7);
+        break;
+      case "ArrowUp":
+        target = addDays(from, -7);
+        break;
+      case "Home":
+        target = `${month}-01`;
+        break;
+      case "End":
+        target = `${month}-${String(daysInMonth).padStart(2, "0")}`;
+        break;
+      case "PageUp":
+        target = addMonth(month, -1) + "-01";
+        break;
+      case "PageDown":
+        target = addMonth(month, 1) + "-01";
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    moveTo(target);
+  };
 
   return (
     <>
@@ -100,7 +185,7 @@ export default function VotdPage() {
 
           {error && <StateNote tone="error">{error}</StateNote>}
 
-          <div className="grid grid-cols-7 gap-1.5">
+          <div className="grid grid-cols-7 gap-1.5" aria-hidden>
             {WEEKDAYS.map((d, i) => (
               <div
                 key={i}
@@ -109,8 +194,16 @@ export default function VotdPage() {
                 {d}
               </div>
             ))}
+          </div>
+          <div
+            ref={gridRef}
+            role="grid"
+            aria-label={`${monthLabel(month)} — set the verse of the day`}
+            onKeyDown={onGridKeyDown}
+            className="grid grid-cols-7 gap-1.5"
+          >
             {Array.from({ length: firstWeekday }).map((_, i) => (
-              <div key={`pad-${i}`} />
+              <div key={`pad-${i}`} role="presentation" />
             ))}
             {Array.from({ length: daysInMonth }).map((_, i) => {
               const day = i + 1;
@@ -121,6 +214,14 @@ export default function VotdPage() {
               return (
                 <button
                   key={date}
+                  data-date={date}
+                  role="gridcell"
+                  tabIndex={date === rovingDate ? 0 : -1}
+                  aria-current={isToday ? "date" : undefined}
+                  aria-selected={isSelected}
+                  aria-label={`${longDate(date)}${
+                    entry ? `, verse ${entry.verseRef}` : ", no verse set"
+                  }${isToday ? ", today" : ""}`}
                   onClick={() => setSelected(date)}
                   className={cn(
                     "flex aspect-square flex-col items-center justify-center rounded-md border text-sm transition-colors",

--- a/app/admin/votd/page.tsx
+++ b/app/admin/votd/page.tsx
@@ -27,6 +27,24 @@ interface TodayInfo {
 }
 
 const WEEKDAYS = ["S", "M", "T", "W", "T", "F", "S"];
+const WEEKDAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+function daysInMonthOf(month: string): number {
+  const [y, m] = month.split("-").map(Number);
+  return new Date(Date.UTC(y, m, 0)).getUTCDate();
+}
+
+function weekdayOf(date: string): number {
+  return new Date(`${date}T00:00:00Z`).getUTCDay();
+}
 
 function addMonth(month: string, delta: number): string {
   const [y, m] = month.split("-").map(Number);
@@ -43,7 +61,6 @@ function monthLabel(month: string): string {
   });
 }
 
-/** "12 March 2026" for a `YYYY-MM-DD` date. */
 function longDate(date: string): string {
   const [dy, dm, dd] = date.split("-").map(Number);
   return new Date(Date.UTC(dy, dm - 1, dd)).toLocaleString("en", {
@@ -56,7 +73,6 @@ function longDate(date: string): string {
 
 const todayStr = () => new Date().toISOString().slice(0, 10);
 
-/** `YYYY-MM-DD` `delta` days away, wrapping across month/year boundaries. */
 function addDays(date: string, delta: number): string {
   const [dy, dm, dd] = date.split("-").map(Number);
   const d = new Date(Date.UTC(dy, dm - 1, dd + delta));
@@ -108,6 +124,16 @@ export default function VotdPage() {
         ? today
         : `${month}-01`;
 
+  // Lay the month out as calendar weeks so the grid can carry `role="row"`
+  // containers — a bare grid of gridcells isn't a valid grid.
+  const cells: (number | null)[] = [
+    ...Array.from({ length: firstWeekday }, () => null),
+    ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+  ];
+  while (cells.length % 7 !== 0) cells.push(null);
+  const weeks: (number | null)[][] = [];
+  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
+
   const moveTo = (date: string) => {
     setSelected(date);
     if (date.slice(0, 7) !== month) {
@@ -135,17 +161,19 @@ export default function VotdPage() {
         target = addDays(from, -7);
         break;
       case "Home":
-        target = `${month}-01`;
+        // Start of the active week (may cross into the previous month).
+        target = addDays(from, -weekdayOf(from));
         break;
       case "End":
-        target = `${month}-${String(daysInMonth).padStart(2, "0")}`;
+        target = addDays(from, 6 - weekdayOf(from));
         break;
       case "PageUp":
-        target = addMonth(month, -1) + "-01";
+      case "PageDown": {
+        const dest = addMonth(month, e.key === "PageUp" ? -1 : 1);
+        const dom = Math.min(Number(from.slice(8, 10)), daysInMonthOf(dest));
+        target = `${dest}-${String(dom).padStart(2, "0")}`;
         break;
-      case "PageDown":
-        target = addMonth(month, 1) + "-01";
-        break;
+      }
       default:
         return;
     }
@@ -185,73 +213,82 @@ export default function VotdPage() {
 
           {error && <StateNote tone="error">{error}</StateNote>}
 
-          <div className="grid grid-cols-7 gap-1.5" aria-hidden>
-            {WEEKDAYS.map((d, i) => (
-              <div
-                key={i}
-                className="pb-1 text-center font-mono text-[10px] uppercase text-text-muted"
-              >
-                {d}
-              </div>
-            ))}
-          </div>
           <div
             ref={gridRef}
             role="grid"
             aria-label={`${monthLabel(month)} — set the verse of the day`}
             onKeyDown={onGridKeyDown}
-            className="grid grid-cols-7 gap-1.5"
+            className="flex flex-col gap-1.5"
           >
-            {Array.from({ length: firstWeekday }).map((_, i) => (
-              <div key={`pad-${i}`} role="presentation" />
-            ))}
-            {Array.from({ length: daysInMonth }).map((_, i) => {
-              const day = i + 1;
-              const date = `${month}-${String(day).padStart(2, "0")}`;
-              const entry = byDate.get(date);
-              const isSelected = selected === date;
-              const isToday = date === today;
-              return (
-                <button
-                  key={date}
-                  data-date={date}
-                  role="gridcell"
-                  tabIndex={date === rovingDate ? 0 : -1}
-                  aria-current={isToday ? "date" : undefined}
-                  aria-selected={isSelected}
-                  aria-label={`${longDate(date)}${
-                    entry ? `, verse ${entry.verseRef}` : ", no verse set"
-                  }${isToday ? ", today" : ""}`}
-                  onClick={() => setSelected(date)}
-                  className={cn(
-                    "flex aspect-square flex-col items-center justify-center rounded-md border text-sm transition-colors",
-                    isSelected
-                      ? "border-gold bg-gold/10 text-gold"
-                      : entry
-                        ? "border-teal/40 bg-teal/5 text-text-primary hover:border-teal"
-                        : "border-border bg-surface text-text-secondary hover:border-gold-muted",
-                    // Marks the live day independent of curated/selected color, so
-                    // it's identifiable even on an uncurated (algorithmic-pick) day.
-                    isToday && !isSelected && "ring-1 ring-inset ring-gold/50"
-                  )}
+            <div role="row" className="grid grid-cols-7 gap-1.5">
+              {WEEKDAYS.map((d, i) => (
+                <div
+                  key={i}
+                  role="columnheader"
+                  aria-label={WEEKDAY_NAMES[i]}
+                  className="pb-1 text-center font-mono text-[10px] uppercase text-text-muted"
                 >
-                  <span className="tabular-nums">{day}</span>
-                  {entry ? (
-                    <span className="mt-0.5 font-mono text-[9px] text-teal">{entry.verseRef}</span>
-                  ) : (
-                    // No curated entry — for today, still surface the live
-                    // algorithmic pick so the admin can see it without leaving
-                    // the calendar, styled distinctly from a curated ref.
-                    isToday &&
-                    data?.today?.ref && (
-                      <span className="mt-0.5 font-mono text-[9px] text-gold">
-                        {data.today.ref}
-                      </span>
-                    )
-                  )}
-                </button>
-              );
-            })}
+                  {d}
+                </div>
+              ))}
+            </div>
+            {weeks.map((week, wi) => (
+              <div key={wi} role="row" className="grid grid-cols-7 gap-1.5">
+                {week.map((day, ci) => {
+                  if (day === null) return <div key={ci} role="gridcell" aria-hidden />;
+                  const date = `${month}-${String(day).padStart(2, "0")}`;
+                  const entry = byDate.get(date);
+                  const isSelected = selected === date;
+                  const isToday = date === today;
+                  return (
+                    <div
+                      key={date}
+                      role="gridcell"
+                      aria-selected={isSelected}
+                      className="aspect-square"
+                    >
+                      <button
+                        data-date={date}
+                        tabIndex={date === rovingDate ? 0 : -1}
+                        aria-current={isToday ? "date" : undefined}
+                        aria-label={`${longDate(date)}${
+                          entry ? `, verse ${entry.verseRef}` : ", no verse set"
+                        }${isToday ? ", today" : ""}`}
+                        onClick={() => setSelected(date)}
+                        className={cn(
+                          "flex h-full w-full flex-col items-center justify-center rounded-md border text-sm transition-colors",
+                          isSelected
+                            ? "border-gold bg-gold/10 text-gold"
+                            : entry
+                              ? "border-teal/40 bg-teal/5 text-text-primary hover:border-teal"
+                              : "border-border bg-surface text-text-secondary hover:border-gold-muted",
+                          // Marks the live day independent of curated/selected color, so
+                          // it's identifiable even on an uncurated (algorithmic-pick) day.
+                          isToday && !isSelected && "ring-1 ring-inset ring-gold/50"
+                        )}
+                      >
+                        <span className="tabular-nums">{day}</span>
+                        {entry ? (
+                          <span className="mt-0.5 font-mono text-[9px] text-teal">
+                            {entry.verseRef}
+                          </span>
+                        ) : (
+                          // No curated entry — for today, still surface the live
+                          // algorithmic pick so the admin can see it without leaving
+                          // the calendar, styled distinctly from a curated ref.
+                          isToday &&
+                          data?.today?.ref && (
+                            <span className="mt-0.5 font-mono text-[9px] text-gold">
+                              {data.today.ref}
+                            </span>
+                          )
+                        )}
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
           </div>
           {loading && <StateNote>Loading…</StateNote>}
         </div>

--- a/components/admin/AdminLiveRegion.tsx
+++ b/components/admin/AdminLiveRegion.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+
+/**
+ * A single polite `role="status"` live region for the whole admin console, so
+ * moderation actions (flag, retire, disable, finalize…) are announced to screen
+ * readers — the visual `StateNote` feedback is otherwise silent to them.
+ *
+ * `announce("")` then the message, on a microtask gap, so re-announcing the
+ * same string (e.g. flagging two rows in a row) still fires an SR update.
+ */
+const AnnounceContext = createContext<(message: string) => void>(() => {});
+
+export function useAdminAnnounce(): (message: string) => void {
+  return useContext(AnnounceContext);
+}
+
+export function AdminLiveRegion({ children }: { children: React.ReactNode }) {
+  const [message, setMessage] = useState("");
+  const clearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const announce = useCallback((next: string) => {
+    setMessage("");
+    // Next microtask: let the empty render commit so a repeated message still
+    // registers as a change.
+    queueMicrotask(() => setMessage(next));
+    if (clearTimer.current) clearTimeout(clearTimer.current);
+    clearTimer.current = setTimeout(() => setMessage(""), 5000);
+  }, []);
+
+  return (
+    <AnnounceContext.Provider value={announce}>
+      {children}
+      <div role="status" aria-live="polite" className="sr-only">
+        {message}
+      </div>
+    </AnnounceContext.Provider>
+  );
+}

--- a/components/admin/ChallengesModeration.tsx
+++ b/components/admin/ChallengesModeration.tsx
@@ -99,10 +99,14 @@ export function ChallengesModeration() {
     setActionError(null);
     try {
       const res = await api<{ resolved: number }>("/challenges/finalize", { method: "POST" });
-      setFinalizeMsg(`Finalized ${res.resolved} ended challenge${res.resolved === 1 ? "" : "s"}.`);
+      const msg = `Finalized ${res.resolved} ended challenge${res.resolved === 1 ? "" : "s"}.`;
+      setFinalizeMsg(msg);
+      announce(msg);
       reload();
     } catch (e) {
-      setActionError(e instanceof AdminApiError ? e.message : "Finalize failed.");
+      const msg = e instanceof AdminApiError ? e.message : "Finalize failed.";
+      setActionError(msg);
+      announce(msg);
     }
   };
 

--- a/components/admin/ChallengesModeration.tsx
+++ b/components/admin/ChallengesModeration.tsx
@@ -14,6 +14,7 @@ import {
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
 import { SkeletonRows } from "@/components/admin/Skeleton";
+import { useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
 import { cn } from "@/lib/utils";
 
 interface AdminChallenge {
@@ -50,6 +51,7 @@ const statusTone = (s: AdminChallenge["status"]) =>
 
 export function ChallengesModeration() {
   const api = useAdminFetch();
+  const announce = useAdminAnnounce();
   const [status, setStatus] = useState<(typeof FILTERS)[number]>("all");
   const [actionError, setActionError] = useState<string | null>(null);
   const [finalizeMsg, setFinalizeMsg] = useState<string | null>(null);
@@ -81,9 +83,12 @@ export function ChallengesModeration() {
     setBusyId(id);
     try {
       await fn();
+      announce(`Challenge ${id} updated.`);
       reload();
     } catch (e) {
-      setActionError(e instanceof AdminApiError ? e.message : "Action failed.");
+      const msg = e instanceof AdminApiError ? e.message : "Action failed.";
+      setActionError(msg);
+      announce(msg);
     } finally {
       setBusyId(null);
     }
@@ -148,6 +153,8 @@ export function ChallengesModeration() {
           {FILTERS.map((f) => (
             <button
               key={f}
+              type="button"
+              aria-pressed={status === f}
               onClick={() => setStatus(f)}
               className={cn(
                 "rounded border px-2 py-1 text-xs capitalize transition-colors",

--- a/components/admin/primitives.tsx
+++ b/components/admin/primitives.tsx
@@ -79,9 +79,18 @@ export function Table({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function Th({ children, className }: { children?: React.ReactNode; className?: string }) {
+export function Th({
+  children,
+  className,
+  scope = "col",
+}: {
+  children?: React.ReactNode;
+  className?: string;
+  scope?: React.ThHTMLAttributes<HTMLTableCellElement>["scope"];
+}) {
   return (
     <th
+      scope={scope}
       className={cn(
         "border-b border-border bg-surface px-3.5 py-2.5 text-left font-mono text-[10px] font-normal uppercase tracking-[0.14em] text-text-muted",
         className


### PR DESCRIPTION
Stacked on #525 (base `feat/admin-ux-polish`).

## Why

The admin console had several screen-reader / keyboard gaps: moderation actions gave only visual feedback, filter toggles didn't expose their state, the VOTD calendar was mouse-only, and table columns had no `scope`.

## What

- **`components/admin/AdminLiveRegion.tsx` + `useAdminAnnounce()`** — one polite `role="status"` region mounted once in `app/admin/layout.tsx`. Wired into the success/error paths of connection status changes, mark-reviewed, user disable/enable, and challenge actions. Re-announcing the same string still fires (empty-then-set on a microtask).
- **`aria-pressed`** on the `FilterRow` buttons (connections) and the inline status filters (challenges moderation).
- **VOTD calendar keyboard support** (`app/admin/votd/page.tsx`):
  - `role="grid"` on the day grid; weekday header row is `aria-hidden` (the info is in each day's label).
  - Roving `tabIndex` — only the selected day (or today, or the 1st) is tab-reachable; arrow keys move within.
  - `onKeyDown`: ←/→ ±1 day, ↑/↓ ±1 week, Home/End = first/last of month, PageUp/PageDown = prev/next month (focus follows across the month boundary).
  - Per-day `aria-label` (`"12 March 2026, verse 2:255"` / `"…, no verse set"` / `"…, today"`), `aria-current="date"` on today, `aria-selected` on the picked day.
- **`Th` defaults to `scope="col"`** (overridable via prop) in `components/admin/primitives.tsx`, so every admin table column is associated for screen readers.

## Tests

`AdminLiveRegion.test.tsx` (region attrs, announce fills it, no-op outside a provider), `primitives.test.tsx` (`Th` scope default + override), `votd/page.test.tsx` new keyboard-nav block (roving tabindex, ArrowRight/ArrowDown selection, PageDown month change). Typecheck + lint clean (the a11y lint rules pass — `aria-selected` not `aria-pressed` on the `gridcell`).

## Deferred from the plan

`@axe-core/playwright` e2e sweep of the admin pages — the repo's e2e setup doesn't currently cover `/admin` (it's dev-token gated); worth a separate infra PR.

## AI / Theological changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added keyboard navigation and improved ARIA semantics to the Verse of the Day calendar.
  * Added screen-reader announcements for admin action successes and errors.
  * Improved filter button state indicators and table header semantics.
* **Bug Fixes**
  * Improved accessibility feedback for connection, user, and challenge management actions.
* **Tests**
  * Added coverage for calendar navigation, live-region announcements, and table-header accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->