### PR TITLE
feat(admin): backfill loop-mode follow-ups — invalid-key rotation, translation-gap resume

### DIFF
--- a/__tests__/integration/connection-batch.integration.test.ts
+++ b/__tests__/integration/connection-batch.integration.test.ts
@@ -25,7 +25,11 @@ vi.stubGlobal(
 import { db } from "@/lib/infra/db";
 import { verses, connections, connectionCoverage, aiGenerations } from "@/lib/infra/db/schema";
 import { runConnectionBatch } from "@/lib/ai/connection-batch";
-import { GeminiDailyQuotaError, GeminiRateLimitError } from "@/lib/ai/gemini-errors";
+import {
+  GeminiDailyQuotaError,
+  GeminiKeyInvalidError,
+  GeminiRateLimitError,
+} from "@/lib/ai/gemini-errors";
 import { getCoverageReport } from "@/lib/admin/coverage-report";
 
 async function reset() {
@@ -299,6 +303,88 @@ describe("runConnectionBatch (integration, real Postgres)", () => {
     expect((await db.select().from(connections)).length).toBe(0);
     // The quota hit is not recorded as a coverage last_error.
     expect((await db.select().from(connectionCoverage)).length).toBe(0);
+  });
+
+  it("invalid key: ends the pass 'key-invalid' without a cell failure or fail-fast", async () => {
+    for (const r of ["1:1", "2:255", "3:18"]) await seed(r);
+    mockCallAI.mockRejectedValue(
+      new GeminiKeyInvalidError({ cls: "key-invalid", status: 400, raw: "API_KEY_INVALID" })
+    );
+
+    const summary = await runConnectionBatch(
+      { mode: "baseline", provider: "gemini", locales: [], maxCalls: 500, maxCostUsd: 100 },
+      hooks
+    );
+
+    expect(summary.stoppedReason).toBe("key-invalid");
+    expect(summary.generated).toBe(0);
+    expect(summary.cellsFailed).toBe(0);
+    expect(summary.cellsProcessed).toBe(0);
+    expect((await db.select().from(connections)).length).toBe(0);
+    expect((await db.select().from(connectionCoverage)).length).toBe(0);
+  });
+
+  it("baseline picks up cells whose translations were never finished — no new generation", async () => {
+    await seed("1:1");
+    await seed("2:255");
+    // Both refs in every response → each verse gets the other as a connection,
+    // so after pass 1 every cell has English coverage (self-refs are filtered).
+    mockCallAI.mockResolvedValue(
+      JSON.stringify([
+        { ref: "1:1", reason: "en reason" },
+        { ref: "2:255", reason: "en reason" },
+      ])
+    );
+
+    // Pass 1: generate English only (no target locales).
+    await runConnectionBatch(
+      { mode: "baseline", provider: "gemini", locales: [], maxCalls: 500, maxCostUsd: 100 },
+      hooks
+    );
+    const enCount = (
+      await db
+        .select()
+        .from(connections)
+        .where(sql`${connections.locale} = 'en'`)
+    ).length;
+    expect(enCount).toBeGreaterThan(0);
+
+    // Pass 2: same mode, now with a target locale. The English cell must be
+    // revisited as translate-only — only translation prompts, no generation.
+    mockCallAI.mockReset();
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      if (!prompt.startsWith("Translate the following sentence")) {
+        throw new Error(
+          `unexpected generation call in translate-only pass: ${prompt.slice(0, 40)}`
+        );
+      }
+      return "localized";
+    });
+    const pass2 = await runConnectionBatch(
+      { mode: "baseline", provider: "gemini", locales: ["tr"], maxCalls: 500, maxCostUsd: 100 },
+      hooks
+    );
+
+    expect(pass2.generated).toBe(0);
+    expect(pass2.cellsFailed).toBe(0);
+    expect(pass2.translated).toBe(enCount);
+    const trCount = (
+      await db
+        .select()
+        .from(connections)
+        .where(sql`${connections.locale} = 'tr'`)
+    ).length;
+    expect(trCount).toBe(enCount);
+
+    // Pass 3: fully translated now → nothing to do, no calls.
+    mockCallAI.mockClear();
+    const pass3 = await runConnectionBatch(
+      { mode: "baseline", provider: "gemini", locales: ["tr"], maxCalls: 500, maxCostUsd: 100 },
+      hooks
+    );
+    expect(mockCallAI).not.toHaveBeenCalled();
+    expect(pass3.generated).toBe(0);
+    expect(pass3.translated).toBe(0);
   });
 
   it("per-minute retries exhausted: treated as an ordinary cell failure", async () => {

--- a/__tests__/integration/connection-batch.integration.test.ts
+++ b/__tests__/integration/connection-batch.integration.test.ts
@@ -22,6 +22,14 @@ vi.stubGlobal(
   vi.fn(async () => ({ ok: false }))
 );
 
+// Count the pacing delays without actually waiting them out.
+const { mockSleep } = vi.hoisted(() => ({
+  mockSleep: vi.fn(async (_ms: number, _signal?: AbortSignal): Promise<void> => {}),
+}));
+vi.mock("@/lib/infra/sleep", () => ({
+  interruptibleSleep: (ms: number, signal?: AbortSignal) => mockSleep(ms, signal),
+}));
+
 import { db } from "@/lib/infra/db";
 import { verses, connections, connectionCoverage, aiGenerations } from "@/lib/infra/db/schema";
 import { runConnectionBatch } from "@/lib/ai/connection-batch";
@@ -55,6 +63,7 @@ const hooks = { onProgress: () => {} };
 
 beforeEach(async () => {
   mockCallAI.mockReset();
+  mockSleep.mockClear();
   await reset();
 });
 
@@ -401,6 +410,40 @@ describe("runConnectionBatch (integration, real Postgres)", () => {
     expect(summary.stoppedReason).toBe("error");
     expect(summary.cellsFailed).toBe(3);
     expect(summary.generated).toBe(0);
+  });
+
+  it("callDelayMs: exactly one delay between consecutive real LLM requests", async () => {
+    await seed("1:1");
+    await seed("2:255");
+    // Each cell generates one English connection and then translates it once.
+    // The pacer must leave exactly one delay in each gap between consecutive
+    // real requests — i.e. (requests - 1) — with no double-delay across the
+    // generation → first-translation boundary.
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      if (prompt.startsWith("Translate the following sentence")) return "localized";
+      return JSON.stringify([
+        { ref: "1:1", reason: "en reason" },
+        { ref: "2:255", reason: "en reason" },
+      ]);
+    });
+
+    const summary = await runConnectionBatch(
+      {
+        mode: "baseline",
+        provider: "gemini",
+        locales: ["tr"],
+        maxCalls: 500,
+        maxCostUsd: 100,
+        callDelayMs: 5,
+      },
+      hooks
+    );
+
+    expect(summary.stoppedReason).toBe("completed");
+    expect(summary.generated).toBeGreaterThan(0);
+    expect(summary.translated).toBe(summary.generated);
+    const realRequests = mockCallAI.mock.calls.length;
+    expect(mockSleep).toHaveBeenCalledTimes(realRequests - 1);
   });
 
   it("callDelayMs: a paced run still completes", async () => {

--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -432,6 +432,7 @@ describe("startJob — backfill-connections loop mode", () => {
       ["all-keys-daily", "success"],
       ["work-exhausted", "success"],
       ["error", "failed"],
+      ["key-invalid", "failed"],
       ["cancelled", "cancelled"],
     ] as const;
     for (const [stoppedReason, expected] of cases) {

--- a/__tests__/lib/ai/connection-batch-loop.test.ts
+++ b/__tests__/lib/ai/connection-batch-loop.test.ts
@@ -58,6 +58,35 @@ describe("runConnectionBatchLoop", () => {
     expect(mockReset).toHaveBeenCalledTimes(2);
   });
 
+  it("rotates to the next key on key-invalid (not a whole-loop stop)", async () => {
+    mockRunConnectionBatch
+      .mockResolvedValueOnce(pass({ stoppedReason: "key-invalid" }))
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed", generated: 2 }))
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed" }))
+      .mockResolvedValueOnce(pass({ stoppedReason: "completed" }));
+
+    const summary = await runConnectionBatchLoop(opts(), hooks, new AbortController().signal);
+    expect(summary.keysInvalid).toEqual(["GEMINI_API1"]);
+    expect(mockRunConnectionBatch.mock.calls[1][0].apiKey).toBe("k2");
+    expect(summary.stoppedReason).toBe("work-exhausted");
+  });
+
+  it("ends 'error' when every selected key is invalid", async () => {
+    mockRunConnectionBatch.mockResolvedValue(pass({ stoppedReason: "key-invalid" }));
+    const summary = await runConnectionBatchLoop(opts(), hooks, new AbortController().signal);
+    expect(summary.stoppedReason).toBe("error");
+    expect(summary.error).toMatch(/invalid\/blocked/);
+    expect(summary.keysInvalid).toEqual(["GEMINI_API1", "GEMINI_API2"]);
+  });
+
+  it("still ends all-keys-daily when keys are a mix of daily-exhausted and invalid", async () => {
+    mockRunConnectionBatch
+      .mockResolvedValueOnce(pass({ stoppedReason: "key-invalid" }))
+      .mockResolvedValueOnce(pass({ stoppedReason: "quota-daily" }));
+    const summary = await runConnectionBatchLoop(opts(), hooks, new AbortController().signal);
+    expect(summary.stoppedReason).toBe("all-keys-daily");
+  });
+
   it("ends all-keys-daily when every key hits its daily quota", async () => {
     mockRunConnectionBatch.mockResolvedValue(pass({ stoppedReason: "quota-daily" }));
     const summary = await runConnectionBatchLoop(opts(), hooks, new AbortController().signal);

--- a/__tests__/lib/ai/gemini-errors.test.ts
+++ b/__tests__/lib/ai/gemini-errors.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
   GeminiDailyQuotaError,
+  GeminiKeyInvalidError,
   GeminiRateLimitError,
   classifyGeminiError,
   perMinuteBackoffMs,
   PER_MINUTE_MAX_DELAY_MS,
+  PER_MINUTE_MIN_DELAY_MS,
 } from "@/lib/ai/gemini-errors";
 
 /** Shape of what `@google/generative-ai` throws for a non-2xx. */
@@ -73,6 +75,27 @@ describe("classifyGeminiError", () => {
     ).toBe("not-rate-limit");
   });
 
+  it("classifies a 400 API_KEY_INVALID as key-invalid", () => {
+    const detail = {
+      "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+      reason: "API_KEY_INVALID",
+      domain: "googleapis.com",
+    };
+    const info = classifyGeminiError(
+      fetchError(400, [detail], "API key not valid. Please pass a valid API key.")
+    );
+    expect(info.cls).toBe("key-invalid");
+    expect(info.status).toBe(400);
+  });
+
+  it("leaves a 403 PERMISSION_DENIED as not-rate-limit (project-level, loop should stop)", () => {
+    expect(
+      classifyGeminiError(
+        fetchError(403, [], "PERMISSION_DENIED: API has not been used in project")
+      ).cls
+    ).toBe("not-rate-limit");
+  });
+
   it("treats a 500 / network error as not-rate-limit", () => {
     expect(classifyGeminiError(fetchError(500, [], "500 Internal Server Error")).cls).toBe(
       "not-rate-limit"
@@ -99,6 +122,14 @@ describe("typed errors", () => {
     const err = new GeminiRateLimitError(classifyGeminiError(fetchError(429, [])), 6);
     expect(err.attempts).toBe(6);
   });
+
+  it("GeminiKeyInvalidError carries the classification info", () => {
+    const info = classifyGeminiError(fetchError(400, [], "API key not valid"));
+    const err = new GeminiKeyInvalidError(info);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.info.cls).toBe("key-invalid");
+    expect(err.name).toBe("GeminiKeyInvalidError");
+  });
 });
 
 describe("perMinuteBackoffMs", () => {
@@ -110,8 +141,19 @@ describe("perMinuteBackoffMs", () => {
     }
   });
 
-  it("caps the exponential backoff", () => {
-    expect(perMinuteBackoffMs(20)).toBeLessThanOrEqual(PER_MINUTE_MAX_DELAY_MS * 1.15);
+  it("never exceeds PER_MINUTE_MAX_DELAY_MS in the fallback path, at any attempt", () => {
+    for (const attempt of [1, 2, 3, 5, 10, 20]) {
+      for (let i = 0; i < 30; i++) {
+        const ms = perMinuteBackoffMs(attempt);
+        expect(ms).toBeGreaterThanOrEqual(PER_MINUTE_MIN_DELAY_MS);
+        expect(ms).toBeLessThanOrEqual(PER_MINUTE_MAX_DELAY_MS);
+      }
+    }
+  });
+
+  it("still honours a provider retryAfterMs that exceeds the max", () => {
+    const huge = PER_MINUTE_MAX_DELAY_MS * 3;
+    expect(perMinuteBackoffMs(1, huge)).toBeGreaterThanOrEqual(huge);
   });
 
   it("floors a zero retryDelay so retries never burst back-to-back", () => {

--- a/__tests__/lib/ai/gemini-errors.test.ts
+++ b/__tests__/lib/ai/gemini-errors.test.ts
@@ -151,9 +151,17 @@ describe("perMinuteBackoffMs", () => {
     }
   });
 
-  it("still honours a provider retryAfterMs that exceeds the max", () => {
+  it("still honours a provider retryAfterMs that exceeds the max, and keeps jitter", () => {
     const huge = PER_MINUTE_MAX_DELAY_MS * 3;
-    expect(perMinuteBackoffMs(1, huge)).toBeGreaterThanOrEqual(huge);
+    const seen = new Set<number>();
+    for (let i = 0; i < 50; i++) {
+      const ms = perMinuteBackoffMs(1, huge);
+      expect(ms).toBeGreaterThanOrEqual(huge);
+      expect(ms).toBeLessThanOrEqual(huge * 1.15 + 1);
+      seen.add(ms);
+    }
+    // Jitter must survive past the cap — otherwise every worker re-fires in sync.
+    expect(seen.size).toBeGreaterThan(1);
   });
 
   it("floors a zero retryDelay so retries never burst back-to-back", () => {

--- a/__tests__/lib/ai/gemini-errors.test.ts
+++ b/__tests__/lib/ai/gemini-errors.test.ts
@@ -102,10 +102,12 @@ describe("typed errors", () => {
 });
 
 describe("perMinuteBackoffMs", () => {
-  it("honours an explicit retryAfterMs (within jitter)", () => {
-    const ms = perMinuteBackoffMs(1, 12_000);
-    expect(ms).toBeGreaterThanOrEqual(12_000 * 0.85);
-    expect(ms).toBeLessThanOrEqual(12_000 * 1.15);
+  it("never returns less than the provider-supplied retryAfterMs", () => {
+    for (let i = 0; i < 50; i++) {
+      const ms = perMinuteBackoffMs(1, 12_000);
+      expect(ms).toBeGreaterThanOrEqual(12_000);
+      expect(ms).toBeLessThanOrEqual(12_000 * 1.15 + 1);
+    }
   });
 
   it("caps the exponential backoff", () => {

--- a/__tests__/lib/ai/gemini-retry.test.ts
+++ b/__tests__/lib/ai/gemini-retry.test.ts
@@ -21,7 +21,11 @@ vi.mock("@/lib/admin/feature-flags", () => ({
 }));
 
 import { callAIDetailed, resetGeminiRateLimitState } from "@/lib/ai/ai";
-import { GeminiDailyQuotaError, GeminiRateLimitError } from "@/lib/ai/gemini-errors";
+import {
+  GeminiDailyQuotaError,
+  GeminiKeyInvalidError,
+  GeminiRateLimitError,
+} from "@/lib/ai/gemini-errors";
 
 function fetchError(details: unknown[], message = "429") {
   return Object.assign(new Error(message), { status: 429, errorDetails: details });
@@ -99,6 +103,39 @@ describe("callGemini retry / classification", () => {
     await expect(callAIDetailed("hi", { provider: "gemini" })).rejects.toMatchObject({
       name: "AbortError",
     });
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a pending in-flight generateContent when the signal aborts — no retry", async () => {
+    // Request stays pending until the signal aborts.
+    mockGenerate.mockImplementation(
+      (_prompt: string, opts?: { signal?: AbortSignal }) =>
+        new Promise((_res, rej) => {
+          opts?.signal?.addEventListener("abort", () =>
+            rej(Object.assign(new Error("aborted"), { name: "AbortError" }))
+          );
+        })
+    );
+    const ac = new AbortController();
+    const p = callAIDetailed("hi", { provider: "gemini", signal: ac.signal }).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(1);
+    ac.abort();
+    const err = await p;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("AbortError");
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws GeminiKeyInvalidError immediately for an invalid key, no retry", async () => {
+    mockGenerate.mockRejectedValue(
+      Object.assign(new Error("API key not valid. Please pass a valid API key."), {
+        status: 400,
+        errorDetails: [{ "@type": "google.rpc.ErrorInfo", reason: "API_KEY_INVALID" }],
+      })
+    );
+    await expect(callAIDetailed("hi", { provider: "gemini" })).rejects.toBeInstanceOf(
+      GeminiKeyInvalidError
+    );
     expect(mockGenerate).toHaveBeenCalledTimes(1);
   });
 

--- a/__tests__/lib/ai/gemini-retry.test.ts
+++ b/__tests__/lib/ai/gemini-retry.test.ts
@@ -85,6 +85,23 @@ describe("callGemini retry / classification", () => {
     expect(ctorKeys).toEqual(["loop-key-2"]);
   });
 
+  it("forwards the AbortSignal into the generateContent request", async () => {
+    mockGenerate.mockResolvedValueOnce(ok);
+    const ac = new AbortController();
+    await callAIDetailed("hi", { provider: "gemini", signal: ac.signal });
+    expect(mockGenerate).toHaveBeenCalledWith("hi", { signal: ac.signal });
+  });
+
+  it("propagates an abort thrown by generateContent itself", async () => {
+    mockGenerate.mockRejectedValueOnce(
+      Object.assign(new Error("The operation was aborted"), { name: "AbortError" })
+    );
+    await expect(callAIDetailed("hi", { provider: "gemini" })).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
   it("aborts a backoff wait when the signal fires", async () => {
     mockGenerate.mockRejectedValue(fetchError(perMinute));
     const ac = new AbortController();

--- a/components/admin/BackfillRunner.tsx
+++ b/components/admin/BackfillRunner.tsx
@@ -287,7 +287,7 @@ export function BackfillRunner({ onStarted }: { onStarted?: () => void }) {
 
             <Field
               label="Delay between LLM calls (ms)"
-              hint="~1500 ms ≈ 3 calls / 4.5 s. Lower risks per-minute 429s (auto-retried)."
+              hint="~1500 ms ≈ 3 calls / 4.5 s. A higher delay lowers the risk of per-minute 429s (which are auto-retried anyway)."
             >
               <Input
                 type="number"

--- a/lib/admin/job-runner.ts
+++ b/lib/admin/job-runner.ts
@@ -269,7 +269,9 @@ function mapTerminalStatus(
   reason: StoppedReason | LoopStoppedReason
 ): "success" | "failed" | "cancelled" {
   if (reason === "cancelled") return "cancelled";
-  if (reason === "error" || reason === "quota-daily") return "failed";
+  // "quota-daily" / "key-invalid" are per-pass reasons the loop consumes
+  // internally; if one ever surfaces as a terminal reason, it's a fault.
+  if (reason === "error" || reason === "quota-daily" || reason === "key-invalid") return "failed";
   return "success";
 }
 

--- a/lib/ai/ai.ts
+++ b/lib/ai/ai.ts
@@ -5,6 +5,7 @@ import { DEFAULT_MODEL, isModelForProvider } from "@/lib/ai/models";
 import {
   AMBIGUOUS_429_ESCALATE_AFTER,
   GeminiDailyQuotaError,
+  GeminiKeyInvalidError,
   GeminiRateLimitError,
   PER_MINUTE_MAX_RETRIES,
   classifyGeminiError,
@@ -218,9 +219,10 @@ async function callGemini(
         model,
       };
     } catch (err) {
-      if (err instanceof GeminiDailyQuotaError) throw err;
+      if (err instanceof GeminiDailyQuotaError || err instanceof GeminiKeyInvalidError) throw err;
       const info = classifyGeminiError(err);
       if (info.cls === "not-rate-limit") throw err;
+      if (info.cls === "key-invalid") throw new GeminiKeyInvalidError(info);
       if (info.cls === "daily") throw new GeminiDailyQuotaError(info);
 
       if (info.cls === "other-429") {

--- a/lib/ai/ai.ts
+++ b/lib/ai/ai.ts
@@ -201,7 +201,9 @@ async function callGemini(
 
   for (let attempt = 1; ; attempt++) {
     try {
-      const result = await genModel.generateContent(prompt);
+      // `signal` aborts the client-side wait on a Stop click; it does not cancel
+      // the request in Google's service (still billed) — SDK docs are explicit.
+      const result = await genModel.generateContent(prompt, signal ? { signal } : {});
       ambiguous429Streak.delete(key);
       const meta = result.response.usageMetadata;
       return {

--- a/lib/ai/connection-batch-loop.ts
+++ b/lib/ai/connection-batch-loop.ts
@@ -52,6 +52,8 @@ export interface LoopSummary {
   keysUsed: number;
   /** Labels of keys that hit their daily quota this run. */
   keysExhausted: string[];
+  /** Labels of keys that turned out to be invalid / revoked this run. */
+  keysInvalid: string[];
   cellsProcessed: number;
   callsUsed: number;
   costUsd: number;
@@ -104,6 +106,7 @@ export async function runConnectionBatchLoop(
     passes: 0,
     keysUsed: 0,
     keysExhausted: [],
+    keysInvalid: [],
     cellsProcessed: 0,
     callsUsed: 0,
     costUsd: 0,
@@ -180,6 +183,13 @@ export async function runConnectionBatchLoop(
           rotate = true;
           break;
 
+        case "key-invalid":
+          // Per-key fault (revoked / invalid key) — rotate, don't stop.
+          agg.keysInvalid.push(label);
+          hooks.onProgress(`[loop] key ${k + 1}/${n} (${label}) invalid/blocked — rotating`);
+          rotate = true;
+          break;
+
         case "cancelled":
           agg.stoppedReason = "cancelled";
           return finish(agg, hooks);
@@ -243,9 +253,16 @@ export async function runConnectionBatchLoop(
     }
   }
 
-  // Fell out of the key loop → every selected key hit its daily quota.
+  // Fell out of the key loop → every key rotated (daily quota and/or invalid).
+  if (agg.keysInvalid.length === n) {
+    // Every selected key is invalid/blocked — nothing the loop can do.
+    agg.stoppedReason = "error";
+    agg.error = `all ${n} selected key(s) are invalid/blocked`;
+    hooks.onProgress(`[loop] ${agg.error} — stopping the loop`);
+    return finish(agg, hooks);
+  }
   agg.stoppedReason = "all-keys-daily";
-  hooks.onProgress(`[loop] all ${n} selected key(s) exhausted for the day — stopping`);
+  hooks.onProgress(`[loop] all ${n} selected key(s) exhausted or invalid — stopping`);
   return finish(agg, hooks);
 }
 
@@ -254,7 +271,8 @@ function finish(agg: LoopSummary, hooks: BatchHooks): LoopSummary {
     `[loop] DONE (${agg.stoppedReason}) | ${agg.passes} pass(es) | ${agg.keysUsed} key(s) | ` +
       `${agg.callsUsed} calls | $${agg.costUsd.toFixed(2)} | ` +
       `gen=${agg.generated} xlt=${agg.translated} exh=${agg.exhausted} fail=${agg.cellsFailed}` +
-      (agg.keysExhausted.length ? ` | exhausted: ${agg.keysExhausted.join(", ")}` : "")
+      (agg.keysExhausted.length ? ` | exhausted: ${agg.keysExhausted.join(", ")}` : "") +
+      (agg.keysInvalid.length ? ` | invalid: ${agg.keysInvalid.join(", ")}` : "")
   );
   return agg;
 }

--- a/lib/ai/connection-batch.ts
+++ b/lib/ai/connection-batch.ts
@@ -134,6 +134,28 @@ async function pace(ms: number | undefined, signal?: AbortSignal): Promise<void>
   await interruptibleSleep(ms, signal);
 }
 
+interface Pacer {
+  waitTurn(): Promise<void>;
+  noteRequest(): void;
+}
+
+/** Spaces consecutive real LLM requests by exactly one `ms` delay — across the
+ *  generation→translation and cell→cell boundaries alike. `waitTurn()` before a
+ *  request waits only if a prior request is owed a delay; `noteRequest()` after a
+ *  request that actually went out arms the next wait. */
+function createPacer(ms: number | undefined, signal?: AbortSignal): Pacer {
+  let owed = false;
+  return {
+    async waitTurn() {
+      if (owed) await pace(ms, signal);
+      owed = false;
+    },
+    noteRequest() {
+      owed = true;
+    },
+  };
+}
+
 /** Cost of one generation call, estimated (the generation path doesn't return
  *  token usage). Deliberately the DEFAULT_TOKENS path so the guard errs early. */
 function perCallCost(provider: Provider, model: string): number {
@@ -313,7 +335,7 @@ async function translateCellReasons(
   provider: Provider,
   model: string,
   budget: { spend: () => boolean; stoppedReason: StoppedReason | null },
-  gen: { apiKey?: string; signal?: AbortSignal; callDelayMs?: number } = {}
+  gen: { apiKey?: string; signal?: AbortSignal; pacer?: Pacer } = {}
 ): Promise<{ inserted: number; stoppedReason: StoppedReason | null }> {
   if (locales.length === 0) return { inserted: 0, stoppedReason: null };
 
@@ -337,7 +359,7 @@ async function translateCellReasons(
     for (const en of enRows) {
       if (existing.has(en.toRef)) continue;
       if (!budget.spend()) return { inserted, stoppedReason: budget.stoppedReason };
-      await pace(gen.callDelayMs, gen.signal);
+      await gen.pacer?.waitTurn();
 
       let translated: string;
       try {
@@ -348,11 +370,13 @@ async function translateCellReasons(
           apiKey: gen.apiKey,
           signal: gen.signal,
         });
+        gen.pacer?.noteRequest();
       } catch (err) {
         // A daily-quota hit or an invalid key is not a translation problem —
         // bubble it to the single handler in runConnectionBatch so the pass ends
         // "quota-daily" / "key-invalid" and the loop rotates keys.
         if (err instanceof GeminiDailyQuotaError || err instanceof GeminiKeyInvalidError) throw err;
+        gen.pacer?.noteRequest();
         console.error(`connection-batch: translation failed ${fromRef} ${kind} ${locale}:`, err);
         incr("connection_batch_translate_failed");
         continue;
@@ -493,6 +517,7 @@ export async function runConnectionBatch(
   };
 
   let consecutiveFailures = 0;
+  const pacer = createPacer(opts.callDelayMs, signal);
 
   for (const cell of cells) {
     // Cooperative cancel from the admin panel (job-runner aborts this signal).
@@ -524,6 +549,7 @@ export async function runConnectionBatch(
           break;
         }
 
+        await pacer.waitTurn();
         const { results, calledAI } = await generateConnectionsForCell(
           cell.fromRef,
           cell.kind,
@@ -536,14 +562,14 @@ export async function runConnectionBatch(
         );
         if (!calledAI) {
           // No grounding data / drained pool — no request was actually made, so
-          // refund the reservation and don't pace (no call to space out).
+          // refund the reservation and don't arm the pacer (no call to space out).
           summary.callsUsed--;
           summary.costUsd -= callCost;
         } else {
           // A request went out and came back without throwing — the provider is
           // alive, so a later isolated failure isn't the fail-fast case.
           consecutiveFailures = 0;
-          await pace(opts.callDelayMs, signal);
+          pacer.noteRequest();
         }
         summary.generated += results.length;
 
@@ -568,7 +594,7 @@ export async function runConnectionBatch(
           opts.provider,
           model,
           budget,
-          { apiKey: opts.apiKey, signal, callDelayMs: opts.callDelayMs }
+          { apiKey: opts.apiKey, signal, pacer }
         );
         summary.translated += xlt.inserted;
         await upsertCoverage(cell.fromRef, cell.kind, { activeCount, lastError: null });

--- a/lib/ai/connection-batch.ts
+++ b/lib/ai/connection-batch.ts
@@ -1,11 +1,11 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { verses, connections, connectionCoverage, aiGenerations } from "@/lib/infra/db/schema";
 import { generateConnectionsForCell } from "@/lib/ai/graph-service";
 import { translateReason } from "@/lib/ai/translate";
 import { estimateCostUsd } from "@/lib/ai/ai-cost";
 import { resolveModel, type Provider } from "@/lib/ai/ai";
-import { GeminiDailyQuotaError } from "@/lib/ai/gemini-errors";
+import { GeminiDailyQuotaError, GeminiKeyInvalidError } from "@/lib/ai/gemini-errors";
 import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 import { incr } from "@/lib/infra/metrics";
 import { interruptibleSleep } from "@/lib/infra/sleep";
@@ -52,7 +52,10 @@ export type StoppedReason =
   | "cancelled"
   /** The active Gemini key hit its per-day quota. The single-pass batch stops
    *  here; the outer loop (connection-batch-loop.ts) rotates to the next key. */
-  | "quota-daily";
+  | "quota-daily"
+  /** The active Gemini key is invalid / revoked. Same handling as `quota-daily`
+   *  — the outer loop rotates to the next key. */
+  | "key-invalid";
 
 export interface BatchOptions {
   mode: BatchMode;
@@ -116,6 +119,10 @@ interface Cell {
   translation: string;
   kind: EdgeKind;
   activeCount: number;
+  /** Baseline only: this cell already has English connections but is missing one
+   *  or more requested-locale rows (an earlier pass stopped mid-cell). Translate
+   *  the existing English reasons; do NOT run generation. */
+  translateOnly?: boolean;
 }
 
 const cellKey = (ref: string, kind: string) => `${ref}|${kind}`;
@@ -133,8 +140,65 @@ function perCallCost(provider: Provider, model: string): number {
   return estimateCostUsd(model, provider, null);
 }
 
-/** Builds the ordered work list from current DB state. */
-async function buildWorkList(mode: BatchMode): Promise<Cell[]> {
+/**
+ * Cells (baseline only) that already have active English connections but are
+ * missing an active row in one or more of `targetLocales` for some English
+ * target. This catches the gap left when an earlier pass generated the English
+ * rows and then stopped (budget / daily quota / invalid key / Stop) before
+ * translating — baseline would otherwise never revisit the cell.
+ *
+ * Row-by-row (not a count compare) so a retired-and-replaced English edge can't
+ * make a locale look complete when it isn't. Mirrors how `translateCellReasons`
+ * decides what to insert.
+ */
+async function findTranslationGaps(targetLocales: Locale[]): Promise<Set<string>> {
+  if (targetLocales.length === 0) return new Set();
+
+  const rows = await db
+    .select({
+      fromRef: connections.fromRef,
+      toRef: connections.toRef,
+      kind: connections.kind,
+      locale: connections.locale,
+    })
+    .from(connections)
+    .where(
+      and(eq(connections.status, "active"), inArray(connections.locale, ["en", ...targetLocales]))
+    );
+
+  // key = `${fromRef}|${kind}` → locale → set of toRefs
+  const byCell = new Map<string, Map<string, Set<string>>>();
+  for (const r of rows) {
+    const key = cellKey(r.fromRef, r.kind);
+    let locales = byCell.get(key);
+    if (!locales) byCell.set(key, (locales = new Map()));
+    let refs = locales.get(r.locale);
+    if (!refs) locales.set(r.locale, (refs = new Set()));
+    refs.add(r.toRef);
+  }
+
+  const gaps = new Set<string>();
+  for (const [key, locales] of byCell) {
+    const enRefs = locales.get("en");
+    if (!enRefs || enRefs.size === 0) continue;
+    for (const loc of targetLocales) {
+      const locRefs = locales.get(loc) ?? new Set<string>();
+      for (const ref of enRefs) {
+        if (!locRefs.has(ref)) {
+          gaps.add(key);
+          break;
+        }
+      }
+      if (gaps.has(key)) break;
+    }
+  }
+  return gaps;
+}
+
+/** Builds the ordered work list from current DB state. `locales` is only used in
+ *  baseline mode, to also pick up cells whose English rows exist but whose
+ *  translations were never finished. */
+async function buildWorkList(mode: BatchMode, locales: Locale[] = []): Promise<Cell[]> {
   const verseRows = await db
     .select({
       ref: verses.ref,
@@ -168,13 +232,30 @@ async function buildWorkList(mode: BatchMode): Promise<Cell[]> {
     countByCell.set(cellKey(row.fromRef, row.kind), row.activeCount);
   }
 
+  const translationGaps =
+    mode === "baseline" ? await findTranslationGaps(locales) : new Set<string>();
+
   const cells: Cell[] = [];
+  const gapCells: Cell[] = [];
   for (const v of verseRows) {
     for (const kind of KINDS) {
       const key = cellKey(v.ref, kind);
       if (mode === "baseline") {
-        // Only cells with no active English connection.
-        if (coveredEn.has(key)) continue;
+        if (coveredEn.has(key)) {
+          // Already has English rows — normally excluded, but pick it up if its
+          // translations were left unfinished.
+          if (translationGaps.has(key)) {
+            gapCells.push({
+              fromRef: v.ref,
+              arabicText: v.arabicText,
+              translation: v.translation,
+              kind,
+              activeCount: countByCell.get(key) ?? 1,
+              translateOnly: true,
+            });
+          }
+          continue;
+        }
       } else {
         // topup: only cells that already have >=1 connection (filling a
         // zero-connection cell is baseline's job) and aren't exhausted.
@@ -195,7 +276,9 @@ async function buildWorkList(mode: BatchMode): Promise<Cell[]> {
   if (mode === "topup") {
     cells.sort((a, b) => a.activeCount - b.activeCount);
   }
-  return cells;
+  // baseline: finish real (zero-English) coverage first, then close translation
+  // gaps.
+  return [...cells, ...gapCells];
 }
 
 /** Existing active en connection targets for a cell. */
@@ -266,10 +349,10 @@ async function translateCellReasons(
           signal: gen.signal,
         });
       } catch (err) {
-        // A daily-quota hit is not a translation problem — bubble it to the
-        // single handler in runConnectionBatch so the pass ends "quota-daily"
-        // and the loop rotates keys.
-        if (err instanceof GeminiDailyQuotaError) throw err;
+        // A daily-quota hit or an invalid key is not a translation problem —
+        // bubble it to the single handler in runConnectionBatch so the pass ends
+        // "quota-daily" / "key-invalid" and the loop rotates keys.
+        if (err instanceof GeminiDailyQuotaError || err instanceof GeminiKeyInvalidError) throw err;
         console.error(`connection-batch: translation failed ${fromRef} ${kind} ${locale}:`, err);
         incr("connection_batch_translate_failed");
         continue;
@@ -364,7 +447,7 @@ export async function runConnectionBatch(
 
   let cells: Cell[];
   try {
-    cells = await buildWorkList(opts.mode);
+    cells = await buildWorkList(opts.mode, opts.locales);
   } catch (err) {
     summary.stoppedReason = "error";
     summary.error = err instanceof Error ? err.message : String(err);
@@ -425,48 +508,58 @@ export async function runConnectionBatch(
     }
 
     try {
-      const excludeRefs =
-        opts.mode === "topup" ? await activeToRefs(cell.fromRef, cell.kind, "en") : [];
+      let exhaustedThisCell = false;
 
-      // Reserve the generation call up front. If the budget is already spent we
-      // stop before making the request.
-      if (!budget.spend()) {
-        summary.stoppedReason = budget.stoppedReason ?? "call-budget";
-        break;
+      // `translateOnly` cells (baseline, closing a translation gap left by an
+      // earlier mid-cell stop) skip generation entirely — no reservation, no
+      // grounding call — and go straight to translating existing English rows.
+      if (!cell.translateOnly) {
+        const excludeRefs =
+          opts.mode === "topup" ? await activeToRefs(cell.fromRef, cell.kind, "en") : [];
+
+        // Reserve the generation call up front. If the budget is already spent we
+        // stop before making the request.
+        if (!budget.spend()) {
+          summary.stoppedReason = budget.stoppedReason ?? "call-budget";
+          break;
+        }
+
+        const { results, calledAI } = await generateConnectionsForCell(
+          cell.fromRef,
+          cell.kind,
+          { arabicText: cell.arabicText, translation: cell.translation },
+          excludeRefs,
+          "en",
+          opts.provider,
+          model,
+          { apiKey: opts.apiKey, signal }
+        );
+        if (!calledAI) {
+          // No grounding data / drained pool — no request was actually made, so
+          // refund the reservation and don't pace (no call to space out).
+          summary.callsUsed--;
+          summary.costUsd -= callCost;
+        } else {
+          // A request went out and came back without throwing — the provider is
+          // alive, so a later isolated failure isn't the fail-fast case.
+          consecutiveFailures = 0;
+          await pace(opts.callDelayMs, signal);
+        }
+        summary.generated += results.length;
+
+        if (opts.mode === "topup" && excludeRefs.length > 0 && results.length === 0) {
+          // Grounded pool is genuinely empty for this cell — record it so no
+          // future run pays for it again.
+          await upsertCoverage(cell.fromRef, cell.kind, {
+            exhaustedAt: new Date(),
+            activeCount: excludeRefs.length,
+          });
+          summary.exhausted++;
+          exhaustedThisCell = true;
+        }
       }
-      await pace(opts.callDelayMs, signal);
 
-      const { results, calledAI } = await generateConnectionsForCell(
-        cell.fromRef,
-        cell.kind,
-        { arabicText: cell.arabicText, translation: cell.translation },
-        excludeRefs,
-        "en",
-        opts.provider,
-        model,
-        { apiKey: opts.apiKey, signal }
-      );
-      if (!calledAI) {
-        // No grounding data / drained pool — no request was actually made, so
-        // refund the reservation.
-        summary.callsUsed--;
-        summary.costUsd -= callCost;
-      } else {
-        // A request went out and came back without throwing — the provider is
-        // alive, so a later isolated failure isn't the fail-fast case.
-        consecutiveFailures = 0;
-      }
-      summary.generated += results.length;
-
-      if (opts.mode === "topup" && excludeRefs.length > 0 && results.length === 0) {
-        // Grounded pool is genuinely empty for this cell — record it so no
-        // future run pays for it again.
-        await upsertCoverage(cell.fromRef, cell.kind, {
-          exhaustedAt: new Date(),
-          activeCount: excludeRefs.length,
-        });
-        summary.exhausted++;
-      } else {
+      if (!exhaustedThisCell) {
         const activeCount = (await activeToRefs(cell.fromRef, cell.kind, "en")).length;
         const xlt = await translateCellReasons(
           cell.fromRef,
@@ -501,6 +594,16 @@ export async function runConnectionBatch(
         summary.lastError = err.message;
         hooks.onProgress(
           `[${opts.mode}] daily quota exhausted for the active key at ${cell.fromRef} ${cell.kind} — ending pass to rotate`
+        );
+        break;
+      }
+      if (err instanceof GeminiKeyInvalidError) {
+        // The key is invalid / revoked — per-key, so the loop rotates. Same
+        // clean-stop treatment as a daily-quota hit.
+        summary.stoppedReason = "key-invalid";
+        summary.lastError = err.message;
+        hooks.onProgress(
+          `[${opts.mode}] active key invalid/blocked at ${cell.fromRef} ${cell.kind} — ending pass to rotate`
         );
         break;
       }

--- a/lib/ai/gemini-errors.ts
+++ b/lib/ai/gemini-errors.ts
@@ -156,13 +156,25 @@ function safeStringify(value: unknown): string {
  *  — retrying instantly 6× is how a key gets flagged. */
 export const PER_MINUTE_MIN_DELAY_MS = 2_000;
 
-/** The backoff wait for per-minute retry `attempt` (1-based), honouring an
- *  explicit `retryAfterMs` when Google sent a usable one, else exponential with
- *  jitter. Always at least `PER_MINUTE_MIN_DELAY_MS`. */
+/** The backoff wait for per-minute retry `attempt` (1-based).
+ *
+ * When Google sends a usable `retryDelay`, that is a MINIMUM — jitter is added
+ * on top, never subtracted, so we never re-fire before the window Google named.
+ * Otherwise: exponential from `PER_MINUTE_BASE_DELAY_MS` with ±15% jitter.
+ * Always at least `PER_MINUTE_MIN_DELAY_MS`, at most `PER_MINUTE_MAX_DELAY_MS`. */
 export function perMinuteBackoffMs(attempt: number, retryAfterMs?: number): number {
-  const exponential = PER_MINUTE_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
-  const base = retryAfterMs && retryAfterMs > 0 ? retryAfterMs : exponential;
+  const hasRetryAfter = retryAfterMs !== undefined && retryAfterMs > 0;
+  const floor = hasRetryAfter
+    ? Math.max(retryAfterMs, PER_MINUTE_MIN_DELAY_MS)
+    : PER_MINUTE_MIN_DELAY_MS;
+  const base = hasRetryAfter
+    ? floor
+    : PER_MINUTE_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
   const capped = Math.min(Math.max(base, PER_MINUTE_MIN_DELAY_MS), PER_MINUTE_MAX_DELAY_MS);
-  const jitter = capped * (0.85 + Math.random() * 0.3);
-  return Math.round(jitter);
+  // Additive jitter only when honouring a provider delay (0..+15%); symmetric
+  // otherwise.
+  const jitter = hasRetryAfter
+    ? capped * (1 + Math.random() * 0.15)
+    : capped * (0.85 + Math.random() * 0.3);
+  return Math.max(Math.round(jitter), floor);
 }

--- a/lib/ai/gemini-errors.ts
+++ b/lib/ai/gemini-errors.ts
@@ -30,7 +30,8 @@ export const PER_MINUTE_MAX_DELAY_MS = 65_000;
  *  only emits shapeless 429s stalling the loop forever. */
 export const AMBIGUOUS_429_ESCALATE_AFTER = 8;
 
-export type GeminiRateClass = "daily" | "per-minute" | "other-429" | "not-rate-limit";
+export type GeminiRateClass =
+  "daily" | "per-minute" | "other-429" | "key-invalid" | "not-rate-limit";
 
 export interface GeminiRateInfo {
   cls: GeminiRateClass;
@@ -51,6 +52,18 @@ export class GeminiDailyQuotaError extends Error {
   constructor(info: GeminiRateInfo) {
     super(`Gemini daily quota exhausted${info.quotaId ? ` (${info.quotaId})` : ""}`);
     this.name = "GeminiDailyQuotaError";
+    this.info = info;
+  }
+}
+
+/** Thrown when the API key is invalid / revoked / blocked (HTTP 400
+ *  `API_KEY_INVALID` or 403 `PERMISSION_DENIED`). Per-key, not a global fault —
+ *  the backfill loop rotates to the next key rather than stopping. */
+export class GeminiKeyInvalidError extends Error {
+  readonly info: GeminiRateInfo;
+  constructor(info: GeminiRateInfo) {
+    super(`Gemini API key invalid or blocked (HTTP ${info.status ?? "?"})`);
+    this.name = "GeminiKeyInvalidError";
     this.info = info;
   }
 }
@@ -107,6 +120,15 @@ export function classifyGeminiError(err: unknown): GeminiRateInfo {
   const signal = `${detailsJson}\n${message}`;
   const lower = signal.toLowerCase();
   const raw = signal.trim().slice(0, 500);
+
+  // An invalid / revoked key (400 API_KEY_INVALID): unambiguously per-key, so the
+  // loop rotates to the next key rather than stopping. Project- / service-level
+  // 403s (consumer suspended, API disabled) are deliberately left to
+  // `not-rate-limit` below — rotating past those is futile, so the loop should
+  // stop. Checked before the generic non-429 bail-out.
+  if (status === 400 && /api[_ ]?key (?:not valid|invalid)|api_key_invalid/i.test(lower)) {
+    return { cls: "key-invalid", status, raw };
+  }
 
   // A concrete non-429 status is never a rate limit for our purposes — a 403
   // "Quota exceeded ... consumer suspended" or a 400 about a quota project
@@ -176,5 +198,7 @@ export function perMinuteBackoffMs(attempt: number, retryAfterMs?: number): numb
   const jitter = hasRetryAfter
     ? capped * (1 + Math.random() * 0.15)
     : capped * (0.85 + Math.random() * 0.3);
-  return Math.max(Math.round(jitter), floor);
+  // Clamp to [floor, MAX] — jitter must not push a fallback wait past the max.
+  // `floor` wins when an honoured provider retryAfterMs exceeds the max.
+  return Math.min(Math.max(Math.round(jitter), floor), Math.max(PER_MINUTE_MAX_DELAY_MS, floor));
 }

--- a/lib/ai/gemini-errors.ts
+++ b/lib/ai/gemini-errors.ts
@@ -180,25 +180,22 @@ export const PER_MINUTE_MIN_DELAY_MS = 2_000;
 
 /** The backoff wait for per-minute retry `attempt` (1-based).
  *
- * When Google sends a usable `retryDelay`, that is a MINIMUM — jitter is added
- * on top, never subtracted, so we never re-fire before the window Google named.
- * Otherwise: exponential from `PER_MINUTE_BASE_DELAY_MS` with ±15% jitter.
- * Always at least `PER_MINUTE_MIN_DELAY_MS`, at most `PER_MINUTE_MAX_DELAY_MS`. */
+ * When Google sends a usable `retryDelay`, that is a hard MINIMUM — jitter is
+ * added on top, never subtracted, so we never re-fire before the window Google
+ * named, and there is no upper cap (a provider delay above
+ * `PER_MINUTE_MAX_DELAY_MS` is honoured in full). Keeping the jitter even past
+ * the cap is what stops concurrent workers that got the same `retryDelay` from
+ * all re-firing on the same tick.
+ *
+ * Otherwise: exponential from `PER_MINUTE_BASE_DELAY_MS` with ±15% jitter,
+ * always at least `PER_MINUTE_MIN_DELAY_MS`, at most `PER_MINUTE_MAX_DELAY_MS`. */
 export function perMinuteBackoffMs(attempt: number, retryAfterMs?: number): number {
-  const hasRetryAfter = retryAfterMs !== undefined && retryAfterMs > 0;
-  const floor = hasRetryAfter
-    ? Math.max(retryAfterMs, PER_MINUTE_MIN_DELAY_MS)
-    : PER_MINUTE_MIN_DELAY_MS;
-  const base = hasRetryAfter
-    ? floor
-    : PER_MINUTE_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
+  if (retryAfterMs !== undefined && retryAfterMs > 0) {
+    const floor = Math.max(retryAfterMs, PER_MINUTE_MIN_DELAY_MS);
+    return Math.round(floor * (1 + Math.random() * 0.15));
+  }
+  const base = PER_MINUTE_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
   const capped = Math.min(Math.max(base, PER_MINUTE_MIN_DELAY_MS), PER_MINUTE_MAX_DELAY_MS);
-  // Additive jitter only when honouring a provider delay (0..+15%); symmetric
-  // otherwise.
-  const jitter = hasRetryAfter
-    ? capped * (1 + Math.random() * 0.15)
-    : capped * (0.85 + Math.random() * 0.3);
-  // Clamp to [floor, MAX] — jitter must not push a fallback wait past the max.
-  // `floor` wins when an honoured provider retryAfterMs exceeds the max.
-  return Math.min(Math.max(Math.round(jitter), floor), Math.max(PER_MINUTE_MAX_DELAY_MS, floor));
+  const jittered = Math.round(capped * (0.85 + Math.random() * 0.3));
+  return Math.min(Math.max(jittered, PER_MINUTE_MIN_DELAY_MS), PER_MINUTE_MAX_DELAY_MS);
 }


### PR DESCRIPTION
## Summary

Follow-up to **#547** clearing the CodeRabbit review debt that was deferred as out-of-scope. Branched off `feat/backfill-loop-mode` so it won't conflict when #547 merges — **until #547 lands this PR's diff will also show #547's commits**, then it collapses to just this work.

Five items:

1. **`perMinuteBackoffMs` clamp** — the fallback (no provider `retryDelay`) path let jitter push a wait ~15% past `PER_MINUTE_MAX_DELAY_MS`. Now clamped to `[floor, MAX]`; a provider `retryAfterMs` above the max still wins.
2. **In-flight cancellation test** — `callGemini` with a *pending* `generateContent`: aborting the signal rejects the call and makes no further retry.
3. **`pace()` only on real calls** — the throttle delay was spent even on cells that make no LLM call (`calledAI === false`); moved past that check.
4. **A revoked / invalid key rotates instead of stopping the loop** — new `GeminiKeyInvalidError` + `classifyGeminiError` `"key-invalid"` for `400 API_KEY_INVALID` (project-level 403s stay `not-rate-limit` — rotating past *those* is futile). `connection-batch` ends the pass `"key-invalid"` (clean, like `"quota-daily"`, no cell failure / fail-fast); the loop rotates to the next key and records it in `keysInvalid`. All-keys-invalid ends the loop as `error`.
5. **Resume incomplete locale translations** (CodeRabbit "heavy lift") — `buildWorkList(mode, locales)` now also picks up baseline cells that have English connections but are **missing** a requested locale's row for some target (a gap left by a mid-cell stop). Those cells are `translateOnly` — they skip generation and only translate. Row-by-row detection (not a count compare) so a retired-and-replaced English edge can't fake completeness.

## Type of change

- [x] New feature

## AI / Theological changes

- [x] No AI or theological changes in this PR — no prompt, divine-name, or theological-framing changes. `translateReason` / `tanzihDirective()` untouched.

## Testing

- [x] `bun run test:ci` — 1505 pass
- [x] `bun run test:integration` (Testcontainers) — 15 pass, incl. new cases: `"key-invalid"` pass end (no cell failure), and baseline resuming a translation gap with **zero** generation calls
- [x] `bun run typecheck` / `bun run lint` / `bun run format:check` clean

New/updated tests: `gemini-errors` (clamp boundary, `key-invalid` classification), `gemini-retry` (in-flight cancel, invalid-key immediate throw), `connection-batch-loop` (`key-invalid` → rotate; all-invalid → error; mixed invalid/daily), `job-runner` (`key-invalid` → failed), `connection-batch.integration` (translation-gap resume, `key-invalid` pass).

## Checklist

- [x] Branch is up to date with its base (`feat/backfill-loop-mode`)
- [x] Conventional commits
- [x] No secrets or real API keys in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invalid or revoked API keys are detected and automatically skipped in favor of other configured keys.
  * Backfill runs resume unfinished translations without regenerating completed English connections.
  * In-progress AI requests can now be canceled without retrying.
  * Requests are paced consistently to reduce unnecessary delays between AI operations.
* **Bug Fixes**
  * Runs ending because all selected keys are invalid are correctly recorded as failed.
  * Provider-requested retry delays are honored more reliably.
* **Documentation**
  * Clarified that higher call delays reduce the risk of per-minute rate limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->