### PR TITLE
fix(admin): keep the backfill form free of job-status polling

### DIFF
--- a/__tests__/components/admin/BackfillRunner.test.tsx
+++ b/__tests__/components/admin/BackfillRunner.test.tsx
@@ -31,25 +31,20 @@ async function clickRun(confirmLabel: string) {
 describe("BackfillRunner", () => {
   beforeEach(() => {
     mockApi.mockReset();
-    // Default: the /jobs status poll reports nothing running.
-    mockApi.mockResolvedValue({ jobs: [] });
+    mockApi.mockResolvedValue({ runId: "run_1" });
   });
 
   it("blocks the run and posts nothing when the budget fields are blank", async () => {
     render(<BackfillRunner />);
-    await act(async () => {}); // flush the mount /jobs fetch
 
-    const postCallsBefore = mockApi.mock.calls.filter((c) => c[1]?.method === "POST").length;
     await clickRun("Run baseline on gemini?");
 
     expect(await screen.findByText(/Set Max LLM calls and Max cost/)).toBeInTheDocument();
-    const postCallsAfter = mockApi.mock.calls.filter((c) => c[1]?.method === "POST").length;
-    expect(postCallsAfter).toBe(postCallsBefore);
+    expect(mockApi).not.toHaveBeenCalled();
   });
 
   it("keeps the admin's typed inputs after an 'already running' error", async () => {
     render(<BackfillRunner />);
-    await act(async () => {});
 
     fireEvent.change(screen.getAllByRole("combobox")[0], { target: { value: "topup" } });
     fillBudgets("50", "3");
@@ -63,6 +58,9 @@ describe("BackfillRunner", () => {
     await waitFor(() =>
       expect(screen.getByText('Job "backfill-connections" is already running')).toBeInTheDocument()
     );
+    // The Run button stays usable — a second attempt is allowed (and rejected
+    // server-side), not blocked client-side.
+    expect(screen.getByRole("button", { name: "Run backfill" })).not.toBeDisabled();
     expect((screen.getAllByRole("combobox")[0] as HTMLSelectElement).value).toBe("topup");
     const spin = screen.getAllByRole("spinbutton");
     expect((spin[spin.length - 2] as HTMLInputElement).value).toBe("50");
@@ -72,7 +70,6 @@ describe("BackfillRunner", () => {
   it("calls onStarted and shows the success note when the job starts", async () => {
     const onStarted = vi.fn();
     render(<BackfillRunner onStarted={onStarted} />);
-    await act(async () => {});
 
     fillBudgets("10", "2");
     mockApi.mockResolvedValueOnce({ runId: "run_1" });
@@ -93,27 +90,12 @@ describe("BackfillRunner", () => {
     );
   });
 
-  it("shows a Stop button when the backfill job is running and posts action:stop", async () => {
-    mockApi.mockResolvedValue({ jobs: [{ id: "backfill-connections", status: "running" }] });
+  it("never fetches job status — the form does not track a running job", async () => {
     render(<BackfillRunner />);
+    fillBudgets("10", "2");
+    await clickRun("Run baseline on gemini?");
 
-    const stop = await screen.findByRole("button", { name: "Stop running job" });
-    fireEvent.click(stop);
-    const confirm = await screen.findByRole("button", {
-      name: "Stop the running backfill job?",
-    });
-    await act(async () => {
-      fireEvent.click(confirm);
-    });
-
-    await waitFor(() =>
-      expect(mockApi).toHaveBeenCalledWith(
-        "/jobs",
-        expect.objectContaining({
-          method: "POST",
-          json: { jobId: "backfill-connections", action: "stop" },
-        })
-      )
-    );
+    // Only the POST to start — no GET /jobs poll.
+    expect(mockApi.mock.calls.every((c) => c[1]?.method === "POST")).toBe(true);
   });
 });

--- a/components/admin/BackfillRunner.tsx
+++ b/components/admin/BackfillRunner.tsx
@@ -1,18 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
-import { useAsync } from "@/components/admin/useAsync";
 import type { Locale } from "@/lib/i18n/config";
 import { SELECTABLE_MODELS } from "@/lib/ai/models";
 
 const TARGET_LOCALES: Exclude<Locale, "en">[] = ["tr", "ru", "az"];
-
-interface JobsResponse {
-  jobs: { id: string; status: string }[];
-}
 
 /**
  * The "Run the backfill job" console. Its inputs are deliberately kept in a
@@ -21,9 +16,11 @@ interface JobsResponse {
  * values an admin just typed (e.g. while retrying against an "already running"
  * job).
  *
- * The budget fields (max calls / max cost) have no default value on purpose —
- * an accidental "Run backfill" click must not be able to start a run that
- * spends money.
+ * This form does NOT track whether a job is running — starting a second run is
+ * rejected server-side with a visible "already running" message, and stopping a
+ * run lives on the Jobs page. The budget fields (max calls / max cost) have no
+ * default value on purpose: an accidental "Run backfill" click must not be able
+ * to start a run that spends money.
  */
 export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
   const api = useAdminFetch();
@@ -40,22 +37,6 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
   const [runNote, setRunNote] = useState<string | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
-  const [stopping, setStopping] = useState(false);
-
-  const { data: jobData, reload: reloadJobs } = useAsync<JobsResponse>(
-    () => api("/jobs"),
-    "backfill-job-status"
-  );
-  const backfillRunning =
-    jobData?.jobs.find((j) => j.id === "backfill-connections")?.status === "running";
-
-  // Poll while the backfill job is running so the Stop button appears/clears
-  // without a manual reload — mirrors JobRunner's poll.
-  useEffect(() => {
-    if (!backfillRunning) return;
-    const id = setInterval(() => reloadJobs({ keepDataOnError: true }), 4000);
-    return () => clearInterval(id);
-  }, [backfillRunning, reloadJobs]);
 
   const startRun = async () => {
     setRunNote(null);
@@ -81,30 +62,11 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
         },
       });
       setRunNote("Started. Watch progress on the Jobs page.");
-      reloadJobs();
       onStarted?.();
     } catch (e) {
       setRunError(e instanceof AdminApiError ? e.message : "Failed to start the backfill job.");
     } finally {
       setStarting(false);
-    }
-  };
-
-  const stopRun = async () => {
-    setRunNote(null);
-    setRunError(null);
-    setStopping(true);
-    try {
-      await api("/jobs", {
-        method: "POST",
-        json: { jobId: "backfill-connections", action: "stop" },
-      });
-      setRunNote("Stop requested. The job halts after the current verse.");
-      reloadJobs();
-    } catch (e) {
-      setRunError(e instanceof AdminApiError ? e.message : "Failed to stop the backfill job.");
-    } finally {
-      setStopping(false);
     }
   };
 
@@ -207,7 +169,12 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
       <p className="mt-2 text-[11px] text-text-muted">
         Max LLM calls and Max cost are both required — there is no default, so a stray click can
         never start a run. The job stops cleanly at whichever limit is hit first: max calls is
-        exact; max cost is a per-call estimate (token counts aren&apos;t tracked on this path).
+        exact; max cost is a per-call estimate (token counts aren&apos;t tracked on this path). Stop
+        a run in progress from the{" "}
+        <Link href="/admin/jobs" className="underline">
+          Jobs page
+        </Link>
+        .
       </p>
 
       {runError && <StateNote tone="error">{runError}</StateNote>}
@@ -220,25 +187,15 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
         </p>
       )}
 
-      <div className="mt-3 flex flex-wrap gap-2">
+      <div className="mt-3">
         <ConfirmButton
           variant="secondary"
-          disabled={starting || backfillRunning}
+          disabled={starting}
           onConfirm={startRun}
           confirmLabel={`Run ${mode} on ${provider}?`}
         >
           {starting ? "Starting…" : "Run backfill"}
         </ConfirmButton>
-        {backfillRunning && (
-          <ConfirmButton
-            variant="danger"
-            disabled={stopping}
-            onConfirm={stopRun}
-            confirmLabel="Stop the running backfill job?"
-          >
-            {stopping ? "Stopping…" : "Stop running job"}
-          </ConfirmButton>
-        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Why

PR #528 added a `/jobs` status poll, a "Stop running job" button, and a disabled-while-running state to the coverage page's `BackfillRunner`. Two problems in practice:

- The "Run backfill" button stayed disabled well past the actual end of a run — the state came off a 4s poll plus `getJobsStatus` staleness.
- A Stop control belongs on the Jobs page next to the live log, not on the form used to *start* a run.

## What

`BackfillRunner` goes back to a plain form:

- No `/jobs` fetch or poll.
- "Run backfill" is never disabled by job state. Starting a second run while one is in progress is rejected server-side and shows the existing "already running" message (its pre-#528 behaviour).
- **Kept from #528:** the budget fields (Max LLM calls / Max cost) start empty, and `startRun` blocks with an inline message until both are set.

Stopping a run stays on `/admin/jobs` (`JobRunner`) — the "Stop" button on the backfill row, unchanged.

## Tests

`BackfillRunner.test.tsx`: blank budgets block the run and post nothing; the "already running" error leaves the Run button enabled; the form never issues a GET `/jobs`. Removed the stop-button / poll test.

## AI / Theological changes

None.