### PR TITLE
feat(admin/backfill): extract job runner into dedicated component and…

### DIFF
--- a/__tests__/components/admin/BackfillRunner.test.tsx
+++ b/__tests__/components/admin/BackfillRunner.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockApi = vi.fn();
+vi.mock("@/components/admin/AdminContext", async () => {
+  const actual = await vi.importActual("@/components/admin/AdminContext");
+  return {
+    ...actual,
+    useAdminFetch: () => mockApi,
+  };
+});
+
+import { BackfillRunner } from "@/components/admin/BackfillRunner";
+import { AdminApiError } from "@/components/admin/AdminContext";
+
+describe("BackfillRunner", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+  });
+
+  it("keeps the admin's typed inputs after an 'already running' error", async () => {
+    render(<BackfillRunner />);
+
+    fireEvent.change(screen.getAllByRole("combobox")[0], { target: { value: "topup" } });
+    fireEvent.change(screen.getAllByRole("spinbutton")[0], { target: { value: "50" } });
+
+    mockApi.mockRejectedValueOnce(
+      new AdminApiError(400, 'Job "backfill-connections" is already running')
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Run backfill" }));
+    const confirm = await screen.findByRole("button", { name: "Run topup on gemini?" });
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Job "backfill-connections" is already running')).toBeInTheDocument()
+    );
+    // The inputs must not have reset to their defaults.
+    expect((screen.getAllByRole("combobox")[0] as HTMLSelectElement).value).toBe("topup");
+    expect((screen.getAllByRole("spinbutton")[0] as HTMLInputElement).value).toBe("50");
+  });
+
+  it("calls onStarted and shows the success note when the job starts", async () => {
+    const onStarted = vi.fn();
+    render(<BackfillRunner onStarted={onStarted} />);
+
+    mockApi.mockResolvedValueOnce({ runId: "run_1" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Run backfill" }));
+    const confirm = await screen.findByRole("button", { name: "Run baseline on gemini?" });
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+
+    await waitFor(() => expect(onStarted).toHaveBeenCalledTimes(1));
+    expect(screen.getByText(/Watch progress on the Jobs page/)).toBeInTheDocument();
+    expect(mockApi).toHaveBeenCalledWith(
+      "/jobs",
+      expect.objectContaining({ method: "POST", json: expect.objectContaining({ jobId: "backfill-connections" }) })
+    );
+  });
+});

--- a/__tests__/components/admin/BackfillRunner.test.tsx
+++ b/__tests__/components/admin/BackfillRunner.test.tsx
@@ -58,7 +58,10 @@ describe("BackfillRunner", () => {
     expect(screen.getByText(/Watch progress on the Jobs page/)).toBeInTheDocument();
     expect(mockApi).toHaveBeenCalledWith(
       "/jobs",
-      expect.objectContaining({ method: "POST", json: expect.objectContaining({ jobId: "backfill-connections" }) })
+      expect.objectContaining({
+        method: "POST",
+        json: expect.objectContaining({ jobId: "backfill-connections" }),
+      })
     );
   });
 });

--- a/components/admin/BackfillRunner.tsx
+++ b/components/admin/BackfillRunner.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { StateNote, ConfirmButton } from "@/components/admin/primitives";
+import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
+import type { Locale } from "@/lib/i18n/config";
+import { SELECTABLE_MODELS } from "@/lib/ai/models";
+
+const TARGET_LOCALES: Exclude<Locale, "en">[] = ["tr", "ru", "az"];
+
+/**
+ * The "Run the backfill job" console. Its inputs are deliberately kept in a
+ * standalone component with no dependency on the coverage report fetch, so a
+ * transient `/coverage` reload failure can never unmount the form and wipe the
+ * values an admin just typed (e.g. while retrying against an "already running"
+ * job).
+ */
+export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
+  const api = useAdminFetch();
+  const [mode, setMode] = useState<"baseline" | "topup">("baseline");
+  const [provider, setProvider] = useState<"claude" | "gemini">("gemini");
+  const [model, setModel] = useState("");
+  const [runLocales, setRunLocales] = useState<Record<string, boolean>>({
+    tr: true,
+    ru: true,
+    az: true,
+  });
+  const [maxCalls, setMaxCalls] = useState(200);
+  const [maxCostUsd, setMaxCostUsd] = useState(5);
+  const [runNote, setRunNote] = useState<string | null>(null);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+
+  const startRun = async () => {
+    setRunNote(null);
+    setRunError(null);
+    setStarting(true);
+    try {
+      await api("/jobs", {
+        method: "POST",
+        json: {
+          jobId: "backfill-connections",
+          params: {
+            mode,
+            provider,
+            ...(model ? { model } : {}),
+            locales: TARGET_LOCALES.filter((l) => runLocales[l]).join(","),
+            maxCalls,
+            maxCostUsd,
+          },
+        },
+      });
+      setRunNote("Started. Watch progress on the Jobs page.");
+      onStarted?.();
+    } catch (e) {
+      setRunError(e instanceof AdminApiError ? e.message : "Failed to start the backfill job.");
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <section className="rounded-lg border border-border bg-surface p-4">
+      <h3 className="text-sm font-semibold text-text-primary">Run the backfill job</h3>
+      <p className="mt-1 text-xs text-text-muted">
+        Generates connections for verses that have none (baseline) or tops up the thinnest cells
+        (top-up). Resumable — already-generated connections are never regenerated, and a cell with no
+        more real connections is marked exhausted so it is never re-run.
+      </p>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <label className="text-xs">
+          <span className="mb-1 block text-text-muted">Mode</span>
+          <select
+            value={mode}
+            onChange={(e) => setMode(e.target.value as "baseline" | "topup")}
+            className="w-full rounded border border-border bg-bg px-2 py-1.5"
+          >
+            <option value="baseline">baseline — fill cells with zero connections</option>
+            <option value="topup">top-up — add more to the thinnest cells</option>
+          </select>
+        </label>
+
+        <label className="text-xs">
+          <span className="mb-1 block text-text-muted">Provider</span>
+          <select
+            value={provider}
+            onChange={(e) => {
+              setProvider(e.target.value as "claude" | "gemini");
+              setModel("");
+            }}
+            className="w-full rounded border border-border bg-bg px-2 py-1.5"
+          >
+            <option value="gemini">gemini — cheapest</option>
+            <option value="claude">claude — highest fidelity</option>
+          </select>
+        </label>
+
+        <label className="text-xs">
+          <span className="mb-1 block text-text-muted">Model</span>
+          <select
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            className="w-full rounded border border-border bg-bg px-2 py-1.5"
+          >
+            <option value="">default</option>
+            {SELECTABLE_MODELS[provider].map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="text-xs">
+          <span className="mb-1 block text-text-muted">Also translate reasons into</span>
+          <div className="flex gap-3">
+            {TARGET_LOCALES.map((l) => (
+              <label key={l} className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={runLocales[l] ?? false}
+                  onChange={(e) => setRunLocales((s) => ({ ...s, [l]: e.target.checked }))}
+                />
+                {l.toUpperCase()}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 text-xs">
+          <label>
+            <span className="mb-1 block text-text-muted">Max LLM calls</span>
+            <input
+              type="number"
+              min={1}
+              value={maxCalls}
+              onChange={(e) => setMaxCalls(Number(e.target.value))}
+              className="w-full rounded border border-border bg-bg px-2 py-1.5 tabular-nums"
+            />
+          </label>
+          <label>
+            <span className="mb-1 block text-text-muted">Max cost (USD, est.)</span>
+            <input
+              type="number"
+              min={0.1}
+              step={0.1}
+              value={maxCostUsd}
+              onChange={(e) => setMaxCostUsd(Number(e.target.value))}
+              className="w-full rounded border border-border bg-bg px-2 py-1.5 tabular-nums"
+            />
+          </label>
+        </div>
+      </div>
+
+      <p className="mt-2 text-[11px] text-text-muted">
+        The job stops cleanly at whichever limit is hit first. Max calls is exact; max cost is a
+        per-call estimate (token counts aren&apos;t tracked on this path).
+      </p>
+
+      {runError && <StateNote tone="error">{runError}</StateNote>}
+      {runNote && (
+        <p className="mt-2 text-xs text-teal">
+          {runNote}{" "}
+          <Link href="/admin/jobs" className="underline">
+            Open Jobs
+          </Link>
+        </p>
+      )}
+
+      <div className="mt-3">
+        <ConfirmButton
+          variant="secondary"
+          disabled={starting}
+          onConfirm={startRun}
+          confirmLabel={`Run ${mode} on ${provider}?`}
+        >
+          {starting ? "Starting…" : "Run backfill"}
+        </ConfirmButton>
+      </div>
+    </section>
+  );
+}

--- a/components/admin/BackfillRunner.tsx
+++ b/components/admin/BackfillRunner.tsx
@@ -65,8 +65,8 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
       <h3 className="text-sm font-semibold text-text-primary">Run the backfill job</h3>
       <p className="mt-1 text-xs text-text-muted">
         Generates connections for verses that have none (baseline) or tops up the thinnest cells
-        (top-up). Resumable — already-generated connections are never regenerated, and a cell with no
-        more real connections is marked exhausted so it is never re-run.
+        (top-up). Resumable — already-generated connections are never regenerated, and a cell with
+        no more real connections is marked exhausted so it is never re-run.
       </p>
 
       <div className="mt-4 grid gap-3 sm:grid-cols-2">

--- a/components/admin/CoverageReport.tsx
+++ b/components/admin/CoverageReport.tsx
@@ -1,28 +1,18 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
-import {
-  Table,
-  Th,
-  Td,
-  Pill,
-  StatTile,
-  StateNote,
-  ConfirmButton,
-} from "@/components/admin/primitives";
-import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
+import { Table, Th, Td, Pill, StatTile, StateNote } from "@/components/admin/primitives";
+import { useAdminFetch } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
+import { BackfillRunner } from "@/components/admin/BackfillRunner";
 import type { CoverageReport as CoverageResponse, CoverageCell } from "@/lib/admin/coverage-report";
 import type { Locale } from "@/lib/i18n/config";
 import type { EdgeKind } from "@/types/quran";
-import { SELECTABLE_MODELS } from "@/lib/ai/models";
 
 type Kind = EdgeKind;
 
 const KINDS: Kind[] = ["thematic", "root", "contrast"];
 const LOCALES: Locale[] = ["en", "tr", "ru", "az"];
-const TARGET_LOCALES: Exclude<Locale, "en">[] = ["tr", "ru", "az"];
 
 const cell = (m: CoverageCell[], kind: Kind, locale: Locale) =>
   m.find((c) => c.kind === kind && c.locale === locale);
@@ -36,48 +26,6 @@ export function CoverageReport() {
     () => api(`/coverage?kind=${focusKind}&locale=${focusLocale}`),
     `admin-coverage-${focusKind}-${focusLocale}`
   );
-
-  const [mode, setMode] = useState<"baseline" | "topup">("baseline");
-  const [provider, setProvider] = useState<"claude" | "gemini">("gemini");
-  const [model, setModel] = useState("");
-  const [runLocales, setRunLocales] = useState<Record<string, boolean>>({
-    tr: true,
-    ru: true,
-    az: true,
-  });
-  const [maxCalls, setMaxCalls] = useState(200);
-  const [maxCostUsd, setMaxCostUsd] = useState(5);
-  const [runNote, setRunNote] = useState<string | null>(null);
-  const [runError, setRunError] = useState<string | null>(null);
-  const [starting, setStarting] = useState(false);
-
-  const startRun = async () => {
-    setRunNote(null);
-    setRunError(null);
-    setStarting(true);
-    try {
-      await api("/jobs", {
-        method: "POST",
-        json: {
-          jobId: "backfill-connections",
-          params: {
-            mode,
-            provider,
-            ...(model ? { model } : {}),
-            locales: TARGET_LOCALES.filter((l) => runLocales[l]).join(","),
-            maxCalls,
-            maxCostUsd,
-          },
-        },
-      });
-      setRunNote("Started. Watch progress on the Jobs page.");
-      reload();
-    } catch (e) {
-      setRunError(e instanceof AdminApiError ? e.message : "Failed to start the backfill job.");
-    } finally {
-      setStarting(false);
-    }
-  };
 
   const totalMissingEn = data
     ? KINDS.reduce((sum, k) => sum + (cell(data.matrix, k, "en")?.missing ?? 0), 0)
@@ -244,128 +192,10 @@ export function CoverageReport() {
               </Table>
             </div>
           </section>
-
-          <section className="rounded-lg border border-border bg-surface p-4">
-            <h3 className="text-sm font-semibold text-text-primary">Run the backfill job</h3>
-            <p className="mt-1 text-xs text-text-muted">
-              Generates connections for verses that have none (baseline) or tops up the thinnest
-              cells (top-up). Resumable — already-generated connections are never regenerated, and a
-              cell with no more real connections is marked exhausted so it is never re-run.
-            </p>
-
-            <div className="mt-4 grid gap-3 sm:grid-cols-2">
-              <label className="text-xs">
-                <span className="mb-1 block text-text-muted">Mode</span>
-                <select
-                  value={mode}
-                  onChange={(e) => setMode(e.target.value as "baseline" | "topup")}
-                  className="w-full rounded border border-border bg-bg px-2 py-1.5"
-                >
-                  <option value="baseline">baseline — fill cells with zero connections</option>
-                  <option value="topup">top-up — add more to the thinnest cells</option>
-                </select>
-              </label>
-
-              <label className="text-xs">
-                <span className="mb-1 block text-text-muted">Provider</span>
-                <select
-                  value={provider}
-                  onChange={(e) => {
-                    setProvider(e.target.value as "claude" | "gemini");
-                    setModel("");
-                  }}
-                  className="w-full rounded border border-border bg-bg px-2 py-1.5"
-                >
-                  <option value="gemini">gemini — cheapest</option>
-                  <option value="claude">claude — highest fidelity</option>
-                </select>
-              </label>
-
-              <label className="text-xs">
-                <span className="mb-1 block text-text-muted">Model</span>
-                <select
-                  value={model}
-                  onChange={(e) => setModel(e.target.value)}
-                  className="w-full rounded border border-border bg-bg px-2 py-1.5"
-                >
-                  <option value="">default</option>
-                  {SELECTABLE_MODELS[provider].map((m) => (
-                    <option key={m} value={m}>
-                      {m}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <div className="text-xs">
-                <span className="mb-1 block text-text-muted">Also translate reasons into</span>
-                <div className="flex gap-3">
-                  {TARGET_LOCALES.map((l) => (
-                    <label key={l} className="flex items-center gap-1">
-                      <input
-                        type="checkbox"
-                        checked={runLocales[l] ?? false}
-                        onChange={(e) => setRunLocales((s) => ({ ...s, [l]: e.target.checked }))}
-                      />
-                      {l.toUpperCase()}
-                    </label>
-                  ))}
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-3 text-xs">
-                <label>
-                  <span className="mb-1 block text-text-muted">Max LLM calls</span>
-                  <input
-                    type="number"
-                    min={1}
-                    value={maxCalls}
-                    onChange={(e) => setMaxCalls(Number(e.target.value))}
-                    className="w-full rounded border border-border bg-bg px-2 py-1.5 tabular-nums"
-                  />
-                </label>
-                <label>
-                  <span className="mb-1 block text-text-muted">Max cost (USD, est.)</span>
-                  <input
-                    type="number"
-                    min={0.1}
-                    step={0.1}
-                    value={maxCostUsd}
-                    onChange={(e) => setMaxCostUsd(Number(e.target.value))}
-                    className="w-full rounded border border-border bg-bg px-2 py-1.5 tabular-nums"
-                  />
-                </label>
-              </div>
-            </div>
-
-            <p className="mt-2 text-[11px] text-text-muted">
-              The job stops cleanly at whichever limit is hit first. Max calls is exact; max cost is
-              a per-call estimate (token counts aren&apos;t tracked on this path).
-            </p>
-
-            {runError && <StateNote tone="error">{runError}</StateNote>}
-            {runNote && (
-              <p className="mt-2 text-xs text-teal">
-                {runNote}{" "}
-                <Link href="/admin/jobs" className="underline">
-                  Open Jobs
-                </Link>
-              </p>
-            )}
-
-            <div className="mt-3">
-              <ConfirmButton
-                variant="secondary"
-                disabled={starting}
-                onConfirm={startRun}
-                confirmLabel={`Run ${mode} on ${provider}?`}
-              >
-                {starting ? "Starting…" : "Run backfill"}
-              </ConfirmButton>
-            </div>
-          </section>
         </>
       )}
+
+      <BackfillRunner onStarted={() => reload({ keepDataOnError: true })} />
     </div>
   );
 }


### PR DESCRIPTION
… preserve inputs on error

## Summary

<!-- 1–3 bullet points: what changed and why -->

-
-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

<!-- Complete this section if you modified any Claude prompts, divine name data, or verse connection logic. Leave blank otherwise. -->

- [ ] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below
- [ ] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)

**Details** (if applicable):
<!-- Describe any changes to prompts, expected output format, or theological framing. Note any deviations from or additions to the Maturidi/Hanafi tradition. -->

## Testing

- [ ] `bun run test:ci` passes locally
- [ ] `bun run typecheck` passes locally
- [ ] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [ ] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Conventional commits
- [ ] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin form for starting connection backfill jobs with configurable modes, providers, models, locales, call limits, and cost limits.
  * Added confirmation before launching a job, with success and error notifications.
  * Added a link to view started jobs and automatically refresh the coverage report after a run begins.

* **Bug Fixes**
  * Preserved selected form values when a job is already running or cannot be started.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->