### PR TITLE
fix(nav): stop off-canvas pages subscribing to canvas node count

### DIFF
--- a/__tests__/hooks/useMobileNavVisible.subscription.test.tsx
+++ b/__tests__/hooks/useMobileNavVisible.subscription.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { Verse } from "@/types/quran";
+
+const { mockUsePathname } = vi.hoisted(() => ({ mockUsePathname: vi.fn() }));
+vi.mock("next/navigation", () => ({ usePathname: mockUsePathname }));
+
+// Match repo precedent (__tests__/store/canvas.test.ts) — keep the heavy
+// @xyflow/react module out of the fast unit suite.
+vi.mock("@xyflow/react", () => ({
+  applyNodeChanges: vi.fn((_changes: unknown[], nodes: unknown[]) => nodes),
+  applyEdgeChanges: vi.fn((_changes: unknown[], edges: unknown[]) => edges),
+}));
+
+// Real store on purpose — this file exists to prove the hook does NOT re-render
+// its consumers on canvas-store changes while off the canvas route. The mocked
+// store in useMobileNavVisible.test.ts can't express subscription behaviour.
+import { useMobileNavVisible } from "@/hooks/useMobileNavVisible";
+import { useCanvasStore } from "@/store/canvas";
+
+const AYAT_AL_KURSI: Verse = {
+  surah: 2,
+  ayah: 255,
+  ref: "2:255",
+  arabicText: "اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ الْحَيُّ الْقَيُّومُ",
+  translation: "Allah - there is no deity except Him, the Ever-Living, the Sustainer of existence.",
+  surahName: "Al-Baqarah",
+  surahNameArabic: "البقرة",
+};
+const AL_FATIHA: Verse = {
+  surah: 1,
+  ayah: 1,
+  ref: "1:1",
+  arabicText: "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ",
+  translation: "In the name of Allah, the Entirely Merciful, the Especially Merciful.",
+  surahName: "Al-Fatihah",
+  surahNameArabic: "الفاتحة",
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  useCanvasStore.getState().reset();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("useMobileNavVisible subscription", () => {
+  it("does not re-render when canvas nodes change off the canvas route", () => {
+    mockUsePathname.mockReturnValue("/search");
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders++;
+      return useMobileNavVisible();
+    });
+
+    const baseline = renders;
+    expect(result.current).toBe(true);
+
+    act(() => {
+      useCanvasStore.getState().addVerseNode(AYAT_AL_KURSI);
+    });
+
+    expect(renders).toBe(baseline);
+    expect(result.current).toBe(true);
+  });
+
+  it("re-renders on the first canvas node when on the canvas route", () => {
+    mockUsePathname.mockReturnValue("/canvas");
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders++;
+      return useMobileNavVisible();
+    });
+
+    const baseline = renders;
+    expect(result.current).toBe(true);
+
+    act(() => {
+      useCanvasStore.getState().addVerseNode(AYAT_AL_KURSI);
+    });
+
+    expect(renders).toBeGreaterThan(baseline);
+    expect(result.current).toBe(false);
+  });
+
+  it("does not re-render on subsequent canvas nodes (only the 0<->1 boundary matters)", () => {
+    mockUsePathname.mockReturnValue("/canvas");
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders++;
+      return useMobileNavVisible();
+    });
+
+    act(() => {
+      useCanvasStore.getState().addVerseNode(AYAT_AL_KURSI);
+    });
+    const afterFirst = renders;
+    expect(result.current).toBe(false);
+
+    act(() => {
+      useCanvasStore.getState().addVerseNode(AL_FATIHA);
+    });
+
+    expect(renders).toBe(afterFirst);
+    expect(result.current).toBe(false);
+  });
+});

--- a/__tests__/hooks/useMobileNavVisible.test.ts
+++ b/__tests__/hooks/useMobileNavVisible.test.ts
@@ -29,4 +29,15 @@ describe("useMobileNavVisible", () => {
     mockNodeCount.mockReturnValue(3);
     expect(renderHook(() => useMobileNavVisible()).result.current).toBe(false);
   });
+
+  it("becomes visible again after navigating off a populated canvas", () => {
+    mockUsePathname.mockReturnValue("/canvas");
+    mockNodeCount.mockReturnValue(3);
+    const { result, rerender } = renderHook(() => useMobileNavVisible());
+    expect(result.current).toBe(false);
+
+    mockUsePathname.mockReturnValue("/search");
+    rerender();
+    expect(result.current).toBe(true);
+  });
 });

--- a/hooks/useMobileNavVisible.ts
+++ b/hooks/useMobileNavVisible.ts
@@ -8,15 +8,20 @@ import { useCanvasStore } from "@/store/canvas";
  * viewports below `md`). Shared with MiniPlayer, which needs to offset itself
  * above the bar instead of overlapping it — kept in one place so the two
  * components' visibility can't drift out of sync.
+ *
+ * The tabs are hidden only once the canvas has nodes — that's when the Header's
+ * mobile action bar takes over the bottom edge (and the two fixed bars would
+ * otherwise collide). On an empty canvas the tabs stay, so mobile users can
+ * still navigate away (the EmptyState is centred and isn't obscured).
  */
 export function useMobileNavVisible(): boolean {
-  const pathname = usePathname();
-  const nodeCount = useCanvasStore((s) => s.nodes.length);
+  const onCanvas = usePathname() === "/canvas";
 
-  // Hidden only once the canvas has nodes — that's when the Header's mobile
-  // action bar takes over the bottom edge (and the two fixed bars would
-  // otherwise collide). On an empty canvas the tabs stay, so mobile users can
-  // still navigate away (the EmptyState is centred and isn't obscured).
-  const hideMobileTabs = pathname === "/canvas" && nodeCount > 0;
-  return !hideMobileTabs;
+  // Fold the route check into the selector so it returns a constant `false` off
+  // canvas: this hook feeds the app-wide MiniPlayer (and per-route MobileNavBar),
+  // and without the guard every canvas node add/remove would re-render them on
+  // routes where the node count is irrelevant.
+  const canvasHasNodes = useCanvasStore((s) => onCanvas && s.nodes.length > 0);
+
+  return !canvasHasNodes;
 }


### PR DESCRIPTION
Fixes #559

## Root cause

`hooks/useMobileNavVisible.ts` subscribed to `useCanvasStore((s) => s.nodes.length)` unconditionally. That value only affects the result on `/canvas` (the mobile tab bar hides once the canvas has nodes, to free the bottom edge for the Header's mobile action bar). Every other route paid for the re-render:

- `MiniPlayer` is mounted app-wide (`components/providers.tsx`) — it re-rendered on **every** canvas node add/remove, on every route.
- `MobileNavBar` is mounted per-route on ~9 pages — same re-render on each of those.

(The issue text says both components are mounted app-wide; only `MiniPlayer` is. The fix applies equally either way.)

## Fix

Fold the route check into the selector so it returns a constant `false` off canvas:

```ts
const onCanvas = usePathname() === "/canvas";
const canvasHasNodes = useCanvasStore((s) => onCanvas && s.nodes.length > 0);
return !canvasHasNodes;
```

`useSyncExternalStore` skips the re-render while the selector output is stable, so off-canvas node churn no longer re-renders these components. The `/canvas` exact-match matches the existing convention in `components/layout/nav-items.ts`.

**Scope note:** zustand has no dependency tracking, so every consumer still holds a live store *subscription* after this change — what's eliminated is the *re-render churn*, which is the impact the issue describes. Removing the subscription entirely would require a conditional hook call, which isn't legal; the selector gate is the correct idiom.

## Behaviour delta

None observable. Off canvas → visible; empty canvas → visible; populated canvas → hidden — unchanged. On `/canvas`, re-renders now happen only on the 0↔1 node boundary (previously on every 1→2→3… transition too).

## Tests

- `__tests__/hooks/useMobileNavVisible.test.ts` — existing 3 cases unchanged; added "becomes visible again after navigating off a populated canvas".
- `__tests__/hooks/useMobileNavVisible.subscription.test.tsx` (new) — uses the **real** canvas store (the other file mocks it, so it can't assert subscription behaviour); `@xyflow/react` is mocked to match repo precedent. Asserts: no re-render when nodes are added off `/canvas`; a re-render on the first node on `/canvas`; **no** re-render on subsequent nodes on `/canvas`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)