### PR TITLE
Feat/backfill loop mode

### DIFF
--- a/__tests__/lib/ai/gemini-errors.test.ts
+++ b/__tests__/lib/ai/gemini-errors.test.ts
@@ -102,10 +102,12 @@ describe("typed errors", () => {
 });
 
 describe("perMinuteBackoffMs", () => {
-  it("honours an explicit retryAfterMs (within jitter)", () => {
-    const ms = perMinuteBackoffMs(1, 12_000);
-    expect(ms).toBeGreaterThanOrEqual(12_000 * 0.85);
-    expect(ms).toBeLessThanOrEqual(12_000 * 1.15);
+  it("never returns less than the provider-supplied retryAfterMs", () => {
+    for (let i = 0; i < 50; i++) {
+      const ms = perMinuteBackoffMs(1, 12_000);
+      expect(ms).toBeGreaterThanOrEqual(12_000);
+      expect(ms).toBeLessThanOrEqual(12_000 * 1.15 + 1);
+    }
   });
 
   it("caps the exponential backoff", () => {

--- a/__tests__/lib/ai/gemini-retry.test.ts
+++ b/__tests__/lib/ai/gemini-retry.test.ts
@@ -85,6 +85,23 @@ describe("callGemini retry / classification", () => {
     expect(ctorKeys).toEqual(["loop-key-2"]);
   });
 
+  it("forwards the AbortSignal into the generateContent request", async () => {
+    mockGenerate.mockResolvedValueOnce(ok);
+    const ac = new AbortController();
+    await callAIDetailed("hi", { provider: "gemini", signal: ac.signal });
+    expect(mockGenerate).toHaveBeenCalledWith("hi", { signal: ac.signal });
+  });
+
+  it("propagates an abort thrown by generateContent itself", async () => {
+    mockGenerate.mockRejectedValueOnce(
+      Object.assign(new Error("The operation was aborted"), { name: "AbortError" })
+    );
+    await expect(callAIDetailed("hi", { provider: "gemini" })).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
   it("aborts a backoff wait when the signal fires", async () => {
     mockGenerate.mockRejectedValue(fetchError(perMinute));
     const ac = new AbortController();

--- a/components/admin/BackfillRunner.tsx
+++ b/components/admin/BackfillRunner.tsx
@@ -287,7 +287,7 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
 
             <Field
               label="Delay between LLM calls (ms)"
-              hint="~1500 ms ≈ 3 calls / 4.5 s. Lower risks per-minute 429s (auto-retried)."
+              hint="~1500 ms ≈ 3 calls / 4.5 s. A higher delay lowers the risk of per-minute 429s (which are auto-retried anyway)."
             >
               <Input
                 type="number"

--- a/lib/ai/ai.ts
+++ b/lib/ai/ai.ts
@@ -201,7 +201,9 @@ async function callGemini(
 
   for (let attempt = 1; ; attempt++) {
     try {
-      const result = await genModel.generateContent(prompt);
+      // `signal` aborts the client-side wait on a Stop click; it does not cancel
+      // the request in Google's service (still billed) — SDK docs are explicit.
+      const result = await genModel.generateContent(prompt, signal ? { signal } : {});
       ambiguous429Streak.delete(key);
       const meta = result.response.usageMetadata;
       return {

--- a/lib/ai/gemini-errors.ts
+++ b/lib/ai/gemini-errors.ts
@@ -156,13 +156,25 @@ function safeStringify(value: unknown): string {
  *  — retrying instantly 6× is how a key gets flagged. */
 export const PER_MINUTE_MIN_DELAY_MS = 2_000;
 
-/** The backoff wait for per-minute retry `attempt` (1-based), honouring an
- *  explicit `retryAfterMs` when Google sent a usable one, else exponential with
- *  jitter. Always at least `PER_MINUTE_MIN_DELAY_MS`. */
+/** The backoff wait for per-minute retry `attempt` (1-based).
+ *
+ * When Google sends a usable `retryDelay`, that is a MINIMUM — jitter is added
+ * on top, never subtracted, so we never re-fire before the window Google named.
+ * Otherwise: exponential from `PER_MINUTE_BASE_DELAY_MS` with ±15% jitter.
+ * Always at least `PER_MINUTE_MIN_DELAY_MS`, at most `PER_MINUTE_MAX_DELAY_MS`. */
 export function perMinuteBackoffMs(attempt: number, retryAfterMs?: number): number {
-  const exponential = PER_MINUTE_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
-  const base = retryAfterMs && retryAfterMs > 0 ? retryAfterMs : exponential;
+  const hasRetryAfter = retryAfterMs !== undefined && retryAfterMs > 0;
+  const floor = hasRetryAfter
+    ? Math.max(retryAfterMs, PER_MINUTE_MIN_DELAY_MS)
+    : PER_MINUTE_MIN_DELAY_MS;
+  const base = hasRetryAfter
+    ? floor
+    : PER_MINUTE_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
   const capped = Math.min(Math.max(base, PER_MINUTE_MIN_DELAY_MS), PER_MINUTE_MAX_DELAY_MS);
-  const jitter = capped * (0.85 + Math.random() * 0.3);
-  return Math.round(jitter);
+  // Additive jitter only when honouring a provider delay (0..+15%); symmetric
+  // otherwise.
+  const jitter = hasRetryAfter
+    ? capped * (1 + Math.random() * 0.15)
+    : capped * (0.85 + Math.random() * 0.3);
+  return Math.max(Math.round(jitter), floor);
 }


### PR DESCRIPTION
## Summary

<!-- 1–3 bullet points: what changed and why -->

-
-

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

<!-- Complete this section if you modified any Claude prompts, divine name data, or verse connection logic. Leave blank otherwise. -->

- [ ] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below
- [ ] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)

**Details** (if applicable):
<!-- Describe any changes to prompts, expected output format, or theological framing. Note any deviations from or additions to the Maturidi/Hanafi tradition. -->

## Testing

- [ ] `bun run test:ci` passes locally
- [ ] `bun run typecheck` passes locally
- [ ] `bun run lint` passes locally
- [ ] `bun run format:check` passes locally
- [ ] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Conventional commits
- [ ] No secrets or real API keys in the diff
- [ ] `.env.example` updated if new environment variables were added
- [ ] `README.md` updated if the feature changes the public interface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stopping an in-progress AI request now immediately ends the client-side wait.
  - Requests that are stopped may still be processed and billed by the AI provider.

- **Bug Fixes**
  - Retry delays now always respect the provider’s requested minimum, reducing the risk of repeated per-minute rate-limit errors.
  - Direct cancellation errors now stop immediately instead of triggering additional retries.

- **Documentation**
  - Updated the backfill runner’s delay guidance to explain how longer delays help reduce rate-limit errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->