### PR TITLE
fix(admin): make failed actions look like failures

### DIFF
--- a/__tests__/app/admin/infra/page.test.tsx
+++ b/__tests__/app/admin/infra/page.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockApi = vi.fn();
+vi.mock("@/components/admin/AdminContext", async () => {
+  const actual = await vi.importActual("@/components/admin/AdminContext");
+  return { ...actual, useAdminFetch: () => mockApi };
+});
+
+vi.mock("@/components/admin/InfoHint", () => ({ InfoHint: () => null }));
+
+import InfraPage from "@/app/admin/infra/page";
+import { AdminApiError } from "@/components/admin/AdminContext";
+
+const INFRA = {
+  redis: "disabled" as const,
+  uptimeSeconds: 120,
+  tokenCacheSize: 3,
+  rateLimitRows: 0,
+  metrics: {},
+};
+
+describe("InfraPage — maintenance action feedback", () => {
+  beforeEach(() => mockApi.mockReset());
+
+  it("shows a failed maintenance action in the error tone, not the neutral success style", async () => {
+    mockApi
+      .mockResolvedValueOnce(INFRA) // initial GET /infra
+      .mockRejectedValueOnce(new AdminApiError(503, "Redis unreachable")) // POST
+      .mockResolvedValue(INFRA); // any later reload
+
+    render(<InfraPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Flush token cache" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Flush tokens?" }));
+
+    const note = await screen.findByText("Redis unreachable");
+    expect(note).toHaveClass("text-error");
+  });
+
+  it("shows a successful action in the success tone", async () => {
+    mockApi
+      .mockResolvedValueOnce(INFRA)
+      .mockResolvedValueOnce({ action: "flush-tokens", cleared: 2 })
+      .mockResolvedValue(INFRA);
+
+    render(<InfraPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Flush token cache" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Flush tokens?" }));
+
+    const note = await screen.findByText("Cleared 2 cached tokens.");
+    expect(note).toHaveClass("text-teal");
+  });
+});

--- a/app/admin/ai/page.tsx
+++ b/app/admin/ai/page.tsx
@@ -2,6 +2,7 @@
 
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { StatTile, Table, Th, Td, StateNote } from "@/components/admin/primitives";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 import { useAdminFetch } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 
@@ -36,8 +37,8 @@ export default function AiPage() {
         subtitle="Generation volume and token spend. One row per cache miss — the bill flattens as the graph fills."
       />
       <div className="space-y-6 p-7">
+        {loading && !data && <SkeletonRows n={6} />}
         {error && <StateNote tone="error">{error}</StateNote>}
-        {loading && <StateNote>Loading…</StateNote>}
 
         {data && (
           <>
@@ -72,58 +73,54 @@ export default function AiPage() {
             <div className="grid gap-6 lg:grid-cols-2">
               <section>
                 <h2 className="mb-2 text-sm font-medium text-text-primary">By model</h2>
-                <Table>
-                  <thead>
-                    <tr>
-                      <Th>Model</Th>
-                      <Th className="text-right">Gens</Th>
-                      <Th className="text-right">Tokens</Th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {data.byModel.map((r) => (
-                      <tr key={r.model}>
-                        <Td className="font-mono text-xs text-text-secondary">{r.model}</Td>
-                        <Td className="text-right tabular-nums">{r.gens}</Td>
-                        <Td className="text-right tabular-nums">{r.tokens.toLocaleString()}</Td>
-                      </tr>
-                    ))}
-                    {data.byModel.length === 0 && (
+                {data.byModel.length === 0 ? (
+                  <StateNote>No generations yet.</StateNote>
+                ) : (
+                  <Table>
+                    <thead>
                       <tr>
-                        <Td className="text-text-muted">No generations yet.</Td>
-                        <Td /> <Td />
+                        <Th>Model</Th>
+                        <Th className="text-right">Gens</Th>
+                        <Th className="text-right">Tokens</Th>
                       </tr>
-                    )}
-                  </tbody>
-                </Table>
+                    </thead>
+                    <tbody>
+                      {data.byModel.map((r) => (
+                        <tr key={r.model}>
+                          <Td className="font-mono text-xs text-text-secondary">{r.model}</Td>
+                          <Td className="text-right tabular-nums">{r.gens}</Td>
+                          <Td className="text-right tabular-nums">{r.tokens.toLocaleString()}</Td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                )}
               </section>
 
               <section>
                 <h2 className="mb-2 text-sm font-medium text-text-primary">By kind</h2>
-                <Table>
-                  <thead>
-                    <tr>
-                      <Th>Kind</Th>
-                      <Th className="text-right">Gens</Th>
-                      <Th className="text-right">Tokens</Th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {data.byKind.map((r) => (
-                      <tr key={r.kind}>
-                        <Td className="text-xs text-text-secondary">{r.kind}</Td>
-                        <Td className="text-right tabular-nums">{r.gens}</Td>
-                        <Td className="text-right tabular-nums">{r.tokens.toLocaleString()}</Td>
-                      </tr>
-                    ))}
-                    {data.byKind.length === 0 && (
+                {data.byKind.length === 0 ? (
+                  <StateNote>No generations yet.</StateNote>
+                ) : (
+                  <Table>
+                    <thead>
                       <tr>
-                        <Td className="text-text-muted">No generations yet.</Td>
-                        <Td /> <Td />
+                        <Th>Kind</Th>
+                        <Th className="text-right">Gens</Th>
+                        <Th className="text-right">Tokens</Th>
                       </tr>
-                    )}
-                  </tbody>
-                </Table>
+                    </thead>
+                    <tbody>
+                      {data.byKind.map((r) => (
+                        <tr key={r.kind}>
+                          <Td className="text-xs text-text-secondary">{r.kind}</Td>
+                          <Td className="text-right tabular-nums">{r.gens}</Td>
+                          <Td className="text-right tabular-nums">{r.tokens.toLocaleString()}</Td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                )}
               </section>
             </div>
 

--- a/app/admin/ai/page.tsx
+++ b/app/admin/ai/page.tsx
@@ -2,6 +2,7 @@
 
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { StatTile, Table, Th, Td, StateNote } from "@/components/admin/primitives";
+import { SectionHeading } from "@/components/admin/SectionHeading";
 import { SkeletonRows } from "@/components/admin/Skeleton";
 import { useAdminFetch } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
@@ -72,7 +73,7 @@ export default function AiPage() {
 
             <div className="grid gap-6 lg:grid-cols-2">
               <section>
-                <h2 className="mb-2 text-sm font-medium text-text-primary">By model</h2>
+                <SectionHeading title="By model" />
                 {data.byModel.length === 0 ? (
                   <StateNote>No generations yet.</StateNote>
                 ) : (
@@ -98,7 +99,7 @@ export default function AiPage() {
               </section>
 
               <section>
-                <h2 className="mb-2 text-sm font-medium text-text-primary">By kind</h2>
+                <SectionHeading title="By kind" />
                 {data.byKind.length === 0 ? (
                   <StateNote>No generations yet.</StateNote>
                 ) : (
@@ -125,7 +126,7 @@ export default function AiPage() {
             </div>
 
             <section>
-              <h2 className="mb-2 text-sm font-medium text-text-primary">Last 30 days</h2>
+              <SectionHeading title="Last 30 days" />
               {data.daily.length === 0 ? (
                 <StateNote>No activity in the last 30 days.</StateNote>
               ) : (

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -2,6 +2,7 @@
 
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { StatTile, Table, Th, Td, StateNote } from "@/components/admin/primitives";
+import { SectionHeading } from "@/components/admin/SectionHeading";
 import { useAdminFetch } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import { RefreshButton } from "@/components/admin/RefreshButton";
@@ -165,11 +166,8 @@ function Section({
   children: React.ReactNode;
 }) {
   return (
-    <div className="space-y-2">
-      <div>
-        <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
-        {subtitle && <p className="text-xs text-text-muted">{subtitle}</p>}
-      </div>
+    <div>
+      <SectionHeading title={title} subtitle={subtitle} />
       {children}
     </div>
   );

--- a/app/admin/audit/page.tsx
+++ b/app/admin/audit/page.tsx
@@ -5,6 +5,7 @@ import { Table, Th, Td, StateNote, LoadMore } from "@/components/admin/primitive
 import { SkeletonRows } from "@/components/admin/Skeleton";
 import { useAdminFetch } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
+import { formatTimestamp } from "@/lib/admin/format";
 
 interface Entry {
   id: number;
@@ -29,7 +30,7 @@ export default function AuditPage() {
   return (
     <>
       <AdminPageHeader title="Audit Log" subtitle="Every mutating admin action, newest first." />
-      <div className="space-y-4 p-7">
+      <div className="space-y-6 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
         {loading && <SkeletonRows />}
         {!loading && !error && rows.length === 0 && (
@@ -50,7 +51,7 @@ export default function AuditPage() {
               {rows.map((e) => (
                 <tr key={e.id}>
                   <Td className="whitespace-nowrap text-xs text-text-muted">
-                    {new Date(e.createdAt).toLocaleString()}
+                    {formatTimestamp(e.createdAt)}
                   </Td>
                   <Td className="whitespace-nowrap font-mono text-xs text-gold">{e.action}</Td>
                   <Td className="whitespace-nowrap text-xs text-text-secondary">

--- a/app/admin/audit/page.tsx
+++ b/app/admin/audit/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { AdminPageHeader } from "@/components/admin/AdminShell";
-import { Table, Th, Td, StateNote } from "@/components/admin/primitives";
+import { Table, Th, Td, StateNote, LoadMore } from "@/components/admin/primitives";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 import { useAdminFetch } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
-import { Button } from "@/components/ui";
 
 interface Entry {
   id: number;
@@ -31,7 +31,7 @@ export default function AuditPage() {
       <AdminPageHeader title="Audit Log" subtitle="Every mutating admin action, newest first." />
       <div className="space-y-4 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
-        {loading && <StateNote>Loading…</StateNote>}
+        {loading && <SkeletonRows />}
         {!loading && !error && rows.length === 0 && (
           <StateNote>No admin actions recorded yet.</StateNote>
         )}
@@ -67,14 +67,12 @@ export default function AuditPage() {
           </Table>
         )}
 
-        {hasMore && (
-          <div className="flex flex-col items-center gap-2">
-            <Button variant="secondary" size="sm" onClick={loadMore} disabled={loadingMore}>
-              {loadingMore ? "Loading…" : "Load more"}
-            </Button>
-            {loadMoreError && <StateNote tone="error">Couldn&apos;t load more entries.</StateNote>}
-          </div>
-        )}
+        <LoadMore
+          hasMore={hasMore}
+          loading={loadingMore}
+          error={loadMoreError}
+          onClick={loadMore}
+        />
       </div>
     </>
   );

--- a/app/admin/connections/page.tsx
+++ b/app/admin/connections/page.tsx
@@ -13,6 +13,7 @@ import {
   LoadMore,
 } from "@/components/admin/primitives";
 import { AdminToggle } from "@/components/admin/AdminToggle";
+import { formatTimestamp } from "@/lib/admin/format";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
 import { ExpandableText } from "@/components/admin/ExpandableText";
@@ -106,7 +107,7 @@ export default function ConnectionsPage() {
         title="Connections"
         subtitle="Moderate AI-generated edges. Flag suspect links or retire them from the graph."
       />
-      <div className="space-y-4 p-7">
+      <div className="space-y-6 p-7">
         <div className="flex flex-wrap items-center gap-4">
           <AdminToggle
             label="Review"
@@ -172,7 +173,7 @@ export default function ConnectionsPage() {
                   </Td>
                   <Td className="whitespace-nowrap text-xs text-text-secondary">
                     {c.reviewedAt ? (
-                      new Date(c.reviewedAt).toLocaleString()
+                      formatTimestamp(c.reviewedAt)
                     ) : (
                       <Pill tone="flagged">pending</Pill>
                     )}

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -6,6 +6,8 @@ import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, StateNote, ConfirmButton, Panel } from "@/components/admin/primitives";
 import { Field } from "@/components/admin/Field";
 import { Feedback } from "@/components/admin/Feedback";
+import { SectionHeading } from "@/components/admin/SectionHeading";
+import { formatTimestamp } from "@/lib/admin/format";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import { KNOWN_OPERATIONAL_FLAG_KEYS } from "@/lib/admin/feature-flag-keys";
@@ -100,7 +102,7 @@ function OperationalSettings({
 
   return (
     <Panel className="space-y-4">
-      <h2 className="text-sm font-medium text-text-primary">Operational settings</h2>
+      <SectionHeading title="Operational settings" />
 
       <div className="space-y-2">
         <span className="text-xs text-text-secondary">
@@ -366,7 +368,7 @@ export default function FlagsPage() {
                     <span className="line-clamp-2 break-all">{JSON.stringify(f.value)}</span>
                   </Td>
                   <Td className="whitespace-nowrap text-xs text-text-muted">
-                    {new Date(f.updatedAt).toLocaleDateString()}
+                    {formatTimestamp(f.updatedAt)}
                   </Td>
                   <Td>
                     <div className="flex justify-end gap-1.5">

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -5,6 +5,7 @@ import { Button, Input, Textarea, NativeSelect } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, StateNote, ConfirmButton, Panel } from "@/components/admin/primitives";
 import { Field } from "@/components/admin/Field";
+import { Feedback } from "@/components/admin/Feedback";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import { KNOWN_OPERATIONAL_FLAG_KEYS } from "@/lib/admin/feature-flag-keys";
@@ -241,7 +242,7 @@ function OperationalSettings({
         </Field>
       </div>
 
-      {msg && <span className="text-xs text-error">{msg}</span>}
+      {msg && <Feedback tone="error">{msg}</Feedback>}
     </Panel>
   );
 }
@@ -339,7 +340,7 @@ export default function FlagsPage() {
             >
               Save flag
             </Button>
-            {msg && <span className="text-xs text-error">{msg}</span>}
+            {msg && <Feedback tone="error">{msg}</Feedback>}
           </div>
         </Panel>
 

--- a/app/admin/infra/page.tsx
+++ b/app/admin/infra/page.tsx
@@ -12,6 +12,8 @@ import {
   ConfirmButton,
 } from "@/components/admin/primitives";
 import { InfoHint } from "@/components/admin/InfoHint";
+import { Feedback } from "@/components/admin/Feedback";
+import { useActionMessage } from "@/components/admin/useActionMessage";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import { RefreshButton } from "@/components/admin/RefreshButton";
@@ -35,22 +37,22 @@ function uptime(s: number): string {
 export default function InfraPage() {
   const api = useAdminFetch();
   const { data, error, loading, reload } = useAsync<Infra>(() => api("/infra"), "infra");
-  const [msg, setMsg] = useState<string | null>(null);
+  const { message, ok, fail, clear } = useActionMessage();
   const [busy, setBusy] = useState(false);
 
   const run = async (action: string) => {
     if (busy) return; // guard against concurrent maintenance operations
-    setMsg(null);
+    clear();
     setBusy(true);
     try {
       const res = await api<Parameters<typeof formatInfraResult>[0]>("/infra", {
         method: "POST",
         json: { action },
       });
-      setMsg(formatInfraResult(res));
+      ok(formatInfraResult(res));
       reload();
     } catch (e) {
-      setMsg(e instanceof AdminApiError ? e.message : "Action failed.");
+      fail(e instanceof AdminApiError ? e.message : "Action failed.");
     } finally {
       setBusy(false);
     }
@@ -137,7 +139,7 @@ export default function InfraPage() {
                   Reset rate limits
                 </ConfirmButton>
               </div>
-              {msg && <p className="text-xs text-text-secondary">{msg}</p>}
+              {message && <Feedback tone={message.tone}>{message.text}</Feedback>}
             </section>
 
             <section>

--- a/app/admin/infra/page.tsx
+++ b/app/admin/infra/page.tsx
@@ -10,8 +10,10 @@ import {
   Pill,
   StateNote,
   ConfirmButton,
+  Panel,
 } from "@/components/admin/primitives";
 import { InfoHint } from "@/components/admin/InfoHint";
+import { SectionHeading } from "@/components/admin/SectionHeading";
 import { Feedback } from "@/components/admin/Feedback";
 import { useActionMessage } from "@/components/admin/useActionMessage";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
@@ -111,8 +113,8 @@ export default function InfraPage() {
               </div>
             </div>
 
-            <section className="space-y-3 rounded-lg border border-border bg-surface p-5">
-              <h2 className="text-sm font-medium text-text-primary">Maintenance</h2>
+            <Panel className="space-y-3">
+              <SectionHeading title="Maintenance" />
               <div className="flex flex-wrap gap-2">
                 <ConfirmButton
                   variant="secondary"
@@ -140,10 +142,10 @@ export default function InfraPage() {
                 </ConfirmButton>
               </div>
               {message && <Feedback tone={message.tone}>{message.text}</Feedback>}
-            </section>
+            </Panel>
 
             <section>
-              <h2 className="mb-2 text-sm font-medium text-text-primary">Process metrics</h2>
+              <SectionHeading title="Process metrics" />
               {Object.keys(data.metrics).length === 0 ? (
                 <StateNote>No counters recorded yet.</StateNote>
               ) : (

--- a/app/admin/names/page.tsx
+++ b/app/admin/names/page.tsx
@@ -12,6 +12,7 @@ import {
   ConfirmButton,
   LoadMore,
 } from "@/components/admin/primitives";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
 import { useArmedConfirm } from "@/hooks/useArmedConfirm";
@@ -92,7 +93,7 @@ export default function NamesPage() {
       <div className="space-y-4 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
         {msg && <StateNote tone="error">{msg}</StateNote>}
-        {loading && <StateNote>Loading…</StateNote>}
+        {loading && <SkeletonRows />}
         {!loading && !error && rows.length === 0 && (
           <StateNote>No cached name content yet.</StateNote>
         )}

--- a/app/admin/names/page.tsx
+++ b/app/admin/names/page.tsx
@@ -90,7 +90,7 @@ export default function NamesPage() {
         title="Names Content"
         subtitle="Cached AI content per Divine Name. Edit the payload or invalidate to regenerate."
       />
-      <div className="space-y-4 p-7">
+      <div className="space-y-6 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
         {msg && <StateNote tone="error">{msg}</StateNote>}
         {loading && <SkeletonRows />}

--- a/app/admin/prompts/page.tsx
+++ b/app/admin/prompts/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/admin/primitives";
 import { AdminToggle } from "@/components/admin/AdminToggle";
 import { SkeletonRows } from "@/components/admin/Skeleton";
+import { formatTimestamp } from "@/lib/admin/format";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import { useArmedConfirm } from "@/hooks/useArmedConfirm";
@@ -84,7 +85,7 @@ export default function PromptsPage() {
         title="Prompts"
         subtitle="Versioned templates for the AI connection generator. No active version means the hardcoded fallback is used."
       />
-      <div className="space-y-4 p-7">
+      <div className="space-y-6 p-7">
         {/* Locked during the armed window — otherwise a confirmed create could
             activate the draft in a slot the user never confirmed for. */}
         <AdminToggle
@@ -165,7 +166,7 @@ export default function PromptsPage() {
                     {v.createdBy ?? "—"}
                   </Td>
                   <Td className="whitespace-nowrap text-xs text-text-secondary">
-                    {new Date(v.createdAt).toLocaleString()}
+                    {formatTimestamp(v.createdAt)}
                   </Td>
                   <Td>
                     <div className="flex justify-end">

--- a/app/admin/prompts/page.tsx
+++ b/app/admin/prompts/page.tsx
@@ -13,6 +13,7 @@ import {
   Panel,
 } from "@/components/admin/primitives";
 import { AdminToggle } from "@/components/admin/AdminToggle";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import { useArmedConfirm } from "@/hooks/useArmedConfirm";
@@ -133,7 +134,7 @@ export default function PromptsPage() {
           </div>
         </Panel>
 
-        {loading && <StateNote>Loading…</StateNote>}
+        {loading && !data && <SkeletonRows />}
         {data && data.versions.length === 0 && (
           <StateNote>No versions yet for this slot — using the hardcoded fallback.</StateNote>
         )}

--- a/app/admin/stories/page.tsx
+++ b/app/admin/stories/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Button, Input } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 
@@ -67,9 +68,10 @@ export default function AdminStoriesPage() {
       <div className="space-y-4 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
         {actionError && <StateNote tone="error">{actionError}</StateNote>}
-        {loading && <StateNote>Loading…</StateNote>}
+        {loading && <SkeletonRows />}
+        {data && data.stories.length === 0 && <StateNote>No stories found.</StateNote>}
 
-        {data && (
+        {data && data.stories.length > 0 && (
           <Table>
             <thead>
               <tr>

--- a/app/admin/stories/page.tsx
+++ b/app/admin/stories/page.tsx
@@ -65,7 +65,7 @@ export default function AdminStoriesPage() {
         title="Stories"
         subtitle="Hardcoded prophetic narratives. Flag one to pull it from /stories immediately if something in it is wrong — it stays hidden until you restore it, no redeploy needed."
       />
-      <div className="space-y-4 p-7">
+      <div className="space-y-6 p-7">
         {error && <StateNote tone="error">{error}</StateNote>}
         {actionError && <StateNote tone="error">{actionError}</StateNote>}
         {loading && <SkeletonRows />}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -3,7 +3,16 @@
 import { useState } from "react";
 import { Button, Input } from "@/components/ui";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
-import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
+import {
+  Table,
+  Th,
+  Td,
+  Pill,
+  StateNote,
+  ConfirmButton,
+  LoadMore,
+} from "@/components/admin/primitives";
+import { formatTimestamp } from "@/lib/admin/format";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
 import { SkeletonRows } from "@/components/admin/Skeleton";
@@ -58,7 +67,7 @@ export default function UsersPage() {
   return (
     <>
       <AdminPageHeader title="Users" subtitle="View activity and moderate accounts." />
-      <div className="space-y-4 p-7">
+      <div className="space-y-6 p-7">
         <form
           className="flex max-w-sm gap-2"
           onSubmit={(e) => {
@@ -109,7 +118,7 @@ export default function UsersPage() {
                     <span className="text-text-muted">/ {u.longestStreak} best</span>
                   </Td>
                   <Td className="whitespace-nowrap text-xs text-text-muted">
-                    {new Date(u.lastActiveAt).toLocaleDateString()}
+                    {formatTimestamp(u.lastActiveAt)}
                   </Td>
                   <Td>
                     {u.disabledAt ? (
@@ -148,14 +157,12 @@ export default function UsersPage() {
           </Table>
         )}
 
-        {hasMore && (
-          <div className="flex flex-col items-center gap-2">
-            <Button variant="secondary" size="sm" onClick={loadMore} disabled={loadingMore}>
-              {loadingMore ? "Loading…" : "Load more"}
-            </Button>
-            {loadMoreError && <StateNote tone="error">Couldn&apos;t load more users.</StateNote>}
-          </div>
-        )}
+        <LoadMore
+          hasMore={hasMore}
+          loading={loadingMore}
+          error={loadMoreError}
+          onClick={loadMore}
+        />
       </div>
     </>
   );

--- a/app/admin/votd/page.tsx
+++ b/app/admin/votd/page.tsx
@@ -7,6 +7,8 @@ import { cn } from "@/lib/utils";
 import { AdminPageHeader } from "@/components/admin/AdminShell";
 import { StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { Field } from "@/components/admin/Field";
+import { Feedback } from "@/components/admin/Feedback";
+import { useActionMessage } from "@/components/admin/useActionMessage";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import type { Verse } from "@/types/quran";
@@ -328,7 +330,7 @@ function DayEditor({
   const [preview, setPreview] = useState<Verse | null>(null);
   const [busy, setBusy] = useState(false);
   const [previewBusy, setPreviewBusy] = useState(false);
-  const [msg, setMsg] = useState<string | null>(null);
+  const { message, ok, fail, clear: clearMsg } = useActionMessage();
   // `todayRef` arrives from an async fetch (useAsync) that can resolve after
   // this component has already mounted with it still null/undefined — sync
   // the field once it lands, but only while the admin hasn't started typing,
@@ -351,23 +353,23 @@ function DayEditor({
 
   const doPreview = async () => {
     if (previewBusy) return;
-    setMsg(null);
+    clearMsg();
     setPreview(null);
     const match = /^(\d+):(\d+)$/.exec(verseRef.trim());
     if (!match) {
-      setMsg("Enter a reference like 2:255.");
+      fail("Enter a reference like 2:255.");
       return;
     }
     setPreviewBusy(true);
     try {
       const v = await fetch(`/api/verse/${match[1]}/${match[2]}`);
       if (!v.ok) {
-        setMsg("That verse could not be found.");
+        fail("That verse could not be found.");
         return;
       }
       setPreview((await v.json()) as Verse);
     } catch {
-      setMsg("Preview failed.");
+      fail("Preview failed.");
     } finally {
       setPreviewBusy(false);
     }
@@ -375,13 +377,13 @@ function DayEditor({
 
   const save = async () => {
     setBusy(true);
-    setMsg(null);
+    clearMsg();
     try {
       await api("/votd", { method: "PUT", json: { date, verseRef: verseRef.trim(), reflection } });
-      setMsg("Saved.");
+      ok("Saved.");
       onSaved();
     } catch (e) {
-      setMsg(e instanceof AdminApiError ? e.message : "Save failed.");
+      fail(e instanceof AdminApiError ? e.message : "Save failed.");
     } finally {
       setBusy(false);
     }
@@ -389,13 +391,13 @@ function DayEditor({
 
   const clear = async () => {
     setBusy(true);
-    setMsg(null);
+    clearMsg();
     try {
       await api(`/votd?date=${date}`, { method: "DELETE" });
-      setMsg("Cleared.");
+      ok("Cleared.");
       onSaved();
     } catch (e) {
-      setMsg(e instanceof AdminApiError ? e.message : "Clear failed.");
+      fail(e instanceof AdminApiError ? e.message : "Clear failed.");
     } finally {
       setBusy(false);
     }
@@ -457,7 +459,7 @@ function DayEditor({
         )}
       </div>
 
-      {msg && <p className="text-xs text-text-secondary">{msg}</p>}
+      {message && <Feedback tone={message.tone}>{message.text}</Feedback>}
     </div>
   );
 }

--- a/components/admin/BackfillRunner.tsx
+++ b/components/admin/BackfillRunner.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Input, NativeSelect } from "@/components/ui";
 import { StateNote, ConfirmButton, Panel } from "@/components/admin/primitives";
 import { Field } from "@/components/admin/Field";
+import { SectionHeading } from "@/components/admin/SectionHeading";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import type { Locale } from "@/lib/i18n/config";
 import { SELECTABLE_MODELS } from "@/lib/ai/models";
@@ -73,7 +74,7 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
 
   return (
     <Panel>
-      <h3 className="text-sm font-semibold text-text-primary">Run the backfill job</h3>
+      <SectionHeading title="Run the backfill job" />
       <p className="mt-1 text-xs text-text-muted">
         Generates connections for verses that have none (baseline) or tops up the thinnest cells
         (top-up). Resumable — already-generated connections are never regenerated, and a cell with

--- a/components/admin/ChallengeSuggestionsManager.tsx
+++ b/components/admin/ChallengeSuggestionsManager.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/admin/primitives";
 import { Field } from "@/components/admin/Field";
 import { Feedback } from "@/components/admin/Feedback";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 
@@ -208,7 +209,7 @@ export function ChallengeSuggestionsManager() {
       </Panel>
 
       {error && <StateNote tone="error">{error}</StateNote>}
-      {loading && <StateNote>Loading…</StateNote>}
+      {loading && !data && <SkeletonRows />}
       {data && data.suggestions.length === 0 && <StateNote>No suggestions yet.</StateNote>}
 
       {data && data.suggestions.length > 0 && (

--- a/components/admin/ChallengeSuggestionsManager.tsx
+++ b/components/admin/ChallengeSuggestionsManager.tsx
@@ -12,6 +12,7 @@ import {
   Panel,
 } from "@/components/admin/primitives";
 import { Field } from "@/components/admin/Field";
+import { Feedback } from "@/components/admin/Feedback";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 
@@ -202,7 +203,7 @@ export function ChallengeSuggestionsManager() {
               Cancel
             </Button>
           )}
-          {msg && <span className="text-xs text-error">{msg}</span>}
+          {msg && <Feedback tone="error">{msg}</Feedback>}
         </div>
       </Panel>
 

--- a/components/admin/ChallengesModeration.tsx
+++ b/components/admin/ChallengesModeration.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import {
   Table,
   Th,
@@ -12,11 +12,12 @@ import {
   LoadMore,
 } from "@/components/admin/primitives";
 import { AdminToggle } from "@/components/admin/AdminToggle";
+import { useArmedConfirm } from "@/hooks/useArmedConfirm";
+import { cn } from "@/lib/utils";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { usePaginated } from "@/components/admin/usePaginated";
 import { SkeletonRows } from "@/components/admin/Skeleton";
 import { useAdminAnnounce } from "@/components/admin/AdminLiveRegion";
-import { cn } from "@/lib/utils";
 
 interface AdminChallenge {
   id: number;
@@ -294,8 +295,9 @@ export function ChallengesModeration() {
   );
 }
 
-/** Same two-click confirm as `ConfirmButton`, but sized for the compact inline
- *  winner-override row instead of the standard `Button`. */
+/** Same two-click confirm as `ConfirmButton` (shares `useArmedConfirm`), but
+ *  sized for the compact inline winner-override row instead of the standard
+ *  `Button`. */
 function OverrideButton({
   label,
   onConfirm,
@@ -305,29 +307,12 @@ function OverrideButton({
   onConfirm: () => void;
   disabled?: boolean;
 }) {
-  const [armed, setArmed] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(
-    () => () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    },
-    []
-  );
+  const { armed, trigger } = useArmedConfirm(onConfirm);
 
   return (
     <button
       disabled={disabled}
-      onClick={() => {
-        if (timerRef.current) clearTimeout(timerRef.current);
-        if (armed) {
-          setArmed(false);
-          onConfirm();
-        } else {
-          setArmed(true);
-          timerRef.current = setTimeout(() => setArmed(false), 3000);
-        }
-      }}
+      onClick={trigger}
       className={cn(
         "rounded px-1 text-[11px] transition-colors disabled:opacity-50",
         armed ? "text-error" : "text-text-secondary hover:text-gold"

--- a/components/admin/CoverageReport.tsx
+++ b/components/admin/CoverageReport.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { NativeSelect } from "@/components/ui";
 import { Table, Th, Td, Pill, StatTile, StateNote } from "@/components/admin/primitives";
+import { SectionHeading } from "@/components/admin/SectionHeading";
 import { useAdminFetch } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 import { SkeletonRows } from "@/components/admin/Skeleton";
@@ -35,7 +36,7 @@ export function CoverageReport() {
   const totalExhausted = data ? data.matrix.reduce((sum, c) => sum + c.exhausted, 0) : 0;
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       {error && <StateNote tone="error">{error}</StateNote>}
       {loading && !data && <SkeletonRows n={8} />}
 
@@ -62,9 +63,7 @@ export function CoverageReport() {
           </div>
 
           <section>
-            <h3 className="mb-2 text-sm font-semibold text-text-primary">
-              Verses missing a connection (kind × language)
-            </h3>
+            <SectionHeading title="Verses missing a connection (kind × language)" />
             <Table>
               <thead>
                 <tr>
@@ -121,7 +120,7 @@ export function CoverageReport() {
           </section>
 
           <section>
-            <h3 className="mb-2 text-sm font-semibold text-text-primary">Missing verses</h3>
+            <SectionHeading title="Missing verses" />
             <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">
               <NativeSelect
                 aria-label="Connection kind"
@@ -162,9 +161,9 @@ export function CoverageReport() {
           </section>
 
           <section>
-            <h3 className="mb-2 text-sm font-semibold text-text-primary">
-              Per-surah coverage ({focusLocale.toUpperCase()}) — verses with a connection, per kind
-            </h3>
+            <SectionHeading
+              title={`Per-surah coverage (${focusLocale.toUpperCase()}) — verses with a connection, per kind`}
+            />
             <div className="max-h-96 overflow-y-auto">
               <Table>
                 <thead>

--- a/components/admin/JobRunner.tsx
+++ b/components/admin/JobRunner.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
+import { SkeletonRows } from "@/components/admin/Skeleton";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 
@@ -75,7 +76,7 @@ export function JobRunner() {
     <div className="space-y-4">
       {error && <StateNote tone="error">{error}</StateNote>}
       {actionError && <StateNote tone="error">{actionError}</StateNote>}
-      {loading && <StateNote>Loading…</StateNote>}
+      {loading && !data && <SkeletonRows n={3} />}
 
       {data && (
         <Table>

--- a/components/admin/JobRunner.tsx
+++ b/components/admin/JobRunner.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Table, Th, Td, Pill, StateNote, ConfirmButton } from "@/components/admin/primitives";
 import { SkeletonRows } from "@/components/admin/Skeleton";
+import { formatTimestamp } from "@/lib/admin/format";
 import { useAdminFetch, AdminApiError } from "@/components/admin/AdminContext";
 import { useAsync } from "@/components/admin/useAsync";
 
@@ -97,7 +98,7 @@ export function JobRunner() {
                   <Pill tone={statusTone(job.status)}>{job.status.replace("-", " ")}</Pill>
                 </Td>
                 <Td className="whitespace-nowrap text-xs text-text-muted">
-                  {job.startedAt ? new Date(job.startedAt).toLocaleString() : "—"}
+                  {job.startedAt ? formatTimestamp(job.startedAt) : "—"}
                 </Td>
                 <Td className="max-w-sm">
                   {job.id === "embed-corpus" && (


### PR DESCRIPTION
Stacked on #533.

## The bug

The Infra maintenance panel and the VOTD day editor stored the result of a save/clear/action in one `msg` string and rendered it in a neutral `text-text-secondary` line — so **"Saved." and "Save failed." were visually identical**. A failed cache flush or a rejected verse save looked exactly like a success.

## Fix

Route both through the shared `Feedback` component via `useActionMessage` (from #531): the tone (teal success / red error) is bound to the message text at the call site (`ok()` / `fail()`), so a failure can't be rendered in the success style.

Also converts the two remaining ad-hoc inline `text-error` spans (flags, ChallengeSuggestionsManager) to `Feedback`, for one error-feedback treatment across the console.

## Tests

New `__tests__/app/admin/infra/page.test.tsx`: a rejected maintenance action surfaces in `text-error`, a success in `text-teal`. votd / flags / suggestions / infra suites pass (22 tests). Typecheck / eslint / prettier clean.

## AI / Theological changes

None — but note this makes a failed **verse-of-the-day save** visibly fail instead of silently appearing to succeed, which is a correctness win for curated Quran content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)