### PR TITLE
feat(names): fall back to Gemini once when Claude generation is empty

### DIFF
--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -168,8 +168,81 @@ describe("getOrGenerateNameContent", () => {
     const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
 
     expect(out).toEqual([]);
+    // Test env defaults to Claude (see vitest setup), so an empty result
+    // triggers one Gemini-fallback retry — also empty here, so still nothing
+    // to persist.
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Gemini once when the primary (Claude) result is empty, and persists the Gemini result", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const ai = await import("@/lib/ai/ai");
+    const providerSpy = vi.spyOn(ai, "resolveProvider").mockResolvedValue("claude");
+    const modelSpy = vi
+      .spyOn(ai, "resolveModel")
+      .mockImplementation(async (_feature, provider) =>
+        provider === "claude" ? "claude-opus-5" : "gemini-3.7-flash"
+      );
+
+    const generate = vi.fn(async (resolved: { provider: string; model: string }) =>
+      resolved.provider === "claude" ? [] : ["a", "b"]
+    );
+
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
+
+    expect(out).toEqual(["a", "b"]);
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(generate.mock.calls[0][0]).toEqual({ provider: "claude", model: "claude-opus-5" });
+    expect(generate.mock.calls[1][0]).toEqual({ provider: "gemini", model: "gemini-3.7-flash" });
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
+    expect(values.model).toBe("gemini-3.7-flash");
+    providerSpy.mockRestore();
+    modelSpy.mockRestore();
+  });
+
+  it("does not fall back when the primary provider is already Gemini", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const ai = await import("@/lib/ai/ai");
+    const providerSpy = vi.spyOn(ai, "resolveProvider").mockResolvedValue("gemini");
+    const modelSpy = vi.spyOn(ai, "resolveModel").mockResolvedValue("gemini-3.7-flash");
+    const generate = vi.fn().mockResolvedValue([]);
+
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
+
+    expect(out).toEqual([]);
     expect(generate).toHaveBeenCalledTimes(1);
     expect(mockInsert).not.toHaveBeenCalled();
+    providerSpy.mockRestore();
+    modelSpy.mockRestore();
+  });
+
+  it("a Gemini fallback that itself throws still returns the primary's (empty) result, not an unhandled rejection", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const ai = await import("@/lib/ai/ai");
+    const providerSpy = vi.spyOn(ai, "resolveProvider").mockResolvedValue("claude");
+    const modelSpy = vi
+      .spyOn(ai, "resolveModel")
+      .mockImplementation(async (_feature, provider) =>
+        provider === "claude" ? "claude-opus-5" : "gemini-3.7-flash"
+      );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const generate = vi.fn(async (resolved: { provider: string; model: string }) => {
+      if (resolved.provider === "gemini") throw new Error("GEMINI_API_KEY is not set");
+      return [];
+    });
+
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
+
+    expect(out).toEqual([]);
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith("Names: Gemini fallback failed:", expect.any(Error));
+    providerSpy.mockRestore();
+    modelSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("round-trips a string payload (reflection)", async () => {
@@ -425,7 +498,35 @@ describe("getOrGenerateVerseReason", () => {
     const out = await getOrGenerateVerseReason("ar-rahman", "2:255", "tr", generate);
 
     expect(out).toBe("");
+    // Test env defaults to Claude, so an empty translation triggers one
+    // Gemini-fallback retry — also empty here, so still nothing to persist.
+    expect(generate).toHaveBeenCalledTimes(2);
     expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Gemini once when the primary (Claude) translation is empty, and persists the Gemini result", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const ai = await import("@/lib/ai/ai");
+    const providerSpy = vi.spyOn(ai, "resolveProvider").mockResolvedValue("claude");
+    const modelSpy = vi
+      .spyOn(ai, "resolveModel")
+      .mockImplementation(async (_feature, provider) =>
+        provider === "claude" ? "claude-opus-5" : "gemini-3.7-flash"
+      );
+
+    const generate = vi.fn(async (resolved: { provider: string; model: string }) =>
+      resolved.provider === "claude" ? "" : "çeviri"
+    );
+
+    const out = await getOrGenerateVerseReason("ar-rahman", "2:255", "tr", generate);
+
+    expect(out).toBe("çeviri");
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
+    expect(values.model).toBe("gemini-3.7-flash");
+    providerSpy.mockRestore();
+    modelSpy.mockRestore();
   });
 
   it("when another process wins the insert race, returns the persisted (stored) translation, not the local one", async () => {

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { nameContent, nameVerseReasons, type NameContentKind } from "@/lib/infra/db/schema";
 import { resolveModel, resolveProvider, type Provider } from "@/lib/ai/ai";
+import { incr } from "@/lib/infra/metrics";
 import type { Locale } from "@/lib/i18n/config";
 
 /** The provider+model to use for (and attribute) one names generation. */
@@ -20,6 +21,42 @@ const resolveNamesModel = async (): Promise<ResolvedNamesModel> => {
   const model = await resolveModel("names", provider);
   return { provider, model };
 };
+
+/**
+ * Resolves the primary provider+model, generates once, and — only when the
+ * primary is Claude and the result comes back empty (the shape a route's own
+ * caught AI failure already takes, see reflection/pairings/verses routes) —
+ * retries once against Gemini, whose API key is already provisioned in every
+ * deployment (see .env.example) and whose free tier easily absorbs an
+ * occasional retry. One-directional (Claude -> Gemini only): a deployment
+ * already pointed at Gemini for "names" has nothing to fall back to.
+ *
+ * Returns whichever (result, model) pair actually produced the value, so the
+ * persisted `model` column never disagrees with what actually ran.
+ */
+async function resolveAndGenerate<T>(
+  generate: (resolved: ResolvedNamesModel) => Promise<T>,
+  isEmpty: (value: T) => boolean
+): Promise<{ result: T; model: string }> {
+  const resolved = await resolveNamesModel();
+  const result = await generate(resolved);
+  if (!isEmpty(result) || resolved.provider !== "claude") {
+    return { result, model: resolved.model };
+  }
+
+  try {
+    const fallbackModel = await resolveModel("names", "gemini");
+    const fallbackResult = await generate({ provider: "gemini", model: fallbackModel });
+    if (!isEmpty(fallbackResult)) incr("names_ai_fallback_used");
+    return { result: fallbackResult, model: fallbackModel };
+  } catch (err) {
+    // A fallback-attempt failure must degrade to the primary's (empty)
+    // result — same as a primary failure already does — never let the retry
+    // surface as an unhandled rejection callers didn't have to handle before.
+    console.error("Names: Gemini fallback failed:", err);
+    return { result, model: resolved.model };
+  }
+}
 
 /**
  * Durable, write-once/read-many cache for the AI-generated 99-Names content
@@ -150,11 +187,7 @@ async function generateAndPersist<T>(
   generate: (resolved: ResolvedNamesModel) => Promise<T>,
   isEmpty: (value: T) => boolean
 ): Promise<T> {
-  // Resolve the provider+model before generation and use the same pair for the
-  // request and the persisted attribution.
-  const resolved = await resolveNamesModel();
-  const result = await generate(resolved);
-  const model = resolved.model;
+  const { result, model } = await resolveAndGenerate(generate, isEmpty);
 
   if (!isEmpty(result)) {
     const data = JSON.stringify(result);
@@ -215,9 +248,7 @@ export async function getOrGenerateVerseReason(
   if (pending) return pending;
 
   const work = (async () => {
-    const resolved = await resolveNamesModel();
-    const reason = await generate(resolved);
-    const model = resolved.model;
+    const { result: reason, model } = await resolveAndGenerate(generate, (r) => r.trim() === "");
     if (reason.trim() === "") return reason;
 
     try {


### PR DESCRIPTION
## Summary
- Divine-name reflection/pairings/verse-reason generation had no recovery when Claude failed — I hit this for real while testing PR #551, where pairings generation returned empty because of an Anthropic "credit balance too low" error. The only recovery path was "retry on the next request," with no automatic backup provider.
- `GEMINI_API_KEY` is already provisioned in every deployment (`.env.example`) and Gemini's free tier easily absorbs an occasional retry, so this adds a one-shot Claude → Gemini fallback: when the primary (Claude) result comes back empty, retry once on Gemini before giving up.
- Scoped entirely to `lib/names/name-content.ts` (a new private `resolveAndGenerate` helper used by both `getOrGenerateNameContent` and `getOrGenerateVerseReason`) — zero changes to `lib/ai/ai.ts`, the three `app/api/names/[slug]/*/route.ts` routes, or `lib/ai/translate.ts`, since they're already parametric over whatever `{provider, model}` pair they're handed.
- One-directional (Claude → Gemini only) and only triggers when the *primary* resolved provider is Claude — a deployment already configured for Gemini on this feature (`ai_provider_names=gemini`) is unaffected.
- Deliberately **not** applied to the "connections" verse-backfill feature, which is intentionally Gemini-only (AGENTS.md: "Gemini-only, free tier") with its own key-rotation resilience — this fallback never touches that code path.
- The persisted `model` column always reflects whichever provider actually produced the cached content (not just the originally-resolved one), preserving the existing attribution invariant documented on `resolveNamesModel`.
- A fallback attempt that itself throws degrades to the primary's (empty) result rather than propagating as an unhandled rejection — verified this matters via a real scenario in the existing `names-ai-validation` test suite (a translation-fallback path with no internal try/catch).
- Added a metrics counter (`names_ai_fallback_used`) so admin analytics can see how often Gemini rescues a failed Claude call.

## AI / Theological changes
N/A — no prompts, divine-name data, or theological framing touched; this only changes which provider generates existing prompts under a resiliency retry.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:ci` (full unit suite, 1509 tests, including 6 new/updated cases in `name-content.test.ts` covering: fallback success + correct persisted model, no-fallback when already on Gemini, and a throwing fallback degrading safely)
- [x] Hand-traced every test in `__tests__/api/names-ai-validation.test.ts` against this change (it mocks the provider to always "claude") — confirmed all pass unmodified, then verified by actually running that suite
- [x] Manual check against the local dev server: hit `/api/names/al-malik/reflection` and `/api/names/al-malik/pairings` — confirmed the fallback is attempted and degrades gracefully (200, empty content, no 500) end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a fallback to Gemini when Claude returns empty content while generating AI-powered names or verse explanations.
  - Successfully generated fallback content is now saved correctly.
  - If the fallback also fails, the original empty result is returned safely without an unhandled error.
  - Gemini is not retried when it is already the primary provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->