### PR TITLE
fix(names): stop non-English name pages 500ing when the AI provider is down

### DIFF
--- a/__tests__/api/names.test.ts
+++ b/__tests__/api/names.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // Mocks must be declared before static imports so Vitest hoists them first
@@ -58,8 +58,8 @@ vi.mock("@/lib/infra/db", () => ({
 // Shared (not per-instance) so tests can inspect every prompt sent to the AI
 // across the module's several `new Anthropic()` call sites (callAI creates a
 // fresh client per call).
-const { mockCreate } = vi.hoisted(() => ({
-  mockCreate: vi.fn(async (_args: { messages: Array<{ content: string }> }) => ({
+const { mockCreate, defaultAiCreate } = vi.hoisted(() => {
+  const defaultAiCreate = async (_args: { messages: Array<{ content: string }> }) => ({
     content: [
       {
         type: "text",
@@ -72,8 +72,9 @@ const { mockCreate } = vi.hoisted(() => ({
         ]),
       },
     ],
-  })),
-}));
+  });
+  return { mockCreate: vi.fn(defaultAiCreate), defaultAiCreate };
+});
 
 vi.mock("@anthropic-ai/sdk", () => {
   class MockAnthropic {
@@ -129,6 +130,13 @@ describe("GET /api/names/[slug]/verses", () => {
     mockGetUiLocale.mockResolvedValue("en");
     mockGetQuranEdition.mockReset();
     mockGetQuranEdition.mockResolvedValue("en.sahih");
+  });
+
+  afterEach(() => {
+    // Restore the default AI response — individual tests may replace it with a
+    // rejecting implementation to simulate a provider outage.
+    mockCreate.mockReset();
+    mockCreate.mockImplementation(defaultAiCreate);
   });
 
   function params(slug: string) {
@@ -237,6 +245,47 @@ describe("GET /api/names/[slug]/verses", () => {
     expect(body.length).toBeGreaterThan(0);
     for (const verse of body) {
       expect(verse.translation).toBe("Türkçe çeviri");
+    }
+  });
+
+  it("returns 200 with the English reason (never 500) for a non-English locale when every AI call fails", async () => {
+    // Reproduces the production outage: with the paid-AI budget spent, every
+    // Claude call throws. English pages serve cached content, but a non-English
+    // request must still translate each verse reason — that call path had no
+    // guard and 500'd the whole response. It must now degrade to the English
+    // reason instead.
+    mockGetUiLocale.mockResolvedValue("tr");
+    mockGetQuranEdition.mockResolvedValue("tr.diyanet");
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url !== "string") return { ok: false };
+      // quran.com search returns real verse keys so selection succeeds with no AI.
+      if (new URL(url).hostname === "api.quran.com")
+        return {
+          ok: true,
+          json: async () => ({
+            search: { results: [{ verse_key: "2:255" }, { verse_key: "3:18" }] },
+          }),
+        };
+      if (url.includes("ar.alafasy")) return arabicResp("اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ");
+      if (url.includes("tr.diyanet")) return transResp("Türkçe çeviri");
+      if (url.includes("en.sahih")) return transResp("English translation");
+      return { ok: false };
+    });
+    mockCreate.mockReset();
+    mockCreate.mockImplementation(async () => {
+      throw new Error("provider unavailable");
+    });
+
+    const req = new NextRequest("http://localhost/api/names/al-alim/verses");
+    const res = await getNameVerses(req, params("al-alim"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    for (const verse of body) {
+      expect(typeof verse.reason).toBe("string");
+      expect(verse.reason.trim().length).toBeGreaterThan(0);
     }
   });
 

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -286,7 +286,19 @@ async function getVersesBySlug(
         slug,
         v.ref,
         locale,
-        (resolved) => translateReason(v.reason, language, { feature: "names", ...resolved }),
+        (resolved) =>
+          translateReason(v.reason, language, { feature: "names", ...resolved }).catch((err) => {
+            // A provider failure on the translation call must degrade to the
+            // English reason (handled just below), never 500 the whole verses
+            // response — mirrors the callAI try/catch in reflection/pairings.
+            // Returned "" is treated as a blank translation by the caller.
+            console.error(
+              `Name verses: translation call failed for ${slug}/${v.ref}/${locale}:`,
+              err
+            );
+            incr("names_ai_call_error");
+            return "";
+          }),
         onBeforeGenerateOnce
       );
       // A blank/failed translation must never silently replace an


### PR DESCRIPTION
## What

Fixes the live production outage where **every "99 Names" detail page is broken for `tr` / `ru` / `az`** (#564): `reflection` returns empty, `pairings` returns empty, and `verses` returns **HTTP 500**. English is unaffected.

Reproduce on prod:
```
for l in en tr ru az; do curl -s -H "Cookie: oh_locale=$l" -o /dev/null -w "$l %{http_code}\n" \
  https://openhikmah.com/api/names/al-latif/verses; done
# en 200 · tr 500 · ru 500 · az 500
```

## Root cause

`reflection/route.ts` and `pairings/route.ts` wrap their `callAI` in `try/catch` and degrade to `""` / `[]` on a provider error. `verses/route.ts` wraps only its **English** selection calls (`buildReasons`, `fallbackAIVerses`). The **non-English path** additionally translates each verse's reason:

`verses/route.ts` → `getOrGenerateVerseReason` → `resolveAndGenerate` (primary `generate()` unguarded) → `translateReason` → `callAI`

With the paid-AI budget spent, `callAI` throws, and nothing on that chain catches it — it propagates to the route's catch-all as a 500. English never reaches this path (it returns cached `en` content first).

## Change

`app/api/names/[slug]/verses/route.ts` — wrap the `translateReason` call passed to `getOrGenerateVerseReason` in `.catch()` → `console.error` + `incr("names_ai_call_error")` + return `""`. The route's existing "blank translation → fall back to the English reason" branch then handles it. Non-English pages render the verse list with English reason text — degraded, not broken. Mirrors the `callAI` try/catch that `reflection`/`pairings` already have.

Deliberately minimal. Hardening the shared `resolveAndGenerate` seam so a *thrown* primary is retried on Gemini (not just an *empty* one) is a sensible follow-up but changes a documented, unit-tested contract of that function — moved to #566.

## Test

`__tests__/api/names.test.ts` — new: non-English `/verses` with every `callAI` rejecting → `200` with a non-empty English reason per verse, not `500`. Verified red before the fix (`expected 500 to be 200`), green after.

## Not in scope

Restores graceful degradation only. It does not make non-English name content localized while the AI budget is unavailable — `reflection`/`pairings` still return empty and verse reasons render in English, the same "no AI budget" degradation English already tolerates. Localized backfill is separate.

## Verification

- `bun run typecheck` · `bun run lint` · `bun run test:ci` (names suites) — clean.
- After deploy: re-run the curl loop → all `200`; load `/names/al-latif` in Türkçe → all three sections render, 0 console errors.

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for verse responses when reason translations fail.
  * Requests now continue successfully with the original English reason instead of returning an error when a translation provider is unavailable.
  * Added coverage for non-English requests to ensure they return usable English reasons even when AI calls fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->