### PR TITLE
fix(ci): stop the gitleaks scan falling back to full history on a no-op branch push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,17 +53,20 @@ jobs:
             # errors out on the range instead of scanning anything. Fall back
             # to the merge-base with the default branch, which is unaffected
             # by how the branch's own history was rewritten and still
-            # captures every commit unique to it. If there's no merge-base to
-            # diff against either (e.g. this push *is* to the default
-            # branch, so the merge-base is just HEAD itself, or the
-            # histories are unrelated), scan everything reachable from HEAD
-            # rather than only the latest commit, so nothing gets skipped.
+            # captures every commit unique to it.
             git fetch --quiet origin "$DEFAULT_BRANCH"
             BASE=$(git merge-base "origin/$DEFAULT_BRANCH" HEAD 2>/dev/null || true)
             if [ -n "$BASE" ] && [ "$BASE" != "$(git rev-parse HEAD)" ]; then
               RANGE="$BASE..HEAD"
             else
-              RANGE="HEAD"
+              # HEAD is already contained in the default branch (a new branch
+              # pushed before it has any commits of its own, or pushed just to
+              # back it up), or the histories are unrelated: nothing new to
+              # scan, and every commit reachable here was already scanned when
+              # it landed on the default branch. Re-check only the tip —
+              # scanning all of history from HEAD would re-flag long-settled
+              # findings on an unrelated branch push.
+              RANGE="HEAD~1..HEAD"
             fi
           fi
           gitleaks detect --source . --redact --log-opts="$RANGE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,20 @@ jobs:
             BASE=$(git merge-base "origin/$DEFAULT_BRANCH" HEAD 2>/dev/null || true)
             if [ -n "$BASE" ] && [ "$BASE" != "$(git rev-parse HEAD)" ]; then
               RANGE="$BASE..HEAD"
-            else
-              # HEAD is already contained in the default branch (a new branch
-              # pushed before it has any commits of its own, or pushed just to
-              # back it up), or the histories are unrelated: nothing new to
-              # scan, and every commit reachable here was already scanned when
-              # it landed on the default branch. Re-check only the tip —
-              # scanning all of history from HEAD would re-flag long-settled
-              # findings on an unrelated branch push.
+            elif [ -n "$BASE" ]; then
+              # BASE == HEAD: HEAD is already contained in the default branch
+              # (a branch pushed before it has any commits of its own, or
+              # pushed just to back it up). It introduces nothing, and every
+              # commit reachable here was already scanned when it landed on the
+              # default branch — re-check only the tip. Scanning all of history
+              # from HEAD here would re-flag long-settled findings on a
+              # no-op branch push and add no coverage.
               RANGE="HEAD~1..HEAD"
+            else
+              # No shared history with the default branch (e.g. an orphan
+              # branch): can't scope to the commits this push introduces, so
+              # scan everything reachable from HEAD rather than skip anything.
+              RANGE="HEAD"
             fi
           fi
           gitleaks detect --source . --redact --log-opts="$RANGE"


### PR DESCRIPTION
## Summary

- The `Secret Scan (gitleaks)` job in `ci.yml` could fall back to scanning the **entire git history** instead of a push's new commits. When a branch's first push points at a commit already on `main` — `github.event.before` is the all-zero SHA **and** `merge-base(origin/main, HEAD) == HEAD` — the fallback set `RANGE="HEAD"`, i.e. `git log HEAD`, which walks all history.
- That is what put a red ✗ `Secret Scan (gitleaks)` on commit `a165a72` (the #553 merge) in `main`'s history: the **first push of #574's branch** (`fix/names-nonenglish-500`) pointed there before its fix commit existed, the whole-history scan re-flagged 3 long-settled findings from commit `ba7b85f` (2026-05-19), and the run was re-tried 3×.
- Fix (2 commits): when `BASE == HEAD` (HEAD already fully contained in `main` — the no-op push, introduces nothing) scan the tip only, `RANGE="HEAD~1..HEAD"`. When `BASE` is empty (no shared history, e.g. an orphan branch) **keep the original full `RANGE="HEAD"` scan** — there's no way to scope to "new" commits there, so coverage is not reduced. The `pull_request`, normal-push, and force-push/rebase paths are untouched.

## Type of change

- [x] Bug fix

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (via pre-commit hook)
- [x] `bun run typecheck` passes locally (via pre-commit hook)
- [x] `bun run lint` passes locally (only a pre-existing warning in a git-ignored local file)
- [x] `bun run format:check` — `ci.yml` is Prettier-clean (unrelated warnings are git-ignored scratch files, not in CI's checkout)
- [ ] New tests added — n/a: the `secret-scan` step is workflow bash with no test harness in this repo; verified by simulation below

### Verification

Simulated the exact failing scenario locally (`before` = `000…0`, HEAD = `a165a72`, which is already on `main`):

| | old logic | new logic |
|---|---|---|
| computed `RANGE` | `HEAD` | `a165a72~1..a165a72` |
| commits scanned | 832 (full history) | 4 (#553's own commits) |
| gitleaks result | `leaks found: 3` → **exit 1** | `no leaks found` → **exit 0** |

Optional post-merge live check: `git branch tmp origin/main && git push origin tmp` → the gitleaks job on that push now passes; then `git push origin :tmp`.

## Security note

The whole-history scan that triggered this failure surfaced **3 real historical commits of Quran Foundation OAuth client secrets** — commit `ba7b85f` ("docs: document two QF environments and correct credentials", 2026-05-19), in `README.md` and `.env.example`. They were removed from the working tree in `b01d8a2` but remain in git history. They sit outside every per-push scan window, so they do not affect CI. **If those client secrets are still valid, rotating them at Quran Foundation (and scrubbing history) is a separate follow-up** — flagged here for a maintainer decision, not addressed in this PR.

## Checklist

- [x] Branch is up to date with `main` (cut from current `origin/main`)
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — n/a
- [x] `README.md` updated if the feature changes the public interface — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
