### PR TITLE
fix(admin): disable backfill Run until budget fields are valid

### DIFF
--- a/__tests__/components/admin/BackfillRunner.test.tsx
+++ b/__tests__/components/admin/BackfillRunner.test.tsx
@@ -34,13 +34,39 @@ describe("BackfillRunner", () => {
     mockApi.mockResolvedValue({ runId: "run_1" });
   });
 
-  it("blocks the run and posts nothing when the budget fields are blank", async () => {
+  it("disables Run and posts nothing while the budget fields are blank", async () => {
     render(<BackfillRunner />);
+
+    expect(screen.getByRole("button", { name: "Run backfill" })).toBeDisabled();
+    expect(screen.getByText(/Enter Max LLM calls and Max cost to enable/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Run backfill" }));
+
+    // Never even arms the two-click confirm.
+    expect(
+      screen.queryByRole("button", { name: "Run baseline on gemini?" })
+    ).not.toBeInTheDocument();
+    expect(mockApi).not.toHaveBeenCalled();
+  });
+
+  it("enables Run once the budgets are filled and then starts the job", async () => {
+    render(<BackfillRunner />);
+
+    expect(screen.getByRole("button", { name: "Run backfill" })).toBeDisabled();
+
+    fillBudgets("10", "2");
+
+    expect(screen.getByRole("button", { name: "Run backfill" })).not.toBeDisabled();
+    expect(
+      screen.queryByText(/Enter Max LLM calls and Max cost to enable/)
+    ).not.toBeInTheDocument();
 
     await clickRun("Run baseline on gemini?");
 
-    expect(await screen.findByText(/Set Max LLM calls and Max cost/)).toBeInTheDocument();
-    expect(mockApi).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByText(/Watch progress on the Jobs page/)).toBeInTheDocument()
+    );
+    expect(mockApi).toHaveBeenCalledWith("/jobs", expect.objectContaining({ method: "POST" }));
   });
 
   it("keeps the admin's typed inputs after an 'already running' error", async () => {

--- a/components/admin/BackfillRunner.tsx
+++ b/components/admin/BackfillRunner.tsx
@@ -38,13 +38,12 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
   const [runError, setRunError] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
 
+  const budgetsInvalid = maxCalls === "" || maxCostUsd === "" || maxCalls <= 0 || maxCostUsd <= 0;
+
   const startRun = async () => {
     setRunNote(null);
     setRunError(null);
-    if (maxCalls === "" || maxCostUsd === "" || maxCalls <= 0 || maxCostUsd <= 0) {
-      setRunError("Set Max LLM calls and Max cost before running.");
-      return;
-    }
+    if (budgetsInvalid) return;
     setStarting(true);
     try {
       await api("/jobs", {
@@ -187,10 +186,16 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
         </p>
       )}
 
+      {budgetsInvalid && (
+        <p className="mt-2 text-[11px] text-text-muted">
+          Enter Max LLM calls and Max cost to enable the run.
+        </p>
+      )}
+
       <div className="mt-3">
         <ConfirmButton
           variant="secondary"
-          disabled={starting}
+          disabled={starting || budgetsInvalid}
           onConfirm={startRun}
           confirmLabel={`Run ${mode} on ${provider}?`}
         >


### PR DESCRIPTION
## Problem

On the admin **Coverage** page, running the backfill job with **Max LLM calls** or **Max cost** blank showed the error *"Set Max LLM calls and Max cost before running."* — and then the form felt permanently stuck: filling in the fields and pressing **Run backfill** again did nothing.

### Root cause

The budget check only ran inside `startRun`, which fires on the **second** (confirming) click of the two-click `ConfirmButton` (3s arm window). After the error, fixing the fields and clicking once only *re-armed* the button (relabel to `Run <mode> on <provider>?`) — no run, no new error. It took a lucky double-click within 3s to actually retry, so it read as broken.

## Fix

- `budgetsInvalid` is now a render-derived condition; the **Run backfill** button is `disabled` until both fields hold positive numbers, with a short hint line so the disabled state is explained.
- The button can no longer arm with invalid input, so the confusing after-the-fact error path is gone. `startRun` keeps a plain defensive early-return (no error text). `runError` now only surfaces API failures.

## Tests

`__tests__/components/admin/BackfillRunner.test.tsx`: replaced the blank-fields error assertion with a disabled-button assertion, and added a test that filling the budgets *after* they were empty enables Run and starts the job. Existing tests unchanged.

- `bun run test:ci -- BackfillRunner` ✅ (6 tests)
- `bun run lint` ✅ / `bun run typecheck` ✅

## AI / Theological changes

None — admin UI only, no prompts or Quran data touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented backfill jobs from starting when budget values are blank or non-positive.
  * Disabled the **Run** button until valid budget values are entered.
  * Added inline guidance prompting administrators to provide both budgets.
  * Confirmed valid budgets allow jobs to start successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->