### PR TITLE
feat(admin): loop mode for the connection backfill — rotate free-tier Gemini keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,18 @@ GEMINI_MODEL=                # optional override, default: gemini-3.5-flash-lite
 # outputDimensionality param to match the verse_embeddings vector(768) column.
 GEMINI_EMBEDDING_MODEL=      # optional override, default: gemini-embedding-001
 
+# Free-tier key pool for the admin connection-backfill "loop mode"
+# (components/admin/BackfillRunner.tsx). Each is an independent
+# aistudio.google.com/apikey key with its own per-day request quota; loop mode
+# rotates to the next selected key when the current one is daily-exhausted, and
+# stops when they all are. Optional — leave blank to disable loop mode. Live
+# traffic and embeddings always use GEMINI_API_KEY, never these.
+GEMINI_API1=
+GEMINI_API2=
+GEMINI_API3=
+GEMINI_API4=
+GEMINI_API5=
+
 # ─── Quran Foundation — Two environments ──────────────────────────────────────
 #
 # ⚠️  PRE-PRODUCTION (use this for local dev — full auth + social features)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Describe the theological implications of any AI prompt change in the PR (see the
 - **Error handling** — no silent `catch` blocks. A failure should surface loudly, especially around parsing AI responses, where silently falling back could produce wrong theological content instead of a visible error.
 - **Testing bar** — new logic requires new tests in the same PR, not left for CI to catch after the fact.
 - **AI-specific correctness** — never "fix" a failing theological/verse-reference test by loosening the validation; only by fixing the underlying data or prompt. This is the failure mode most specific to this repo: an agent under test pressure weakening a real guardrail.
+- **Connection-backfill loop mode** — the admin coverage page can run the backfill in a continuous loop (Gemini-only, free tier) that rotates through a pool of keys named `GEMINI_API1..GEMINI_API5` (see `.env.example`). It advances to the next key only on a per-day quota exhaustion; per-minute 429s are waited out and retried, and a non-quota pass failure stops the loop. Gemini 429s are classified in exactly one place — `lib/ai/gemini-errors.ts` — do not scatter status-code checks elsewhere. Default pace is ~1500 ms between LLM calls.
 
 ## Available tooling
 

--- a/__tests__/api/admin/gemini-keys.test.ts
+++ b/__tests__/api/admin/gemini-keys.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "@/lib/infra/db/schema";
+
+vi.mock("@/lib/admin/admin-auth", () => ({ requireAdmin: vi.fn() }));
+
+const { mockConfiguredGeminiKeys } = vi.hoisted(() => ({
+  mockConfiguredGeminiKeys: vi.fn(() => ["GEMINI_API1", "GEMINI_API3"]),
+}));
+vi.mock("@/lib/admin/job-runner", () => ({ configuredGeminiKeys: mockConfiguredGeminiKeys }));
+
+import { GET } from "@/app/api/admin/gemini-keys/route";
+import { requireAdmin } from "@/lib/admin/admin-auth";
+
+const admin = { userId: 1, user: { qfId: "qf-admin" } as User };
+const req = () =>
+  new NextRequest("http://localhost/api/admin/gemini-keys", {
+    headers: { Authorization: "Bearer t" },
+  });
+
+beforeEach(() => {
+  vi.mocked(requireAdmin).mockResolvedValue(admin);
+  mockConfiguredGeminiKeys.mockClear().mockReturnValue(["GEMINI_API1", "GEMINI_API3"]);
+});
+
+describe("GET /api/admin/gemini-keys", () => {
+  it("returns the configured key names for an admin", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ keys: ["GEMINI_API1", "GEMINI_API3"] });
+  });
+
+  it("returns the guard's response for a non-admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(404);
+    expect(mockConfiguredGeminiKeys).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/admin/jobs.test.ts
+++ b/__tests__/api/admin/jobs.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/lib/admin/job-runner", async () => {
     embedCoverage: mockEmbedCoverage,
     startJob: mockStartJob,
     stopJob: mockStopJob,
+    configuredGeminiKeys: () => ["GEMINI_API1", "GEMINI_API2"],
   };
 });
 
@@ -82,6 +83,7 @@ describe("GET /api/admin/jobs", () => {
     const body = await res.json();
     expect(body.jobs).toHaveLength(1);
     expect(body.embedCoverage).toEqual({ embedded: 6000, total: 6236 });
+    expect(body.geminiKeys).toEqual(["GEMINI_API1", "GEMINI_API2"]);
   });
 });
 

--- a/__tests__/components/admin/BackfillRunner.test.tsx
+++ b/__tests__/components/admin/BackfillRunner.test.tsx
@@ -28,10 +28,25 @@ async function clickRun(confirmLabel: string) {
   });
 }
 
+/** The form fetches `/gemini-keys` on mount and POSTs to `/jobs` on submit. */
+function mockApiImpl(keys: string[] = ["GEMINI_API1", "GEMINI_API2"]) {
+  return (path: string, init?: { method?: string }) => {
+    if (path === "/gemini-keys" && init?.method === undefined) {
+      return Promise.resolve({ keys });
+    }
+    return Promise.resolve({ runId: "run_1" });
+  };
+}
+
+/** POST calls to /jobs only (excludes the /gemini-keys mount fetch). */
+function jobPosts() {
+  return mockApi.mock.calls.filter((c) => c[0] === "/jobs");
+}
+
 describe("BackfillRunner", () => {
   beforeEach(() => {
     mockApi.mockReset();
-    mockApi.mockResolvedValue({ runId: "run_1" });
+    mockApi.mockImplementation(mockApiImpl());
   });
 
   it("disables Run and posts nothing while the budget fields are blank", async () => {
@@ -46,7 +61,7 @@ describe("BackfillRunner", () => {
     expect(
       screen.queryByRole("button", { name: "Run baseline on gemini?" })
     ).not.toBeInTheDocument();
-    expect(mockApi).not.toHaveBeenCalled();
+    expect(jobPosts()).toHaveLength(0);
   });
 
   it("enables Run once the budgets are filled and then starts the job", async () => {
@@ -121,7 +136,57 @@ describe("BackfillRunner", () => {
     fillBudgets("10", "2");
     await clickRun("Run baseline on gemini?");
 
-    // Only the POST to start — no GET /jobs poll.
-    expect(mockApi.mock.calls.every((c) => c[1]?.method === "POST")).toBe(true);
+    // The only non-POST call is the /gemini-keys mount fetch — never GET /jobs.
+    expect(mockApi.mock.calls.some((c) => c[0] === "/jobs" && c[1]?.method !== "POST")).toBe(false);
+  });
+
+  describe("loop mode", () => {
+    async function enableLoop() {
+      render(<BackfillRunner />);
+      fireEvent.click(await screen.findByRole("checkbox", { name: /Loop —/ }));
+      await screen.findByRole("checkbox", { name: "GEMINI_API1" });
+    }
+
+    it("reveals key checkboxes + delay and makes budgets optional", async () => {
+      await enableLoop();
+      expect(screen.getByRole("checkbox", { name: "GEMINI_API1" })).toBeChecked();
+      expect(screen.getByRole("checkbox", { name: "GEMINI_API2" })).toBeChecked();
+      expect(screen.getByText(/Delay between LLM calls/)).toBeInTheDocument();
+      // Run enabled with blank budgets.
+      expect(screen.getByRole("button", { name: "Start loop" })).not.toBeDisabled();
+    });
+
+    it("forces the Gemini provider and disables Claude", async () => {
+      await enableLoop();
+      const provider = screen.getAllByRole("combobox")[1] as HTMLSelectElement;
+      expect(provider.value).toBe("gemini");
+      expect(provider).toBeDisabled();
+    });
+
+    it("submits loop:true with the selected keys, delay, and no blank budgets", async () => {
+      await enableLoop();
+      fireEvent.click(screen.getByRole("checkbox", { name: "GEMINI_API2" })); // deselect
+      fireEvent.click(screen.getByRole("button", { name: "Start loop" }));
+      const confirm = await screen.findByRole("button", { name: "Loop baseline on 1 key(s)?" });
+      await act(async () => fireEvent.click(confirm));
+
+      await waitFor(() => expect(jobPosts()).toHaveLength(1));
+      expect(jobPosts()[0][1].json.params).toEqual({
+        mode: "baseline",
+        provider: "gemini",
+        locales: "tr,ru,az",
+        loop: true,
+        keys: ["GEMINI_API1"],
+        callDelayMs: 1500,
+      });
+    });
+
+    it("shows an explanatory note and keeps Run disabled when no keys are configured", async () => {
+      mockApi.mockImplementation(mockApiImpl([]));
+      render(<BackfillRunner />);
+      fireEvent.click(await screen.findByRole("checkbox", { name: /Loop —/ }));
+      expect(screen.getByText(/No GEMINI_API1\.\.5 keys configured/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Start loop" })).toBeDisabled();
+    });
   });
 });

--- a/__tests__/integration/connection-batch.integration.test.ts
+++ b/__tests__/integration/connection-batch.integration.test.ts
@@ -25,6 +25,7 @@ vi.stubGlobal(
 import { db } from "@/lib/infra/db";
 import { verses, connections, connectionCoverage, aiGenerations } from "@/lib/infra/db/schema";
 import { runConnectionBatch } from "@/lib/ai/connection-batch";
+import { GeminiDailyQuotaError, GeminiRateLimitError } from "@/lib/ai/gemini-errors";
 import { getCoverageReport } from "@/lib/admin/coverage-report";
 
 async function reset() {
@@ -277,6 +278,63 @@ describe("runConnectionBatch (integration, real Postgres)", () => {
     expect(summary.stoppedReason).toBe("error");
     expect(summary.error).toContain("0 generated");
     expect(summary.lastError).toBe("bad api key");
+  });
+
+  it("daily quota: ends the pass 'quota-daily' without a cell failure or fail-fast", async () => {
+    for (const r of ["1:1", "2:255", "3:18"]) await seed(r);
+    mockCallAI.mockRejectedValue(
+      new GeminiDailyQuotaError({ cls: "daily", status: 429, raw: "PerDay" })
+    );
+
+    const summary = await runConnectionBatch(
+      { mode: "baseline", provider: "gemini", locales: [], maxCalls: 500, maxCostUsd: 100 },
+      hooks
+    );
+
+    expect(summary.stoppedReason).toBe("quota-daily");
+    expect(summary.generated).toBe(0);
+    expect(summary.cellsFailed).toBe(0);
+    // Stops at the first cell — no fail-fast draining of the work list.
+    expect(summary.cellsProcessed).toBe(0);
+    expect((await db.select().from(connections)).length).toBe(0);
+    // The quota hit is not recorded as a coverage last_error.
+    expect((await db.select().from(connectionCoverage)).length).toBe(0);
+  });
+
+  it("per-minute retries exhausted: treated as an ordinary cell failure", async () => {
+    await seed("1:1");
+    mockCallAI.mockRejectedValue(
+      new GeminiRateLimitError({ cls: "per-minute", status: 429, raw: "PerMinute" }, 6)
+    );
+
+    const summary = await runConnectionBatch(
+      { mode: "baseline", provider: "gemini", locales: [], maxCalls: 500, maxCostUsd: 100 },
+      hooks
+    );
+
+    expect(summary.stoppedReason).toBe("error");
+    expect(summary.cellsFailed).toBe(3);
+    expect(summary.generated).toBe(0);
+  });
+
+  it("callDelayMs: a paced run still completes", async () => {
+    await seed("1:1");
+    mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
+    await seed("2:255");
+
+    const summary = await runConnectionBatch(
+      {
+        mode: "baseline",
+        provider: "gemini",
+        locales: [],
+        maxCalls: 500,
+        maxCostUsd: 100,
+        callDelayMs: 5,
+      },
+      hooks
+    );
+    expect(summary.stoppedReason).toBe("completed");
+    expect(summary.generated).toBeGreaterThan(0);
   });
 
   it("resumability: a second run picks up cells the budget-stopped run did not reach", async () => {

--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -428,15 +428,28 @@ describe("startJob — backfill-connections loop mode", () => {
   });
 
   it("maps all-keys-daily → success, error → failed, cancelled → cancelled", async () => {
-    for (const [stoppedReason] of [["all-keys-daily"], ["error"], ["cancelled"]] as const) {
-      mockRunConnectionBatchLoop.mockResolvedValueOnce({ stoppedReason });
+    const cases = [
+      ["all-keys-daily", "success"],
+      ["work-exhausted", "success"],
+      ["error", "failed"],
+      ["cancelled", "cancelled"],
+    ] as const;
+    for (const [stoppedReason, expected] of cases) {
+      // Capture the status object passed to db.update(...).set({ status, ... }).
+      const setSpy = vi.fn().mockReturnValue(makeDbChain([]));
+      mockUpdate.mockReturnValue(
+        new Proxy(() => {}, { get: (_t, p) => (p === "set" ? setSpy : () => mockUpdate()) })
+      );
+      mockRunConnectionBatchLoop.mockResolvedValueOnce({ stoppedReason, error: "x" });
       await startJob("backfill-connections", "qf-admin", { ...base, keys: ["GEMINI_API1"] });
       await Promise.resolve();
       await Promise.resolve();
+      expect(setSpy).toHaveBeenCalledWith(expect.objectContaining({ status: expected }));
       const next = await startJob("seed-quran", "qf-admin");
       expect(next.runId).toBe(42);
       lastChild.current?.emit("close", 0);
       await Promise.resolve();
+      mockUpdate.mockReturnValue(makeDbChain([]));
     }
   });
 

--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -48,7 +48,20 @@ vi.mock("node:child_process", () => ({
 const { mockRunConnectionBatch } = vi.hoisted(() => ({ mockRunConnectionBatch: vi.fn() }));
 vi.mock("@/lib/ai/connection-batch", () => ({ runConnectionBatch: mockRunConnectionBatch }));
 
-import { startJob, stopJob, embedCoverage, JOBS } from "@/lib/admin/job-runner";
+const { mockRunConnectionBatchLoop } = vi.hoisted(() => ({
+  mockRunConnectionBatchLoop: vi.fn(),
+}));
+vi.mock("@/lib/ai/connection-batch-loop", () => ({
+  runConnectionBatchLoop: mockRunConnectionBatchLoop,
+}));
+
+import {
+  startJob,
+  stopJob,
+  embedCoverage,
+  JOBS,
+  configuredGeminiKeys,
+} from "@/lib/admin/job-runner";
 
 beforeEach(() => {
   mockInsert.mockReset().mockReturnValue(makeDbChain([{ id: 42 }]));
@@ -60,6 +73,7 @@ beforeEach(() => {
     return child;
   });
   mockRunConnectionBatch.mockReset().mockResolvedValue({ stoppedReason: "completed" });
+  mockRunConnectionBatchLoop.mockReset().mockResolvedValue({ stoppedReason: "all-keys-daily" });
 });
 
 // `running` is module-level state in job-runner.ts (by design — it's the
@@ -328,6 +342,125 @@ describe("stopJob", () => {
   it("refuses to stop a spawned (script) job", async () => {
     await startJob("seed-morphology", "qf-admin");
     expect(() => stopJob("qf-admin")).toThrow(/can't be stopped/);
+  });
+});
+
+describe("startJob — backfill-connections loop mode", () => {
+  const base = { mode: "baseline", provider: "gemini", locales: "tr,ru", loop: true };
+
+  beforeEach(() => {
+    process.env.GEMINI_API1 = "key-1";
+    process.env.GEMINI_API2 = "key-2";
+    delete process.env.GEMINI_API3;
+  });
+  afterEach(() => {
+    delete process.env.GEMINI_API1;
+    delete process.env.GEMINI_API2;
+  });
+
+  it("rejects loop mode with provider=claude", async () => {
+    await expect(
+      startJob("backfill-connections", "qf-admin", {
+        ...base,
+        provider: "claude",
+        keys: ["GEMINI_API1"],
+      })
+    ).rejects.toThrow(/gemini/i);
+  });
+
+  it("rejects loop mode with no keys / an unknown key / an unset key", async () => {
+    await expect(
+      startJob("backfill-connections", "qf-admin", { ...base, keys: [] })
+    ).rejects.toThrow(/at least one Gemini key/);
+    await expect(
+      startJob("backfill-connections", "qf-admin", { ...base, keys: ["GEMINI_API9"] })
+    ).rejects.toThrow(/unknown key/);
+    await expect(
+      startJob("backfill-connections", "qf-admin", { ...base, keys: ["GEMINI_API3"] })
+    ).rejects.toThrow(/not configured in env/);
+  });
+
+  it("rejects an out-of-range or non-integer callDelayMs", async () => {
+    for (const callDelayMs of [-5, 70000, 1.5]) {
+      await expect(
+        startJob("backfill-connections", "qf-admin", {
+          ...base,
+          keys: ["GEMINI_API1"],
+          callDelayMs,
+        })
+      ).rejects.toThrow(/callDelayMs/);
+    }
+  });
+
+  it("dispatches to runConnectionBatchLoop with resolved key values, labels, and Infinity caps", async () => {
+    mockRunConnectionBatchLoop.mockReturnValueOnce(new Promise(() => {}));
+    await startJob("backfill-connections", "qf-admin", {
+      ...base,
+      keys: ["GEMINI_API2", "GEMINI_API1"],
+    });
+    expect(mockRunConnectionBatch).not.toHaveBeenCalled();
+    expect(mockRunConnectionBatchLoop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "baseline",
+        locales: ["tr", "ru"],
+        apiKeys: ["key-1", "key-2"],
+        apiKeyLabels: ["GEMINI_API1", "GEMINI_API2"],
+        callDelayMs: 1500,
+        maxCalls: Number.POSITIVE_INFINITY,
+        maxCostUsd: Number.POSITIVE_INFINITY,
+      }),
+      expect.objectContaining({ onProgress: expect.any(Function) }),
+      expect.any(AbortSignal)
+    );
+  });
+
+  it("does not require GEMINI_API_KEY for loop mode", async () => {
+    const prev = process.env.GEMINI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    try {
+      mockRunConnectionBatchLoop.mockReturnValueOnce(new Promise(() => {}));
+      await expect(
+        startJob("backfill-connections", "qf-admin", { ...base, keys: ["GEMINI_API1"] })
+      ).resolves.toEqual({ runId: 42 });
+    } finally {
+      if (prev !== undefined) process.env.GEMINI_API_KEY = prev;
+    }
+  });
+
+  it("maps all-keys-daily → success, error → failed, cancelled → cancelled", async () => {
+    for (const [stoppedReason] of [["all-keys-daily"], ["error"], ["cancelled"]] as const) {
+      mockRunConnectionBatchLoop.mockResolvedValueOnce({ stoppedReason });
+      await startJob("backfill-connections", "qf-admin", { ...base, keys: ["GEMINI_API1"] });
+      await Promise.resolve();
+      await Promise.resolve();
+      const next = await startJob("seed-quran", "qf-admin");
+      expect(next.runId).toBe(42);
+      lastChild.current?.emit("close", 0);
+      await Promise.resolve();
+    }
+  });
+
+  it("stopJob aborts the loop's signal", async () => {
+    mockRunConnectionBatchLoop.mockReturnValueOnce(new Promise(() => {}));
+    await startJob("backfill-connections", "qf-admin", { ...base, keys: ["GEMINI_API1"] });
+    const signal = mockRunConnectionBatchLoop.mock.calls[0][2] as AbortSignal;
+    expect(signal.aborted).toBe(false);
+    expect(stopJob("qf-admin")).toEqual({ jobId: "backfill-connections" });
+    expect(signal.aborted).toBe(true);
+  });
+});
+
+describe("configuredGeminiKeys", () => {
+  it("returns only the pool names whose env var is set, in pool order", () => {
+    delete process.env.GEMINI_API1;
+    process.env.GEMINI_API2 = "b";
+    process.env.GEMINI_API4 = "d";
+    try {
+      expect(configuredGeminiKeys()).toEqual(["GEMINI_API2", "GEMINI_API4"]);
+    } finally {
+      delete process.env.GEMINI_API2;
+      delete process.env.GEMINI_API4;
+    }
   });
 });
 

--- a/__tests__/lib/ai/connection-batch-loop.test.ts
+++ b/__tests__/lib/ai/connection-batch-loop.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockRunConnectionBatch, mockReset } = vi.hoisted(() => ({
+  mockRunConnectionBatch: vi.fn(),
+  mockReset: vi.fn(),
+}));
+vi.mock("@/lib/ai/connection-batch", () => ({ runConnectionBatch: mockRunConnectionBatch }));
+vi.mock("@/lib/ai/ai", () => ({ resetGeminiRateLimitState: mockReset }));
+
+import { runConnectionBatchLoop, type LoopOptions } from "@/lib/ai/connection-batch-loop";
+
+const ZERO = {
+  cellsProcessed: 0,
+  callsUsed: 0,
+  costUsd: 0,
+  generated: 0,
+  translated: 0,
+  exhausted: 0,
+  cellsFailed: 0,
+  workListSize: 10,
+};
+const pass = (over: Record<string, unknown>) => ({ ...ZERO, ...over });
+
+function opts(over: Partial<LoopOptions> = {}): LoopOptions {
+  return {
+    mode: "baseline",
+    locales: ["tr"],
+    apiKeys: ["k1", "k2"],
+    apiKeyLabels: ["GEMINI_API1", "GEMINI_API2"],
+    callDelayMs: 0,
+    maxCalls: Number.POSITIVE_INFINITY,
+    maxCostUsd: Number.POSITIVE_INFINITY,
+    ...over,
+  };
+}
+
+const hooks = { onProgress: vi.fn() };
+
+beforeEach(() => {
+  mockRunConnectionBatch.mockReset();
+  mockReset.mockReset();
+  hooks.onProgress.mockReset();
+});
+
+describe("runConnectionBatchLoop", () => {
+  it("rotates to the next key on quota-daily and uses that key's value", async () => {
+    mockRunConnectionBatch
+      .mockResolvedValueOnce(pass({ stoppedReason: "quota-daily", generated: 3 }))
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed" }))
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed" }));
+
+    const summary = await runConnectionBatchLoop(opts(), hooks, new AbortController().signal);
+
+    expect(mockRunConnectionBatch.mock.calls[0][0].apiKey).toBe("k1");
+    expect(mockRunConnectionBatch.mock.calls[1][0].apiKey).toBe("k2");
+    expect(summary.keysExhausted).toEqual(["GEMINI_API1"]);
+    expect(summary.stoppedReason).toBe("work-exhausted");
+    expect(mockReset).toHaveBeenCalledTimes(2);
+  });
+
+  it("ends all-keys-daily when every key hits its daily quota", async () => {
+    mockRunConnectionBatch.mockResolvedValue(pass({ stoppedReason: "quota-daily" }));
+    const summary = await runConnectionBatchLoop(opts(), hooks, new AbortController().signal);
+    expect(summary.stoppedReason).toBe("all-keys-daily");
+    expect(summary.keysExhausted).toEqual(["GEMINI_API1", "GEMINI_API2"]);
+  });
+
+  it("keeps looping the same key while a completed pass still makes progress", async () => {
+    mockRunConnectionBatch
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed", generated: 5 }))
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed", generated: 2 }))
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed" }))
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed" }));
+
+    const summary = await runConnectionBatchLoop(
+      opts({ apiKeys: ["k1"], apiKeyLabels: ["GEMINI_API1"] }),
+      hooks,
+      new AbortController().signal
+    );
+    expect(summary.passes).toBe(4);
+    expect(summary.generated).toBe(7);
+    expect(summary.stoppedReason).toBe("work-exhausted");
+  });
+
+  it("stops the whole loop (no rotation) on a non-quota pass error", async () => {
+    mockRunConnectionBatch.mockResolvedValueOnce(
+      pass({ stoppedReason: "error", error: "provider likely down" })
+    );
+    const summary = await runConnectionBatchLoop(opts(), hooks, new AbortController().signal);
+    expect(summary.stoppedReason).toBe("error");
+    expect(summary.error).toBe("provider likely down");
+    expect(mockRunConnectionBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns cancelled immediately for an already-aborted signal", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const summary = await runConnectionBatchLoop(opts(), hooks, ac.signal);
+    expect(summary.stoppedReason).toBe("cancelled");
+    expect(mockRunConnectionBatch).not.toHaveBeenCalled();
+  });
+
+  it("aggregates callsUsed across passes and stops at the maxCalls cap", async () => {
+    mockRunConnectionBatch
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed", generated: 1, callsUsed: 6 }))
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed", generated: 1, callsUsed: 6 }));
+    const summary = await runConnectionBatchLoop(
+      opts({ apiKeys: ["k1"], apiKeyLabels: ["GEMINI_API1"], maxCalls: 10 }),
+      hooks,
+      new AbortController().signal
+    );
+    expect(summary.callsUsed).toBe(12);
+    expect(summary.stoppedReason).toBe("call-budget");
+    // second pass was given the remaining budget
+    expect(mockRunConnectionBatch.mock.calls[1][0].maxCalls).toBe(4);
+  });
+
+  it("never trips the budget with Infinity caps", async () => {
+    mockRunConnectionBatch.mockResolvedValue(
+      pass({ stoppedReason: "quota-daily", callsUsed: 999 })
+    );
+    const summary = await runConnectionBatchLoop(opts(), hooks, new AbortController().signal);
+    expect(summary.stoppedReason).toBe("all-keys-daily");
+  });
+});

--- a/__tests__/lib/ai/connection-batch-loop.test.ts
+++ b/__tests__/lib/ai/connection-batch-loop.test.ts
@@ -115,6 +115,40 @@ describe("runConnectionBatchLoop", () => {
     expect(mockRunConnectionBatch.mock.calls[1][0].maxCalls).toBe(4);
   });
 
+  it("stops the loop (error) after consecutive passes that only fail cells", async () => {
+    mockRunConnectionBatch.mockResolvedValue(
+      pass({ stoppedReason: "completed", cellsFailed: 4, lastError: "bad JSON" })
+    );
+    const summary = await runConnectionBatchLoop(
+      opts({ apiKeys: ["k1"], apiKeyLabels: ["GEMINI_API1"] }),
+      hooks,
+      new AbortController().signal
+    );
+    expect(summary.stoppedReason).toBe("error");
+    expect(summary.error).toMatch(/only failed cells/);
+    // FAILING_PASSES_BEFORE_ABORT = 3 → does not run thousands of passes
+    expect(summary.passes).toBe(3);
+  });
+
+  it("propagates a cancelled inner pass", async () => {
+    mockRunConnectionBatch.mockResolvedValueOnce(pass({ stoppedReason: "cancelled" }));
+    const summary = await runConnectionBatchLoop(opts(), hooks, new AbortController().signal);
+    expect(summary.stoppedReason).toBe("cancelled");
+  });
+
+  it("treats an empty work list as immediately done", async () => {
+    mockRunConnectionBatch.mockResolvedValueOnce(
+      pass({ stoppedReason: "completed", workListSize: 0 })
+    );
+    const summary = await runConnectionBatchLoop(
+      opts({ apiKeys: ["k1"], apiKeyLabels: ["GEMINI_API1"] }),
+      hooks,
+      new AbortController().signal
+    );
+    expect(summary.stoppedReason).toBe("work-exhausted");
+    expect(summary.passes).toBe(1);
+  });
+
   it("never trips the budget with Infinity caps", async () => {
     mockRunConnectionBatch.mockResolvedValue(
       pass({ stoppedReason: "quota-daily", callsUsed: 999 })

--- a/__tests__/lib/ai/gemini-errors.test.ts
+++ b/__tests__/lib/ai/gemini-errors.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  GeminiDailyQuotaError,
+  GeminiRateLimitError,
+  classifyGeminiError,
+  perMinuteBackoffMs,
+  PER_MINUTE_MAX_DELAY_MS,
+} from "@/lib/ai/gemini-errors";
+
+/** Shape of what `@google/generative-ai` throws for a non-2xx. */
+function fetchError(
+  status: number,
+  errorDetails: unknown[],
+  message = `[GoogleGenerativeAI Error]: ${status}`
+) {
+  return Object.assign(new Error(message), {
+    status,
+    statusText: "Too Many Requests",
+    errorDetails,
+  });
+}
+
+const perDayViolation = {
+  "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+  violations: [
+    {
+      quotaMetric: "generativelanguage.googleapis.com/generate_content_free_tier_requests",
+      quotaId: "GenerateRequestsPerDayPerProjectPerModel-FreeTier",
+      quotaDimensions: { model: "gemini-3.5-flash-lite", location: "global" },
+    },
+  ],
+};
+const perMinuteViolation = {
+  "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+  violations: [{ quotaId: "GenerateRequestsPerMinutePerProjectPerModel-FreeTier" }],
+};
+const retryInfo = { "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "39s" };
+
+describe("classifyGeminiError", () => {
+  it("classifies a per-day QuotaFailure from errorDetails as daily", () => {
+    const info = classifyGeminiError(fetchError(429, [perDayViolation, retryInfo]));
+    expect(info.cls).toBe("daily");
+    expect(info.quotaId).toMatch(/PerDay/);
+    expect(info.retryAfterMs).toBe(39_000);
+  });
+
+  it("classifies a per-day quota from the message string alone", () => {
+    const info = classifyGeminiError(
+      fetchError(429, [], "You exceeded your current quota: GenerateRequestsPerDay limit")
+    );
+    expect(info.cls).toBe("daily");
+  });
+
+  it("classifies a per-minute QuotaFailure as per-minute", () => {
+    const info = classifyGeminiError(fetchError(429, [perMinuteViolation]));
+    expect(info.cls).toBe("per-minute");
+  });
+
+  it("falls back to other-429 for a bare 429 with no quota markers", () => {
+    const info = classifyGeminiError(fetchError(429, [], "429 Too Many Requests"));
+    expect(info.cls).toBe("other-429");
+  });
+
+  it("treats a 500 / network error as not-rate-limit", () => {
+    expect(classifyGeminiError(fetchError(500, [], "500 Internal Server Error")).cls).toBe(
+      "not-rate-limit"
+    );
+    expect(classifyGeminiError(new Error("fetch failed")).cls).toBe("not-rate-limit");
+  });
+
+  it("tolerates non-Error input", () => {
+    expect(classifyGeminiError(undefined).cls).toBe("not-rate-limit");
+    expect(classifyGeminiError("boom").cls).toBe("not-rate-limit");
+  });
+});
+
+describe("typed errors", () => {
+  it("GeminiDailyQuotaError carries the classification info", () => {
+    const info = classifyGeminiError(fetchError(429, [perDayViolation]));
+    const err = new GeminiDailyQuotaError(info);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.info.cls).toBe("daily");
+    expect(err.name).toBe("GeminiDailyQuotaError");
+  });
+
+  it("GeminiRateLimitError records the attempt count", () => {
+    const err = new GeminiRateLimitError(classifyGeminiError(fetchError(429, [])), 6);
+    expect(err.attempts).toBe(6);
+  });
+});
+
+describe("perMinuteBackoffMs", () => {
+  it("honours an explicit retryAfterMs (within jitter)", () => {
+    const ms = perMinuteBackoffMs(1, 12_000);
+    expect(ms).toBeGreaterThanOrEqual(12_000 * 0.85);
+    expect(ms).toBeLessThanOrEqual(12_000 * 1.15);
+  });
+
+  it("caps the exponential backoff", () => {
+    expect(perMinuteBackoffMs(20)).toBeLessThanOrEqual(PER_MINUTE_MAX_DELAY_MS * 1.15);
+  });
+});

--- a/__tests__/lib/ai/gemini-errors.test.ts
+++ b/__tests__/lib/ai/gemini-errors.test.ts
@@ -61,6 +61,18 @@ describe("classifyGeminiError", () => {
     expect(info.cls).toBe("other-429");
   });
 
+  it("does NOT treat a non-429 status as rate-limited even when it mentions quota", () => {
+    // 403 PERMISSION_DENIED "Quota exceeded ... consumer suspended", 400 quota-project
+    expect(
+      classifyGeminiError(
+        fetchError(403, [], "Quota exceeded for quota metric; consumer suspended")
+      ).cls
+    ).toBe("not-rate-limit");
+    expect(
+      classifyGeminiError(fetchError(400, [], "RESOURCE_EXHAUSTED quota project issue")).cls
+    ).toBe("not-rate-limit");
+  });
+
   it("treats a 500 / network error as not-rate-limit", () => {
     expect(classifyGeminiError(fetchError(500, [], "500 Internal Server Error")).cls).toBe(
       "not-rate-limit"
@@ -98,5 +110,10 @@ describe("perMinuteBackoffMs", () => {
 
   it("caps the exponential backoff", () => {
     expect(perMinuteBackoffMs(20)).toBeLessThanOrEqual(PER_MINUTE_MAX_DELAY_MS * 1.15);
+  });
+
+  it("floors a zero retryDelay so retries never burst back-to-back", () => {
+    // Google does emit "retryDelay": "0s" → parsed as 0, must not mean "no wait".
+    expect(perMinuteBackoffMs(1, 0)).toBeGreaterThanOrEqual(1000);
   });
 });

--- a/__tests__/lib/ai/gemini-retry.test.ts
+++ b/__tests__/lib/ai/gemini-retry.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockGenerate, ctorKeys } = vi.hoisted(() => ({
+  mockGenerate: vi.fn(),
+  ctorKeys: [] as string[],
+}));
+
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: class {
+    constructor(key: string) {
+      ctorKeys.push(key);
+    }
+    getGenerativeModel() {
+      return { generateContent: mockGenerate };
+    }
+  },
+}));
+vi.mock("@anthropic-ai/sdk", () => ({ default: class {} }));
+vi.mock("@/lib/admin/feature-flags", () => ({
+  getFlagString: vi.fn((_k: string, fallback: string) => fallback),
+}));
+
+import { callAIDetailed, resetGeminiRateLimitState } from "@/lib/ai/ai";
+import { GeminiDailyQuotaError, GeminiRateLimitError } from "@/lib/ai/gemini-errors";
+
+function fetchError(details: unknown[], message = "429") {
+  return Object.assign(new Error(message), { status: 429, errorDetails: details });
+}
+const perMinute = [
+  { "@type": "google.rpc.QuotaFailure", violations: [{ quotaId: "GenerateRequestsPerMinute" }] },
+  { "@type": "google.rpc.RetryInfo", retryDelay: "1s" },
+];
+const perDay = [
+  {
+    "@type": "google.rpc.QuotaFailure",
+    violations: [{ quotaId: "GenerateRequestsPerDayPerModel" }],
+  },
+];
+const ok = { response: { text: () => "generated", usageMetadata: null } };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockGenerate.mockReset();
+  ctorKeys.length = 0;
+  resetGeminiRateLimitState();
+  process.env.GEMINI_API_KEY = "env-key";
+});
+afterEach(() => {
+  vi.useRealTimers();
+  delete process.env.GEMINI_API_KEY;
+});
+
+describe("callGemini retry / classification", () => {
+  it("retries a per-minute 429 then succeeds", async () => {
+    mockGenerate
+      .mockRejectedValueOnce(fetchError(perMinute))
+      .mockRejectedValueOnce(fetchError(perMinute))
+      .mockResolvedValueOnce(ok);
+
+    const p = callAIDetailed("hi", { provider: "gemini" });
+    await vi.runAllTimersAsync();
+    const res = await p;
+    expect(res.text).toBe("generated");
+    expect(mockGenerate).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws GeminiRateLimitError once per-minute retries are exhausted", async () => {
+    mockGenerate.mockRejectedValue(fetchError(perMinute));
+    const p = callAIDetailed("hi", { provider: "gemini" }).catch((e) => e);
+    await vi.runAllTimersAsync();
+    expect(await p).toBeInstanceOf(GeminiRateLimitError);
+  });
+
+  it("throws GeminiDailyQuotaError immediately on a per-day quota, with no retry", async () => {
+    mockGenerate.mockRejectedValue(fetchError(perDay));
+    await expect(callAIDetailed("hi", { provider: "gemini" })).rejects.toBeInstanceOf(
+      GeminiDailyQuotaError
+    );
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the explicit apiKey, not process.env.GEMINI_API_KEY", async () => {
+    mockGenerate.mockResolvedValueOnce(ok);
+    await callAIDetailed("hi", { provider: "gemini", apiKey: "loop-key-2" });
+    expect(ctorKeys).toEqual(["loop-key-2"]);
+  });
+
+  it("aborts a backoff wait when the signal fires", async () => {
+    mockGenerate.mockRejectedValue(fetchError(perMinute));
+    const ac = new AbortController();
+    const p = callAIDetailed("hi", { provider: "gemini", signal: ac.signal }).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(10);
+    ac.abort();
+    const err = await p;
+    expect(err).toBeInstanceOf(Error);
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("escalates to GeminiDailyQuotaError after 8 consecutive ambiguous 429s", async () => {
+    mockGenerate.mockRejectedValue(fetchError([], "429 Too Many Requests"));
+    // Each call does up to PER_MINUTE_MAX_RETRIES (6) attempts; the ambiguous
+    // streak persists across calls until it crosses 8.
+    let last: unknown;
+    for (let i = 0; i < 3; i++) {
+      const p = callAIDetailed("hi", { provider: "gemini" }).catch((e) => e);
+      await vi.runAllTimersAsync();
+      last = await p;
+      if (last instanceof GeminiDailyQuotaError) break;
+    }
+    expect(last).toBeInstanceOf(GeminiDailyQuotaError);
+  });
+});

--- a/app/api/admin/gemini-keys/route.ts
+++ b/app/api/admin/gemini-keys/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin/admin-auth";
+import { configuredGeminiKeys } from "@/lib/admin/job-runner";
+
+/** Which of the `GEMINI_API1..5` env vars are set — NAMES only, never values.
+ *  The coverage page's backfill form uses this to build the "loop mode" key
+ *  picker (a client can't read env). Admin-gated; key names are not secret. */
+export async function GET(req: NextRequest) {
+  const auth = await requireAdmin(req);
+  if (auth instanceof NextResponse) return auth;
+  return NextResponse.json({ keys: configuredGeminiKeys() });
+}

--- a/app/api/admin/jobs/route.ts
+++ b/app/api/admin/jobs/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin, rateLimitAdminMutation } from "@/lib/admin/admin-auth";
 import { logAdminAction } from "@/lib/admin/admin-audit";
-import { JOBS, getJobsStatus, embedCoverage, startJob, stopJob } from "@/lib/admin/job-runner";
+import {
+  JOBS,
+  getJobsStatus,
+  embedCoverage,
+  startJob,
+  stopJob,
+  configuredGeminiKeys,
+} from "@/lib/admin/job-runner";
 
 /** Job list + latest run status, plus the embedding-coverage check. */
 export async function GET(req: NextRequest) {
@@ -10,7 +17,11 @@ export async function GET(req: NextRequest) {
 
   try {
     const [jobs, coverage] = await Promise.all([getJobsStatus(), embedCoverage()]);
-    return NextResponse.json({ jobs, embedCoverage: coverage });
+    return NextResponse.json({
+      jobs,
+      embedCoverage: coverage,
+      geminiKeys: configuredGeminiKeys(),
+    });
   } catch (err) {
     console.error("admin jobs GET error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/components/admin/BackfillRunner.tsx
+++ b/components/admin/BackfillRunner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Input, NativeSelect } from "@/components/ui";
 import { StateNote, ConfirmButton, Panel } from "@/components/admin/primitives";
@@ -11,6 +11,9 @@ import type { Locale } from "@/lib/i18n/config";
 import { SELECTABLE_MODELS } from "@/lib/ai/models";
 
 const TARGET_LOCALES: Exclude<Locale, "en">[] = ["tr", "ru", "az"];
+
+const DEFAULT_CALL_DELAY_MS = 1500;
+const MAX_CALL_DELAY_MS = 60_000;
 
 /**
  * The "Run the backfill job" console. Its inputs are deliberately kept in a
@@ -24,6 +27,13 @@ const TARGET_LOCALES: Exclude<Locale, "en">[] = ["tr", "ru", "az"];
  * run lives on the Jobs page. The budget fields (max calls / max cost) have no
  * default value on purpose: an accidental "Run backfill" click must not be able
  * to start a run that spends money.
+ *
+ * "Loop" mode (Gemini-only, free tier): the job re-runs pass after pass,
+ * rotating through the selected `GEMINI_API1..5` keys, advancing to the next key
+ * only when the current one hits its per-day quota, and pacing every LLM call by
+ * the given delay. It stops when every selected key is daily-exhausted, the work
+ * list is fully covered, the admin clicks Stop, or an optional safety budget cap
+ * is reached. Per-minute 429s are waited out and retried, never fatal.
  */
 export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
   const api = useAdminFetch();
@@ -37,16 +47,49 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
   });
   const [maxCalls, setMaxCalls] = useState<number | "">("");
   const [maxCostUsd, setMaxCostUsd] = useState<number | "">("");
+
+  const [loop, setLoop] = useState(false);
+  const [geminiKeys, setGeminiKeys] = useState<string[] | null>(null);
+  const [selectedKeys, setSelectedKeys] = useState<Record<string, boolean>>({});
+  const [callDelayMs, setCallDelayMs] = useState<number | "">(DEFAULT_CALL_DELAY_MS);
+
   const [runNote, setRunNote] = useState<string | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
 
+  useEffect(() => {
+    let cancelled = false;
+    api<{ keys: string[] }>("/gemini-keys")
+      .then((r) => {
+        if (cancelled) return;
+        setGeminiKeys(r.keys);
+        setSelectedKeys(Object.fromEntries(r.keys.map((k) => [k, true])));
+      })
+      .catch(() => {
+        if (!cancelled) setGeminiKeys([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
+
+  const selectedKeyList = (geminiKeys ?? []).filter((k) => selectedKeys[k]);
+  const delayInvalid = callDelayMs === "" || callDelayMs < 0 || callDelayMs > MAX_CALL_DELAY_MS;
   const budgetsInvalid = maxCalls === "" || maxCostUsd === "" || maxCalls <= 0 || maxCostUsd <= 0;
+  const formInvalid = loop ? delayInvalid || selectedKeyList.length === 0 : budgetsInvalid;
+
+  const toggleLoop = (checked: boolean) => {
+    setLoop(checked);
+    if (checked && provider !== "gemini") {
+      setProvider("gemini");
+      setModel("");
+    }
+  };
 
   const startRun = async () => {
     setRunNote(null);
     setRunError(null);
-    if (budgetsInvalid) return;
+    if (formInvalid) return;
     setStarting(true);
     try {
       await api("/jobs", {
@@ -55,11 +98,18 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
           jobId: "backfill-connections",
           params: {
             mode,
-            provider,
+            provider: loop ? "gemini" : provider,
             ...(model ? { model } : {}),
             locales: TARGET_LOCALES.filter((l) => runLocales[l]).join(","),
-            maxCalls,
-            maxCostUsd,
+            ...(loop
+              ? {
+                  loop: true,
+                  keys: selectedKeyList,
+                  callDelayMs: callDelayMs === "" ? DEFAULT_CALL_DELAY_MS : callDelayMs,
+                  ...(maxCalls !== "" ? { maxCalls } : {}),
+                  ...(maxCostUsd !== "" ? { maxCostUsd } : {}),
+                }
+              : { maxCalls, maxCostUsd }),
           },
         },
       });
@@ -94,21 +144,24 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
 
         <Field label="Provider">
           <NativeSelect
-            value={provider}
+            value={loop ? "gemini" : provider}
+            disabled={loop}
             onChange={(e) => {
               setProvider(e.target.value as "claude" | "gemini");
               setModel("");
             }}
           >
             <option value="gemini">gemini — cheapest</option>
-            <option value="claude">claude — highest fidelity</option>
+            <option value="claude" disabled={loop}>
+              claude — highest fidelity
+            </option>
           </NativeSelect>
         </Field>
 
         <Field label="Model">
           <NativeSelect value={model} onChange={(e) => setModel(e.target.value)}>
             <option value="">default</option>
-            {SELECTABLE_MODELS[provider].map((m) => (
+            {SELECTABLE_MODELS[loop ? "gemini" : provider].map((m) => (
               <option key={m} value={m}>
                 {m}
               </option>
@@ -133,23 +186,23 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
         </div>
 
         <div className="grid grid-cols-2 gap-3">
-          <Field label="Max LLM calls">
+          <Field label={loop ? "Max LLM calls (optional)" : "Max LLM calls"}>
             <Input
               type="number"
               min={1}
               value={maxCalls}
-              placeholder="required"
+              placeholder={loop ? "unbounded" : "required"}
               onChange={(e) => setMaxCalls(e.target.value === "" ? "" : Number(e.target.value))}
               className="tabular-nums"
             />
           </Field>
-          <Field label="Max cost (USD, est.)">
+          <Field label={loop ? "Max cost (optional cap)" : "Max cost (USD, est.)"}>
             <Input
               type="number"
               min={0.1}
               step={0.1}
               value={maxCostUsd}
-              placeholder="required"
+              placeholder={loop ? "unbounded" : "required"}
               onChange={(e) => setMaxCostUsd(e.target.value === "" ? "" : Number(e.target.value))}
               className="tabular-nums"
             />
@@ -157,15 +210,95 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
         </div>
       </div>
 
+      <div className="mt-4 border-t border-border pt-3">
+        <label className="flex items-start gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={loop}
+            className="mt-0.5"
+            onChange={(e) => toggleLoop(e.target.checked)}
+          />
+          <span>
+            <span className="text-text-secondary">
+              Loop — keep running, rotating Gemini keys, until every selected key hits its daily
+              quota
+            </span>
+            <span className="mt-0.5 block text-text-muted">
+              Gemini-only (free tier). Per-minute rate limits are waited out and retried; only a
+              per-day quota rotates to the next key. Stop a run from the{" "}
+              <Link href="/admin/jobs" className="underline">
+                Jobs page
+              </Link>
+              .
+            </span>
+          </span>
+        </label>
+
+        {loop && (
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div className="text-xs">
+              <span className="mb-1 block text-text-secondary">Gemini keys (rotation order)</span>
+              {geminiKeys === null ? (
+                <span className="text-text-muted">Loading…</span>
+              ) : geminiKeys.length === 0 ? (
+                <span className="text-text-muted">
+                  No GEMINI_API1..5 keys configured — set them in the environment to use loop mode.
+                </span>
+              ) : (
+                <div className="flex flex-wrap gap-3">
+                  {geminiKeys.map((k) => (
+                    <label key={k} className="flex items-center gap-1">
+                      <input
+                        type="checkbox"
+                        checked={selectedKeys[k] ?? false}
+                        onChange={(e) => setSelectedKeys((s) => ({ ...s, [k]: e.target.checked }))}
+                      />
+                      {k}
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <Field
+              label="Delay between LLM calls (ms)"
+              hint="~1500 ms ≈ 3 calls / 4.5 s. Lower risks per-minute 429s (auto-retried)."
+            >
+              <Input
+                type="number"
+                min={0}
+                max={MAX_CALL_DELAY_MS}
+                step={100}
+                value={callDelayMs}
+                onChange={(e) =>
+                  setCallDelayMs(e.target.value === "" ? "" : Number(e.target.value))
+                }
+                className="tabular-nums"
+              />
+            </Field>
+          </div>
+        )}
+      </div>
+
       <p className="mt-2 text-[11px] text-text-muted">
-        Max LLM calls and Max cost are both required — there is no default, so a stray click can
-        never start a run. The job stops cleanly at whichever limit is hit first: max calls is
-        exact; max cost is a per-call estimate (token counts aren&apos;t tracked on this path). Stop
-        a run in progress from the{" "}
-        <Link href="/admin/jobs" className="underline">
-          Jobs page
-        </Link>
-        .
+        {loop ? (
+          <>
+            In loop mode both budget fields are optional safety caps — leave them blank to run until
+            the keys are exhausted or you click Stop. Free-tier keys cost $0, so the $ figure shown
+            on the Jobs page is a notional list price.
+          </>
+        ) : (
+          <>
+            Max LLM calls and Max cost are both required — there is no default, so a stray click can
+            never start a run. The job stops cleanly at whichever limit is hit first: max calls is
+            exact; max cost is a per-call estimate (token counts aren&apos;t tracked on this path).
+            Stop a run in progress from the{" "}
+            <Link href="/admin/jobs" className="underline">
+              Jobs page
+            </Link>
+            .
+          </>
+        )}
       </p>
 
       {runError && <StateNote tone="error">{runError}</StateNote>}
@@ -178,20 +311,26 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
         </p>
       )}
 
-      {budgetsInvalid && (
+      {formInvalid && (
         <p className="mt-2 text-[11px] text-text-muted">
-          Enter Max LLM calls and Max cost to enable the run.
+          {loop
+            ? "Select at least one Gemini key and a valid delay to enable the run."
+            : "Enter Max LLM calls and Max cost to enable the run."}
         </p>
       )}
 
       <div className="mt-3">
         <ConfirmButton
           variant="secondary"
-          disabled={starting || budgetsInvalid}
+          disabled={starting || formInvalid}
           onConfirm={startRun}
-          confirmLabel={`Run ${mode} on ${provider}?`}
+          confirmLabel={
+            loop
+              ? `Loop ${mode} on ${selectedKeyList.length} key(s)?`
+              : `Run ${mode} on ${provider}?`
+          }
         >
-          {starting ? "Starting…" : "Run backfill"}
+          {starting ? "Starting…" : loop ? "Start loop" : "Run backfill"}
         </ConfirmButton>
       </div>
     </Panel>

--- a/components/admin/BackfillRunner.tsx
+++ b/components/admin/BackfillRunner.tsx
@@ -50,6 +50,7 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
 
   const [loop, setLoop] = useState(false);
   const [geminiKeys, setGeminiKeys] = useState<string[] | null>(null);
+  const [keysError, setKeysError] = useState(false);
   const [selectedKeys, setSelectedKeys] = useState<Record<string, boolean>>({});
   const [callDelayMs, setCallDelayMs] = useState<number | "">(DEFAULT_CALL_DELAY_MS);
 
@@ -62,11 +63,21 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
     api<{ keys: string[] }>("/gemini-keys")
       .then((r) => {
         if (cancelled) return;
+        setKeysError(false);
         setGeminiKeys(r.keys);
-        setSelectedKeys(Object.fromEntries(r.keys.map((k) => [k, true])));
+        // Seed the selection once, on first load — a token refresh re-runs this
+        // effect (api is memoised on the access token) and must not silently
+        // re-check keys the admin deliberately unticked.
+        setSelectedKeys((prev) =>
+          Object.keys(prev).length > 0 ? prev : Object.fromEntries(r.keys.map((k) => [k, true]))
+        );
       })
       .catch(() => {
-        if (!cancelled) setGeminiKeys([]);
+        if (cancelled) return;
+        // Distinguish "couldn't check" from "none configured" — otherwise an auth
+        // blip reads as "set your env vars" (which are already fine).
+        setKeysError(true);
+        setGeminiKeys((prev) => prev ?? []);
       });
     return () => {
       cancelled = true;
@@ -74,9 +85,19 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
   }, [api]);
 
   const selectedKeyList = (geminiKeys ?? []).filter((k) => selectedKeys[k]);
-  const delayInvalid = callDelayMs === "" || callDelayMs < 0 || callDelayMs > MAX_CALL_DELAY_MS;
+  const delayInvalid =
+    callDelayMs === "" ||
+    !Number.isInteger(callDelayMs) ||
+    callDelayMs < 0 ||
+    callDelayMs > MAX_CALL_DELAY_MS;
+  const budgetInvalid = (v: number | "") => v !== "" && (!Number.isFinite(v) || v <= 0);
   const budgetsInvalid = maxCalls === "" || maxCostUsd === "" || maxCalls <= 0 || maxCostUsd <= 0;
-  const formInvalid = loop ? delayInvalid || selectedKeyList.length === 0 : budgetsInvalid;
+  const formInvalid = loop
+    ? delayInvalid ||
+      selectedKeyList.length === 0 ||
+      budgetInvalid(maxCalls) ||
+      budgetInvalid(maxCostUsd)
+    : budgetsInvalid;
 
   const toggleLoop = (checked: boolean) => {
     setLoop(checked);
@@ -240,6 +261,10 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
               <span className="mb-1 block text-text-secondary">Gemini keys (rotation order)</span>
               {geminiKeys === null ? (
                 <span className="text-text-muted">Loading…</span>
+              ) : keysError ? (
+                <span className="text-text-muted">
+                  Couldn&apos;t load the key list — reload the page to retry.
+                </span>
               ) : geminiKeys.length === 0 ? (
                 <span className="text-text-muted">
                   No GEMINI_API1..5 keys configured — set them in the environment to use loop mode.

--- a/lib/admin/job-runner.ts
+++ b/lib/admin/job-runner.ts
@@ -2,7 +2,16 @@ import { spawn } from "node:child_process";
 import { desc, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { jobRuns, verses, verseEmbeddings } from "@/lib/infra/db/schema";
-import { runConnectionBatch, type BatchOptions } from "@/lib/ai/connection-batch";
+import {
+  runConnectionBatch,
+  type BatchOptions,
+  type StoppedReason,
+} from "@/lib/ai/connection-batch";
+import {
+  runConnectionBatchLoop,
+  type LoopOptions,
+  type LoopStoppedReason,
+} from "@/lib/ai/connection-batch-loop";
 import type { Provider } from "@/lib/ai/ai";
 import { SELECTABLE_MODELS, isModelForProvider } from "@/lib/ai/models";
 import { LOCALES, type Locale } from "@/lib/i18n/config";
@@ -67,9 +76,33 @@ export const JOBS: readonly JobDefinition[] = [
   },
 ] as const;
 
-/** Validates raw admin input for the backfill job into the typed options
- *  `runConnectionBatch` takes. Throws on bad input (routes map to 400). */
-function parseBackfillParams(raw: Record<string, unknown>): BatchOptions {
+/** Env var names holding the free-tier Gemini keys the backfill "loop mode"
+ *  rotates through. Order here is the rotation order. */
+export const GEMINI_KEY_POOL = [
+  "GEMINI_API1",
+  "GEMINI_API2",
+  "GEMINI_API3",
+  "GEMINI_API4",
+  "GEMINI_API5",
+] as const;
+
+/** The subset of `GEMINI_KEY_POOL` whose env var is actually set. Names only —
+ *  never values. The coverage form fetches this to build its key picker. */
+export function configuredGeminiKeys(): string[] {
+  return GEMINI_KEY_POOL.filter((name) => !!process.env[name]);
+}
+
+const MAX_CALL_DELAY_MS = 60_000;
+const DEFAULT_CALL_DELAY_MS = 1500;
+
+export type ParsedBackfill =
+  { kind: "single"; opts: BatchOptions } | { kind: "loop"; opts: LoopOptions };
+
+/** Validates raw admin input for the backfill job. Returns either the one-pass
+ *  options `runConnectionBatch` takes, or — when `raw.loop` is set — the
+ *  key-rotating options `runConnectionBatchLoop` takes. Throws on bad input
+ *  (routes map to 400). */
+function parseBackfillParams(raw: Record<string, unknown>): ParsedBackfill {
   const mode = raw.mode;
   if (mode !== "baseline" && mode !== "topup") throw new Error("mode must be baseline or topup");
 
@@ -90,6 +123,48 @@ function parseBackfillParams(raw: Record<string, unknown>): BatchOptions {
   if (localeList.some((l) => !["tr", "ru", "az"].includes(l))) {
     throw new Error("locales must be a subset of tr,ru,az");
   }
+  const locales = localeList.filter((l): l is Locale => (LOCALES as readonly string[]).includes(l));
+
+  if (raw.loop) {
+    if (provider !== "gemini") {
+      throw new Error("loop mode requires provider=gemini (Claude has no free tier)");
+    }
+
+    const rawKeys = Array.isArray(raw.keys) ? raw.keys : [];
+    const poolOrder = GEMINI_KEY_POOL as readonly string[];
+    const keyLabels = poolOrder.filter(
+      (name) => rawKeys.includes(name) // dedupe + pool order in one pass
+    );
+    const unknown = rawKeys.filter((k) => typeof k !== "string" || !poolOrder.includes(k));
+    if (unknown.length > 0) throw new Error(`unknown key name(s): ${unknown.join(", ")}`);
+    if (keyLabels.length === 0) throw new Error("loop mode requires at least one Gemini key");
+    const missing = keyLabels.filter((name) => !process.env[name]);
+    if (missing.length > 0) {
+      throw new Error(`keys not configured in env: ${missing.join(", ")}`);
+    }
+
+    let callDelayMs = DEFAULT_CALL_DELAY_MS;
+    if (raw.callDelayMs !== undefined && raw.callDelayMs !== "") {
+      callDelayMs = Number(raw.callDelayMs);
+      if (!Number.isInteger(callDelayMs) || callDelayMs < 0 || callDelayMs > MAX_CALL_DELAY_MS) {
+        throw new Error(`callDelayMs must be an integer between 0 and ${MAX_CALL_DELAY_MS}`);
+      }
+    }
+
+    return {
+      kind: "loop",
+      opts: {
+        mode,
+        model: model as string | undefined,
+        locales,
+        apiKeys: keyLabels.map((name) => process.env[name] as string),
+        apiKeyLabels: keyLabels,
+        callDelayMs,
+        maxCalls: optionalPositiveInt(raw.maxCalls, "maxCalls"),
+        maxCostUsd: optionalPositiveNumber(raw.maxCostUsd, "maxCostUsd"),
+      },
+    };
+  }
 
   const maxCalls = Number(raw.maxCalls);
   if (!Number.isInteger(maxCalls) || maxCalls <= 0)
@@ -104,16 +179,37 @@ function parseBackfillParams(raw: Record<string, unknown>): BatchOptions {
   if (!process.env[requiredKey]) throw new Error(`Missing required env var: ${requiredKey}`);
 
   return {
-    mode,
-    provider: provider as Provider,
-    model: model as string | undefined,
-    locales: localeList.filter((l): l is Locale => (LOCALES as readonly string[]).includes(l)),
-    maxCalls,
-    maxCostUsd,
+    kind: "single",
+    opts: {
+      mode,
+      provider: provider as Provider,
+      model: model as string | undefined,
+      locales,
+      maxCalls,
+      maxCostUsd,
+    },
   };
 }
 
-const LOG_TAIL_LINES = 50;
+/** A blank optional ceiling means "no cap" — `Number.POSITIVE_INFINITY`, which
+ *  the batch's `+1 > max` / `+cost > max` guards treat as always-allowed. */
+function optionalPositiveInt(value: unknown, name: string): number {
+  if (value === undefined || value === "" || value === null) return Number.POSITIVE_INFINITY;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) throw new Error(`${name} must be a positive integer`);
+  return n;
+}
+
+function optionalPositiveNumber(value: unknown, name: string): number {
+  if (value === undefined || value === "" || value === null) return Number.POSITIVE_INFINITY;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) throw new Error(`${name} must be a positive number`);
+  return n;
+}
+
+// 100, not 50: a loop run's per-key rotation lines need to stay visible on the
+// Jobs page alongside the inner batch's periodic progress lines.
+const LOG_TAIL_LINES = 100;
 
 interface RunningJob {
   jobId: JobDefinition["id"];
@@ -165,6 +261,18 @@ function finishRun(
   if (running?.runId === state.runId) running = null;
 }
 
+/** Maps a batch / loop terminal reason to the `job_runs.status` the Jobs page
+ *  renders. "All selected keys hit their daily quota" and "work list fully
+ *  covered" are the loop's *designed* clean endings — `success`, with the log
+ *  tail explaining which. Only a genuine fault is `failed`. */
+function mapTerminalStatus(
+  reason: StoppedReason | LoopStoppedReason
+): "success" | "failed" | "cancelled" {
+  if (reason === "cancelled") return "cancelled";
+  if (reason === "error" || reason === "quota-daily") return "failed";
+  return "success";
+}
+
 /** Starts a job if none is currently running. Throws on bad input or an
  *  already-running job — routes should catch and translate to a 400/409.
  *  `params` is required for jobs with `acceptsParams` and rejected for others. */
@@ -182,10 +290,10 @@ export async function startJob(
     throw new Error(`Missing required env var(s): ${missingEnv.join(", ")}`);
   }
 
-  let backfillOpts: BatchOptions | null = null;
+  let backfill: ParsedBackfill | null = null;
   if (job.acceptsParams) {
     if (!params) throw new Error(`Job "${job.id}" requires params`);
-    if (job.id === "backfill-connections") backfillOpts = parseBackfillParams(params);
+    if (job.id === "backfill-connections") backfill = parseBackfillParams(params);
   } else if (params) {
     throw new Error(`Job "${job.id}" does not accept params`);
   }
@@ -220,20 +328,15 @@ export async function startJob(
     // endpoint reads. `runConnectionBatch` is budget-capped and single-flight,
     // and a redeploy kills it exactly like it killed the spawned child — the
     // `job_runs` row + resumable work list cover restart recovery.
+    const parsed = backfill as ParsedBackfill;
     void (async () => {
       try {
-        const summary = await runConnectionBatch(
-          backfillOpts as BatchOptions,
-          { onProgress: (line) => pushLogLine(state, line) },
-          state.controller.signal
-        );
-        const status =
-          summary.stoppedReason === "error"
-            ? "failed"
-            : summary.stoppedReason === "cancelled"
-              ? "cancelled"
-              : "success";
-        finishRun(state, status, summary.error ?? null);
+        const hooks = { onProgress: (line: string) => pushLogLine(state, line) };
+        const summary =
+          parsed.kind === "loop"
+            ? await runConnectionBatchLoop(parsed.opts, hooks, state.controller.signal)
+            : await runConnectionBatch(parsed.opts, hooks, state.controller.signal);
+        finishRun(state, mapTerminalStatus(summary.stoppedReason), summary.error ?? null);
       } catch (err) {
         pushLogLine(state, `job failed: ${err instanceof Error ? err.message : String(err)}`);
         finishRun(state, "failed", err instanceof Error ? err.message : String(err));

--- a/lib/ai/ai.ts
+++ b/lib/ai/ai.ts
@@ -2,6 +2,15 @@ import Anthropic from "@anthropic-ai/sdk";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { getFlagString } from "@/lib/admin/feature-flags";
 import { DEFAULT_MODEL, isModelForProvider } from "@/lib/ai/models";
+import {
+  AMBIGUOUS_429_ESCALATE_AFTER,
+  GeminiDailyQuotaError,
+  GeminiRateLimitError,
+  PER_MINUTE_MAX_RETRIES,
+  classifyGeminiError,
+  perMinuteBackoffMs,
+} from "@/lib/ai/gemini-errors";
+import { interruptibleSleep } from "@/lib/infra/sleep";
 
 export type Provider = "claude" | "gemini";
 
@@ -30,6 +39,12 @@ export interface CallAiOptions {
   /** Hard model override (the admin batch job's per-run pick). Applied only when
    *  it belongs to the resolved provider; otherwise ignored. */
   model?: string;
+  /** Explicit Gemini API key for this call — the admin backfill loop's per-key
+   *  pick. When set, overrides `process.env.GEMINI_API_KEY`. Ignored for Claude. */
+  apiKey?: string;
+  /** Cooperative-cancel signal. Currently only Gemini honours it, to abort a
+   *  rate-limit backoff wait mid-sleep when the admin stops the job. */
+  signal?: AbortSignal;
 }
 
 /** The model id a provider will use by default: the `<PROVIDER>_MODEL` env var
@@ -118,7 +133,9 @@ export async function resolveProvider(feature?: AiFeature, override?: Provider):
 export async function callAIDetailed(prompt: string, opts: CallAiOptions = {}): Promise<AiResult> {
   const provider = await resolveProvider(opts.feature, opts.provider);
   const model = await resolveModel(opts.feature, provider, opts.model);
-  return provider === "gemini" ? callGemini(prompt, model) : callClaude(prompt, model);
+  return provider === "gemini"
+    ? callGemini(prompt, model, opts.apiKey, opts.signal)
+    : callClaude(prompt, model);
 }
 
 /**
@@ -153,24 +170,64 @@ async function callClaude(prompt: string, model: string): Promise<AiResult> {
   };
 }
 
-async function callGemini(prompt: string, model: string): Promise<AiResult> {
-  const apiKey = process.env.GEMINI_API_KEY;
-  if (!apiKey) throw new Error("GEMINI_API_KEY is not set");
-  const ai = new GoogleGenerativeAI(apiKey);
+/**
+ * Consecutive ambiguous 429s (429 with no clear per-day / per-minute marker)
+ * seen across `callGemini` invocations, with no successful call in between. Reset
+ * on any success and by `resetGeminiRateLimitState` (the backfill loop calls it
+ * when it switches keys). At `AMBIGUOUS_429_ESCALATE_AFTER` a `callGemini` throws
+ * `GeminiDailyQuotaError` so a daily-dead key that only emits shapeless 429s
+ * still triggers a key rotation instead of retrying forever.
+ */
+let ambiguous429Streak = 0;
+
+export function resetGeminiRateLimitState(): void {
+  ambiguous429Streak = 0;
+}
+
+async function callGemini(
+  prompt: string,
+  model: string,
+  apiKey?: string,
+  signal?: AbortSignal
+): Promise<AiResult> {
+  const key = apiKey ?? process.env.GEMINI_API_KEY;
+  if (!key) throw new Error("GEMINI_API_KEY is not set");
+  const ai = new GoogleGenerativeAI(key);
   const genModel = ai.getGenerativeModel({ model });
-  const result = await genModel.generateContent(prompt);
-  const meta = result.response.usageMetadata;
-  return {
-    text: result.response.text(),
-    usage: meta
-      ? {
-          inputTokens: meta.promptTokenCount ?? 0,
-          outputTokens: meta.candidatesTokenCount ?? 0,
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      const result = await genModel.generateContent(prompt);
+      ambiguous429Streak = 0;
+      const meta = result.response.usageMetadata;
+      return {
+        text: result.response.text(),
+        usage: meta
+          ? {
+              inputTokens: meta.promptTokenCount ?? 0,
+              outputTokens: meta.candidatesTokenCount ?? 0,
+            }
+          : null,
+        provider: "gemini",
+        model,
+      };
+    } catch (err) {
+      if (err instanceof GeminiDailyQuotaError) throw err;
+      const info = classifyGeminiError(err);
+      if (info.cls === "not-rate-limit") throw err;
+      if (info.cls === "daily") throw new GeminiDailyQuotaError(info);
+
+      if (info.cls === "other-429") {
+        ambiguous429Streak++;
+        if (ambiguous429Streak >= AMBIGUOUS_429_ESCALATE_AFTER) {
+          ambiguous429Streak = 0;
+          throw new GeminiDailyQuotaError(info);
         }
-      : null,
-    provider: "gemini",
-    model,
-  };
+      }
+      if (attempt >= PER_MINUTE_MAX_RETRIES) throw new GeminiRateLimitError(info, attempt);
+      await interruptibleSleep(perMinuteBackoffMs(attempt, info.retryAfterMs), signal);
+    }
+  }
 }
 
 // ─── Embeddings ───────────────────────────────────────────────────────────────

--- a/lib/ai/ai.ts
+++ b/lib/ai/ai.ts
@@ -171,17 +171,21 @@ async function callClaude(prompt: string, model: string): Promise<AiResult> {
 }
 
 /**
- * Consecutive ambiguous 429s (429 with no clear per-day / per-minute marker)
- * seen across `callGemini` invocations, with no successful call in between. Reset
- * on any success and by `resetGeminiRateLimitState` (the backfill loop calls it
- * when it switches keys). At `AMBIGUOUS_429_ESCALATE_AFTER` a `callGemini` throws
- * `GeminiDailyQuotaError` so a daily-dead key that only emits shapeless 429s
- * still triggers a key rotation instead of retrying forever.
+ * Consecutive ambiguous 429s (429 with no clear per-day / per-minute marker) per
+ * API key, with no successful call on that key in between. Keyed by the key value
+ * so the admin backfill loop's pool keys and live site traffic (which uses
+ * `process.env.GEMINI_API_KEY`) never reset or trip each other's counter. Reset
+ * on any success for that key and by `resetGeminiRateLimitState(key)` (the loop
+ * calls it when it switches keys). At `AMBIGUOUS_429_ESCALATE_AFTER` a
+ * `callGemini` throws `GeminiDailyQuotaError` so a daily-dead key that only emits
+ * shapeless 429s still triggers a key rotation instead of retrying forever.
  */
-let ambiguous429Streak = 0;
+const ambiguous429Streak = new Map<string, number>();
 
-export function resetGeminiRateLimitState(): void {
-  ambiguous429Streak = 0;
+/** Clears the ambiguous-429 streak for one key, or all keys when omitted. */
+export function resetGeminiRateLimitState(key?: string): void {
+  if (key === undefined) ambiguous429Streak.clear();
+  else ambiguous429Streak.delete(key);
 }
 
 async function callGemini(
@@ -198,7 +202,7 @@ async function callGemini(
   for (let attempt = 1; ; attempt++) {
     try {
       const result = await genModel.generateContent(prompt);
-      ambiguous429Streak = 0;
+      ambiguous429Streak.delete(key);
       const meta = result.response.usageMetadata;
       return {
         text: result.response.text(),
@@ -218,9 +222,10 @@ async function callGemini(
       if (info.cls === "daily") throw new GeminiDailyQuotaError(info);
 
       if (info.cls === "other-429") {
-        ambiguous429Streak++;
-        if (ambiguous429Streak >= AMBIGUOUS_429_ESCALATE_AFTER) {
-          ambiguous429Streak = 0;
+        const streak = (ambiguous429Streak.get(key) ?? 0) + 1;
+        ambiguous429Streak.set(key, streak);
+        if (streak >= AMBIGUOUS_429_ESCALATE_AFTER) {
+          ambiguous429Streak.delete(key);
           throw new GeminiDailyQuotaError(info);
         }
       }

--- a/lib/ai/connection-batch-loop.ts
+++ b/lib/ai/connection-batch-loop.ts
@@ -1,0 +1,228 @@
+import { resetGeminiRateLimitState } from "@/lib/ai/ai";
+import {
+  runConnectionBatch,
+  type BatchHooks,
+  type BatchMode,
+  type BatchSummary,
+} from "@/lib/ai/connection-batch";
+import type { Locale } from "@/lib/i18n/config";
+
+/**
+ * The admin backfill "loop mode": run `runConnectionBatch` pass after pass on a
+ * pool of free-tier Gemini keys, so the connection graph fills continuously at
+ * zero budget.
+ *
+ * One key at a time. A pass that ends "quota-daily" means that key is spent for
+ * the day → rotate to the next selected key. The loop stops only when:
+ *   - every selected key has hit its daily quota          → "all-keys-daily"
+ *   - the work list is fully covered (a completed pass     → "work-exhausted"
+ *     that generated / translated / exhausted / failed nothing)
+ *   - the admin clicks Stop (the job's AbortSignal)        → "cancelled"
+ *   - an optional safety budget cap is reached             → "call-budget" / "cost-budget"
+ *   - a pass fails for a non-quota reason (e.g. bad model, → "error"
+ *     network, malformed responses tripping fail-fast) — do NOT rotate, the
+ *     same fault would hit every key
+ *
+ * Per-minute 429s never reach here: `callGemini` waits them out and retries.
+ */
+
+export interface LoopOptions {
+  mode: BatchMode;
+  /** Gemini model id, or undefined for the resolved default. */
+  model?: string;
+  locales: Locale[];
+  /** Key VALUES, in rotation order. Non-empty. */
+  apiKeys: string[];
+  /** Parallel labels ("GEMINI_API2") for the job log — never the values. */
+  apiKeyLabels: string[];
+  /** Delay between LLM calls, ms. */
+  callDelayMs: number;
+  /** Optional safety ceilings across the whole loop. `Number.POSITIVE_INFINITY`
+   *  when the admin left the field blank. */
+  maxCalls: number;
+  maxCostUsd: number;
+}
+
+export type LoopStoppedReason =
+  "work-exhausted" | "all-keys-daily" | "call-budget" | "cost-budget" | "cancelled" | "error";
+
+export interface LoopSummary {
+  stoppedReason: LoopStoppedReason;
+  passes: number;
+  keysUsed: number;
+  /** Labels of keys that hit their daily quota this run. */
+  keysExhausted: string[];
+  cellsProcessed: number;
+  callsUsed: number;
+  costUsd: number;
+  generated: number;
+  translated: number;
+  exhausted: number;
+  cellsFailed: number;
+  /** Whole-loop failure message (a non-quota pass error). Drives `job_runs.error`. */
+  error?: string;
+  lastError?: string;
+}
+
+/** Defensive ceiling: a single key that keeps returning "completed, work remains"
+ *  without ever converging (should be impossible — every pass commits progress or
+ *  is caught by the zero-progress guard) must not spin forever. */
+const MAX_PASSES_PER_KEY = 5000;
+
+function mergeCounters(agg: LoopSummary, pass: BatchSummary): void {
+  agg.cellsProcessed += pass.cellsProcessed;
+  agg.callsUsed += pass.callsUsed;
+  agg.costUsd += pass.costUsd;
+  agg.generated += pass.generated;
+  agg.translated += pass.translated;
+  agg.exhausted += pass.exhausted;
+  agg.cellsFailed += pass.cellsFailed;
+  if (pass.lastError) agg.lastError = pass.lastError;
+}
+
+function passChangedSomething(pass: BatchSummary): boolean {
+  return pass.generated > 0 || pass.translated > 0 || pass.exhausted > 0 || pass.cellsFailed > 0;
+}
+
+export async function runConnectionBatchLoop(
+  opts: LoopOptions,
+  hooks: BatchHooks,
+  signal: AbortSignal
+): Promise<LoopSummary> {
+  const agg: LoopSummary = {
+    stoppedReason: "all-keys-daily",
+    passes: 0,
+    keysUsed: 0,
+    keysExhausted: [],
+    cellsProcessed: 0,
+    callsUsed: 0,
+    costUsd: 0,
+    generated: 0,
+    translated: 0,
+    exhausted: 0,
+    cellsFailed: 0,
+  };
+
+  const n = opts.apiKeys.length;
+  hooks.onProgress(
+    `[loop] ${opts.mode} | ${n} key(s): ${opts.apiKeyLabels.join(", ")} | ` +
+      `model=${opts.model ?? "default"} | locales=${opts.locales.join(",") || "none"} | ` +
+      `delay=${opts.callDelayMs}ms | ` +
+      `maxCalls=${Number.isFinite(opts.maxCalls) ? opts.maxCalls : "∞"} | ` +
+      `maxCost=${Number.isFinite(opts.maxCostUsd) ? `$${opts.maxCostUsd}` : "∞"}`
+  );
+
+  for (let k = 0; k < n; k++) {
+    if (signal.aborted) {
+      agg.stoppedReason = "cancelled";
+      return finish(agg, hooks);
+    }
+
+    const label = opts.apiKeyLabels[k];
+    agg.keysUsed = k + 1;
+    hooks.onProgress(`[loop] key ${k + 1}/${n} (${label}) — starting`);
+    // Per-key: the ambiguous-429 escalation counter in ai.ts is about "this key
+    // looks daily-dead", so it must not carry over from the previous key.
+    resetGeminiRateLimitState();
+
+    let prevPassChanged = true;
+
+    for (let p = 0; p < MAX_PASSES_PER_KEY; p++) {
+      if (signal.aborted) {
+        agg.stoppedReason = "cancelled";
+        return finish(agg, hooks);
+      }
+      if (agg.callsUsed >= opts.maxCalls) {
+        agg.stoppedReason = "call-budget";
+        return finish(agg, hooks);
+      }
+      if (agg.costUsd >= opts.maxCostUsd) {
+        agg.stoppedReason = "cost-budget";
+        return finish(agg, hooks);
+      }
+
+      const pass = await runConnectionBatch(
+        {
+          mode: opts.mode,
+          provider: "gemini",
+          model: opts.model,
+          locales: opts.locales,
+          maxCalls: opts.maxCalls - agg.callsUsed,
+          maxCostUsd: opts.maxCostUsd - agg.costUsd,
+          apiKey: opts.apiKeys[k],
+          callDelayMs: opts.callDelayMs,
+        },
+        { onProgress: (line) => hooks.onProgress(`  ${line}`) },
+        signal
+      );
+      agg.passes++;
+      mergeCounters(agg, pass);
+
+      switch (pass.stoppedReason) {
+        case "quota-daily":
+          agg.keysExhausted.push(label);
+          hooks.onProgress(
+            `[loop] key ${k + 1}/${n} (${label}) daily quota hit after ${agg.passes} pass(es) — rotating`
+          );
+          p = MAX_PASSES_PER_KEY; // break to next key
+          continue;
+
+        case "cancelled":
+          agg.stoppedReason = "cancelled";
+          return finish(agg, hooks);
+
+        case "call-budget":
+          agg.stoppedReason = "call-budget";
+          return finish(agg, hooks);
+
+        case "cost-budget":
+          agg.stoppedReason = "cost-budget";
+          return finish(agg, hooks);
+
+        case "error":
+          // Non-quota failure — every key would hit the same wall. Stop.
+          agg.stoppedReason = "error";
+          agg.error = pass.error;
+          hooks.onProgress(`[loop] pass failed (${pass.error}) — stopping the loop`);
+          return finish(agg, hooks);
+
+        case "completed": {
+          const changed = passChangedSomething(pass);
+          if (!changed && !prevPassChanged) {
+            // Two consecutive completed passes that changed nothing: the work
+            // list has nothing left this mode can act on.
+            agg.stoppedReason = "work-exhausted";
+            hooks.onProgress(`[loop] ${opts.mode} work list fully covered — done`);
+            return finish(agg, hooks);
+          }
+          if (!changed && pass.workListSize === 0) {
+            agg.stoppedReason = "work-exhausted";
+            hooks.onProgress(`[loop] ${opts.mode} work list empty — done`);
+            return finish(agg, hooks);
+          }
+          prevPassChanged = changed;
+          hooks.onProgress(
+            `[loop] pass ${agg.passes} done (gen=${pass.generated} xlt=${pass.translated} ` +
+              `exh=${pass.exhausted} fail=${pass.cellsFailed}) — work remains, continuing on ${label}`
+          );
+          continue;
+        }
+      }
+    }
+  }
+
+  // Fell out of the key loop → every selected key hit its daily quota.
+  agg.stoppedReason = "all-keys-daily";
+  hooks.onProgress(`[loop] all ${n} selected key(s) exhausted for the day — stopping`);
+  return finish(agg, hooks);
+}
+
+function finish(agg: LoopSummary, hooks: BatchHooks): LoopSummary {
+  hooks.onProgress(
+    `[loop] DONE (${agg.stoppedReason}) | ${agg.passes} pass(es) | ${agg.keysUsed} key(s) | ` +
+      `${agg.callsUsed} calls | $${agg.costUsd.toFixed(2)} | ` +
+      `gen=${agg.generated} xlt=${agg.translated} exh=${agg.exhausted} fail=${agg.cellsFailed}` +
+      (agg.keysExhausted.length ? ` | exhausted: ${agg.keysExhausted.join(", ")}` : "")
+  );
+  return agg;
+}

--- a/lib/ai/connection-batch-loop.ts
+++ b/lib/ai/connection-batch-loop.ts
@@ -64,10 +64,24 @@ export interface LoopSummary {
   lastError?: string;
 }
 
-/** Defensive ceiling: a single key that keeps returning "completed, work remains"
- *  without ever converging (should be impossible — every pass commits progress or
- *  is caught by the zero-progress guard) must not spin forever. */
+/** Defensive ceiling per key — the productivity guards below should always stop a
+ *  key first; hitting this means something is wrong, so it ends the loop as an
+ *  error, not a clean rotation. */
 const MAX_PASSES_PER_KEY = 5000;
+/** Consecutive `completed` passes that generated / translated / exhausted
+ *  nothing AND failed nothing → the work list is genuinely done for this mode. */
+const UNPRODUCTIVE_PASSES_BEFORE_DONE = 2;
+/** Consecutive `completed` passes that produced nothing useful and DID fail
+ *  cells → the model is misbehaving (e.g. mostly-malformed JSON) rather than the
+ *  work being done. Stop the whole loop — the same fault will hit every key. */
+const FAILING_PASSES_BEFORE_ABORT = 3;
+
+/** A `completed` pass that actually moved the graph forward. `cellsFailed` is
+ *  deliberately NOT progress — a pass that only fails cells must not keep the
+ *  loop alive. */
+function passWasProductive(pass: BatchSummary): boolean {
+  return pass.generated > 0 || pass.translated > 0 || pass.exhausted > 0;
+}
 
 function mergeCounters(agg: LoopSummary, pass: BatchSummary): void {
   agg.cellsProcessed += pass.cellsProcessed;
@@ -78,10 +92,6 @@ function mergeCounters(agg: LoopSummary, pass: BatchSummary): void {
   agg.exhausted += pass.exhausted;
   agg.cellsFailed += pass.cellsFailed;
   if (pass.lastError) agg.lastError = pass.lastError;
-}
-
-function passChangedSomething(pass: BatchSummary): boolean {
-  return pass.generated > 0 || pass.translated > 0 || pass.exhausted > 0 || pass.cellsFailed > 0;
 }
 
 export async function runConnectionBatchLoop(
@@ -121,13 +131,16 @@ export async function runConnectionBatchLoop(
     const label = opts.apiKeyLabels[k];
     agg.keysUsed = k + 1;
     hooks.onProgress(`[loop] key ${k + 1}/${n} (${label}) — starting`);
-    // Per-key: the ambiguous-429 escalation counter in ai.ts is about "this key
-    // looks daily-dead", so it must not carry over from the previous key.
-    resetGeminiRateLimitState();
+    // Per-key: the ambiguous-429 escalation counter in ai.ts is keyed by the key
+    // value, so clear THIS key's before we start (a redeploy or a previous run
+    // could have left a stale count).
+    resetGeminiRateLimitState(opts.apiKeys[k]);
 
-    let prevPassChanged = true;
+    let unproductivePasses = 0;
+    let failingPasses = 0;
+    let rotate = false;
 
-    for (let p = 0; p < MAX_PASSES_PER_KEY; p++) {
+    for (let p = 0; p < MAX_PASSES_PER_KEY && !rotate; p++) {
       if (signal.aborted) {
         agg.stoppedReason = "cancelled";
         return finish(agg, hooks);
@@ -164,8 +177,8 @@ export async function runConnectionBatchLoop(
           hooks.onProgress(
             `[loop] key ${k + 1}/${n} (${label}) daily quota hit after ${agg.passes} pass(es) — rotating`
           );
-          p = MAX_PASSES_PER_KEY; // break to next key
-          continue;
+          rotate = true;
+          break;
 
         case "cancelled":
           agg.stoppedReason = "cancelled";
@@ -187,27 +200,46 @@ export async function runConnectionBatchLoop(
           return finish(agg, hooks);
 
         case "completed": {
-          const changed = passChangedSomething(pass);
-          if (!changed && !prevPassChanged) {
-            // Two consecutive completed passes that changed nothing: the work
-            // list has nothing left this mode can act on.
-            agg.stoppedReason = "work-exhausted";
-            hooks.onProgress(`[loop] ${opts.mode} work list fully covered — done`);
+          if (passWasProductive(pass)) {
+            unproductivePasses = 0;
+            failingPasses = 0;
+            hooks.onProgress(
+              `[loop] pass ${agg.passes} done (gen=${pass.generated} xlt=${pass.translated} ` +
+                `exh=${pass.exhausted} fail=${pass.cellsFailed}) — work remains, continuing on ${label}`
+            );
+            break;
+          }
+          // Nothing useful this pass.
+          if (pass.workListSize === 0 || pass.cellsFailed === 0) {
+            if (
+              ++unproductivePasses >= UNPRODUCTIVE_PASSES_BEFORE_DONE ||
+              pass.workListSize === 0
+            ) {
+              agg.stoppedReason = "work-exhausted";
+              hooks.onProgress(`[loop] ${opts.mode} work list fully covered — done`);
+              return finish(agg, hooks);
+            }
+          } else if (++failingPasses >= FAILING_PASSES_BEFORE_ABORT) {
+            agg.stoppedReason = "error";
+            agg.error = `${failingPasses} consecutive passes generated nothing and only failed cells — last error: ${pass.lastError ?? "unknown"}`;
+            hooks.onProgress(`[loop] ${agg.error} — stopping the loop`);
             return finish(agg, hooks);
           }
-          if (!changed && pass.workListSize === 0) {
-            agg.stoppedReason = "work-exhausted";
-            hooks.onProgress(`[loop] ${opts.mode} work list empty — done`);
-            return finish(agg, hooks);
-          }
-          prevPassChanged = changed;
           hooks.onProgress(
-            `[loop] pass ${agg.passes} done (gen=${pass.generated} xlt=${pass.translated} ` +
-              `exh=${pass.exhausted} fail=${pass.cellsFailed}) — work remains, continuing on ${label}`
+            `[loop] pass ${agg.passes} made no progress (fail=${pass.cellsFailed}) — retrying on ${label}`
           );
-          continue;
+          break;
         }
       }
+    }
+
+    if (!rotate) {
+      // Inner loop hit MAX_PASSES_PER_KEY without converging or rotating — the
+      // productivity guards above should have caught this, so treat it as a bug.
+      agg.stoppedReason = "error";
+      agg.error = `key ${label} ran ${MAX_PASSES_PER_KEY} passes without converging`;
+      hooks.onProgress(`[loop] ${agg.error} — stopping the loop`);
+      return finish(agg, hooks);
     }
   }
 

--- a/lib/ai/connection-batch.ts
+++ b/lib/ai/connection-batch.ts
@@ -5,8 +5,10 @@ import { generateConnectionsForCell } from "@/lib/ai/graph-service";
 import { translateReason } from "@/lib/ai/translate";
 import { estimateCostUsd } from "@/lib/ai/ai-cost";
 import { resolveModel, type Provider } from "@/lib/ai/ai";
+import { GeminiDailyQuotaError } from "@/lib/ai/gemini-errors";
 import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 import { incr } from "@/lib/infra/metrics";
+import { interruptibleSleep } from "@/lib/infra/sleep";
 import type { EdgeKind } from "@/types/quran";
 
 /**
@@ -42,7 +44,15 @@ const PROGRESS_EVERY = 25;
 const FAIL_FAST_THRESHOLD = 5;
 
 export type BatchMode = "baseline" | "topup";
-export type StoppedReason = "completed" | "call-budget" | "cost-budget" | "error" | "cancelled";
+export type StoppedReason =
+  | "completed"
+  | "call-budget"
+  | "cost-budget"
+  | "error"
+  | "cancelled"
+  /** The active Gemini key hit its per-day quota. The single-pass batch stops
+   *  here; the outer loop (connection-batch-loop.ts) rotates to the next key. */
+  | "quota-daily";
 
 export interface BatchOptions {
   mode: BatchMode;
@@ -56,8 +66,16 @@ export interface BatchOptions {
   /** Hard ceiling on LLM calls this run. Always exact. */
   maxCalls: number;
   /** Best-effort USD ceiling. Estimated per call (tokens aren't tracked on the
-   *  generation path), so treat as approximate — maxCalls is the real guard. */
+   *  generation path), so treat as approximate — maxCalls is the real guard.
+   *  `Number.POSITIVE_INFINITY` in loop mode when the admin leaves it blank. */
   maxCostUsd: number;
+  /** Explicit Gemini API key for this pass — the backfill loop's per-key pick.
+   *  Undefined for a normal single run (uses `process.env.GEMINI_API_KEY`). */
+  apiKey?: string;
+  /** Delay in ms after each successful `budget.spend()` (i.e. before each LLM
+   *  request), to stay under free-tier per-minute limits. 0 / undefined = none.
+   *  Abort-aware — a Stop click interrupts the wait. */
+  callDelayMs?: number;
 }
 
 export interface BatchHooks {
@@ -83,6 +101,9 @@ export interface BatchSummary {
   /** Message from the most recent cell-level failure, surfaced even when the run
    *  as a whole is not marked failed. */
   lastError?: string;
+  /** How many (verse × kind) cells the work list held at the start of this pass.
+   *  The loop uses `0 changes on a completed pass` to detect "work fully done." */
+  workListSize: number;
 }
 
 interface Cell {
@@ -94,6 +115,13 @@ interface Cell {
 }
 
 const cellKey = (ref: string, kind: string) => `${ref}|${kind}`;
+
+/** Throttle between LLM requests in loop mode. No-op when unset. Abort-aware so a
+ *  Stop click doesn't have to wait out the full delay. */
+async function pace(ms: number | undefined, signal?: AbortSignal): Promise<void> {
+  if (!ms || ms <= 0) return;
+  await interruptibleSleep(ms, signal);
+}
 
 /** Cost of one generation call, estimated (the generation path doesn't return
  *  token usage). Deliberately the DEFAULT_TOKENS path so the guard errs early. */
@@ -197,7 +225,8 @@ async function translateCellReasons(
   locales: Locale[],
   provider: Provider,
   model: string,
-  budget: { spend: () => boolean; stoppedReason: StoppedReason | null }
+  budget: { spend: () => boolean; stoppedReason: StoppedReason | null },
+  gen: { apiKey?: string; signal?: AbortSignal; callDelayMs?: number } = {}
 ): Promise<{ inserted: number; stoppedReason: StoppedReason | null }> {
   if (locales.length === 0) return { inserted: 0, stoppedReason: null };
 
@@ -221,6 +250,7 @@ async function translateCellReasons(
     for (const en of enRows) {
       if (existing.has(en.toRef)) continue;
       if (!budget.spend()) return { inserted, stoppedReason: budget.stoppedReason };
+      await pace(gen.callDelayMs, gen.signal);
 
       let translated: string;
       try {
@@ -228,8 +258,14 @@ async function translateCellReasons(
           feature: "connections",
           provider,
           model,
+          apiKey: gen.apiKey,
+          signal: gen.signal,
         });
       } catch (err) {
+        // A daily-quota hit is not a translation problem — bubble it to the
+        // single handler in runConnectionBatch so the pass ends "quota-daily"
+        // and the loop rotates keys.
+        if (err instanceof GeminiDailyQuotaError) throw err;
         console.error(`connection-batch: translation failed ${fromRef} ${kind} ${locale}:`, err);
         incr("connection_batch_translate_failed");
         continue;
@@ -312,6 +348,7 @@ export async function runConnectionBatch(
     translated: 0,
     exhausted: 0,
     cellsFailed: 0,
+    workListSize: 0,
   };
 
   // Resolve the effective model once, up front: with no per-run pick,
@@ -330,6 +367,7 @@ export async function runConnectionBatch(
     hooks.onProgress(`[${opts.mode}] failed to build work list: ${summary.error}`);
     return summary;
   }
+  summary.workListSize = cells.length;
 
   hooks.onProgress(
     `[${opts.mode}] ${cells.length} cells to consider | provider=${opts.provider} | ` +
@@ -392,6 +430,7 @@ export async function runConnectionBatch(
         summary.stoppedReason = budget.stoppedReason ?? "call-budget";
         break;
       }
+      await pace(opts.callDelayMs, signal);
 
       const { results, calledAI } = await generateConnectionsForCell(
         cell.fromRef,
@@ -400,7 +439,8 @@ export async function runConnectionBatch(
         excludeRefs,
         "en",
         opts.provider,
-        model
+        model,
+        { apiKey: opts.apiKey, signal }
       );
       if (!calledAI) {
         // No grounding data / drained pool — no request was actually made, so
@@ -430,7 +470,8 @@ export async function runConnectionBatch(
           opts.locales,
           opts.provider,
           model,
-          budget
+          budget,
+          { apiKey: opts.apiKey, signal, callDelayMs: opts.callDelayMs }
         );
         summary.translated += xlt.inserted;
         await upsertCoverage(cell.fromRef, cell.kind, { activeCount, lastError: null });
@@ -441,6 +482,17 @@ export async function runConnectionBatch(
         }
       }
     } catch (err) {
+      if (err instanceof GeminiDailyQuotaError) {
+        // Not a per-cell failure: the key is spent for the day. End the pass
+        // cleanly so the outer loop rotates to the next key. Deliberately does
+        // NOT touch cellsFailed / consecutiveFailures / coverage lastError.
+        summary.stoppedReason = "quota-daily";
+        summary.lastError = err.message;
+        hooks.onProgress(
+          `[${opts.mode}] daily quota exhausted for the active key at ${cell.fromRef} ${cell.kind} — ending pass to rotate`
+        );
+        break;
+      }
       const message = err instanceof Error ? err.message : String(err);
       console.error(`connection-batch: cell ${cell.fromRef} ${cell.kind} failed:`, err);
       incr("connection_batch_cell_failed");

--- a/lib/ai/connection-batch.ts
+++ b/lib/ai/connection-batch.ts
@@ -63,7 +63,11 @@ export interface BatchOptions {
   model?: string;
   /** Target locales to translate the English reason into (subset of tr/ru/az). */
   locales: Locale[];
-  /** Hard ceiling on LLM calls this run. Always exact. */
+  /** Ceiling on *reserved* LLM calls this run — one per generation + one per
+   *  locale translation. `callGemini` may issue up to PER_MINUTE_MAX_RETRIES real
+   *  HTTP requests per reservation when it hits per-minute 429s, so against
+   *  Google's quota this under-counts; it is the run's spend guard, not a request
+   *  meter. `Number.POSITIVE_INFINITY` in loop mode when left blank. */
   maxCalls: number;
   /** Best-effort USD ceiling. Estimated per call (tokens aren't tracked on the
    *  generation path), so treat as approximate — maxCalls is the real guard.
@@ -482,6 +486,13 @@ export async function runConnectionBatch(
         }
       }
     } catch (err) {
+      // A cooperative cancel (Stop button) can land here as the rejection of an
+      // in-flight `pace()` delay or a `callGemini` rate-limit backoff. That is
+      // not a cell failure — don't poison the coverage row or trip fail-fast.
+      if (signal?.aborted || (err instanceof Error && err.name === "AbortError")) {
+        summary.stoppedReason = "cancelled";
+        break;
+      }
       if (err instanceof GeminiDailyQuotaError) {
         // Not a per-cell failure: the key is spent for the day. End the pass
         // cleanly so the outer loop rotates to the next key. Deliberately does

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -28,6 +28,11 @@ import type { ConnectionResult, EdgeKind, Verse } from "@/types/quran";
 export interface GenerateOpts {
   provider?: Provider;
   model?: string;
+  /** Explicit Gemini API key (the admin backfill loop's per-key pick). */
+  apiKey?: string;
+  /** Cooperative-cancel signal, threaded to the LLM call so a rate-limit backoff
+   *  wait aborts when the admin stops the job. */
+  signal?: AbortSignal;
 }
 
 function tokensFromUsage(
@@ -163,6 +168,8 @@ export async function generateConnections(
     feature: "connections",
     provider: opts.provider,
     model: opts.model,
+    apiKey: opts.apiKey,
+    signal: opts.signal,
   });
   const text = res.text;
 
@@ -305,6 +312,8 @@ export async function generateGroundedConnections(
     feature: "connections",
     provider: opts.provider,
     model: opts.model,
+    apiKey: opts.apiKey,
+    signal: opts.signal,
   });
   const text = res.text;
 

--- a/lib/ai/gemini-errors.ts
+++ b/lib/ai/gemini-errors.ts
@@ -108,6 +108,14 @@ export function classifyGeminiError(err: unknown): GeminiRateInfo {
   const lower = signal.toLowerCase();
   const raw = signal.trim().slice(0, 500);
 
+  // A concrete non-429 status is never a rate limit for our purposes — a 403
+  // "Quota exceeded ... consumer suspended" or a 400 about a quota project
+  // contain the word "quota" but must NOT route into the retry/rotate path
+  // (they'd cost ~4 min of backoff per key and end the run as a false "success").
+  if (status !== undefined && status !== 429) {
+    return { cls: "not-rate-limit", status, raw };
+  }
+
   const looksRateLimited =
     status === 429 ||
     lower.includes("resource_exhausted") ||
@@ -144,11 +152,17 @@ function safeStringify(value: unknown): string {
   }
 }
 
+/** Smallest per-minute backoff wait, even when Google says `"retryDelay": "0s"`
+ *  — retrying instantly 6× is how a key gets flagged. */
+export const PER_MINUTE_MIN_DELAY_MS = 2_000;
+
 /** The backoff wait for per-minute retry `attempt` (1-based), honouring an
- *  explicit `retryAfterMs` when Google sent one, else exponential with jitter. */
+ *  explicit `retryAfterMs` when Google sent a usable one, else exponential with
+ *  jitter. Always at least `PER_MINUTE_MIN_DELAY_MS`. */
 export function perMinuteBackoffMs(attempt: number, retryAfterMs?: number): number {
-  const base = retryAfterMs ?? PER_MINUTE_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
-  const capped = Math.min(base, PER_MINUTE_MAX_DELAY_MS);
+  const exponential = PER_MINUTE_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
+  const base = retryAfterMs && retryAfterMs > 0 ? retryAfterMs : exponential;
+  const capped = Math.min(Math.max(base, PER_MINUTE_MIN_DELAY_MS), PER_MINUTE_MAX_DELAY_MS);
   const jitter = capped * (0.85 + Math.random() * 0.3);
   return Math.round(jitter);
 }

--- a/lib/ai/gemini-errors.ts
+++ b/lib/ai/gemini-errors.ts
@@ -1,0 +1,154 @@
+/**
+ * The single place Gemini 429 / RESOURCE_EXHAUSTED errors are classified.
+ *
+ * The admin backfill "loop mode" (lib/ai/connection-batch-loop.ts) rotates through
+ * a pool of free-tier Gemini keys. It must tell apart:
+ *
+ *   - a PER-DAY quota exhaustion  → that key is done until the quota resets;
+ *                                   rotate to the next key.
+ *   - a PER-MINUTE rate limit     → transient; wait out `retryDelay` and retry
+ *                                   the same key.
+ *
+ * `@google/generative-ai@^0.24.1` is Google's legacy SDK. On a non-2xx it throws
+ * `GoogleGenerativeAIFetchError` with `.status`, `.statusText`, and
+ * `.errorDetails` (parsed `error.details[]`), and also stringifies the RPC error
+ * into `.message`. The exact shape is not contractual, so the classifier reads
+ * whatever is present and degrades to a conservative fallback (see
+ * `classifyGeminiError`).
+ */
+
+/** Attempts before a per-minute retry loop gives up on a request. */
+export const PER_MINUTE_MAX_RETRIES = 6;
+/** Base wait between per-minute retries (doubled each attempt). Free-tier RPM
+ *  windows are ~60s, so the first waits are deliberately long. */
+export const PER_MINUTE_BASE_DELAY_MS = 20_000;
+/** Ceiling for a single per-minute backoff wait. */
+export const PER_MINUTE_MAX_DELAY_MS = 65_000;
+/** Consecutive ambiguous 429s (429 with no clear per-day / per-minute marker) on
+ *  one key, with no successful call in between, after which the key is assumed
+ *  daily-exhausted and the loop rotates. Guards against a genuinely dead key that
+ *  only emits shapeless 429s stalling the loop forever. */
+export const AMBIGUOUS_429_ESCALATE_AFTER = 8;
+
+export type GeminiRateClass = "daily" | "per-minute" | "other-429" | "not-rate-limit";
+
+export interface GeminiRateInfo {
+  cls: GeminiRateClass;
+  status?: number;
+  /** Parsed from the RPC `RetryInfo.retryDelay` ("39s") or a Retry-After header. */
+  retryAfterMs?: number;
+  /** The RPC `QuotaFailure` violation quotaId, when present. */
+  quotaId?: string;
+  /** A short slice of the underlying error, for the job log. */
+  raw: string;
+}
+
+/** Thrown up through the generation call chain to signal the loop must rotate to
+ *  the next key. Deliberately NOT caught as an ordinary per-cell failure by
+ *  `runConnectionBatch`. */
+export class GeminiDailyQuotaError extends Error {
+  readonly info: GeminiRateInfo;
+  constructor(info: GeminiRateInfo) {
+    super(`Gemini daily quota exhausted${info.quotaId ? ` (${info.quotaId})` : ""}`);
+    this.name = "GeminiDailyQuotaError";
+    this.info = info;
+  }
+}
+
+/** Thrown when a per-minute retry loop is exhausted. Treated by
+ *  `runConnectionBatch` as an ordinary cell failure (run continues; fail-fast
+ *  still applies). */
+export class GeminiRateLimitError extends Error {
+  readonly info: GeminiRateInfo;
+  readonly attempts: number;
+  constructor(info: GeminiRateInfo, attempts: number) {
+    super(`Gemini rate limit not cleared after ${attempts} attempts`);
+    this.name = "GeminiRateLimitError";
+    this.info = info;
+    this.attempts = attempts;
+  }
+}
+
+interface FetchErrorLike {
+  status?: number;
+  statusText?: string;
+  errorDetails?: unknown;
+  message?: string;
+}
+
+function asFetchErrorLike(err: unknown): FetchErrorLike | null {
+  if (typeof err !== "object" || err === null) return null;
+  return err as FetchErrorLike;
+}
+
+function parseRetryAfterMs(text: string): number | undefined {
+  const retryDelay = text.match(/"retryDelay"\s*:\s*"(\d+(?:\.\d+)?)s"/i);
+  if (retryDelay) return Math.ceil(parseFloat(retryDelay[1]) * 1000);
+  const retryAfter = text.match(/retry-?after["\s:]+(\d+)/i);
+  if (retryAfter) return parseInt(retryAfter[1], 10) * 1000;
+  return undefined;
+}
+
+/**
+ * Classifies an error thrown by a Gemini `generateContent` call.
+ *
+ * Conservative fallback: an unrecognised 429 is `other-429`, which the retry
+ * wrapper treats as per-minute (wait + retry). A misclassified per-minute error
+ * that were treated as daily would burn a key permanently on a transient blip;
+ * the reverse only wastes bounded, capped retry time. `AMBIGUOUS_429_ESCALATE_AFTER`
+ * is the backstop for a truly daily-dead key that only emits `other-429`.
+ */
+export function classifyGeminiError(err: unknown): GeminiRateInfo {
+  const e = asFetchErrorLike(err);
+  const message = typeof e?.message === "string" ? e.message : "";
+  const detailsJson = e?.errorDetails !== undefined ? safeStringify(e.errorDetails) : "";
+  const status = typeof e?.status === "number" ? e.status : undefined;
+
+  const signal = `${detailsJson}\n${message}`;
+  const lower = signal.toLowerCase();
+  const raw = signal.trim().slice(0, 500);
+
+  const looksRateLimited =
+    status === 429 ||
+    lower.includes("resource_exhausted") ||
+    lower.includes("too many requests") ||
+    lower.includes("rate limit") ||
+    lower.includes("quota");
+
+  if (!looksRateLimited) {
+    return { cls: "not-rate-limit", status, raw };
+  }
+
+  const retryAfterMs = parseRetryAfterMs(signal);
+  const quotaId = signal.match(/"quotaId"\s*:\s*"([^"]+)"/)?.[1];
+
+  const perDay =
+    /per\s*day|perday|requests per day|generaterequestsperday/i.test(quotaId ?? "") ||
+    /perdayper|requests per day|generaterequestsperday/i.test(lower);
+  const perMinute =
+    /per\s*minute|perminute|requests per minute/i.test(quotaId ?? "") ||
+    /perminuteper|requests per minute|input tokens per model per minute|tokens per minute/i.test(
+      lower
+    );
+
+  if (perDay) return { cls: "daily", status, retryAfterMs, quotaId, raw };
+  if (perMinute) return { cls: "per-minute", status, retryAfterMs, quotaId, raw };
+  return { cls: "other-429", status, retryAfterMs, quotaId, raw };
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** The backoff wait for per-minute retry `attempt` (1-based), honouring an
+ *  explicit `retryAfterMs` when Google sent one, else exponential with jitter. */
+export function perMinuteBackoffMs(attempt: number, retryAfterMs?: number): number {
+  const base = retryAfterMs ?? PER_MINUTE_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
+  const capped = Math.min(base, PER_MINUTE_MAX_DELAY_MS);
+  const jitter = capped * (0.85 + Math.random() * 0.3);
+  return Math.round(jitter);
+}

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -188,9 +188,10 @@ export async function generateConnectionsForCell(
   excludeRefs: string[] = [],
   locale: Locale = "en",
   provider: Provider,
-  model: string
+  model: string,
+  gen: { apiKey?: string; signal?: AbortSignal } = {}
 ): Promise<CellGenerationResult> {
-  const genOpts = [{ provider, model }] as const;
+  const genOpts = [{ provider, model, apiKey: gen.apiKey, signal: gen.signal }] as const;
   const candidates = await discoverCandidates(fromRef, kind, undefined, excludeRefs);
   const calledAI = candidates.length > 0 || excludeRefs.length === 0;
   // The legacy ungrounded path has no notion of excludeRefs — it would just

--- a/lib/infra/sleep.ts
+++ b/lib/infra/sleep.ts
@@ -1,0 +1,27 @@
+/**
+ * A `setTimeout` that resolves after `ms`, or rejects immediately if the given
+ * `AbortSignal` fires. Used wherever a delay must never outlive a cooperative
+ * cancel (the admin "Stop job" button aborts the job's signal) — a bare
+ * `setTimeout` would make a Stop click wait out the full backoff.
+ */
+export function interruptibleSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error("aborted"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      cleanup();
+      reject(signal?.reason ?? new Error("aborted"));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a **Loop** checkbox to the coverage-page backfill runner. When checked, the backfill job re-runs pass after pass, rotating through an admin-selected pool of free-tier Gemini keys (`GEMINI_API1`..`GEMINI_API5`), so the connection graph fills continuously at zero budget.
- It advances to the next key **only** on a per-day quota exhaustion. Per-minute 429s ("Too Many Requests") are waited out (honouring `retryDelay`) and retried. A non-quota pass failure stops the whole loop.
- Every LLM call is paced by an adjustable delay (default ~1500 ms ≈ 3 calls / 4.5 s). The loop stops when every selected key is daily-exhausted, the work list is fully covered, the admin clicks Stop, or an optional safety budget cap is hit.
- **Nothing about the existing one-shot run changes** — all current fields stay, and both budget fields stay required when Loop is unchecked.

## How it works

| Piece | File |
| --- | --- |
| 429 classification (daily / per-minute / other-429), typed `GeminiDailyQuotaError` + `GeminiRateLimitError`, backoff constants, 8-in-a-row ambiguous-429 escalation guard | `lib/ai/gemini-errors.ts` (new) |
| `callGemini` takes an explicit `apiKey` + `AbortSignal`, wraps `generateContent` in the classify/retry loop | `lib/ai/ai.ts` |
| `apiKey` + `callDelayMs` threaded down the generation chain; `"quota-daily"` stop reason that bypasses the per-cell failure path; abort-aware pacing | `lib/ai/connection-batch.ts`, `connection-generator.ts`, `graph-service.ts` |
| The key-rotating outer loop | `lib/ai/connection-batch-loop.ts` (new) |
| `GEMINI_KEY_POOL` / `configuredGeminiKeys`, loop-mode param validation, dispatch, terminal-status mapping; `LOG_TAIL_LINES` 50 → 100 | `lib/admin/job-runner.ts` |
| Admin-gated endpoint exposing configured key **names** only (never values) for the form's key picker | `app/api/admin/gemini-keys/route.ts` (new) |
| Loop checkbox, key multiselect, delay field, optional budgets | `components/admin/BackfillRunner.tsx` |

Key threading is an explicit parameter (not `process.env` mutation) so the public "+" expander and embeddings keep using `GEMINI_API_KEY` while a loop job runs.

## Type of change

- [x] New feature

## AI / Theological changes

- [x] No AI or theological changes in this PR
- [x] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)

**Details:** No prompt wording, divine-name data, or theological framing changed. `translateReason`'s prompt and `tanzihDirective()` are untouched; the new `apiKey`/`signal` just flow through `CallAiOptions`. Loop mode does make Gemini the only provider and runs it heavily, so connection/translation quality tracks the admin-selected Gemini model — the model picker and the "translate reasons into" locales are unchanged from the existing runner.

## Testing

- [x] `bun run test:ci` passes locally (ran in the pre-commit hook)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (pre-existing `.superpowers/` warnings only)
- [x] New tests added: `gemini-errors`, `gemini-retry`, `connection-batch-loop`, `gemini-keys` route, plus loop-mode cases in `job-runner`, `jobs` route, `BackfillRunner`, and the `connection-batch` integration suite (typed-error handling + pacing)

Integration tests ran in the pre-push hook (Testcontainers).

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff (endpoint returns env var *names* only)
- [x] `.env.example` updated (`GEMINI_API1`..`GEMINI_API5`) + `AGENTS.md` note

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Gemini free-tier loop mode for admin connection backfills.
  - Admins can select configured Gemini keys, set request delays, and rotate keys when daily quotas are reached.
  - Added Gemini key visibility to admin job and coverage interfaces without exposing key values.
  - Added cancellation support and clearer quota and rate-limit handling.

- **Bug Fixes**
  - Per-minute rate limits now retry with backoff and report exhausted retries as failures.
  - Key-list loading errors are now distinguished from having no configured keys.

- **Tests**
  - Expanded coverage for loop mode, rotation, pacing, cancellation, and authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->