### PR TITLE
feat(admin): stop a running backfill job + require explicit budgets

### DIFF
--- a/__tests__/api/admin/jobs.test.ts
+++ b/__tests__/api/admin/jobs.test.ts
@@ -8,10 +8,11 @@ vi.mock("@/lib/admin/admin-auth", () => ({
 }));
 vi.mock("@/lib/admin/admin-audit", () => ({ logAdminAction: vi.fn() }));
 
-const { mockGetJobsStatus, mockEmbedCoverage, mockStartJob } = vi.hoisted(() => ({
+const { mockGetJobsStatus, mockEmbedCoverage, mockStartJob, mockStopJob } = vi.hoisted(() => ({
   mockGetJobsStatus: vi.fn<() => Promise<unknown[]>>(() => Promise.resolve([])),
   mockEmbedCoverage: vi.fn(() => Promise.resolve({ embedded: 0, total: 0 })),
   mockStartJob: vi.fn(() => Promise.resolve({ runId: 1 })),
+  mockStopJob: vi.fn(() => ({ jobId: "backfill-connections" as const })),
 }));
 vi.mock("@/lib/admin/job-runner", async () => {
   const actual =
@@ -21,6 +22,7 @@ vi.mock("@/lib/admin/job-runner", async () => {
     getJobsStatus: mockGetJobsStatus,
     embedCoverage: mockEmbedCoverage,
     startJob: mockStartJob,
+    stopJob: mockStopJob,
   };
 });
 
@@ -48,6 +50,7 @@ beforeEach(() => {
   mockGetJobsStatus.mockClear().mockResolvedValue([]);
   mockEmbedCoverage.mockClear().mockResolvedValue({ embedded: 0, total: 0 });
   mockStartJob.mockClear().mockResolvedValue({ runId: 1 });
+  mockStopJob.mockClear().mockReturnValue({ jobId: "backfill-connections" });
   vi.mocked(logAdminAction).mockClear();
 });
 
@@ -137,5 +140,26 @@ describe("POST /api/admin/jobs", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toMatch(/already running/);
+  });
+
+  it("stops the running job and logs job.stop", async () => {
+    const res = await POST(post({ jobId: "backfill-connections", action: "stop" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ stopped: "backfill-connections" });
+    expect(mockStopJob).toHaveBeenCalledWith("qf-admin");
+    expect(mockStartJob).not.toHaveBeenCalled();
+    expect(logAdminAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "job.stop", targetId: "backfill-connections" })
+    );
+  });
+
+  it("returns 400 when stopJob throws (nothing running / not stoppable)", async () => {
+    mockStopJob.mockImplementation(() => {
+      throw new Error("No job is running");
+    });
+    const res = await POST(post({ jobId: "backfill-connections", action: "stop" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/No job is running/);
+    expect(logAdminAction).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/components/admin/BackfillRunner.test.tsx
+++ b/__tests__/components/admin/BackfillRunner.test.tsx
@@ -13,46 +13,71 @@ vi.mock("@/components/admin/AdminContext", async () => {
 import { BackfillRunner } from "@/components/admin/BackfillRunner";
 import { AdminApiError } from "@/components/admin/AdminContext";
 
+/** Fills both required budget fields so `startRun` clears its guard. */
+function fillBudgets(calls = "10", cost = "2") {
+  const spin = screen.getAllByRole("spinbutton");
+  fireEvent.change(spin[spin.length - 2], { target: { value: calls } });
+  fireEvent.change(spin[spin.length - 1], { target: { value: cost } });
+}
+
+async function clickRun(confirmLabel: string) {
+  fireEvent.click(screen.getByRole("button", { name: "Run backfill" }));
+  const confirm = await screen.findByRole("button", { name: confirmLabel });
+  await act(async () => {
+    fireEvent.click(confirm);
+  });
+}
+
 describe("BackfillRunner", () => {
   beforeEach(() => {
     mockApi.mockReset();
+    // Default: the /jobs status poll reports nothing running.
+    mockApi.mockResolvedValue({ jobs: [] });
+  });
+
+  it("blocks the run and posts nothing when the budget fields are blank", async () => {
+    render(<BackfillRunner />);
+    await act(async () => {}); // flush the mount /jobs fetch
+
+    const postCallsBefore = mockApi.mock.calls.filter((c) => c[1]?.method === "POST").length;
+    await clickRun("Run baseline on gemini?");
+
+    expect(await screen.findByText(/Set Max LLM calls and Max cost/)).toBeInTheDocument();
+    const postCallsAfter = mockApi.mock.calls.filter((c) => c[1]?.method === "POST").length;
+    expect(postCallsAfter).toBe(postCallsBefore);
   });
 
   it("keeps the admin's typed inputs after an 'already running' error", async () => {
     render(<BackfillRunner />);
+    await act(async () => {});
 
     fireEvent.change(screen.getAllByRole("combobox")[0], { target: { value: "topup" } });
-    fireEvent.change(screen.getAllByRole("spinbutton")[0], { target: { value: "50" } });
+    fillBudgets("50", "3");
 
     mockApi.mockRejectedValueOnce(
       new AdminApiError(400, 'Job "backfill-connections" is already running')
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Run backfill" }));
-    const confirm = await screen.findByRole("button", { name: "Run topup on gemini?" });
-    await act(async () => {
-      fireEvent.click(confirm);
-    });
+    await clickRun("Run topup on gemini?");
 
     await waitFor(() =>
       expect(screen.getByText('Job "backfill-connections" is already running')).toBeInTheDocument()
     );
-    // The inputs must not have reset to their defaults.
     expect((screen.getAllByRole("combobox")[0] as HTMLSelectElement).value).toBe("topup");
-    expect((screen.getAllByRole("spinbutton")[0] as HTMLInputElement).value).toBe("50");
+    const spin = screen.getAllByRole("spinbutton");
+    expect((spin[spin.length - 2] as HTMLInputElement).value).toBe("50");
+    expect((spin[spin.length - 1] as HTMLInputElement).value).toBe("3");
   });
 
   it("calls onStarted and shows the success note when the job starts", async () => {
     const onStarted = vi.fn();
     render(<BackfillRunner onStarted={onStarted} />);
+    await act(async () => {});
 
+    fillBudgets("10", "2");
     mockApi.mockResolvedValueOnce({ runId: "run_1" });
 
-    fireEvent.click(screen.getByRole("button", { name: "Run backfill" }));
-    const confirm = await screen.findByRole("button", { name: "Run baseline on gemini?" });
-    await act(async () => {
-      fireEvent.click(confirm);
-    });
+    await clickRun("Run baseline on gemini?");
 
     await waitFor(() => expect(onStarted).toHaveBeenCalledTimes(1));
     expect(screen.getByText(/Watch progress on the Jobs page/)).toBeInTheDocument();
@@ -60,8 +85,35 @@ describe("BackfillRunner", () => {
       "/jobs",
       expect.objectContaining({
         method: "POST",
-        json: expect.objectContaining({ jobId: "backfill-connections" }),
+        json: expect.objectContaining({
+          jobId: "backfill-connections",
+          params: expect.objectContaining({ maxCalls: 10, maxCostUsd: 2 }),
+        }),
       })
+    );
+  });
+
+  it("shows a Stop button when the backfill job is running and posts action:stop", async () => {
+    mockApi.mockResolvedValue({ jobs: [{ id: "backfill-connections", status: "running" }] });
+    render(<BackfillRunner />);
+
+    const stop = await screen.findByRole("button", { name: "Stop running job" });
+    fireEvent.click(stop);
+    const confirm = await screen.findByRole("button", {
+      name: "Stop the running backfill job?",
+    });
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+
+    await waitFor(() =>
+      expect(mockApi).toHaveBeenCalledWith(
+        "/jobs",
+        expect.objectContaining({
+          method: "POST",
+          json: { jobId: "backfill-connections", action: "stop" },
+        })
+      )
     );
   });
 });

--- a/__tests__/integration/connection-batch.integration.test.ts
+++ b/__tests__/integration/connection-batch.integration.test.ts
@@ -117,6 +117,22 @@ describe("runConnectionBatch (integration, real Postgres)", () => {
     expect(rerun.generated).toBe(0);
   });
 
+  it("stops immediately with reason 'cancelled' when the signal is already aborted", async () => {
+    await seed("1:1");
+    await seed("2:255");
+    mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
+
+    const summary = await runConnectionBatch(
+      { mode: "baseline", provider: "claude", locales: [], maxCalls: 500, maxCostUsd: 100 },
+      hooks,
+      AbortSignal.abort()
+    );
+
+    expect(summary.stoppedReason).toBe("cancelled");
+    expect(summary.cellsProcessed).toBe(0);
+    expect(mockCallAI).not.toHaveBeenCalled();
+  });
+
   it("topup: marks a cell exhausted when generation returns nothing new, then skips it", async () => {
     await seed("1:1");
     await seed("2:255");

--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -48,7 +48,7 @@ vi.mock("node:child_process", () => ({
 const { mockRunConnectionBatch } = vi.hoisted(() => ({ mockRunConnectionBatch: vi.fn() }));
 vi.mock("@/lib/ai/connection-batch", () => ({ runConnectionBatch: mockRunConnectionBatch }));
 
-import { startJob, embedCoverage, JOBS } from "@/lib/admin/job-runner";
+import { startJob, stopJob, embedCoverage, JOBS } from "@/lib/admin/job-runner";
 
 beforeEach(() => {
   mockInsert.mockReset().mockReturnValue(makeDbChain([{ id: 42 }]));
@@ -185,7 +185,8 @@ describe("startJob — backfill-connections params", () => {
     });
     expect(mockRunConnectionBatch).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "gemini", model: "gemini-3.7-flash" }),
-      expect.anything()
+      expect.anything(),
+      expect.any(AbortSignal)
     );
   });
 
@@ -234,7 +235,8 @@ describe("startJob — backfill-connections params", () => {
         maxCalls: 10,
         maxCostUsd: 2,
       },
-      expect.objectContaining({ onProgress: expect.any(Function) })
+      expect.objectContaining({ onProgress: expect.any(Function) }),
+      expect.any(AbortSignal)
     );
 
     resolveBatch({ stoppedReason: "completed" });
@@ -273,6 +275,59 @@ describe("startJob — backfill-connections params", () => {
     await expect(startJob("seed-quran", "qf-admin", { mode: "baseline" })).rejects.toThrow(
       /does not accept params/
     );
+  });
+
+  it("records a cancelled run when the batch stops with reason 'cancelled'", async () => {
+    mockRunConnectionBatch.mockResolvedValueOnce({ stoppedReason: "cancelled" });
+    await startJob("backfill-connections", "qf-admin", validParams);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockUpdate).toHaveBeenCalled();
+    const next = await startJob("seed-quran", "qf-admin");
+    expect(next.runId).toBe(42);
+  });
+});
+
+describe("stopJob", () => {
+  const validParams = {
+    mode: "baseline",
+    provider: "claude",
+    locales: "tr,ru",
+    maxCalls: 10,
+    maxCostUsd: 2,
+  };
+
+  beforeEach(() => {
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    process.env.GEMINI_API_KEY = "test-gemini-key";
+  });
+
+  it("throws when no job is running", () => {
+    expect(() => stopJob("qf-admin")).toThrow(/No job is running/);
+  });
+
+  it("aborts the in-process backfill run's signal and releases the guard", async () => {
+    let resolveBatch!: (v: unknown) => void;
+    mockRunConnectionBatch.mockReturnValueOnce(new Promise((r) => (resolveBatch = r)));
+    await startJob("backfill-connections", "qf-admin", validParams);
+
+    const signal = mockRunConnectionBatch.mock.calls[0][2] as AbortSignal;
+    expect(signal.aborted).toBe(false);
+
+    expect(stopJob("qf-admin")).toEqual({ jobId: "backfill-connections" });
+    expect(signal.aborted).toBe(true);
+
+    resolveBatch({ stoppedReason: "cancelled" });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockUpdate).toHaveBeenCalled();
+    const next = await startJob("seed-quran", "qf-admin");
+    expect(next.runId).toBe(42);
+  });
+
+  it("refuses to stop a spawned (script) job", async () => {
+    await startJob("seed-morphology", "qf-admin");
+    expect(() => stopJob("qf-admin")).toThrow(/can't be stopped/);
   });
 });
 

--- a/app/api/admin/jobs/route.ts
+++ b/app/api/admin/jobs/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin, rateLimitAdminMutation } from "@/lib/admin/admin-auth";
 import { logAdminAction } from "@/lib/admin/admin-audit";
-import { JOBS, getJobsStatus, embedCoverage, startJob } from "@/lib/admin/job-runner";
+import { JOBS, getJobsStatus, embedCoverage, startJob, stopJob } from "@/lib/admin/job-runner";
 
 /** Job list + latest run status, plus the embedding-coverage check. */
 export async function GET(req: NextRequest) {
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
   const limited = await rateLimitAdminMutation(auth);
   if (limited) return limited;
 
-  let body: { jobId?: string; params?: Record<string, unknown> };
+  let body: { jobId?: string; params?: Record<string, unknown>; action?: "start" | "stop" };
   try {
     body = await req.json();
   } catch {
@@ -33,6 +33,23 @@ export async function POST(req: NextRequest) {
   const jobId = body.jobId;
   if (!jobId || !JOBS.some((j) => j.id === jobId)) {
     return NextResponse.json({ error: "Unknown job" }, { status: 400 });
+  }
+
+  if (body.action === "stop") {
+    try {
+      const { jobId: stopped } = stopJob(auth.user.qfId);
+      await logAdminAction({
+        adminQfId: auth.user.qfId,
+        action: "job.stop",
+        targetType: "job",
+        targetId: stopped,
+      });
+      return NextResponse.json({ stopped });
+    } catch (err) {
+      // Nothing running / not stoppable are expected client errors.
+      const message = err instanceof Error ? err.message : "Failed to stop job";
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
   }
 
   try {

--- a/components/admin/BackfillRunner.tsx
+++ b/components/admin/BackfillRunner.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
+import { useAsync } from "@/components/admin/useAsync";
 import type { Locale } from "@/lib/i18n/config";
 import { SELECTABLE_MODELS } from "@/lib/ai/models";
 
 const TARGET_LOCALES: Exclude<Locale, "en">[] = ["tr", "ru", "az"];
+
+interface JobsResponse {
+  jobs: { id: string; status: string }[];
+}
 
 /**
  * The "Run the backfill job" console. Its inputs are deliberately kept in a
@@ -15,6 +20,10 @@ const TARGET_LOCALES: Exclude<Locale, "en">[] = ["tr", "ru", "az"];
  * transient `/coverage` reload failure can never unmount the form and wipe the
  * values an admin just typed (e.g. while retrying against an "already running"
  * job).
+ *
+ * The budget fields (max calls / max cost) have no default value on purpose —
+ * an accidental "Run backfill" click must not be able to start a run that
+ * spends money.
  */
 export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
   const api = useAdminFetch();
@@ -26,15 +35,35 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
     ru: true,
     az: true,
   });
-  const [maxCalls, setMaxCalls] = useState(200);
-  const [maxCostUsd, setMaxCostUsd] = useState(5);
+  const [maxCalls, setMaxCalls] = useState<number | "">("");
+  const [maxCostUsd, setMaxCostUsd] = useState<number | "">("");
   const [runNote, setRunNote] = useState<string | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
+  const [stopping, setStopping] = useState(false);
+
+  const { data: jobData, reload: reloadJobs } = useAsync<JobsResponse>(
+    () => api("/jobs"),
+    "backfill-job-status"
+  );
+  const backfillRunning =
+    jobData?.jobs.find((j) => j.id === "backfill-connections")?.status === "running";
+
+  // Poll while the backfill job is running so the Stop button appears/clears
+  // without a manual reload — mirrors JobRunner's poll.
+  useEffect(() => {
+    if (!backfillRunning) return;
+    const id = setInterval(() => reloadJobs({ keepDataOnError: true }), 4000);
+    return () => clearInterval(id);
+  }, [backfillRunning, reloadJobs]);
 
   const startRun = async () => {
     setRunNote(null);
     setRunError(null);
+    if (maxCalls === "" || maxCostUsd === "" || maxCalls <= 0 || maxCostUsd <= 0) {
+      setRunError("Set Max LLM calls and Max cost before running.");
+      return;
+    }
     setStarting(true);
     try {
       await api("/jobs", {
@@ -52,11 +81,30 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
         },
       });
       setRunNote("Started. Watch progress on the Jobs page.");
+      reloadJobs();
       onStarted?.();
     } catch (e) {
       setRunError(e instanceof AdminApiError ? e.message : "Failed to start the backfill job.");
     } finally {
       setStarting(false);
+    }
+  };
+
+  const stopRun = async () => {
+    setRunNote(null);
+    setRunError(null);
+    setStopping(true);
+    try {
+      await api("/jobs", {
+        method: "POST",
+        json: { jobId: "backfill-connections", action: "stop" },
+      });
+      setRunNote("Stop requested. The job halts after the current verse.");
+      reloadJobs();
+    } catch (e) {
+      setRunError(e instanceof AdminApiError ? e.message : "Failed to stop the backfill job.");
+    } finally {
+      setStopping(false);
     }
   };
 
@@ -136,7 +184,8 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
               type="number"
               min={1}
               value={maxCalls}
-              onChange={(e) => setMaxCalls(Number(e.target.value))}
+              placeholder="required"
+              onChange={(e) => setMaxCalls(e.target.value === "" ? "" : Number(e.target.value))}
               className="w-full rounded border border-border bg-bg px-2 py-1.5 tabular-nums"
             />
           </label>
@@ -147,7 +196,8 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
               min={0.1}
               step={0.1}
               value={maxCostUsd}
-              onChange={(e) => setMaxCostUsd(Number(e.target.value))}
+              placeholder="required"
+              onChange={(e) => setMaxCostUsd(e.target.value === "" ? "" : Number(e.target.value))}
               className="w-full rounded border border-border bg-bg px-2 py-1.5 tabular-nums"
             />
           </label>
@@ -155,8 +205,9 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
       </div>
 
       <p className="mt-2 text-[11px] text-text-muted">
-        The job stops cleanly at whichever limit is hit first. Max calls is exact; max cost is a
-        per-call estimate (token counts aren&apos;t tracked on this path).
+        Max LLM calls and Max cost are both required — there is no default, so a stray click can
+        never start a run. The job stops cleanly at whichever limit is hit first: max calls is
+        exact; max cost is a per-call estimate (token counts aren&apos;t tracked on this path).
       </p>
 
       {runError && <StateNote tone="error">{runError}</StateNote>}
@@ -169,15 +220,25 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
         </p>
       )}
 
-      <div className="mt-3">
+      <div className="mt-3 flex flex-wrap gap-2">
         <ConfirmButton
           variant="secondary"
-          disabled={starting}
+          disabled={starting || backfillRunning}
           onConfirm={startRun}
           confirmLabel={`Run ${mode} on ${provider}?`}
         >
           {starting ? "Starting…" : "Run backfill"}
         </ConfirmButton>
+        {backfillRunning && (
+          <ConfirmButton
+            variant="danger"
+            disabled={stopping}
+            onConfirm={stopRun}
+            confirmLabel="Stop the running backfill job?"
+          >
+            {stopping ? "Stopping…" : "Stop running job"}
+          </ConfirmButton>
+        )}
       </div>
     </section>
   );

--- a/components/admin/JobRunner.tsx
+++ b/components/admin/JobRunner.tsx
@@ -8,7 +8,7 @@ import { useAsync } from "@/components/admin/useAsync";
 interface JobStatus {
   id: string;
   label: string;
-  status: "never-run" | "running" | "success" | "failed";
+  status: "never-run" | "running" | "success" | "failed" | "cancelled";
   startedAt: string | null;
   completedAt: string | null;
   error: string | null;
@@ -22,6 +22,8 @@ interface JobsResponse {
 
 const statusTone = (s: JobStatus["status"]) =>
   s === "running" ? "flagged" : s === "success" ? "active" : s === "failed" ? "retired" : "neutral";
+
+const STOPPABLE = new Set(["backfill-connections"]);
 
 export function JobRunner() {
   const api = useAdminFetch();
@@ -51,6 +53,19 @@ export function JobRunner() {
       reload();
     } catch (e) {
       setActionError(e instanceof AdminApiError ? e.message : "Failed to start job.");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const stop = async (jobId: JobStatus["id"]) => {
+    setActionError(null);
+    setBusyId(jobId);
+    try {
+      await api("/jobs", { method: "POST", json: { jobId, action: "stop" } });
+      reload();
+    } catch (e) {
+      setActionError(e instanceof AdminApiError ? e.message : "Failed to stop job.");
     } finally {
       setBusyId(null);
     }
@@ -97,14 +112,26 @@ export function JobRunner() {
                   )}
                 </Td>
                 <Td>
-                  <div className="flex justify-end">
-                    {job.id === "backfill-connections" ? (
-                      <a
-                        href="/admin/coverage"
-                        className="text-xs text-text-muted underline hover:text-text-secondary"
+                  <div className="flex justify-end gap-2">
+                    {job.status === "running" && STOPPABLE.has(job.id) && (
+                      <ConfirmButton
+                        variant="danger"
+                        disabled={busyId === job.id}
+                        onConfirm={() => stop(job.id)}
+                        confirmLabel="Stop the running job?"
                       >
-                        Run from Coverage →
-                      </a>
+                        Stop
+                      </ConfirmButton>
+                    )}
+                    {job.id === "backfill-connections" ? (
+                      job.status !== "running" && (
+                        <a
+                          href="/admin/coverage"
+                          className="text-xs text-text-muted underline hover:text-text-secondary"
+                        >
+                          Run from Coverage →
+                        </a>
+                      )
                     ) : (
                       <ConfirmButton
                         variant="secondary"

--- a/lib/admin/job-runner.ts
+++ b/lib/admin/job-runner.ts
@@ -119,6 +119,8 @@ interface RunningJob {
   jobId: JobDefinition["id"];
   runId: number;
   logTail: string[];
+  /** Aborted by `stopJob`. Only the in-process backfill job watches it. */
+  controller: AbortController;
 }
 
 // Module-level, so it survives across requests within this `next start`
@@ -129,6 +131,20 @@ export function currentlyRunningJobId(): JobDefinition["id"] | null {
   return running?.jobId ?? null;
 }
 
+/** Cooperatively stops the running job. Only `inProcess` jobs (currently just
+ *  `backfill-connections`) watch the abort signal; the batch loop checks it
+ *  between cells and records a `cancelled` run via `finishRun`. Throws when
+ *  nothing is running or the running job can't be stopped — routes map to 400. */
+export function stopJob(adminQfId: string): { jobId: JobDefinition["id"] } {
+  const job = running;
+  if (!job) throw new Error("No job is running");
+  const def = JOBS.find((j) => j.id === job.jobId);
+  if (!def?.inProcess) throw new Error(`Job "${job.jobId}" can't be stopped`);
+  job.controller.abort();
+  pushLogLine(job, `stop requested by admin ${adminQfId}`);
+  return { jobId: job.jobId };
+}
+
 function pushLogLine(job: RunningJob, line: string) {
   job.logTail.push(line);
   if (job.logTail.length > LOG_TAIL_LINES) job.logTail.shift();
@@ -136,7 +152,11 @@ function pushLogLine(job: RunningJob, line: string) {
 
 /** Records the terminal `job_runs` row and releases the in-memory slot. Shared
  *  by the spawn path (child close/error) and the in-process path. */
-function finishRun(state: RunningJob, status: "success" | "failed", error: string | null) {
+function finishRun(
+  state: RunningJob,
+  status: "success" | "failed" | "cancelled",
+  error: string | null
+) {
   void db
     .update(jobRuns)
     .set({ status, completedAt: new Date(), error, logTail: state.logTail.join("\n") })
@@ -174,7 +194,12 @@ export async function startJob(
   // above and this assignment) so two near-simultaneous calls can't both pass
   // the guard — matches lib/names/name-content.ts's inFlight/reasonInFlight
   // pattern. `runId` is filled in once the insert below resolves.
-  const state: RunningJob = { jobId: job.id, runId: -1, logTail: [] };
+  const state: RunningJob = {
+    jobId: job.id,
+    runId: -1,
+    logTail: [],
+    controller: new AbortController(),
+  };
   running = state;
 
   let row: { id: number };
@@ -197,14 +222,18 @@ export async function startJob(
     // `job_runs` row + resumable work list cover restart recovery.
     void (async () => {
       try {
-        const summary = await runConnectionBatch(backfillOpts as BatchOptions, {
-          onProgress: (line) => pushLogLine(state, line),
-        });
-        finishRun(
-          state,
-          summary.stoppedReason === "error" ? "failed" : "success",
-          summary.error ?? null
+        const summary = await runConnectionBatch(
+          backfillOpts as BatchOptions,
+          { onProgress: (line) => pushLogLine(state, line) },
+          state.controller.signal
         );
+        const status =
+          summary.stoppedReason === "error"
+            ? "failed"
+            : summary.stoppedReason === "cancelled"
+              ? "cancelled"
+              : "success";
+        finishRun(state, status, summary.error ?? null);
       } catch (err) {
         pushLogLine(state, `job failed: ${err instanceof Error ? err.message : String(err)}`);
         finishRun(state, "failed", err instanceof Error ? err.message : String(err));
@@ -239,7 +268,7 @@ export async function startJob(
 export interface JobStatus {
   id: JobDefinition["id"];
   label: string;
-  status: "never-run" | "running" | "success" | "failed";
+  status: "never-run" | "running" | "success" | "failed" | "cancelled";
   startedAt: string | null;
   completedAt: string | null;
   error: string | null;

--- a/lib/ai/connection-batch.ts
+++ b/lib/ai/connection-batch.ts
@@ -38,7 +38,7 @@ const POPULAR_SURAHS = [1, 36, 67, 18, 2, 112, 55, 56];
 const PROGRESS_EVERY = 25;
 
 export type BatchMode = "baseline" | "topup";
-export type StoppedReason = "completed" | "call-budget" | "cost-budget" | "error";
+export type StoppedReason = "completed" | "call-budget" | "cost-budget" | "error" | "cancelled";
 
 export interface BatchOptions {
   mode: BatchMode;
@@ -289,7 +289,8 @@ async function upsertCoverage(
 
 export async function runConnectionBatch(
   opts: BatchOptions,
-  hooks: BatchHooks
+  hooks: BatchHooks,
+  signal?: AbortSignal
 ): Promise<BatchSummary> {
   const summary: BatchSummary = {
     stoppedReason: "completed",
@@ -355,6 +356,13 @@ export async function runConnectionBatch(
   };
 
   for (const cell of cells) {
+    // Cooperative cancel from the admin panel (job-runner aborts this signal).
+    // Between-cell granularity matches the budget stop — at most one more cell's
+    // worth of calls after the click.
+    if (signal?.aborted) {
+      summary.stoppedReason = "cancelled";
+      break;
+    }
     if (wouldExceedBudget()) {
       summary.stoppedReason = summary.callsUsed + 1 > opts.maxCalls ? "call-budget" : "cost-budget";
       break;


### PR DESCRIPTION
## Why

Two safety gaps in the admin panel around the in-process **Backfill verse connections** job (`/admin/coverage` → `BackfillRunner`, watched on `/admin/jobs`):

1. **No way to stop a running job.** `startJob` fires `runConnectionBatch` fire-and-forget; the only stop was a redeploy. An admin who starts a wrong or too-large run has to wait it out — and pay for it.
2. **Dangerous default budgets.** The runner pre-filled *Max LLM calls = 200* / *Max cost = $5*. A stray click on "Run backfill" could immediately spend that.

## What

- **Cooperative cancel.** `runConnectionBatch` takes an optional `AbortSignal` and checks it between cells (same granularity as the existing budget stop — at most one more cell after the click). `lib/admin/job-runner.ts` holds one `AbortController` per run; new `stopJob()` aborts it and the batch loop records a `cancelled` `job_runs` row.
- **API.** `POST /api/admin/jobs` now accepts `{ jobId, action: "stop" }` (default `"start"`), audit-logged as `job.stop`. Expected errors (nothing running / job not stoppable) → 400, like the start path.
- **UI.** "Stop running job" button in `BackfillRunner` (polls `/jobs` every 4s while running, mirroring `JobRunner`) and a "Stop" button on the backfill row in `JobRunner`. The new `cancelled` status renders as a neutral pill.
- **Budgets.** Max LLM calls / Max cost start empty; `startRun` blocks with an inline "Set Max LLM calls and Max cost before running." until both are positive. `parseBackfillParams` already 400s on non-positive values — this just turns that into a friendly message instead of a server round-trip.

Scope is limited to `backfill-connections` (the only `inProcess` job); the spawned script jobs are unchanged.

## Tests

- `job-runner.test.ts` — `stopJob` throws with nothing running / on a script job; aborts the signal and records a `cancelled` run for the in-process job.
- `jobs.test.ts` — `POST { action: "stop" }` calls `stopJob` + logs `job.stop`; 400 when it throws.
- `connection-batch.integration.test.ts` — a pre-aborted signal stops the batch with `stoppedReason: "cancelled"` and zero cells processed.
- `BackfillRunner.test.tsx` — blank budgets block the run and post nothing; the Stop button appears when `/jobs` reports the job running and posts `action: "stop"`.

Full unit suite + pre-push integration tests pass; typecheck + lint clean.

## Guardrails

- **Auth / security surface:** `app/api/admin/jobs/route.ts` gains the `stop` branch — still behind `requireAdmin` + `rateLimitAdminMutation`, and audit-logged.
- No DB migration (`job_runs.status` is a free-text column). No new env vars / secrets. No CSP or auth-check changes.

## AI / Theological changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to stop running backfill jobs from the admin interface.
  * Running jobs now display cancellation status and provide clear success or error feedback.
  * Backfill runs can be cancelled before additional connection processing or AI calls occur.
  * Budget limits are now required before starting a backfill.

* **Bug Fixes**
  * Prevented duplicate starts while a backfill job is already running.
  * Improved job status refreshes after starting or stopping a run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->