### PR TITLE
fix(ai): hold names generation + connection reasons to the same output bar as admin edits

### DIFF
--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -104,9 +104,10 @@ describe("names AI routes — model output validation", () => {
     mockCallAI.mockResolvedValue(
       JSON.stringify([
         {
-          transliteration: "Ar-Rahim",
+          // Exact DIVINE_NAMES values so it resolves to one of the 99.
+          transliteration: "Ar-Rahīm",
           arabic: "الرَّحِيم",
-          explanation: "Balances majesty with mercy.",
+          explanation: "Balances universal grace with mercy specific to the believers.",
         },
         { transliteration: 42, arabic: null },
         "junk",
@@ -118,7 +119,55 @@ describe("names AI routes — model output validation", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveLength(1);
-    expect(body[0].transliteration).toBe("Ar-Rahim");
+    expect(body[0]).toMatchObject({ name: "ar-rahim", transliteration: "Ar-Rahīm" });
+  });
+
+  it("pairings: a shape-valid entry whose name doesn't resolve to one of the 99 is dropped", async () => {
+    mockCallAI.mockResolvedValue(
+      JSON.stringify([
+        {
+          transliteration: "Ar-Rahīm",
+          arabic: "الرَّحِيم",
+          explanation: "Resolves — kept.",
+        },
+        {
+          transliteration: "Al-Fictitious",
+          arabic: "لا شيء",
+          explanation: 'Not one of the 99 — must be dropped, never cached with name: "".',
+        },
+      ])
+    );
+
+    const res = await getPairings(req("ar-rahman", "pairings"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.map((p: { transliteration: string }) => p.transliteration)).toEqual(["Ar-Rahīm"]);
+    expect(body.every((p: { name: string }) => p.name.length > 0)).toBe(true);
+  });
+
+  it("reflection: a model refusal is not cached — returns 200 with empty content", async () => {
+    mockCallAI.mockResolvedValue("I'm sorry, but I can't help with religious interpretation.");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await getReflection(req("ar-rahman", "reflection"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ reflection: "" });
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("returned a refusal"));
+    errorSpy.mockRestore();
+  });
+
+  it("pairings: a model refusal is not cached — returns 200 with an empty array", async () => {
+    mockCallAI.mockResolvedValue("As an AI, I cannot produce this content.");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await getPairings(req("ar-rahman", "pairings"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("returned a refusal"));
+    errorSpy.mockRestore();
   });
 
   it("verses: AI fallback refs outside real Quran bounds are dropped (no 500)", async () => {

--- a/__tests__/lib/ai/connection-generator.test.ts
+++ b/__tests__/lib/ai/connection-generator.test.ts
@@ -155,6 +155,29 @@ describe("generateConnections", () => {
     ).rejects.toBeInstanceOf(ConnectionParseError);
   });
 
+  it("throws ConnectionParseError when every entry has a blank reason", async () => {
+    mockCallAI.mockResolvedValue(
+      JSON.stringify([
+        { ref: "2:255", reason: "" },
+        { ref: "3:18", reason: "   " },
+      ])
+    );
+    await expect(
+      generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic")
+    ).rejects.toBeInstanceOf(ConnectionParseError);
+  });
+
+  it("drops entries with a blank reason but keeps the well-formed ones", async () => {
+    mockCallAI.mockResolvedValue(
+      JSON.stringify([
+        { ref: "2:255", reason: "A grounded explanation." },
+        { ref: "3:18", reason: "" },
+      ])
+    );
+    const out = await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic");
+    expect(out.map((c) => c.ref)).toEqual(["2:255"]);
+  });
+
   it("returns [] (no throw) when the model well-formedly selects nothing", async () => {
     mockCallAI.mockResolvedValue("[]");
     const out = await generateConnections("1:1", SOURCE_AR, SOURCE_TR, "thematic");

--- a/__tests__/lib/ai/refusal.test.ts
+++ b/__tests__/lib/ai/refusal.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { looksLikeRefusal } from "@/lib/ai/refusal";
+
+describe("looksLikeRefusal", () => {
+  it("flags refusal / disclaimer openers", () => {
+    for (const s of [
+      "I'm sorry, but I can't help with religious interpretation.",
+      "I cannot provide a theological reflection on this.",
+      "I can't assist with that request.",
+      "I won't generate content that could be misused.",
+      "As an AI, I don't have the ability to issue religious rulings.",
+      "As a language model, I cannot offer this.",
+      "I apologize, but this falls outside what I can do.",
+      "I must decline to answer.",
+      "Unfortunately, I am unable to complete this.",
+      "  I'm not able to write that.",
+    ]) {
+      expect(looksLikeRefusal(s)).toBe(true);
+    }
+  });
+
+  it("does not flag genuine theological prose", () => {
+    for (const s of [
+      "The believer's realisation of Al-Latif is not to imagine possessing any share of that subtlety, but to rest the heart in certainty.",
+      "Allah is the Subtle, the Acquainted; His awareness reaches what no created perception can access.",
+      "In Surah al-An'am (6:103), vision does not grasp Him while He grasps all vision.",
+      "Ar-Rahman and Ar-Rahim are paired so universal mercy is completed by mercy specific to the believers.",
+      "This name expresses Allah's transcendence over every created limitation.",
+      "Imperceptible to the senses, He is nonetheless fully known to Himself.",
+      "I-consciousness dissolves before the divine reality in true tawakkul.",
+    ]) {
+      expect(looksLikeRefusal(s)).toBe(false);
+    }
+  });
+});

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { callAI } from "@/lib/ai/ai";
+import { looksLikeRefusal } from "@/lib/ai/refusal";
 import { getNameBySlug, DIVINE_NAMES } from "@/lib/names/divine-names";
 import { getOrGenerateNameContent } from "@/lib/names/name-content";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
@@ -77,6 +78,14 @@ async function getPairings(
         return [];
       }
 
+      if (looksLikeRefusal(text)) {
+        // A soft refusal is not canonical content — treat it like an empty
+        // result (not cached, retried), same as the no-JSON-array case below.
+        console.error(`Pairings: model returned a refusal for ${slug}, not caching`);
+        incr("names_ai_refusal");
+        return [];
+      }
+
       let raw: unknown;
       try {
         const match = text.match(/\[[\s\S]*\]/);
@@ -108,19 +117,31 @@ async function getPairings(
         return [];
       }
 
-      return items.slice(0, 3).map((p) => {
-        const match = DIVINE_NAMES.find(
-          (n) =>
-            n.transliteration.toLowerCase() === p.transliteration.toLowerCase() ||
-            n.arabic === p.arabic
-        );
-        return {
-          name: match?.slug ?? "",
-          transliteration: p.transliteration,
-          arabic: p.arabic,
-          explanation: p.explanation,
-        };
-      });
+      return items
+        .slice(0, 3)
+        .map((p): Pairing | null => {
+          const match = DIVINE_NAMES.find(
+            (n) =>
+              n.transliteration.toLowerCase() === p.transliteration.toLowerCase() ||
+              n.arabic === p.arabic
+          );
+          if (!match) {
+            // The admin editor's isValidPairings rejects a pairing whose name
+            // doesn't resolve to one of the 99 — hold generation to the same
+            // bar. A pairing we can't link isn't cacheable canonical content.
+            console.error(
+              `Pairings: dropping unresolved pairing "${p.transliteration}" for ${slug}`
+            );
+            return null;
+          }
+          return {
+            name: match.slug,
+            transliteration: p.transliteration,
+            arabic: p.arabic,
+            explanation: p.explanation,
+          };
+        })
+        .filter((p): p is Pairing => p !== null);
     },
     (v) => v.length === 0,
     onBeforeGenerate

--- a/app/api/names/[slug]/reflection/route.ts
+++ b/app/api/names/[slug]/reflection/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { callAI } from "@/lib/ai/ai";
+import { looksLikeRefusal } from "@/lib/ai/refusal";
 import { getNameBySlug } from "@/lib/names/divine-names";
 import { getOrGenerateNameContent } from "@/lib/names/name-content";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
@@ -56,10 +57,19 @@ async function getReflection(
     REFLECTION_VERSION,
     async (resolved) => {
       try {
-        return await callAI(
+        const text = await callAI(
           buildPrompt(name.arabic, name.transliteration, name.meaning, name.description, locale),
           { feature: "names", ...resolved }
         );
+        if (looksLikeRefusal(text)) {
+          // A soft refusal / disclaimer is not canonical theology — treat it
+          // like an empty result (not cached, retried) rather than version-pin
+          // it as this name's reflection.
+          console.error(`Reflection: model returned a refusal for ${slug}, not caching`);
+          incr("names_ai_refusal");
+          return "";
+        }
+        return text;
       } catch (err) {
         // Not cached (empty result), so the next request retries — mirrors how
         // buildReasons/fallbackAIVerses in verses/route.ts tolerate a provider

--- a/lib/ai/connection-generator.ts
+++ b/lib/ai/connection-generator.ts
@@ -156,12 +156,18 @@ function parseRawConnections(text: string): Array<{ ref: string; reason: string 
   }
   const valid = parsed.filter(
     (c): c is { ref: string; reason: string } =>
-      c && typeof c.ref === "string" && typeof c.reason === "string"
+      c &&
+      typeof c.ref === "string" &&
+      typeof c.reason === "string" &&
+      // A blank reason is the wrong shape here too: every edge on the canvas
+      // links to its explanation, so a connection with no text isn't one. The
+      // translation write-paths already reject blank output.
+      c.reason.trim() !== ""
   );
-  // A non-empty array whose entries are ALL the wrong shape is malformed output,
-  // not a valid empty selection — the caller must not read it as "pool
-  // exhausted". A partially-valid array (some good entries, some junk) keeps the
-  // good ones, matching the model's evident intent.
+  // A non-empty array whose entries are ALL the wrong shape (or all blank) is
+  // malformed output, not a valid empty selection — the caller must not read it
+  // as "pool exhausted". A partially-valid array (some good entries, some junk)
+  // keeps the good ones, matching the model's evident intent.
   if (parsed.length > 0 && valid.length === 0) {
     throw new ConnectionParseError("AI response array had no well-formed entries", jsonMatch[0]);
   }

--- a/lib/ai/refusal.ts
+++ b/lib/ai/refusal.ts
@@ -1,0 +1,17 @@
+/**
+ * Heuristic: does an AI response *begin* with a refusal / disclaimer opener?
+ *
+ * Deliberately narrow — anchored to the start of the text and matching only
+ * unambiguous refusal phrasings — so it never suppresses genuine theological
+ * content. A "Believer's Reflection" opens with its subject ("The believer's
+ * realisation of ..."), never "I'm sorry" or "As an AI". Used so a soft model
+ * refusal is treated like an empty result (logged, not cached as canonical,
+ * retried) rather than persisted verbatim. See the names reflection/pairings
+ * routes.
+ */
+const REFUSAL_OPENER =
+  /^\s*(?:i(?:['’ ]?a?m)? (?:sorry|unable|not able)\b|i can(?:not|['’]t)\b|i (?:can(?:not|['’]t)|won['’]t|will not) (?:help|assist|provide|comply|generate|write)\b|i (?:must|have to) decline\b|i['’]m not (?:going to|able to)\b|as an ai\b|as a language model\b|i (?:apologi[sz]e|cannot in good conscience)\b|unfortunately,?\s+i\b)/i;
+
+export function looksLikeRefusal(text: string): boolean {
+  return REFUSAL_OPENER.test(text);
+}


### PR DESCRIPTION
## What

Three AI write paths accepted model output that the admin editors / translation paths would reject. Partially addresses #566 (parts B1, B3, B4 — B2, the graph-service per-locale selection divergence, is a hot-path change handled on its own branch).

## Changes

**B1 — `lib/ai/connection-generator.ts`**
`parseRawConnections` kept entries with a blank / whitespace-only `reason` (`typeof "" === "string"` passed the shape filter). A connection with no explanation then persisted — "every edge on the canvas links to that explanation". Now requires `reason.trim() !== ""`. An array whose entries are all blank throws `ConnectionParseError` (caller retries); a partially-blank array keeps the good entries.

**B3 — refusal screen (new `lib/ai/refusal.ts`)**
`app/api/names/[slug]/reflection/route.ts` persisted *any* non-empty model reply verbatim as canonical, version-pinned theology — a soft refusal or "As an AI, I cannot…" disclaimer slipped through. New `looksLikeRefusal(text)` is deliberately narrow (anchored to the start, unambiguous openers only, so it never suppresses a genuine "The believer's realisation of…" paragraph). A match is treated like an empty result: logged, `incr("names_ai_refusal")`, not cached, retried next request. Applied to `pairings/route.ts` too for symmetry (pairings was already partly covered by its "no JSON array" guard).

**B4 — `app/api/names/[slug]/pairings/route.ts`**
Cached a pairing with `name: ""` when the model's proposed name didn't resolve to one of the 99 — the admin editor's `isValidPairings` rejects `name: ""`. Now drops the unresolved pairing (logged) before caching. All-unresolved → `[]` → not cached → retried.

## Tests

- `__tests__/lib/ai/refusal.test.ts` (new) — refusal openers vs. genuine theological prose.
- `__tests__/lib/ai/connection-generator.test.ts` — all-blank reasons → `ConnectionParseError`; partially-blank → keeps the good ones.
- `__tests__/api/names-ai-validation.test.ts` — reflection/pairings refusal → 200 + empty (not cached); unresolved pairing name → dropped. Updated one existing pairings case to use exact `DIVINE_NAMES` values so it exercises name resolution.

## Verification

`bun run typecheck` · `bun run lint` · affected suites — clean.

Refs #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
