### PR TITLE
fix(quran): gate raw verse path params through isValidRef

### DIFF
--- a/__tests__/api/verse-morphology.test.ts
+++ b/__tests__/api/verse-morphology.test.ts
@@ -47,6 +47,18 @@ describe("GET /api/verse/[surah]/[ayah]/morphology", () => {
     expect(res.status).toBe(400);
   });
 
+  it("400s on non-canonical path params without touching the DB", async () => {
+    for (const [surah, ayah] of [
+      ["02", "255"],
+      ["2", "0255"],
+      ["2abc", "255"],
+    ]) {
+      const res = await GET(req(), params(surah, ayah));
+      expect(res.status).toBe(400);
+    }
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
   it("returns the seeded words for a valid, seeded verse", async () => {
     const words = [
       { position: 1, surface: "اللَّهُ", root: "أله", lemma: "الله" },

--- a/__tests__/api/verse-similar.test.ts
+++ b/__tests__/api/verse-similar.test.ts
@@ -51,6 +51,18 @@ describe("GET /api/verse/[surah]/[ayah]/similar", () => {
     expect(mockSimilarVerses).not.toHaveBeenCalled();
   });
 
+  it("returns 400 for non-canonical path params", async () => {
+    for (const [surah, ayah] of [
+      ["02", "255"],
+      ["2", "0255"],
+      ["2abc", "255"],
+    ]) {
+      const res = await call(surah, ayah);
+      expect(res.status).toBe(400);
+    }
+    expect(mockSimilarVerses).not.toHaveBeenCalled();
+  });
+
   it("returns [] (200) when the service throws", async () => {
     mockSimilarVerses.mockRejectedValueOnce(new Error("no embeddings"));
     const res = await call("1", "1");

--- a/__tests__/api/verse-tafsir.test.ts
+++ b/__tests__/api/verse-tafsir.test.ts
@@ -41,6 +41,18 @@ describe("GET /api/verse/[surah]/[ayah]/tafsir", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("returns 400 for non-canonical path params without calling the upstream API", async () => {
+    for (const [surah, ayah] of [
+      ["02", "255"],
+      ["2", "0255"],
+      ["2abc", "255"],
+    ]) {
+      const res = await call(surah, ayah);
+      expect(res.status).toBe(400);
+    }
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("returns tafsir blocks for a valid ref", async () => {
     const res = await call("1", "1");
     expect(res.status).toBe(200);

--- a/__tests__/api/verse.test.ts
+++ b/__tests__/api/verse.test.ts
@@ -93,6 +93,22 @@ describe("GET /api/verse/[surah]/[ayah]", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("returns 400 for non-canonical path params, without a live fetch", async () => {
+    // The ref gate used to parseInt the segments first, so "02" and "2abc" both
+    // normalized to 2 and resolved a real verse. isValidRef now sees the raw
+    // segments and its canonical-spelling check rejects them.
+    for (const [surah, ayah] of [
+      ["02", "255"],
+      ["2", "0255"],
+      ["2abc", "255"],
+    ]) {
+      const req = new NextRequest(`http://localhost/api/verse/${surah}/${ayah}`);
+      const res = await GET(req, params(surah, ayah));
+      expect(res.status).toBe(400);
+    }
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("returns 404 when external API returns non-ok", async () => {
     mockFetch.mockResolvedValue({ ok: false });
     const req = new NextRequest("http://localhost/api/verse/1/1");

--- a/app/api/verse/[surah]/[ayah]/morphology/route.ts
+++ b/app/api/verse/[surah]/[ayah]/morphology/route.ts
@@ -15,7 +15,9 @@ export async function GET(
   { params }: { params: Promise<{ surah: string; ayah: string }> }
 ) {
   const { surah, ayah } = await params;
-  const ref = `${parseInt(surah, 10)}:${parseInt(ayah, 10)}`;
+  // Raw segments, not parseInt'd — lets isValidRef reject non-canonical spellings
+  // ("02:255", "2abc:1") instead of silently normalizing them.
+  const ref = `${surah}:${ayah}`;
 
   if (!isValidRef(ref)) {
     return NextResponse.json({ error: "Invalid reference" }, { status: 400 });

--- a/app/api/verse/[surah]/[ayah]/route.ts
+++ b/app/api/verse/[surah]/[ayah]/route.ts
@@ -12,10 +12,12 @@ export async function GET(
   { params }: { params: Promise<{ surah: string; ayah: string }> }
 ) {
   const { surah, ayah } = await params;
-  const ref = `${parseInt(surah, 10)}:${parseInt(ayah, 10)}`;
+  const ref = `${surah}:${ayah}`;
 
-  // Single gate for every ref-accepting endpoint: surah 1–114 and ayah within
-  // that surah's real length (so "1:8" is a fast 400, not a live round-trip).
+  // Single gate for every ref-accepting endpoint: surah 1–114, ayah within that
+  // surah's real length, and canonical spelling (so "1:8", "02:255" and "2abc:1"
+  // are all a fast 400, not a live round-trip). Passing the raw segments — not
+  // parseInt'd ones — is what lets isValidRef reject non-canonical spellings.
   if (!isValidRef(ref)) {
     return NextResponse.json({ error: "Invalid reference" }, { status: 400 });
   }

--- a/app/api/verse/[surah]/[ayah]/similar/route.ts
+++ b/app/api/verse/[surah]/[ayah]/similar/route.ts
@@ -12,7 +12,9 @@ export async function GET(
   { params }: { params: Promise<{ surah: string; ayah: string }> }
 ) {
   const { surah, ayah } = await params;
-  const ref = `${parseInt(surah, 10)}:${parseInt(ayah, 10)}`;
+  // Raw segments, not parseInt'd — lets isValidRef reject non-canonical spellings
+  // ("02:255", "2abc:1") instead of silently normalizing them.
+  const ref = `${surah}:${ayah}`;
 
   if (!isValidRef(ref)) {
     return NextResponse.json({ error: "Invalid reference" }, { status: 400 });

--- a/app/api/verse/[surah]/[ayah]/tafsir/route.ts
+++ b/app/api/verse/[surah]/[ayah]/tafsir/route.ts
@@ -33,7 +33,9 @@ export async function GET(
   if (limited) return limited;
 
   const { surah, ayah } = await params;
-  const ref = `${parseInt(surah, 10)}:${parseInt(ayah, 10)}`;
+  // Raw segments, not parseInt'd — lets isValidRef reject non-canonical spellings
+  // ("02:255", "2abc:1") instead of silently normalizing them into the fetch URL.
+  const ref = `${surah}:${ayah}`;
 
   if (!isValidRef(ref)) {
     return NextResponse.json({ error: "Invalid reference" }, { status: 400 });


### PR DESCRIPTION
## Summary

Follow-up to #575 / `bbcf576` ("make `isValidRef` the single gate on every ref-accepting endpoint").

All four `app/api/verse/[surah]/[ayah]/**` routes built the ref as
`` `${parseInt(surah, 10)}:${parseInt(ayah, 10)}` `` **before** calling `isValidRef`.
`parseInt` normalized away exactly the input `isValidRef` exists to reject:

| Request | Before | After |
| --- | --- | --- |
| `/api/verse/02/0255` | `parseInt` → `"2:255"` → **200** | **400** |
| `/api/verse/2abc/255` | `parseInt` stops at first non-digit → `"2:255"` → **200** | **400** |
| `/api/verse/2/255` (canonical) | 200 | 200 (unchanged) |

`isValidRef` (`lib/quran/quran-corpus.ts`) already does the full check — anchored regex `^(\d+):(\d+)$`, per-surah range, and a canonical round-trip `` `${surah}:${ayah}` === ref `` — with its own docstring and unit test covering `"02:255"` / `"2:0255"`. The routes defeated that by pre-normalizing, so the canonical-spelling rejection was dead code when reached through them. On a corpus miss / DB error, normalizable-bad input also reached a live third-party fetch (alquran.cloud for the verse route, quran.com for tafsir).

## Changes

- Build `ref` from the **raw** path segments in all four routes (`route.ts`, `morphology`, `similar`, `tafsir`). Nothing else in these routes used the parsed ints — every downstream consumer takes the `ref` string. One-line change each, plus a short comment on why `parseInt` is deliberately gone.
- Added a non-canonical-input case (`02/255`, `2/0255`, `2abc/255` → 400, no downstream fetch/DB/service call) to each of the four route test files, matching each file's existing "expensive path not taken" assertion.

## Testing

- `bun run test:ci` — 1547 pass (4 new; all pre-existing verse-route + `quran-corpus` + `verse-resolver` + `search` tests still green).
- `bun run typecheck`, `bun run lint` — clean.
- Manual dev-server curl was blocked by an unrelated local infra issue (no Postgres on `:5434`, `proxy.ts` maintenance-mode check 500s every route upstream of the handler). The four route test files invoke the real `GET` handlers with the real `isValidRef`, so the behavior is covered directly.

## AI / Theological changes

None. This **tightens** verse-reference validation (strengthens the AGENTS.md standard-#3 guardrail — verified refs only), it does not loosen it. No change to prompts, divine-name data, or theological framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Verse API endpoints now reject non-canonical references, such as leading-zero or non-numeric chapter and verse values, with a 400 response.
  - Invalid references no longer trigger database queries, external API requests, or similar-verse lookups.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->