### PR TITLE
fix(quran): make isValidRef the single gate on every ref-accepting endpoint

### DIFF
--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -29,10 +29,11 @@ vi.mock("@/lib/infra/rate-limit", () => ({
   KEYWORD_SEARCH_LIMIT: 60,
   KEYWORD_SEARCH_WINDOW_SECONDS: 60,
 }));
-vi.mock("@/lib/quran/quran-corpus", () => ({
-  getVerse: mockGetVerse,
-  getVerses: mockGetVerses,
-}));
+// Partial mock: real isValidRef (the shared ref gate), stubbed getVerse/getVerses.
+vi.mock("@/lib/quran/quran-corpus", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/quran/quran-corpus")>();
+  return { ...actual, getVerse: mockGetVerse, getVerses: mockGetVerses };
+});
 vi.mock("@/lib/infra/search-log", () => ({ logSearchQuery: mockLogSearchQuery }));
 vi.mock("@/lib/i18n/request-prefs", () => ({
   getQuranEdition: mockGetQuranEdition,
@@ -123,6 +124,15 @@ describe("GET /api/search", () => {
 
   it("does not crash when the local DB lookup throws for a ref-format query", async () => {
     mockGetVerse.mockRejectedValueOnce(new Error("connection refused"));
+    // DB down → resolveVerse falls through to the live fetch, still returns the verse.
+    mockFetch.mockImplementation(async (url: string) =>
+      String(url).includes("ar.alafasy")
+        ? { ok: true, json: async () => ({ data: { text: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ" } }) }
+        : {
+            ok: true,
+            json: async () => ({ data: { text: "Allah - there is no deity except Him." } }),
+          }
+    );
     const req = makeSearchReq("2:255");
     const res = await GET(req);
     expect(res.status).toBe(200);
@@ -130,12 +140,26 @@ describe("GET /api/search", () => {
     expect(body.results[0].ref).toBe("2:255");
   });
 
-  it("includes correct surahNameArabic for ref-format query", async () => {
-    mockGetVerse.mockResolvedValueOnce(null);
-    const req = makeSearchReq("1:1");
-    const res = await GET(req);
+  it("carries the resolved verse's surah names on a ref-format query", async () => {
+    mockGetVerse.mockResolvedValueOnce(verse("2:255", "Allah - there is no deity except Him."));
+    const res = await GET(makeSearchReq("2:255"));
     const body = await res.json();
-    expect(body.results[0].surahNameArabic).toBe("الفاتحة");
+    expect(body.results[0].surahName).toBe("Surah");
+    expect(body.results[0].surahNameArabic).toBe("سورة");
+  });
+
+  it("returns no results for a ref-shaped query that isn't a real verse", async () => {
+    // Out of range, past a surah's length, and zero-padded — none must produce a
+    // fabricated verse card (AGENTS.md: no invented references).
+    for (const q of ["2:9999", "200:1", "1:8", "02:255"]) {
+      const res = await GET(makeSearchReq(q));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results).toEqual([]);
+      expect(body.total).toBe(0);
+    }
+    expect(mockGetVerse).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("calls quran.com for text query and returns results", async () => {

--- a/__tests__/api/verse.test.ts
+++ b/__tests__/api/verse.test.ts
@@ -5,7 +5,11 @@ const { mockGetVerse, mockGetQuranEdition } = vi.hoisted(() => ({
   mockGetVerse: vi.fn(),
   mockGetQuranEdition: vi.fn(),
 }));
-vi.mock("@/lib/quran/quran-corpus", () => ({ getVerse: mockGetVerse }));
+// Partial mock: real isValidRef (the shared ref gate), stubbed getVerse.
+vi.mock("@/lib/quran/quran-corpus", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/quran/quran-corpus")>();
+  return { ...actual, getVerse: mockGetVerse };
+});
 vi.mock("@/lib/i18n/request-prefs", () => ({ getQuranEdition: mockGetQuranEdition }));
 
 import { GET } from "@/app/api/verse/[surah]/[ayah]/route";
@@ -78,6 +82,15 @@ describe("GET /api/verse/[surah]/[ayah]", () => {
     const req = new NextRequest("http://localhost/api/verse/1/0");
     const res = await GET(req, params("1", "0"));
     expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an out-of-range ayah, without a live fetch", async () => {
+    // Al-Fatihah has 7 ayahs — "1:8" must be a fast 400, not a 404 after a
+    // wasted alquran.cloud round-trip.
+    const req = new NextRequest("http://localhost/api/verse/1/8");
+    const res = await GET(req, params("1", "8"));
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("returns 404 when external API returns non-ok", async () => {

--- a/__tests__/lib/quran/quran-corpus.test.ts
+++ b/__tests__/lib/quran/quran-corpus.test.ts
@@ -83,6 +83,12 @@ describe("quran-corpus", () => {
       expect(isValidRef("50:45")).toBe(true); // Qaf's last ayah
       expect(isValidRef("50:46")).toBe(false);
     });
+    it("rejects non-canonical (zero-padded) spellings that would miss the corpus", () => {
+      expect(isValidRef("02:255")).toBe(false);
+      expect(isValidRef("2:0255")).toBe(false);
+      expect(isValidRef("002:007")).toBe(false);
+      expect(isValidRef("1:07")).toBe(false);
+    });
   });
 
   describe("getVerse", () => {

--- a/__tests__/lib/quran/verse-resolver.test.ts
+++ b/__tests__/lib/quran/verse-resolver.test.ts
@@ -6,7 +6,11 @@ const { mockGetVerse, mockGetSurahName } = vi.hoisted(() => ({
   mockGetSurahName: vi.fn(),
 }));
 
-vi.mock("@/lib/quran/quran-corpus", () => ({ getVerse: mockGetVerse }));
+// Partial mock: real isValidRef (the live-fetch gate), stubbed getVerse.
+vi.mock("@/lib/quran/quran-corpus", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/quran/quran-corpus")>();
+  return { ...actual, getVerse: mockGetVerse };
+});
 vi.mock("@/lib/quran/surah-names", () => ({ getSurahName: mockGetSurahName }));
 
 import { resolveVerse } from "@/lib/quran/verse-resolver";
@@ -81,6 +85,20 @@ describe("resolveVerse", () => {
   it("returns null for a surah number out of bounds", async () => {
     mockGetVerse.mockResolvedValue(null);
     const result = await resolveVerse("115:1");
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null for an out-of-range ayah without hitting the live API", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    const result = await resolveVerse("1:8"); // Al-Fatihah has only 7 ayahs
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a zero-padded ref without hitting the live API", async () => {
+    mockGetVerse.mockResolvedValue(null);
+    const result = await resolveVerse("02:255");
     expect(result).toBeNull();
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -4,7 +4,7 @@ import { getSurahName, isExactSurahNameMatch, matchSurahsByQuery } from "@/lib/q
 import { fetchLocalizedChapterNames } from "@/lib/quran/chapters";
 import { SURAH_LENGTHS } from "@/lib/quran/audio";
 import { searchByMeaning, type SemanticMatch } from "@/lib/quran/semantic-search";
-import { getVerses } from "@/lib/quran/quran-corpus";
+import { getVerses, isValidRef } from "@/lib/quran/quran-corpus";
 import { resolveVerse } from "@/lib/quran/verse-resolver";
 import {
   consume,
@@ -195,17 +195,22 @@ export async function GET(req: NextRequest) {
   }
 
   if (/^\d+:\d+$/.test(q)) {
-    // resolveVerse falls back to a live alquran.cloud fetch on a local DB
-    // failure — unlike a bare getVerse() call, this never crashes the route.
-    const verse = await resolveVerse(q, edition);
-    const [surahName, surahNameArabic] = getSurahName(parseInt(q.split(":")[0], 10));
+    // A ref-shaped query that isn't a real verse (out of range, zero-padded),
+    // or that resolves nowhere, is not a result — never fabricate a verse card
+    // (AGENTS.md: no invented references). resolveVerse still falls back to a
+    // live fetch on a local DB failure, so a valid ref never 500s the route.
+    const verse = isValidRef(q) ? await resolveVerse(q, edition) : null;
+    if (!verse) {
+      const response: SearchResponse = { results: [], total: 0, page: 1, pageSize };
+      return NextResponse.json(response);
+    }
     const result: SearchResult = {
-      ref: q as VerseRef,
-      surahName: verse?.surahName ?? surahName,
-      surahNameArabic: verse?.surahNameArabic ?? surahNameArabic,
-      snippet: verse?.translation ?? `${surahName} ${q.split(":")[1]}`,
-      arabicText: verse?.arabicText ?? "",
-      translation: verse?.translation ?? "",
+      ref: verse.ref,
+      surahName: verse.surahName,
+      surahNameArabic: verse.surahNameArabic,
+      snippet: verse.translation,
+      arabicText: verse.arabicText,
+      translation: verse.translation,
     };
     const response: SearchResponse = { results: [result], total: 1, page: 1, pageSize };
     return NextResponse.json(response);

--- a/app/api/verse/[surah]/[ayah]/route.ts
+++ b/app/api/verse/[surah]/[ayah]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveVerse } from "@/lib/quran/verse-resolver";
+import { isValidRef } from "@/lib/quran/quran-corpus";
 import { getQuranEdition } from "@/lib/i18n/request-prefs";
 
 // The response varies on the oh_edition cookie, so it can't be a shared/static
@@ -11,16 +12,17 @@ export async function GET(
   { params }: { params: Promise<{ surah: string; ayah: string }> }
 ) {
   const { surah, ayah } = await params;
-  const surahNum = parseInt(surah, 10);
-  const ayahNum = parseInt(ayah, 10);
+  const ref = `${parseInt(surah, 10)}:${parseInt(ayah, 10)}`;
 
-  if (!surahNum || !ayahNum || surahNum < 1 || surahNum > 114 || ayahNum < 1) {
+  // Single gate for every ref-accepting endpoint: surah 1–114 and ayah within
+  // that surah's real length (so "1:8" is a fast 400, not a live round-trip).
+  if (!isValidRef(ref)) {
     return NextResponse.json({ error: "Invalid reference" }, { status: 400 });
   }
 
   // Local corpus first, live fetch as fallback — see lib/verse-resolver.ts.
   const edition = await getQuranEdition();
-  const verse = await resolveVerse(`${surahNum}:${ayahNum}`, edition);
+  const verse = await resolveVerse(ref, edition);
   if (!verse) {
     return NextResponse.json({ error: "Verse not found" }, { status: 404 });
   }

--- a/lib/quran/quran-corpus.ts
+++ b/lib/quran/quran-corpus.ts
@@ -32,13 +32,19 @@ function rowToVerse(row: VerseRow, translationOverride?: string): Verse {
  * A syntactically valid verse reference within real Quran bounds: surah 1–114
  * and ayah within that surah's actual Hafs/Uthmani ayah count (so "1:8" is
  * rejected — Al-Fatihah has 7 ayahs — not just refs beyond a global ceiling).
+ *
+ * Also rejects non-canonical spellings ("02:255", "2:0255"): they pass the
+ * numeric bounds but miss the corpus lookup (which keys on the canonical
+ * "surah:ayah" string), and the live fallback would then resolve real verse
+ * text under the malformed ref.
  */
 export function isValidRef(ref: string): boolean {
   const match = /^(\d+):(\d+)$/.exec(ref);
   if (!match) return false;
   const surah = parseInt(match[1], 10);
   const ayah = parseInt(match[2], 10);
-  return surah >= 1 && surah <= 114 && ayah >= 1 && ayah <= SURAH_LENGTHS[surah - 1];
+  if (surah < 1 || surah > 114 || ayah < 1 || ayah > SURAH_LENGTHS[surah - 1]) return false;
+  return `${surah}:${ayah}` === ref;
 }
 
 /**

--- a/lib/quran/verse-resolver.ts
+++ b/lib/quran/verse-resolver.ts
@@ -1,4 +1,4 @@
-import { getVerse } from "@/lib/quran/quran-corpus";
+import { getVerse, isValidRef } from "@/lib/quran/quran-corpus";
 import { getSurahName } from "@/lib/quran/surah-names";
 import { isValidEdition } from "@/lib/i18n/config";
 import type { Verse, VerseRef } from "@/types/quran";
@@ -27,11 +27,12 @@ export async function resolveVerse(ref: string, edition?: string): Promise<Verse
 }
 
 async function fetchVerseLive(ref: string, edition: string): Promise<Verse | null> {
-  const match = /^(\d+):(\d+)$/.exec(ref);
-  if (!match) return null;
+  // Same gate as the generation path: rejects out-of-range ayahs (e.g. "1:8")
+  // and non-canonical refs ("02:255") before they cost a live round-trip.
+  if (!isValidRef(ref)) return null;
+  const match = /^(\d+):(\d+)$/.exec(ref)!;
   const surahNum = parseInt(match[1], 10);
   const ayahNum = parseInt(match[2], 10);
-  if (surahNum < 1 || surahNum > 114 || ayahNum < 1) return null;
 
   try {
     const [arabicRes, translationRes] = await Promise.all([


### PR DESCRIPTION
## What

`isValidRef` already enforces surah 1–114 and each surah's real ayah count, but three read paths didn't route through it and disagreed — one of them fabricating verse references, which the theological standards forbid outright. Closes #565; also closes the runtime half of #561.

## Findings fixed

| endpoint | before | after |
|---|---|---|
| `GET /api/search?q=<ref>` | `?q=2:9999` → `200 {"results":[{"ref":"2:9999","surahName":"Al-Baqarah","snippet":"Al-Baqarah 9999",…}],"total":1}` — a **fabricated verse card**. Gated only by `/^\d+:\d+$/`; a `null` from `resolveVerse` still returned a synthesized result. | `isValidRef` gate; `{results: [], total: 0}` when the ref is invalid or resolves nowhere. |
| `fetchVerseLive` (`lib/quran/verse-resolver.ts`) | checked surah bounds + `ayah ≥ 1` but **not** the per-surah ceiling — `1:8` did a live alquran.cloud round-trip before failing. | gates on `isValidRef`. |
| `GET /api/verse/[surah]/[ayah]` | hand-rolled `surahNum > 114 \|\| ayahNum < 1` — same missing ceiling; `/api/verse/1/8` → 404 after a wasted fetch. | gates on `isValidRef` → fast `400`. |
| `isValidRef` itself | `/^(\d+):(\d+)$/` + `parseInt` accepted zero-padded `02:255`, `2:0255` — they pass numeric bounds but miss the corpus lookup, then **resolve real text under the malformed ref** via the live fallback (confirmed on prod: `?q=02:255` → Ayat al-Kursi text with `"ref":"02:255"`). | additionally requires `` `${surah}:${ayah}` === ref ``. |

## Changes

- `lib/quran/quran-corpus.ts` — `isValidRef` rejects non-canonical spellings.
- `lib/quran/verse-resolver.ts` — `fetchVerseLive` gates on `isValidRef`.
- `app/api/verse/[surah]/[ayah]/route.ts` — gates on `isValidRef`.
- `app/api/search/route.ts` — bare-ref branch gates on `isValidRef`; returns empty results (no fabricated card) when the ref resolves nowhere.
- Tests: zero-padded + out-of-range cases in `quran-corpus.test.ts`, `verse-resolver.test.ts`, `verse.test.ts`, `search.test.ts`. Two `search.test.ts` cases that asserted the old fabricated-fallback behaviour were rewritten to assert the resolved verse's real names / empty results.

## Verification

- `bun run typecheck` · `bun run lint` · affected suites (117 tests across 8 files) — clean.
- After deploy: `curl 'https://<preview>/api/search?q=2:9999'` → `{"results":[],"total":0}`; `curl -o /dev/null -w '%{http_code}' 'https://<preview>/api/verse/1/8'` → `400`.

Fixes #565
Refs #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Quran verse and search requests now reject invalid, out-of-range, and non-canonical references.
  - Invalid references return clear empty results or validation errors instead of fabricated verse information.
  - Verse lookups avoid unnecessary external requests when the reference is invalid.
  - Search results now consistently use the resolved verse’s accurate surah names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->