### PR TITLE
chore(ci): auto-triage issues and PRs (labels, assignee, milestone)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,61 @@
+# Path -> label map for actions/labeler (see .github/workflows/pr-labeler.yml).
+# Labels must already exist in the repo. `sync-labels: false` in the workflow
+# means these are only ever added, never removed — a human-applied label stays.
+
+API:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/api/**"
+          - "lib/ai/**"
+          - "lib/quran/**"
+
+admin:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/admin/**"
+          - "lib/admin/**"
+
+db:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "lib/infra/db/**"
+          - "drizzle.config.ts"
+
+CI/CD:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - "docker-compose.yml"
+
+dockerfile:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Dockerfile"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "__tests__/**"
+          - "e2e/**"
+          - "**/*.test.ts"
+          - "**/*.spec.ts"
+
+UX/UI:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "components/**"
+          - "app/**/*.tsx"
+          - "app/globals.css"
+          - "messages/**"
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package.json"
+          - "bun.lock"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,26 @@
+name: PR labeler
+
+# Adds area labels to PRs based on which paths changed (map in
+# .github/labeler.yml). Uses `pull_request_target` so PRs from forks also get
+# labeled — labeler@v5 reads its config from the base branch and never checks
+# out PR head code, so there is no untrusted-code execution here.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply path labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: false

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -51,12 +51,16 @@ jobs:
             // 2. Milestone — the ongoing one: earliest open milestone whose due
             //    date is still in the future. Skip if the item already has one.
             if (!item.milestone) {
-              const { data: milestones } = await github.rest.issues.listMilestones({
-                ...context.repo,
-                state: "open",
-                sort: "due_on",
-                direction: "asc",
-              });
+              const milestones = await github.paginate(
+                github.rest.issues.listMilestones,
+                {
+                  ...context.repo,
+                  state: "open",
+                  sort: "due_on",
+                  direction: "asc",
+                  per_page: 100,
+                },
+              );
               const now = Date.now();
               const target = milestones.find(
                 (m) => m.due_on && Date.parse(m.due_on) >= now,

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,92 @@
+name: Auto triage
+
+# On issue / PR creation, fill in the fields that are otherwise set by hand:
+#   - assignee: the author (if unset and the author is a real user)
+#   - milestone: the currently-running milestone (earliest open one whose due
+#     date has not passed), if unset
+#   - label: a conventional-commit prefix on the title -> matching label, as a
+#     fallback for items opened without an issue template
+# None of these override a choice a human already made on the item.
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: triage-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    name: Assign, milestone, label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const item = context.payload.issue ?? context.payload.pull_request;
+            const issue_number = item.number;
+            const author = item.user?.login;
+
+            // 1. Assignee — author, if nobody is assigned and the author is a real user.
+            if ((item.assignees ?? []).length === 0 && author && !author.endsWith("[bot]")) {
+              try {
+                await github.rest.issues.addAssignees({
+                  ...context.repo,
+                  issue_number,
+                  assignees: [author],
+                });
+              } catch (e) {
+                // External contributors who aren't collaborators can't be assigned.
+                core.warning(`Could not assign @${author}: ${e.message}`);
+              }
+            }
+
+            // 2. Milestone — the ongoing one: earliest open milestone whose due
+            //    date is still in the future. Skip if the item already has one.
+            if (!item.milestone) {
+              const { data: milestones } = await github.rest.issues.listMilestones({
+                ...context.repo,
+                state: "open",
+                sort: "due_on",
+                direction: "asc",
+              });
+              const now = Date.now();
+              const target = milestones.find(
+                (m) => m.due_on && Date.parse(m.due_on) >= now,
+              );
+              if (target) {
+                await github.rest.issues.update({
+                  ...context.repo,
+                  issue_number,
+                  milestone: target.number,
+                });
+                core.info(`Milestone set to "${target.title}" (#${target.number}).`);
+              } else {
+                core.info("No open milestone with a future due date; leaving milestone unset.");
+              }
+            }
+
+            // 3. Label fallback — conventional-commit prefix on the title.
+            const prefixLabels = {
+              feat: "enhancement",
+              fix: "bug",
+              docs: "docs",
+              chore: "chore",
+            };
+            const prefix = (item.title || "").match(/^(\w+)(\([^)]*\))?!?:/)?.[1];
+            const label = prefixLabels[prefix];
+            const current = (item.labels ?? []).map((l) => (typeof l === "string" ? l : l.name));
+            if (label && !current.includes(label)) {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number,
+                labels: [label],
+              });
+            }


### PR DESCRIPTION
## Summary

The GitHub Project board already auto-moves items to **Done** on merge/close, but
labels, assignee, and milestone are still set by hand on every issue and PR. This
adds three workflows that fill those in on creation, without overriding anything a
human already set.

- **`.github/labeler.yml` + `.github/workflows/pr-labeler.yml`** — `actions/labeler@v5`
  applies area labels from the changed paths (`lib/ai/**` → `API`, `app/admin/**`
  → `admin`, `lib/infra/db/**` → `db`, `.github/workflows/**` → `CI/CD`, tests,
  docs, deps, …). `sync-labels: false` — labels are only ever added, a
  manually-applied label is never stripped. Runs on `pull_request_target` so fork
  PRs are covered; labeler@v5 reads its config from the base branch and never
  checks out PR head code.
- **`.github/workflows/triage.yml`** — on issue / PR `opened`/`reopened`, one
  `actions/github-script@v7` step:
  - assigns the **author** (skipped if already assigned, or author is a bot, or
    the author isn't a repo collaborator — that last case just logs a warning);
  - sets the **ongoing milestone**: the earliest open milestone whose `due_on` is
    still in the future (today: `Enhancement`, due 2026-09-07). Skipped if the
    item already has a milestone, or if no open milestone has a future due date.
  - maps a conventional-commit title prefix (`feat:`/`fix:`/`docs:`/`chore:`) to a
    label, as a fallback for items opened without a template.

The Project board's set-Done automation is unchanged.

## Type of change

- [x] Chore / tooling (CI automation — `CI/CD` surface)

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `.github/workflows/*.yml` validated with `@action-validator/cli`
- [x] `prettier --check` passes on all three files
- Runtime check after merge: open a throwaway issue titled `feat: triage smoke
  test` → expect author assigned, milestone `Enhancement`, `enhancement` label;
  open a draft PR touching `lib/ai/` → expect `API` label + assignee + milestone;
  confirm a manually-set milestone on a second issue is not overwritten; then
  clean up.

## Notes / risks

- Requires the repo/org to allow `pull_request_target` and Actions write
  permissions. If `pull_request_target` is disallowed, fall back to
  `pull_request` (fork PRs then won't get labeled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests are automatically labeled according to affected areas, such as API, database, documentation, tests, and user interface.
  * New issues and pull requests receive labels based on conventional title prefixes.
  * Items can be assigned to their author and matched with an upcoming milestone when no assignment or milestone is already set.
* **Chores**
  * Automated repository triage improves organization while preserving existing assignments, milestones, and labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->