### PR TITLE
fix: latent bug sweep (names detail, streak, connection generation)

### DIFF
--- a/__tests__/api/connections.test.ts
+++ b/__tests__/api/connections.test.ts
@@ -382,6 +382,26 @@ describe("POST /api/connections", () => {
     expect(mockAnthropicCreate).toHaveBeenCalled();
   });
 
+  it("returns 502 (not 200 []) when the model returns an unparseable response", async () => {
+    // A miss that reaches generation, but the model refuses / returns prose.
+    // That must surface as a retryable failure, never be cached as "no results".
+    mockSelect.mockReturnValue(makeDbChain([]));
+    mockAnthropicCreate.mockResolvedValue({
+      content: [{ type: "text", text: "I'm sorry, I can't help with that." }],
+    });
+
+    const req = makeRequest({
+      fromRef: "1:1",
+      kind: "thematic",
+      arabicText: "بِسْمِ اللَّهِ الرَّحْمَنِ الرَّحِيمِ",
+      translation: "In the name of Allah, the Most Gracious, the Most Merciful.",
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/retry/i);
+  });
+
   it("returns 200 with an empty array (not a 500) when excludeRefs exhausts a repeat request", async () => {
     // Cache hit path would normally return the stored edge, but with excludeRefs
     // matching it, the DB filter should exclude it — simulate that by returning

--- a/__tests__/api/names.test.ts
+++ b/__tests__/api/names.test.ts
@@ -179,6 +179,29 @@ describe("GET /api/names/[slug]/verses", () => {
     }
   });
 
+  it("strips footnote markup from AI-fallback verse translations (search returned nothing)", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url !== "string") return { ok: false };
+      // quran.com search finds nothing → the route takes the AI-fallback path.
+      if (new URL(url).hostname === "api.quran.com")
+        return { ok: true, json: async () => ({ search: { results: [] } }) };
+      if (url.includes("ar.alafasy")) return arabicResp("اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ");
+      if (url.includes("en.sahih"))
+        return transResp('And He is the Most Merciful.<sup foot_note="12345">1</sup>');
+      return { ok: false };
+    });
+
+    const req = new NextRequest("http://localhost/api/names/ar-rahman/verses");
+    const res = await getNameVerses(req, params("ar-rahman"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.length).toBeGreaterThan(0);
+    for (const verse of body) {
+      expect(verse.translation).not.toMatch(/<sup/);
+      expect(verse.translation).toBe("And He is the Most Merciful.1");
+    }
+  });
+
   it("quran.com search fetch passes an abort signal so a hung upstream fails fast", async () => {
     mockFetch.mockImplementation(async (url: string) => {
       if (typeof url !== "string") return { ok: false };

--- a/__tests__/api/social/activity.test.ts
+++ b/__tests__/api/social/activity.test.ts
@@ -263,14 +263,16 @@ describe("POST /api/social/activity", () => {
     expect(mockTransaction).toHaveBeenCalledOnce();
   });
 
-  it("buckets by the client's local_date, not UTC", async () => {
+  it("buckets by the client's local day (from its tz offset), not UTC", async () => {
     // 23:30 UTC on the 28th — a UTC+3 client is already on the 29th. Activity
     // was last logged for the client's local day, so this is a same-day no-op.
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-28T23:30:00Z"));
     try {
       authedAs(makeUser({ currentStreak: 4, lastActivityDate: "2026-08-29" }));
-      const res = await POST(makeReq({ type: "verse_added", local_date: "2026-08-29" }));
+      const res = await POST(
+        makeReq({ type: "verse_added", local_date: "2026-08-29", tz_offset_minutes: 180 })
+      );
       const body = await res.json();
       expect(body.isNewDay).toBe(false);
       expect(body.streak).toBe(4);
@@ -285,7 +287,9 @@ describe("POST /api/social/activity", () => {
     vi.setSystemTime(new Date("2026-08-28T23:30:00Z"));
     try {
       authedAs(makeUser({ currentStreak: 4, lastActivityDate: "2026-08-28" }));
-      const res = await POST(makeReq({ type: "verse_added", local_date: "2026-08-29" }));
+      const res = await POST(
+        makeReq({ type: "verse_added", local_date: "2026-08-29", tz_offset_minutes: 180 })
+      );
       const body = await res.json();
       expect(body.isNewDay).toBe(true);
       expect(body.streak).toBe(5);
@@ -340,6 +344,23 @@ describe("POST /api/social/activity", () => {
       );
       const body = await res.json();
       expect(body.activityDate).toBe("2026-08-28");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("buckets by UTC (not the client date) when no tz offset is sent — streak-inflation guard", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T12:00:00Z"));
+    try {
+      // A crafted request omits the offset and claims tomorrow. Without the
+      // guard this would credit the 29th and let the next real ping double-count.
+      authedAs(makeUser({ currentStreak: 3, lastActivityDate: "2026-08-28" }));
+      const res = await POST(makeReq({ type: "verse_added", local_date: "2026-08-29" }));
+      const body = await res.json();
+      expect(body.activityDate).toBe("2026-08-28");
+      expect(body.isNewDay).toBe(false);
+      expect(body.streak).toBe(3);
     } finally {
       vi.useRealTimers();
     }

--- a/__tests__/api/social/activity.test.ts
+++ b/__tests__/api/social/activity.test.ts
@@ -412,4 +412,17 @@ describe("GET /api/social/activity", () => {
     expect(body.longestStreak).toBe(14);
     expect(body.lastActivityDate).toBe(todayStr());
   });
+
+  it("returns streakDate = the local day the streak was decayed against", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T22:30:00Z"));
+    try {
+      authedAs(makeUser({ currentStreak: 3, timezoneOffsetMinutes: 180 }));
+      const res = await GET(makeGetReq());
+      const body = await res.json();
+      expect(body.streakDate).toBe("2026-08-29");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/__tests__/api/social/me.test.ts
+++ b/__tests__/api/social/me.test.ts
@@ -127,6 +127,20 @@ describe("GET /api/social/me", () => {
     expect(body.longestStreak).toBe(30);
   });
 
+  it("returns streakDate = the local day the streak was decayed against", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T22:30:00Z"));
+    try {
+      authedAs(makeUser({ currentStreak: 5, timezoneOffsetMinutes: 180 }));
+      const res = await GET(makeGetReq());
+      const body = await res.json();
+      // UTC+3 → already the 29th locally.
+      expect(body.streakDate).toBe("2026-08-29");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("decays against the user's local day using the stored timezone offset", async () => {
     // 01:00 UTC on the 29th: UTC has rolled over, but a UTC-5 user is still on
     // the evening of the 28th. Last activity on the 27th is local-yesterday for

--- a/__tests__/app/names/NameDetailPage.test.tsx
+++ b/__tests__/app/names/NameDetailPage.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import en from "@/messages/en.json";
+
+// The page prefetches name content server-side; return a per-slug value so a
+// prev/next navigation would visibly bleed if the page stopped keying its
+// client sections by slug.
+const { getCachedNameContent } = vi.hoisted(() => ({
+  getCachedNameContent: vi.fn(async (slug: string, kind: string) =>
+    kind === "reflection" ? `Reflection for ${slug}` : []
+  ),
+}));
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: async () => (key: string) => key,
+}));
+vi.mock("@/lib/names/name-content", () => ({ getCachedNameContent }));
+vi.mock("@/lib/i18n/request-prefs", () => ({ getUiLocale: async () => "en" }));
+vi.mock("@/components/layout/LandingHeader", () => ({ LandingHeader: () => null }));
+vi.mock("@/components/layout/MobileNavBar", () => ({ MobileNavBar: () => null }));
+vi.mock("@/app/names/[slug]/NameVerses", () => ({ NameVerses: () => null }));
+vi.mock("@/app/names/[slug]/NamePairings", () => ({ NamePairings: () => null }));
+
+import NameDetailPage from "@/app/names/[slug]/page";
+
+async function renderSlug(slug: string) {
+  const tree = await NameDetailPage({ params: Promise.resolve({ slug }) });
+  return render(
+    <NextIntlClientProvider locale="en" messages={en}>
+      {tree}
+    </NextIntlClientProvider>
+  );
+}
+
+describe("NameDetailPage", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn()); // NameReflection must not fetch on a prefetch hit
+  });
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    getCachedNameContent.mockClear();
+  });
+
+  it("keys the reflection/pairings/verses section by slug so a prev/next nav shows the new name, not the old", async () => {
+    const { rerender } = await renderSlug("ar-rahman");
+    expect(screen.getByText("Reflection for ar-rahman")).toBeInTheDocument();
+
+    const nextTree = await NameDetailPage({ params: Promise.resolve({ slug: "ar-rahim" }) });
+    rerender(
+      <NextIntlClientProvider locale="en" messages={en}>
+        {nextTree}
+      </NextIntlClientProvider>
+    );
+
+    // key={slug} on the section container remounts NameReflection, so it seeds
+    // from the new name's prefetched content instead of keeping ar-rahman's.
+    expect(screen.getByText("Reflection for ar-rahim")).toBeInTheDocument();
+    expect(screen.queryByText("Reflection for ar-rahman")).not.toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/names/NameDetailPage.test.tsx
+++ b/__tests__/app/names/NameDetailPage.test.tsx
@@ -19,8 +19,28 @@ vi.mock("@/lib/names/name-content", () => ({ getCachedNameContent }));
 vi.mock("@/lib/i18n/request-prefs", () => ({ getUiLocale: async () => "en" }));
 vi.mock("@/components/layout/LandingHeader", () => ({ LandingHeader: () => null }));
 vi.mock("@/components/layout/MobileNavBar", () => ({ MobileNavBar: () => null }));
-vi.mock("@/app/names/[slug]/NameVerses", () => ({ NameVerses: () => null }));
-vi.mock("@/app/names/[slug]/NamePairings", () => ({ NamePairings: () => null }));
+
+// Stateful stubs: each freezes the slug it first mounted with. If the page stops
+// keying the section by slug, these keep rendering the previous name after a
+// prev/next nav — which is exactly the bleed this test guards against.
+vi.mock("@/app/names/[slug]/NameVerses", async () => {
+  const { useState } = await import("react");
+  return {
+    NameVerses: ({ slug }: { slug: string }) => {
+      const [initial] = useState(slug);
+      return <div>Verses for {initial}</div>;
+    },
+  };
+});
+vi.mock("@/app/names/[slug]/NamePairings", async () => {
+  const { useState } = await import("react");
+  return {
+    NamePairings: ({ slug }: { slug: string }) => {
+      const [initial] = useState(slug);
+      return <div>Pairings for {initial}</div>;
+    },
+  };
+});
 
 import NameDetailPage from "@/app/names/[slug]/page";
 
@@ -46,6 +66,8 @@ describe("NameDetailPage", () => {
   it("keys the reflection/pairings/verses section by slug so a prev/next nav shows the new name, not the old", async () => {
     const { rerender } = await renderSlug("ar-rahman");
     expect(screen.getByText("Reflection for ar-rahman")).toBeInTheDocument();
+    expect(screen.getByText("Pairings for ar-rahman")).toBeInTheDocument();
+    expect(screen.getByText("Verses for ar-rahman")).toBeInTheDocument();
 
     const nextTree = await NameDetailPage({ params: Promise.resolve({ slug: "ar-rahim" }) });
     rerender(
@@ -54,10 +76,12 @@ describe("NameDetailPage", () => {
       </NextIntlClientProvider>
     );
 
-    // key={slug} on the section container remounts NameReflection, so it seeds
-    // from the new name's prefetched content instead of keeping ar-rahman's.
+    // key={slug} on the section container remounts all three client sections, so
+    // each seeds from the new name instead of keeping ar-rahman's state.
     expect(screen.getByText("Reflection for ar-rahim")).toBeInTheDocument();
-    expect(screen.queryByText("Reflection for ar-rahman")).not.toBeInTheDocument();
+    expect(screen.getByText("Pairings for ar-rahim")).toBeInTheDocument();
+    expect(screen.getByText("Verses for ar-rahim")).toBeInTheDocument();
+    expect(screen.queryByText(/for ar-rahman$/)).not.toBeInTheDocument();
     expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/app/names/NameReflection.test.tsx
+++ b/__tests__/app/names/NameReflection.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { cleanup, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import en from "@/messages/en.json";
 import { renderWithIntl } from "@/__tests__/test-utils/render-with-intl";
 import { NameReflection } from "@/app/names/[slug]/NameReflection";
 
@@ -44,6 +46,29 @@ describe("NameReflection", () => {
       expect(screen.getByText("Could not load the reflection at this time.")).toBeInTheDocument()
     );
     expect(container).not.toBeEmptyDOMElement();
+  });
+
+  it("shows the new name's reflection (no bleed) when remounted per slug, as the detail page does with key={slug}", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const wrap = (slug: string, text: string) => (
+      <NextIntlClientProvider locale="en" messages={en}>
+        <NameReflection key={slug} slug={slug} accent="#000" initialReflection={text} />
+      </NextIntlClientProvider>
+    );
+
+    const { rerender } = render(wrap("ar-rahman", "Ar-Rahman's reflection."));
+    expect(screen.getByText("Ar-Rahman's reflection.")).toBeInTheDocument();
+
+    // The page keys these components by slug, so a prev/next navigation remounts
+    // rather than reusing the fetch-once state that caused the previous name's
+    // text to persist under the new heading.
+    rerender(wrap("ar-rahim", "Ar-Rahim's reflection."));
+
+    expect(screen.getByText("Ar-Rahim's reflection.")).toBeInTheDocument();
+    expect(screen.queryByText("Ar-Rahman's reflection.")).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("shows the error message, not a perpetual skeleton, when the API returns 200 with an empty reflection", async () => {

--- a/__tests__/app/names/NameReflection.test.tsx
+++ b/__tests__/app/names/NameReflection.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
-import { NextIntlClientProvider } from "next-intl";
-import en from "@/messages/en.json";
+import { cleanup, screen, waitFor } from "@testing-library/react";
 import { renderWithIntl } from "@/__tests__/test-utils/render-with-intl";
 import { NameReflection } from "@/app/names/[slug]/NameReflection";
 
@@ -46,29 +44,6 @@ describe("NameReflection", () => {
       expect(screen.getByText("Could not load the reflection at this time.")).toBeInTheDocument()
     );
     expect(container).not.toBeEmptyDOMElement();
-  });
-
-  it("shows the new name's reflection (no bleed) when remounted per slug, as the detail page does with key={slug}", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
-    const wrap = (slug: string, text: string) => (
-      <NextIntlClientProvider locale="en" messages={en}>
-        <NameReflection key={slug} slug={slug} accent="#000" initialReflection={text} />
-      </NextIntlClientProvider>
-    );
-
-    const { rerender } = render(wrap("ar-rahman", "Ar-Rahman's reflection."));
-    expect(screen.getByText("Ar-Rahman's reflection.")).toBeInTheDocument();
-
-    // The page keys these components by slug, so a prev/next navigation remounts
-    // rather than reusing the fetch-once state that caused the previous name's
-    // text to persist under the new heading.
-    rerender(wrap("ar-rahim", "Ar-Rahim's reflection."));
-
-    expect(screen.getByText("Ar-Rahim's reflection.")).toBeInTheDocument();
-    expect(screen.queryByText("Ar-Rahman's reflection.")).not.toBeInTheDocument();
-    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("shows the error message, not a perpetual skeleton, when the API returns 200 with an empty reflection", async () => {

--- a/__tests__/components/layout/AccountMenu.test.tsx
+++ b/__tests__/components/layout/AccountMenu.test.tsx
@@ -25,6 +25,34 @@ describe("AccountMenu — logged-out sign-in button", () => {
   });
 });
 
+describe("AccountMenu — avatar initial", () => {
+  const previousAuth = useAuthStore.getState();
+  const previousSocial = useSocialStore.getState();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+    useAuthStore.setState({ accessToken: "test-token", isSessionLoading: false });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useAuthStore.setState(previousAuth);
+    useSocialStore.setState(previousSocial);
+  });
+
+  it.each([
+    ["a normal username", "shabnam", "S"],
+    ["a null username", null, "?"],
+    ["an empty-string username", "", "?"],
+    ["a whitespace-only username", "   ", "?"],
+  ])("renders %s without throwing, initial %s", (_desc, username, expected) => {
+    useSocialStore.setState({ username, streak: 3, longestStreak: 10 });
+    renderWithIntl(<AccountMenu />);
+    const trigger = screen.getByRole("button", { name: /account menu/i });
+    expect(trigger.textContent?.trimStart().startsWith(expected)).toBe(true);
+  });
+});
+
 describe("AccountMenu — dropdown a11y", () => {
   const previousAuth = useAuthStore.getState();
   const previousSocial = useSocialStore.getState();

--- a/__tests__/lib/ai/connection-generator.test.ts
+++ b/__tests__/lib/ai/connection-generator.test.ts
@@ -49,6 +49,11 @@ import {
 } from "@/lib/ai/connection-generator";
 import { getPrompt } from "@/lib/ai/prompt-registry";
 
+// Sacred-data rule (AGENTS.md): plausible Arabic + a real translation even in
+// fixtures. Al-Fatiha 1:1.
+const SOURCE_AR = "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ";
+const SOURCE_TR = "In the name of Allah, the Entirely Merciful, the Especially Merciful.";
+
 function verse(ref: string): Verse {
   const [s, a] = ref.split(":");
   return {
@@ -90,7 +95,7 @@ describe("generateConnections", () => {
         { ref: "112:1", reason: "Pure tawhid." },
       ])
     );
-    const out = await generateConnections("1:1", "ar", "tr", "thematic");
+    const out = await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic");
     expect(mockCallAI).toHaveBeenCalledTimes(1);
     expect(out).toHaveLength(3);
     expect(out[0]).toMatchObject({ ref: "2:255", reason: "Throne verse.", kind: "thematic" });
@@ -98,7 +103,7 @@ describe("generateConnections", () => {
 
   it("logs exactly one ai_generations row per generation", async () => {
     mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
-    await generateConnections("1:1", "ar", "tr", "root");
+    await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "root");
     expect(mockInsert).toHaveBeenCalledTimes(1);
   });
 
@@ -112,7 +117,7 @@ describe("generateConnections", () => {
     mockGetVerses.mockImplementation(
       async (refs: string[]) => new Map(refs.filter((r) => r !== "9:999").map((r) => [r, verse(r)]))
     );
-    const out = await generateConnections("1:1", "ar", "tr", "thematic");
+    const out = await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic");
     expect(out.map((c) => c.ref)).toEqual(["2:255"]);
   });
 
@@ -125,34 +130,34 @@ describe("generateConnections", () => {
         { ref: "2:255", reason: "valid" },
       ])
     );
-    const out = await generateConnections("1:1", "ar", "tr", "contrast");
+    const out = await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "contrast");
     expect(out.map((c) => c.ref)).toEqual(["2:255"]);
   });
 
   it("throws ConnectionParseError when the AI returns no JSON array (e.g. a refusal)", async () => {
     mockCallAI.mockResolvedValue("Sorry, I cannot help with that.");
-    await expect(generateConnections("1:1", "ar", "tr", "thematic")).rejects.toBeInstanceOf(
-      ConnectionParseError
-    );
+    await expect(
+      generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic")
+    ).rejects.toBeInstanceOf(ConnectionParseError);
   });
 
   it("throws ConnectionParseError when the JSON array is malformed", async () => {
     mockCallAI.mockResolvedValue("[{ not: valid json }]");
-    await expect(generateConnections("1:1", "ar", "tr", "thematic")).rejects.toBeInstanceOf(
-      ConnectionParseError
-    );
+    await expect(
+      generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic")
+    ).rejects.toBeInstanceOf(ConnectionParseError);
   });
 
   it("throws ConnectionParseError when the response JSON is not an array", async () => {
     mockCallAI.mockResolvedValue('{ "ref": "2:255", "reason": "x" }');
-    await expect(generateConnections("1:1", "ar", "tr", "thematic")).rejects.toBeInstanceOf(
-      ConnectionParseError
-    );
+    await expect(
+      generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic")
+    ).rejects.toBeInstanceOf(ConnectionParseError);
   });
 
   it("returns [] (no throw) when the model well-formedly selects nothing", async () => {
     mockCallAI.mockResolvedValue("[]");
-    const out = await generateConnections("1:1", "ar", "tr", "thematic");
+    const out = await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic");
     expect(out).toEqual([]);
   });
 
@@ -165,13 +170,13 @@ describe("generateConnections", () => {
         { ref: "2:4", reason: "d" },
       ])
     );
-    const out = await generateConnections("1:1", "ar", "tr", "thematic");
+    const out = await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic");
     expect(out).toHaveLength(3);
   });
 
   it("omits any language directive and keeps the Tanzih rule for the default (English) locale", async () => {
     mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
-    await generateConnections("1:1", "ar", "tr", "thematic");
+    await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic");
     const prompt = mockCallAI.mock.calls[0][0] as string;
     expect(prompt).not.toMatch(/write each "reason" in/i);
     expect(prompt).toMatch(/strict tanzih/i);
@@ -179,7 +184,7 @@ describe("generateConnections", () => {
 
   it("appends a language directive for a non-English locale without dropping the Tanzih rule", async () => {
     mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
-    await generateConnections("1:1", "ar", "tr", "thematic", "tr");
+    await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic", "tr");
     const prompt = mockCallAI.mock.calls[0][0] as string;
     expect(prompt).toMatch(/write each "reason" in turkish/i);
     expect(prompt).toMatch(/strict tanzih/i);
@@ -197,7 +202,7 @@ Return ONLY a valid JSON array of { "ref": "surah:ayah", "reason": "..." }.`,
       version: 7,
     });
     mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
-    await generateConnections("1:1", "ar", "tr", "thematic");
+    await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic");
     const prompt = mockCallAI.mock.calls[0][0] as string;
     expect(prompt).not.toMatch(/you are a classical islamic scholar/i);
     expect(prompt).toMatch(/strict tanzih/i);
@@ -210,7 +215,7 @@ Return ONLY a valid JSON array of { "ref": "surah:ayah", "reason": "..." }.`,
       provider: "gemini" as const,
       model: "gemini-3.5-flash-lite",
     });
-    await generateConnections("1:1", "ar", "tr", "thematic", "en", {
+    await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic", "en", {
       provider: "gemini",
       model: "gemini-3.7-flash",
     });
@@ -249,7 +254,7 @@ describe("generateGroundedConnections", () => {
         { ref: "3:18", reason: "witness of oneness" },
       ])
     );
-    const out = await generateGroundedConnections("1:1", "ar", "tr", "thematic", [
+    const out = await generateGroundedConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic", [
       "2:255",
       "3:18",
       "112:1",
@@ -265,7 +270,10 @@ describe("generateGroundedConnections", () => {
         { ref: "9:99", reason: "NOT a candidate — must be dropped" },
       ])
     );
-    const out = await generateGroundedConnections("1:1", "ar", "tr", "root", ["2:255", "3:18"]);
+    const out = await generateGroundedConnections("1:1", SOURCE_AR, SOURCE_TR, "root", [
+      "2:255",
+      "3:18",
+    ]);
     expect(out.map((c) => c.ref)).toEqual(["2:255"]);
   });
 
@@ -276,13 +284,17 @@ describe("generateGroundedConnections", () => {
         { ref: "2:255", reason: "valid" },
       ])
     );
-    const out = await generateGroundedConnections("1:1", "ar", "tr", "contrast", ["2:255"]);
+    const out = await generateGroundedConnections("1:1", SOURCE_AR, SOURCE_TR, "contrast", [
+      "2:255",
+    ]);
     expect(out.map((c) => c.ref)).toEqual(["2:255"]);
   });
 
   it("returns [] without calling the AI when no candidate verse resolves", async () => {
     mockGetVerses.mockResolvedValue(new Map());
-    const out = await generateGroundedConnections("1:1", "ar", "tr", "thematic", ["2:255"]);
+    const out = await generateGroundedConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic", [
+      "2:255",
+    ]);
     expect(out).toEqual([]);
     expect(mockCallAI).not.toHaveBeenCalled();
   });
@@ -290,25 +302,27 @@ describe("generateGroundedConnections", () => {
   it("throws ConnectionParseError on an unparseable grounded response", async () => {
     mockCallAI.mockResolvedValue("I can't assist with that request.");
     await expect(
-      generateGroundedConnections("1:1", "ar", "tr", "thematic", ["2:255"])
+      generateGroundedConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic", ["2:255"])
     ).rejects.toBeInstanceOf(ConnectionParseError);
   });
 
   it("returns [] (no throw) when the model well-formedly picks none of the candidates", async () => {
     mockCallAI.mockResolvedValue("[]");
-    const out = await generateGroundedConnections("1:1", "ar", "tr", "thematic", ["2:255"]);
+    const out = await generateGroundedConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic", [
+      "2:255",
+    ]);
     expect(out).toEqual([]);
   });
 
   it("logs exactly one ai_generations row per grounded generation", async () => {
     mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
-    await generateGroundedConnections("1:1", "ar", "tr", "root", ["2:255"]);
+    await generateGroundedConnections("1:1", SOURCE_AR, SOURCE_TR, "root", ["2:255"]);
     expect(mockInsert).toHaveBeenCalledTimes(1);
   });
 
   it("omits any language directive and keeps the Tanzih rule for the default (English) locale", async () => {
     mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
-    await generateGroundedConnections("1:1", "ar", "tr", "thematic", ["2:255"]);
+    await generateGroundedConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic", ["2:255"]);
     const prompt = mockCallAI.mock.calls[0][0] as string;
     expect(prompt).not.toMatch(/write each "reason" in/i);
     expect(prompt).toMatch(/strict tanzih/i);
@@ -316,7 +330,7 @@ describe("generateGroundedConnections", () => {
 
   it("appends a language directive for a non-English locale without dropping the Tanzih rule", async () => {
     mockCallAI.mockResolvedValue(JSON.stringify([{ ref: "2:255", reason: "x" }]));
-    await generateGroundedConnections("1:1", "ar", "tr", "thematic", ["2:255"], "ru");
+    await generateGroundedConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic", ["2:255"], "ru");
     const prompt = mockCallAI.mock.calls[0][0] as string;
     expect(prompt).toMatch(/write each "reason" in russian/i);
     expect(prompt).toMatch(/strict tanzih/i);
@@ -329,7 +343,7 @@ describe("generateGroundedConnections", () => {
       provider: "gemini" as const,
       model: "gemini-3.5-flash-lite",
     });
-    await generateGroundedConnections("1:1", "ar", "tr", "root", ["2:255"], "en", {
+    await generateGroundedConnections("1:1", SOURCE_AR, SOURCE_TR, "root", ["2:255"], "en", {
       provider: "gemini",
       model: "gemini-3.7-flash",
     });

--- a/__tests__/lib/ai/connection-generator.test.ts
+++ b/__tests__/lib/ai/connection-generator.test.ts
@@ -42,7 +42,11 @@ vi.mock("@/lib/ai/prompt-registry", async (importOriginal) => {
   };
 });
 
-import { generateConnections, generateGroundedConnections } from "@/lib/ai/connection-generator";
+import {
+  generateConnections,
+  generateGroundedConnections,
+  ConnectionParseError,
+} from "@/lib/ai/connection-generator";
 import { getPrompt } from "@/lib/ai/prompt-registry";
 
 function verse(ref: string): Verse {
@@ -125,41 +129,31 @@ describe("generateConnections", () => {
     expect(out.map((c) => c.ref)).toEqual(["2:255"]);
   });
 
-  it("returns [] when the AI returns no parseable JSON", async () => {
+  it("throws ConnectionParseError when the AI returns no JSON array (e.g. a refusal)", async () => {
     mockCallAI.mockResolvedValue("Sorry, I cannot help with that.");
+    await expect(generateConnections("1:1", "ar", "tr", "thematic")).rejects.toBeInstanceOf(
+      ConnectionParseError
+    );
+  });
+
+  it("throws ConnectionParseError when the JSON array is malformed", async () => {
+    mockCallAI.mockResolvedValue("[{ not: valid json }]");
+    await expect(generateConnections("1:1", "ar", "tr", "thematic")).rejects.toBeInstanceOf(
+      ConnectionParseError
+    );
+  });
+
+  it("throws ConnectionParseError when the response JSON is not an array", async () => {
+    mockCallAI.mockResolvedValue('{ "ref": "2:255", "reason": "x" }');
+    await expect(generateConnections("1:1", "ar", "tr", "thematic")).rejects.toBeInstanceOf(
+      ConnectionParseError
+    );
+  });
+
+  it("returns [] (no throw) when the model well-formedly selects nothing", async () => {
+    mockCallAI.mockResolvedValue("[]");
     const out = await generateConnections("1:1", "ar", "tr", "thematic");
     expect(out).toEqual([]);
-  });
-
-  it("logs when the AI response contains no JSON array", async () => {
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    try {
-      mockCallAI.mockResolvedValue("Sorry, I cannot help with that.");
-      const out = await generateConnections("1:1", "ar", "tr", "thematic");
-      expect(out).toEqual([]);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("no JSON array"),
-        expect.stringContaining("Sorry, I cannot help")
-      );
-    } finally {
-      consoleErrorSpy.mockRestore();
-    }
-  });
-
-  it("logs when the AI response's JSON array is malformed", async () => {
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    try {
-      mockCallAI.mockResolvedValue("[{ not: valid json }]");
-      const out = await generateConnections("1:1", "ar", "tr", "thematic");
-      expect(out).toEqual([]);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("failed to parse"),
-        expect.stringContaining("not: valid json"),
-        expect.any(Error)
-      );
-    } finally {
-      consoleErrorSpy.mockRestore();
-    }
   });
 
   it("caps at 3 connections even if the model returns more", async () => {
@@ -291,6 +285,19 @@ describe("generateGroundedConnections", () => {
     const out = await generateGroundedConnections("1:1", "ar", "tr", "thematic", ["2:255"]);
     expect(out).toEqual([]);
     expect(mockCallAI).not.toHaveBeenCalled();
+  });
+
+  it("throws ConnectionParseError on an unparseable grounded response", async () => {
+    mockCallAI.mockResolvedValue("I can't assist with that request.");
+    await expect(
+      generateGroundedConnections("1:1", "ar", "tr", "thematic", ["2:255"])
+    ).rejects.toBeInstanceOf(ConnectionParseError);
+  });
+
+  it("returns [] (no throw) when the model well-formedly picks none of the candidates", async () => {
+    mockCallAI.mockResolvedValue("[]");
+    const out = await generateGroundedConnections("1:1", "ar", "tr", "thematic", ["2:255"]);
+    expect(out).toEqual([]);
   });
 
   it("logs exactly one ai_generations row per grounded generation", async () => {

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -59,9 +59,18 @@ const {
 });
 
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, insert: mockInsert } }));
+const { ConnectionParseError } = vi.hoisted(() => ({
+  ConnectionParseError: class ConnectionParseError extends Error {
+    constructor(msg = "unparseable") {
+      super(msg);
+      this.name = "ConnectionParseError";
+    }
+  },
+}));
 vi.mock("@/lib/ai/connection-generator", () => ({
   generateConnections: mockGenerate,
   generateGroundedConnections: mockGenerateGrounded,
+  ConnectionParseError,
 }));
 vi.mock("@/lib/ai/connection-discovery", () => ({ discoverCandidates: mockDiscover }));
 vi.mock("@/lib/quran/verse-resolver", () => ({ resolveVerse: mockResolveVerse }));
@@ -202,6 +211,27 @@ describe("getConnections", () => {
     expect(mockGenerate).toHaveBeenCalledTimes(1);
     expect(mockInsert).not.toHaveBeenCalled();
     expect(out).toEqual([]);
+  });
+
+  it("propagates a ConnectionParseError from generation (not swallowed to []) and persists nothing", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    mockGenerate.mockRejectedValue(new ConnectionParseError("no JSON array in AI response"));
+
+    await expect(getConnections("1:1", "thematic", source)).rejects.toBeInstanceOf(
+      ConnectionParseError
+    );
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("propagates a ConnectionParseError from the grounded path too", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    mockDiscover.mockResolvedValue(["2:255", "3:18"]); // grounded path
+    mockGenerateGrounded.mockRejectedValue(new ConnectionParseError());
+
+    await expect(getConnections("1:1", "thematic", source)).rejects.toBeInstanceOf(
+      ConnectionParseError
+    );
+    expect(mockInsert).not.toHaveBeenCalled();
   });
 
   it("rate-limits the generation path: over budget throws and does not generate", async () => {

--- a/__tests__/lib/social/activity-date.test.ts
+++ b/__tests__/lib/social/activity-date.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { resolveActivityDate } from "@/lib/social/activity-date";
+
+describe("resolveActivityDate", () => {
+  afterEach(() => vi.useRealTimers());
+
+  function freeze(iso: string) {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(iso));
+  }
+
+  it("with an offset, credits the day the offset yields right now", () => {
+    freeze("2026-08-28T22:30:00Z");
+    // UTC+3 → local day is already the 29th.
+    expect(resolveActivityDate("2026-08-29", 180)).toBe("2026-08-29");
+  });
+
+  it("with an offset, ignores a mismatched client local_date (can't pre-credit another day)", () => {
+    freeze("2026-08-28T12:00:00Z");
+    expect(resolveActivityDate("2026-09-15", 180)).toBe("2026-08-28");
+  });
+
+  it("with NO offset, buckets by UTC even when the client sends tomorrow (streak-inflation guard)", () => {
+    freeze("2026-08-28T12:00:00Z");
+    expect(resolveActivityDate("2026-08-29", null)).toBe("2026-08-28");
+  });
+
+  it("with NO offset, buckets by UTC even when the client sends today's local_date", () => {
+    freeze("2026-08-28T12:00:00Z");
+    expect(resolveActivityDate("2026-08-28", null)).toBe("2026-08-28");
+  });
+
+  it("falls back to UTC for a missing or malformed local_date", () => {
+    freeze("2026-08-28T12:00:00Z");
+    expect(resolveActivityDate(undefined, 180)).toBe("2026-08-28");
+    expect(resolveActivityDate("not-a-date", 180)).toBe("2026-08-28");
+    expect(resolveActivityDate("2026-02-30", 180)).toBe("2026-08-28");
+  });
+});

--- a/__tests__/store/social.test.ts
+++ b/__tests__/store/social.test.ts
@@ -96,6 +96,18 @@ describe("social store", () => {
     expect(useSocialStore.getState().streak).toBe(5);
   });
 
+  it("bumpStreak applies a server decay to 0 on reload when asOf is the current day (broken-streak case)", () => {
+    // The persisted state from an earlier active day.
+    useSocialStore.setState({ streak: 10, longestStreak: 10, streakAsOf: "2026-09-04" });
+    // On reload days later, the server reports the streak is dead. The hydration
+    // caller passes *today's* local date as asOf (NOT lastActivityDate, which is
+    // still "2026-09-04" and would trip the same-day regression guard).
+    useSocialStore.getState().bumpStreak(0, 10, "2026-09-10");
+    expect(useSocialStore.getState().streak).toBe(0);
+    expect(useSocialStore.getState().longestStreak).toBe(10);
+    expect(useSocialStore.getState().streakAsOf).toBe("2026-09-10");
+  });
+
   it("bumpStreak applies a newer hydration read, including a legitimate decay to 0", () => {
     useSocialStore.getState().applyActivityResult({
       streak: 5,

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getConnections } from "@/lib/ai/graph-service";
+import { ConnectionParseError } from "@/lib/ai/connection-generator";
 import { isValidRef } from "@/lib/quran/quran-corpus";
 import { RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
@@ -76,6 +77,16 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     if (err instanceof RateLimitError) {
       return NextResponse.json({ error: "Too many requests — please slow down." }, { status: 429 });
+    }
+    if (err instanceof ConnectionParseError) {
+      // The model returned something unparseable (refusal, prose, truncated
+      // JSON). That is a transient upstream failure, not "no connections" —
+      // surface it so the client can retry rather than caching an empty result.
+      console.error("Connections route: unparseable AI response:", err);
+      return NextResponse.json(
+        { error: "Connection generation failed — please retry." },
+        { status: 502 }
+      );
     }
     console.error("Connections route error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -212,7 +212,14 @@ async function getVersesBySlug(
         .map((item, i) => {
           const vd = verseDataResults[i];
           if (!vd) return null;
-          return { ...vd, reason: item.reason } as NameVerse;
+          // Same as the search path above: Saheeh International text carries
+          // footnote markup (<sup foot_note=…>) that must be stripped before it
+          // is cached and rendered.
+          return {
+            ...vd,
+            translation: stripHtml(vd.translation),
+            reason: item.reason,
+          } as NameVerse;
         })
         .filter((v): v is NameVerse => v !== null);
     },

--- a/app/api/social/activity/route.ts
+++ b/app/api/social/activity/route.ts
@@ -3,7 +3,13 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { activityLog, users } from "@/lib/infra/db/schema";
 import { requireUser, invalidateTokenCache } from "@/lib/auth/social-auth";
-import { todayUTC, yesterdayUTC, previousDay, effectiveStreak } from "@/lib/social/streak";
+import {
+  todayUTC,
+  yesterdayUTC,
+  previousDay,
+  effectiveStreak,
+  localDateFromOffset,
+} from "@/lib/social/streak";
 import { resolveActivityDate } from "@/lib/social/activity-date";
 import { rateLimitOrNull, MUTATION_WINDOW_SECONDS } from "@/lib/infra/rate-limit";
 
@@ -163,5 +169,7 @@ export async function GET(req: NextRequest) {
     streak: effectiveStreak(user.currentStreak, user.lastActivityDate, user.timezoneOffsetMinutes),
     longestStreak: user.longestStreak,
     lastActivityDate: user.lastActivityDate,
+    // The local calendar day `streak` was decayed against — see /api/social/me.
+    streakDate: localDateFromOffset(user.timezoneOffsetMinutes),
   });
 }

--- a/app/api/social/activity/route.ts
+++ b/app/api/social/activity/route.ts
@@ -3,13 +3,8 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { activityLog, users } from "@/lib/infra/db/schema";
 import { requireUser, invalidateTokenCache } from "@/lib/auth/social-auth";
-import {
-  todayUTC,
-  yesterdayUTC,
-  previousDay,
-  effectiveStreak,
-  localDateFromOffset,
-} from "@/lib/social/streak";
+import { todayUTC, yesterdayUTC, previousDay, effectiveStreak } from "@/lib/social/streak";
+import { resolveActivityDate } from "@/lib/social/activity-date";
 import { rateLimitOrNull, MUTATION_WINDOW_SECONDS } from "@/lib/infra/rate-limit";
 
 // Activity pings fire on ordinary reading (each verse/connection), so a genuinely
@@ -19,42 +14,9 @@ const ACTIVITY_LIMIT = 300;
 
 const VALID_TYPES = new Set(["verse_added", "connection_made", "hadith_read"]);
 
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 // Widest real UTC offset is ±14h; allow a little slack for a client clock that's
 // a bit off without letting a wildly-wrong clock fabricate consecutive days.
 const MAX_TZ_OFFSET_MIN = 840;
-
-/**
- * The day to credit this activity to. Prefer the client's local calendar day so
- * streaks bucket by the user's midnight, not UTC — but clamp to the server's UTC
- * date if the client's date is more than ~26h away (a broken clock), so it can't
- * jump the streak forward or drop a day.
- */
-function resolveActivityDate(localDate: string | undefined, offsetMinutes: number | null): string {
-  const utc = todayUTC();
-  if (!localDate || !DATE_RE.test(localDate)) return utc;
-
-  // Reject a well-formed but non-existent calendar date ("2026-99-99",
-  // "2026-02-30"): Date.parse gives NaN or silently rolls over, and the raw
-  // string would otherwise hit the Postgres `date` column as a 500.
-  const parsedMs = Date.parse(`${localDate}T00:00:00Z`);
-  if (!Number.isFinite(parsedMs) || new Date(parsedMs).toISOString().slice(0, 10) !== localDate) {
-    return utc;
-  }
-
-  // When the client sent its offset too, the offset is authoritative: the day it
-  // yields right now is the only day we credit, so a signed-in client can't
-  // pre-credit tomorrow (or any other day) by sending a mismatched local_date.
-  if (offsetMinutes !== null) {
-    const reference = localDateFromOffset(offsetMinutes);
-    return localDate === reference ? localDate : reference;
-  }
-
-  // No offset — fall back to UTC with ~26h of clock slack so a slightly-off
-  // client clock near midnight still buckets to its own day.
-  const diffDays = Math.abs((parsedMs - Date.parse(`${utc}T00:00:00Z`)) / 86_400_000);
-  return diffDays > 1 ? utc : localDate;
-}
 
 export async function POST(req: NextRequest) {
   const authed = await requireUser(req);

--- a/app/api/social/me/route.ts
+++ b/app/api/social/me/route.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { users } from "@/lib/infra/db/schema";
 import { requireUser } from "@/lib/auth/social-auth";
-import { effectiveStreak } from "@/lib/social/streak";
+import { effectiveStreak, localDateFromOffset } from "@/lib/social/streak";
 import { isUniqueViolation } from "@/lib/infra/http";
 
 export async function GET(req: NextRequest) {
@@ -22,6 +22,11 @@ export async function GET(req: NextRequest) {
     ),
     longestStreak: user.longestStreak,
     lastActivityDate: user.lastActivityDate,
+    // The local calendar day currentStreak was decayed against — the client
+    // passes this to the store's same-day guard so it reconciles against the
+    // server's notion of "today", not the browser's (which can disagree when
+    // the stored offset is null/stale).
+    streakDate: localDateFromOffset(user.timezoneOffsetMinutes),
     createdAt: user.createdAt,
   });
 }

--- a/app/names/[slug]/page.tsx
+++ b/app/names/[slug]/page.tsx
@@ -112,8 +112,13 @@ export default async function NameDetailPage({ params }: Props) {
           </p>
         </div>
 
-        {/* Reflection + Pairings + Verses */}
-        <div className="max-w-3xl mx-auto px-6 py-10 space-y-10">
+        {/* Reflection + Pairings + Verses.
+            key={slug}: prev/next and pairing cross-links are client-side
+            navigations within this same route segment, so without a key React
+            reuses these client components across names and their fetch-once
+            state (and the "server prefetch present ⇒ skip fetch" guard) would
+            keep showing the previous name's content. */}
+        <div key={slug} className="max-w-3xl mx-auto px-6 py-10 space-y-10">
           {/* Believer's Reflection */}
           <NameReflection
             slug={slug}

--- a/components/layout/AccountMenu.tsx
+++ b/components/layout/AccountMenu.tsx
@@ -128,7 +128,7 @@ export function AccountMenu() {
     );
   }
 
-  const initial = (username ?? "?")[0].toUpperCase();
+  const initial = (username?.trim() || "?")[0].toUpperCase();
 
   return (
     <div ref={ref} className="relative">

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -230,10 +230,11 @@ export function Header({ onSearchOpen }: HeaderProps) {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data?.streak !== undefined)
-          // asOf = the client-local day this read is reconciled against, not
-          // lastActivityDate (which doesn't advance on a broken streak — see
-          // components/providers.tsx).
-          bumpStreak(data.streak, data.longestStreak, clientLocalDate());
+          // asOf = the day the server decayed the streak against (streakDate),
+          // not lastActivityDate (which doesn't advance on a broken streak) and
+          // not the browser's day (which can disagree with the stored offset).
+          // See components/providers.tsx.
+          bumpStreak(data.streak, data.longestStreak, data.streakDate ?? clientLocalDate());
       })
       .catch((e) => console.error("header: streak hydration failed", e));
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -23,7 +23,6 @@ import { useAudioStore } from "@/store/audio";
 import type { AudioVerse } from "@/store/audio";
 import type { Verse } from "@/types/quran";
 import { buildShareUrl } from "@/hooks/useCanvasPersistence";
-import { clientLocalDate } from "@/lib/social/post-activity";
 import { useState, useEffect, useRef, forwardRef, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { useCopyFeedback } from "@/hooks/useCopyFeedback";
@@ -230,11 +229,10 @@ export function Header({ onSearchOpen }: HeaderProps) {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data?.streak !== undefined)
-          // asOf = the day the server decayed the streak against (streakDate),
-          // not lastActivityDate (which doesn't advance on a broken streak) and
-          // not the browser's day (which can disagree with the stored offset).
-          // See components/providers.tsx.
-          bumpStreak(data.streak, data.longestStreak, data.streakDate ?? clientLocalDate());
+          // asOf = the day the server decayed the streak against (streakDate) —
+          // see components/providers.tsx for why not lastActivityDate / the
+          // browser's day.
+          bumpStreak(data.streak, data.longestStreak, data.streakDate);
       })
       .catch((e) => console.error("header: streak hydration failed", e));
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -23,6 +23,7 @@ import { useAudioStore } from "@/store/audio";
 import type { AudioVerse } from "@/store/audio";
 import type { Verse } from "@/types/quran";
 import { buildShareUrl } from "@/hooks/useCanvasPersistence";
+import { clientLocalDate } from "@/lib/social/post-activity";
 import { useState, useEffect, useRef, forwardRef, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { useCopyFeedback } from "@/hooks/useCopyFeedback";
@@ -229,7 +230,10 @@ export function Header({ onSearchOpen }: HeaderProps) {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data?.streak !== undefined)
-          bumpStreak(data.streak, data.longestStreak, data.lastActivityDate ?? null);
+          // asOf = the client-local day this read is reconciled against, not
+          // lastActivityDate (which doesn't advance on a broken streak — see
+          // components/providers.tsx).
+          bumpStreak(data.streak, data.longestStreak, clientLocalDate());
       })
       .catch((e) => console.error("header: streak hydration failed", e));
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
 import { usePreferencesStore } from "@/store/preferences";
 import { mergeGuestWorkspace } from "@/hooks/useCanvasPersistence";
+import { clientLocalDate } from "@/lib/social/post-activity";
 import { HAS_SESSION_COOKIE_NAME } from "@/lib/auth/session-cookie";
 import type { Locale } from "@/lib/i18n/config";
 
@@ -145,7 +146,12 @@ export function SessionRestorer() {
           if (p.id && p.username) {
             setProfile({ userId: p.id, username: p.username });
             if (p.currentStreak !== undefined)
-              bumpStreak(p.currentStreak, p.longestStreak, p.lastActivityDate ?? null);
+              // asOf is the client-local day this read was reconciled against,
+              // NOT lastActivityDate — that doesn't advance when a streak breaks,
+              // so passing it would let bumpStreak's same-day regression guard
+              // reject the server's legitimate decay to 0 and keep showing a
+              // stale value forever.
+              bumpStreak(p.currentStreak, p.longestStreak, clientLocalDate());
           }
         }
       })

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -142,16 +142,17 @@ export function SessionRestorer() {
             currentStreak?: number;
             longestStreak?: number;
             lastActivityDate?: string | null;
+            streakDate?: string;
           };
           if (p.id && p.username) {
             setProfile({ userId: p.id, username: p.username });
             if (p.currentStreak !== undefined)
-              // asOf is the client-local day this read was reconciled against,
-              // NOT lastActivityDate — that doesn't advance when a streak breaks,
-              // so passing it would let bumpStreak's same-day regression guard
-              // reject the server's legitimate decay to 0 and keep showing a
-              // stale value forever.
-              bumpStreak(p.currentStreak, p.longestStreak, clientLocalDate());
+              // asOf is the day the server decayed currentStreak against
+              // (streakDate), NOT lastActivityDate — that doesn't advance when a
+              // streak breaks, so passing it would let bumpStreak's same-day
+              // guard reject the server's legitimate decay to 0. Fall back to the
+              // browser's local day only if the server didn't send streakDate.
+              bumpStreak(p.currentStreak, p.longestStreak, p.streakDate ?? clientLocalDate());
           }
         }
       })

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -9,7 +9,6 @@ import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
 import { usePreferencesStore } from "@/store/preferences";
 import { mergeGuestWorkspace } from "@/hooks/useCanvasPersistence";
-import { clientLocalDate } from "@/lib/social/post-activity";
 import { HAS_SESSION_COOKIE_NAME } from "@/lib/auth/session-cookie";
 import type { Locale } from "@/lib/i18n/config";
 
@@ -142,17 +141,17 @@ export function SessionRestorer() {
             currentStreak?: number;
             longestStreak?: number;
             lastActivityDate?: string | null;
-            streakDate?: string;
+            streakDate: string;
           };
           if (p.id && p.username) {
             setProfile({ userId: p.id, username: p.username });
             if (p.currentStreak !== undefined)
               // asOf is the day the server decayed currentStreak against
-              // (streakDate), NOT lastActivityDate — that doesn't advance when a
-              // streak breaks, so passing it would let bumpStreak's same-day
-              // guard reject the server's legitimate decay to 0. Fall back to the
-              // browser's local day only if the server didn't send streakDate.
-              bumpStreak(p.currentStreak, p.longestStreak, p.streakDate ?? clientLocalDate());
+              // (streakDate) — NOT lastActivityDate (doesn't advance on a broken
+              // streak) and NOT the browser's day (can disagree with the stored
+              // offset). bumpStreak's same-day guard then reconciles against the
+              // same calendar day the server used.
+              bumpStreak(p.currentStreak, p.longestStreak, p.streakDate);
           }
         }
       })

--- a/lib/ai/connection-batch.ts
+++ b/lib/ai/connection-batch.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { verses, connections, connectionCoverage, aiGenerations } from "@/lib/infra/db/schema";
 import { generateConnectionsForCell } from "@/lib/ai/graph-service";
+import { ConnectionParseError } from "@/lib/ai/connection-generator";
 import { translateReason } from "@/lib/ai/translate";
 import { estimateCostUsd } from "@/lib/ai/ai-cost";
 import { resolveModel, type Provider } from "@/lib/ai/ai";
@@ -573,6 +574,11 @@ export async function runConnectionBatch(
         }
         summary.generated += results.length;
 
+        // NB: an unparseable model response (refusal, prose, truncated JSON)
+        // throws ConnectionParseError out of generateConnectionsForCell before
+        // this point, so it's handled as a cell failure in the catch below and
+        // never reaches the exhausted branch. Only a *well-formed* empty
+        // selection lands here with results.length === 0.
         if (opts.mode === "topup" && excludeRefs.length > 0 && results.length === 0) {
           // Grounded pool is genuinely empty for this cell — record it so no
           // future run pays for it again.
@@ -635,7 +641,11 @@ export async function runConnectionBatch(
       }
       const message = err instanceof Error ? err.message : String(err);
       console.error(`connection-batch: cell ${cell.fromRef} ${cell.kind} failed:`, err);
-      incr("connection_batch_cell_failed");
+      incr(
+        err instanceof ConnectionParseError
+          ? "connection_batch_unparseable_response"
+          : "connection_batch_cell_failed"
+      );
       summary.cellsFailed++;
       summary.lastError = message;
       consecutiveFailures++;

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -154,10 +154,18 @@ function parseRawConnections(text: string): Array<{ ref: string; reason: string 
   if (!Array.isArray(parsed)) {
     throw new ConnectionParseError("AI response JSON was not an array", jsonMatch[0]);
   }
-  return parsed.filter(
+  const valid = parsed.filter(
     (c): c is { ref: string; reason: string } =>
       c && typeof c.ref === "string" && typeof c.reason === "string"
   );
+  // A non-empty array whose entries are ALL the wrong shape is malformed output,
+  // not a valid empty selection — the caller must not read it as "pool
+  // exhausted". A partially-valid array (some good entries, some junk) keeps the
+  // good ones, matching the model's evident intent.
+  if (parsed.length > 0 && valid.length === 0) {
+    throw new ConnectionParseError("AI response array had no well-formed entries", jsonMatch[0]);
+  }
+  return valid;
 }
 
 /**

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -123,31 +123,49 @@ async function buildPrompt(
   return { text, promptVersion: version };
 }
 
+/**
+ * A connection-generation response that could not be parsed as a JSON array —
+ * a refusal, a prose preamble, truncated output, or invalid JSON. Distinct from
+ * a *well-formed* empty selection (`[]`), which is a valid "nothing more to
+ * connect" answer. Callers must treat this as a transient generation failure,
+ * never as a genuinely exhausted candidate pool (see lib/ai/connection-batch.ts).
+ */
+export class ConnectionParseError extends Error {
+  constructor(reason: string, sample: string) {
+    super(`${reason}: ${sample.slice(0, 300)}`);
+    this.name = "ConnectionParseError";
+  }
+}
+
 function parseRawConnections(text: string): Array<{ ref: string; reason: string }> {
   const jsonMatch = text.match(/\[[\s\S]*\]/);
   if (!jsonMatch) {
-    console.error("Connections: no JSON array found in AI response:", text.slice(0, 500));
-    return [];
+    throw new ConnectionParseError("no JSON array in AI response", text);
   }
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(jsonMatch[0]);
-    if (!Array.isArray(parsed)) {
-      console.error("Connections: AI response JSON was not an array:", jsonMatch[0].slice(0, 500));
-      return [];
-    }
-    return parsed.filter(
-      (c): c is { ref: string; reason: string } =>
-        c && typeof c.ref === "string" && typeof c.reason === "string"
-    );
+    parsed = JSON.parse(jsonMatch[0]);
   } catch (err) {
-    console.error("Connections: failed to parse AI response:", text.slice(0, 500), err);
-    return [];
+    throw new ConnectionParseError(
+      `invalid JSON in AI response (${(err as Error).message})`,
+      jsonMatch[0]
+    );
   }
+  if (!Array.isArray(parsed)) {
+    throw new ConnectionParseError("AI response JSON was not an array", jsonMatch[0]);
+  }
+  return parsed.filter(
+    (c): c is { ref: string; reason: string } =>
+      c && typeof c.ref === "string" && typeof c.reason === "string"
+  );
 }
 
 /**
  * Generates up to 3 validated, fully-hydrated connections for a source verse.
- * Returns an empty array if generation fails or nothing resolves.
+ * Returns an empty array when the model well-formedly proposes nothing (or
+ * nothing survives corpus validation). Throws {@link ConnectionParseError} when
+ * the model response can't be parsed — callers must treat that as a transient
+ * failure, not an empty result.
  */
 export async function generateConnections(
   fromRef: string,
@@ -283,7 +301,9 @@ function toResult(verse: Verse, reason: string, kind: EdgeKind): ConnectionResul
  * Grounded generation: the model SELECTS from real discovered candidates and
  * explains each. Refs are validated against the candidate set, so a verse the
  * discovery step did not surface can never appear. Returns [] if no candidate
- * verses resolve (caller falls back to legacy generation).
+ * verses resolve (caller falls back to legacy generation) or the model
+ * well-formedly selects nothing. Throws {@link ConnectionParseError} when the
+ * model response can't be parsed.
  */
 export async function generateGroundedConnections(
   fromRef: string,

--- a/lib/social/activity-date.ts
+++ b/lib/social/activity-date.ts
@@ -1,0 +1,38 @@
+import { todayUTC, localDateFromOffset } from "@/lib/social/streak";
+
+export const ACTIVITY_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * The day to credit an activity to.
+ *
+ * - With a client `tz_offset_minutes`, the offset is authoritative: the only day
+ *   we credit is the one the offset yields right now, so a signed-in client
+ *   can't pre-credit another day by sending a mismatched `local_date`.
+ * - Without an offset we cannot place the client's calendar day at all, and
+ *   trusting the raw `local_date` lets a crafted request (offset omitted,
+ *   `local_date` = tomorrow) pre-credit a future day and inflate the streak on
+ *   the next real ping. Bucket by UTC instead — the real client always sends its
+ *   offset (`lib/social/post-activity.ts`).
+ */
+export function resolveActivityDate(
+  localDate: string | undefined,
+  offsetMinutes: number | null
+): string {
+  const utc = todayUTC();
+  if (!localDate || !ACTIVITY_DATE_RE.test(localDate)) return utc;
+
+  // Reject a well-formed but non-existent calendar date ("2026-99-99",
+  // "2026-02-30"): Date.parse gives NaN or silently rolls over, and the raw
+  // string would otherwise hit the Postgres `date` column as a 500.
+  const parsedMs = Date.parse(`${localDate}T00:00:00Z`);
+  if (!Number.isFinite(parsedMs) || new Date(parsedMs).toISOString().slice(0, 10) !== localDate) {
+    return utc;
+  }
+
+  if (offsetMinutes !== null) {
+    const reference = localDateFromOffset(offsetMinutes);
+    return localDate === reference ? localDate : reference;
+  }
+
+  return utc;
+}


### PR DESCRIPTION
## What

A bug-sweep PR: six confirmed, user-affecting defects found by a full read-through of the AI/theological pipeline, the auth/API/store layer, and the UI/component layer. Each is well-contained and covered by tests in this PR.

| # | Severity | Area | Bug |
|---|----------|------|-----|
| 1 | High | `app/names/[slug]` | Name-detail sections show the **previous name's** reflection/pairings/verses after a prev/next or pairing-link navigation |
| 2 | Med | `store/social` + hydration | A broken streak keeps displaying the **stale value forever** after reload |
| 3 | Med | `/api/social/activity` | Streak inflation / leaderboard cheating when a request omits `tz_offset_minutes` |
| 4 | Med | `components/layout/AccountMenu` | Empty-string username throws and takes down the app-shell header |
| 5 | High | `lib/ai/connection-*` | Unparseable model output silently marks a connection cell **`exhaustedAt` forever** |
| 6 | Low | `/api/names/[slug]/verses` | AI-fallback verses cached with `<sup>` footnote markup (no `stripHtml`) |

## Details

**1 — name-detail content bleed.** `NameReflection` / `NamePairings` / `NameVerses` were rendered with no `key`. Prev/next and pairing cross-links are client-side navigations within the same `/names/[slug]` segment, so React reused the components across names; their fetch-once state and the "server prefetch present ⇒ skip fetch" guard (`NameReflection.tsx:20`) kept name A's content under name B's heading, and a once-failed fetch poisoned every later name. Fixed with `key={slug}` on the container.

**2 — stale streak.** `bumpStreak`'s third arg is the client-local day the value was reconciled against and doubles as a same-day regression guard (`store/social.ts:72`). The hydration callers (`providers.tsx`, `Header.tsx`) passed `lastActivityDate`, which does **not** advance when a streak breaks — so after a gap the store saw `asOf === streakAsOf && 0 < 10` and rejected the server's legitimate decay to 0, persisting the stale streak to `localStorage`. Now passes `clientLocalDate()`.

**3 — streak inflation.** `resolveActivityDate` trusted a raw client `local_date` within ~26h of UTC when no `tz_offset_minutes` was sent, so a crafted request omitting the offset and claiming *tomorrow* was credited to tomorrow; the next real ping then hit the "consecutive day" branch and double-incremented `currentStreak`. The real client always sends its offset, so the no-offset path now buckets by UTC. Logic extracted to `lib/social/activity-date.ts` for unit tests.

**4 — AccountMenu crash.** `(username ?? "?")[0].toUpperCase()` — `?? "?"` only guards null/undefined; `""[0]` is `undefined` and `.toUpperCase()` throws, with no per-widget error boundary around the header. Now `(username?.trim() || "?")[0]`.

**5 — silent connection-cell exhaustion.** `parseRawConnections` returned `[]` on *any* failure (no JSON array, non-array, `JSON.parse` throw) — indistinguishable from a well-formed empty selection. In the backfill (`connection-batch.ts:576`) that set `exhaustedAt` and permanently skipped the cell, so the verse stayed under-covered forever and the public "+" expander under-reported. It now throws a typed `ConnectionParseError`; the batch loop's existing per-cell catch counts it as a cell failure (never `exhaustedAt`, and it feeds the fail-fast / unproductive-pass guards), and `/api/connections` returns **502** instead of caching an empty result. Also resolves the AGENTS.md "no silent catch around AI-response parsing" violation.

**6 — footnote markup.** The `fallbackAIVerses` branch in `getVersesBySlug` returned `{ ...vd, reason }` without `stripHtml(vd.translation)`, unlike the search path. Saheeh International text carries `<sup foot_note=…>` markup that was then cached and rendered.

## Tests

- `resolveActivityDate` unit tests (offset authoritative, no-offset ⇒ UTC, malformed dates)
- `bumpStreak` applies a server decay to 0 when `asOf` is the current day
- `parseRawConnections` throws `ConnectionParseError` on unparseable / non-array output, returns `[]` on well-formed `[]`
- updated `/api/social/activity` route tests to send `tz_offset_minutes` (matching the real client) + a new no-offset UTC-bucketing case
- All 1519 unit tests pass; `typecheck` + `lint` clean; pre-push integration tests pass.

## AI / Theological changes

- [x] Other: connection-generation error handling — an unparseable model response is now a **visible failure** (502 / counted cell failure) instead of a silently-cached empty result or a permanently-exhausted cell. No prompt, divine-name data, or theological framing changed. No change to verse-reference validation.

## Follow-ups (filed separately)

Deeper structural findings from the same sweep, tracked as their own issues:

- #554 — bookmark resurrection (no tombstone / last-sync marker)
- #555 — refresh-token single-flight is per-process (breaks with >1 instance)
- #556 — OIDC nonce check fails open when no nonce is sent
- #557 — `translateCellReasons` persists refusal/preamble text as canonical theology
- #558 — Claude→Gemini names fallback masks refusals
- #559 — `useMobileNavVisible` over-subscribes every page to canvas node changes
- #560 — unbounded Gemini `retryDelay` honored
- #561 — zero-padded refs pass `isValidRef` then miss corpus lookup
- #562 — `bookmarks/[ref]` DELETE does no trim/normalization
- #563 — activity streak day is derived from a client-controlled tz offset (pre-existing; needs a trusted-timezone design)

## Review follow-ups (commit `3b266f0`)

Addressed CodeRabbit feedback: `parseRawConnections` also throws on a non-empty all-malformed array; `/api/social/me` + `/api/social/activity` now return `streakDate` (the server's decay day) and the client passes that to `bumpStreak` instead of the browser date; added regression tests (502 path, `ConnectionParseError` propagation through `graph-service`, `streakDate`, verses footnote strip, `AccountMenu` initials, `NameReflection` remount); replaced `"ar"`/`"tr"` test placeholders with real Arabic/translation constants. The client-controlled-offset concern is tracked as #563 (not a regression from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streak tracking across time zones and prevented invalid client dates from inflating streaks.
  - Added reliable streak-date synchronization during sign-in and session restoration.
  - AI connection-generation failures now return a clear retry message instead of appearing as empty results.
  - Fixed stale content when navigating between different names.
  - Removed footnote markup from fallback verse translations.
  - Corrected avatar initials for usernames containing whitespace.
  - Improved handling and reporting of malformed AI responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->