### PR TITLE
fix(names): add shared header and mobile nav bar to name detail page

### DIFF
--- a/app/names/[slug]/page.tsx
+++ b/app/names/[slug]/page.tsx
@@ -8,7 +8,8 @@ import {
   CATEGORY_LABEL_KEYS,
   type NameCategory,
 } from "@/lib/names/divine-names";
-import { Wordmark } from "@/components/layout/Wordmark";
+import { LandingHeader } from "@/components/layout/LandingHeader";
+import { MobileNavBar } from "@/components/layout/MobileNavBar";
 import { NameVerses } from "./NameVerses";
 import { NameReflection } from "./NameReflection";
 import { NamePairings, type Pairing } from "./NamePairings";
@@ -71,22 +72,20 @@ export default async function NameDetailPage({ params }: Props) {
   const nextName = DIVINE_NAMES.find((n) => n.id === name.id + 1);
 
   return (
-    <div className="min-h-screen bg-bg text-text-primary">
-      {/* Header */}
-      <header className="sticky top-0 z-20 flex h-12 items-center justify-between border-b border-border bg-surface px-6">
-        <Wordmark />
-        <Link
-          href="/names"
-          className="flex items-center gap-1.5 text-xs text-text-secondary transition-colors hover:text-text-primary"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" />
-          <span>{t("allNames")}</span>
-        </Link>
-      </header>
+    <div className="min-h-dvh bg-bg pb-mobile-nav text-text-primary md:pb-0">
+      <LandingHeader />
+      <MobileNavBar />
 
       <main>
         {/* Name hero */}
         <div className="mx-auto max-w-3xl border-b border-border-subtle px-6 pt-14 pb-12 text-center">
+          <Link
+            href="/names"
+            className="mb-6 inline-flex items-center gap-1.5 text-xs text-text-secondary transition-colors hover:text-text-primary"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            <span>{t("allNames")}</span>
+          </Link>
           <div className="mb-6 inline-block rounded border border-border bg-surface-raised px-2 py-1 font-mono text-xs text-text-muted">
             {t("ofNinetyNine", { id: name.id })}
           </div>

--- a/e2e/mobile-nav-overlap.spec.ts
+++ b/e2e/mobile-nav-overlap.spec.ts
@@ -84,4 +84,16 @@ test.describe("mobile nav bar overlap", () => {
     expect(textBottom).not.toBeNull();
     expect(textBottom!).toBeLessThanOrEqual(navTop + 1);
   });
+
+  test("verse feed on a divine name detail page clears the nav bar", async ({ page }) => {
+    await page.goto("/names/al-malik");
+    const navTop = await navBarTop(page);
+    await scrollToBottom(page, null);
+
+    const lastVerse = page.locator("main p:not([dir='rtl'])").last();
+    await expect(lastVerse).toBeVisible();
+    const box = await lastVerse.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.y + box!.height).toBeLessThanOrEqual(navTop + 1);
+  });
 });


### PR DESCRIPTION
## Summary
- \`app/names/[slug]/page.tsx\` (e.g. \`/names/al-malik\`) rendered a bare custom header (Wordmark + a plain back-link) and never mounted \`MobileNavBar\` — unlike every sibling detail page (\`stories/[slug]\`, \`surah/[number]\`) and the \`/names\` index itself, all of which use the shared \`<LandingHeader />\` + \`<MobileNavBar />\` pair. On mobile this left the page with no primary navigation at all (only the in-page "All Names" link or the browser back button).
- Found via a manual Playwright pass over the public routes at 390×844 and desktop; confirmed the gap by comparing screenshots of \`/names\` and \`/stories/adam\` (both show the bottom tab bar) against \`/names/al-malik\` (nothing).
- This is the same nav-bar surface PR #550 (\`fix/mobile-nav-overlap\`) just hardened for \`/\`, \`/surah/[n]\`, and \`/stories/[slug]\` — this route was simply missed since it never had the bar to begin with.
- Brings the page in line with its siblings: swaps the custom header for \`<LandingHeader />\` + \`<MobileNavBar />\`, matches the \`min-h-dvh ... pb-mobile-nav ... md:pb-0\` wrapper, and moves the "All Names" back-link into the hero content block (styled like the surah page's "back to search" link).
- Added a regression case to \`e2e/mobile-nav-overlap.spec.ts\` covering this page, following the existing pattern (scroll to bottom, assert real content clears the fixed nav bar).

Not in scope: \`/bookmarks\`, \`/settings\`, and the \`AuthShell\`-based pages (\`/mentions\`, \`/social\`, \`/workspaces\`) also don't render \`MobileNavBar\`. Flagging rather than fixing — those are account/utility pages one level removed from the content-detail pattern (names/stories/surah), so it may be intentional. Worth a follow-up discussion if not.

## AI / Theological changes
N/A — no AI prompts, divine-name data, or theological framing touched; this is a layout/navigation parity fix only.

## Test plan
- [x] \`bun run typecheck\`
- [x] \`bun run lint\`
- [x] \`bun run test:ci\` (full unit suite, 1505 tests)
- [x] \`bun run test:e2e -- mobile-nav-overlap\` (4/4 passing, including the new case)
- [x] Manual Playwright check at 390×844: bottom nav bar present on \`/names/al-malik\`, hero/reflection/pairings/verses sections render correctly, back-link and prev/next name navigation still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated name detail pages with the shared desktop and mobile navigation.
  - Moved the “All names” link into the main page content for easier access.
  - Improved mobile page spacing so content remains visible above the bottom navigation.

- **Bug Fixes**
  - Prevented the mobile navigation bar from obscuring the final verse when scrolling to the bottom of a name detail page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->