### PR TITLE
fix(ai): cap honoured Gemini retryDelay and rotate keys past the cap

### DIFF
--- a/__tests__/lib/ai/gemini-errors.test.ts
+++ b/__tests__/lib/ai/gemini-errors.test.ts
@@ -7,6 +7,7 @@ import {
   perMinuteBackoffMs,
   PER_MINUTE_MAX_DELAY_MS,
   PER_MINUTE_MIN_DELAY_MS,
+  PER_MINUTE_PROVIDER_DELAY_CAP_MS,
 } from "@/lib/ai/gemini-errors";
 
 /** Shape of what `@google/generative-ai` throws for a non-2xx. */
@@ -37,6 +38,10 @@ const perMinuteViolation = {
   violations: [{ quotaId: "GenerateRequestsPerMinutePerProjectPerModel-FreeTier" }],
 };
 const retryInfo = { "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "39s" };
+const absurdRetryInfo = {
+  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+  retryDelay: "86400s",
+};
 
 describe("classifyGeminiError", () => {
   it("classifies a per-day QuotaFailure from errorDetails as daily", () => {
@@ -56,6 +61,42 @@ describe("classifyGeminiError", () => {
   it("classifies a per-minute QuotaFailure as per-minute", () => {
     const info = classifyGeminiError(fetchError(429, [perMinuteViolation]));
     expect(info.cls).toBe("per-minute");
+  });
+
+  it("keeps per-minute classification when retryDelay is within the cap", () => {
+    const info = classifyGeminiError(fetchError(429, [perMinuteViolation, retryInfo]));
+    expect(info.cls).toBe("per-minute");
+    expect(info.retryAfterMs).toBe(39_000);
+  });
+
+  it("reclassifies as daily when a per-minute 429 carries an absurd retryDelay", () => {
+    // "retryDelay":"86400s" on one cell would otherwise stall the loop 24h with
+    // no key rotation — past the cap it is effectively a per-day exhaustion.
+    const info = classifyGeminiError(fetchError(429, [perMinuteViolation, absurdRetryInfo]));
+    expect(info.cls).toBe("daily");
+    expect(info.retryAfterMs).toBe(86_400_000);
+  });
+
+  it("reclassifies a bare 429 as daily when its retryDelay exceeds the cap", () => {
+    const info = classifyGeminiError(fetchError(429, [absurdRetryInfo], "429 Too Many Requests"));
+    expect(info.cls).toBe("daily");
+  });
+
+  it("treats the cap boundary as inclusive — exactly the cap stays per-minute, just past it is daily", () => {
+    const retry = (ms: number) => ({
+      "@type": "type.googleapis.com/google.rpc.RetryInfo",
+      retryDelay: `${ms / 1000}s`,
+    });
+    expect(
+      classifyGeminiError(
+        fetchError(429, [perMinuteViolation, retry(PER_MINUTE_PROVIDER_DELAY_CAP_MS)])
+      ).cls
+    ).toBe("per-minute");
+    expect(
+      classifyGeminiError(
+        fetchError(429, [perMinuteViolation, retry(PER_MINUTE_PROVIDER_DELAY_CAP_MS + 1000)])
+      ).cls
+    ).toBe("daily");
   });
 
   it("falls back to other-429 for a bare 429 with no quota markers", () => {
@@ -151,16 +192,26 @@ describe("perMinuteBackoffMs", () => {
     }
   });
 
-  it("still honours a provider retryAfterMs that exceeds the max, and keeps jitter", () => {
-    const huge = PER_MINUTE_MAX_DELAY_MS * 3;
+  it("honours a provider retryAfterMs between the max and the cap (inclusive)", () => {
+    for (const target of [PER_MINUTE_MAX_DELAY_MS + 20_000, PER_MINUTE_PROVIDER_DELAY_CAP_MS]) {
+      for (let i = 0; i < 50; i++) {
+        const ms = perMinuteBackoffMs(1, target);
+        expect(ms).toBeGreaterThanOrEqual(target);
+        expect(ms).toBeLessThanOrEqual(target * 1.15 + 1);
+      }
+    }
+  });
+
+  it("clamps a provider retryAfterMs above the cap, and keeps jitter", () => {
+    const huge = PER_MINUTE_PROVIDER_DELAY_CAP_MS * 5;
     const seen = new Set<number>();
     for (let i = 0; i < 50; i++) {
       const ms = perMinuteBackoffMs(1, huge);
-      expect(ms).toBeGreaterThanOrEqual(huge);
-      expect(ms).toBeLessThanOrEqual(huge * 1.15 + 1);
+      expect(ms).toBeGreaterThanOrEqual(PER_MINUTE_PROVIDER_DELAY_CAP_MS);
+      expect(ms).toBeLessThanOrEqual(PER_MINUTE_PROVIDER_DELAY_CAP_MS * 1.15 + 1);
       seen.add(ms);
     }
-    // Jitter must survive past the cap — otherwise every worker re-fires in sync.
+    // Jitter must survive the clamp — otherwise every worker re-fires in sync.
     expect(seen.size).toBeGreaterThan(1);
   });
 

--- a/__tests__/lib/ai/gemini-retry.test.ts
+++ b/__tests__/lib/ai/gemini-retry.test.ts
@@ -83,6 +83,24 @@ describe("callGemini retry / classification", () => {
     expect(mockGenerate).toHaveBeenCalledTimes(1);
   });
 
+  it("throws GeminiDailyQuotaError immediately for a per-minute 429 with an absurd retryDelay", async () => {
+    // A per-minute-shaped 429 carrying "retryDelay":"86400s" must NOT become a
+    // 24h interruptibleSleep on one cell — it is promoted to daily so the loop
+    // rotates keys, exactly like a per-day quota.
+    const absurd = [
+      {
+        "@type": "google.rpc.QuotaFailure",
+        violations: [{ quotaId: "GenerateRequestsPerMinute" }],
+      },
+      { "@type": "google.rpc.RetryInfo", retryDelay: "86400s" },
+    ];
+    mockGenerate.mockRejectedValue(fetchError(absurd));
+    await expect(callAIDetailed("hi", { provider: "gemini" })).rejects.toBeInstanceOf(
+      GeminiDailyQuotaError
+    );
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
   it("uses the explicit apiKey, not process.env.GEMINI_API_KEY", async () => {
     mockGenerate.mockResolvedValueOnce(ok);
     await callAIDetailed("hi", { provider: "gemini", apiKey: "loop-key-2" });

--- a/lib/ai/gemini-errors.ts
+++ b/lib/ai/gemini-errors.ts
@@ -24,6 +24,13 @@ export const PER_MINUTE_MAX_RETRIES = 6;
 export const PER_MINUTE_BASE_DELAY_MS = 20_000;
 /** Ceiling for a single per-minute backoff wait. */
 export const PER_MINUTE_MAX_DELAY_MS = 65_000;
+/** Longest provider-supplied `retryDelay` still treated as a per-minute wait.
+ *  Free-tier RPM windows reset in ~60s, so a provider delay past a couple of
+ *  minutes is not a per-minute window — it means that key is out for the day.
+ *  `classifyGeminiError` promotes such an error to `daily` so the loop rotates
+ *  keys instead of sleeping minutes/hours on one cell with no rotation, and
+ *  `perMinuteBackoffMs` clamps to this as a backstop. */
+export const PER_MINUTE_PROVIDER_DELAY_CAP_MS = 120_000;
 /** Consecutive ambiguous 429s (429 with no clear per-day / per-minute marker) on
  *  one key, with no successful call in between, after which the key is assumed
  *  daily-exhausted and the loop rotates. Guards against a genuinely dead key that
@@ -106,10 +113,13 @@ function parseRetryAfterMs(text: string): number | undefined {
  * Classifies an error thrown by a Gemini `generateContent` call.
  *
  * Conservative fallback: an unrecognised 429 is `other-429`, which the retry
- * wrapper treats as per-minute (wait + retry). A misclassified per-minute error
- * that were treated as daily would burn a key permanently on a transient blip;
- * the reverse only wastes bounded, capped retry time. `AMBIGUOUS_429_ESCALATE_AFTER`
- * is the backstop for a truly daily-dead key that only emits `other-429`.
+ * wrapper treats as per-minute (wait + retry). Treating a per-minute error as
+ * daily would burn a key on a transient blip, while the reverse only wastes
+ * bounded, capped retry time — so the default leans per-minute. The one
+ * exception is a provider `retryDelay` past `PER_MINUTE_PROVIDER_DELAY_CAP_MS`:
+ * honouring it would cost far more than a wrong rotation, so it is promoted to
+ * `daily` regardless of the quota markers. `AMBIGUOUS_429_ESCALATE_AFTER` is the
+ * backstop for a truly daily-dead key that only emits `other-429`.
  */
 export function classifyGeminiError(err: unknown): GeminiRateInfo {
   const e = asFetchErrorLike(err);
@@ -152,6 +162,13 @@ export function classifyGeminiError(err: unknown): GeminiRateInfo {
   const retryAfterMs = parseRetryAfterMs(signal);
   const quotaId = signal.match(/"quotaId"\s*:\s*"([^"]+)"/)?.[1];
 
+  // A retryDelay past the per-minute cap is not a transient window — honouring it
+  // would stall the backfill loop for minutes/hours on one cell with no key
+  // rotation. Treat it as daily so the loop moves to the next key.
+  if (retryAfterMs !== undefined && retryAfterMs > PER_MINUTE_PROVIDER_DELAY_CAP_MS) {
+    return { cls: "daily", status, retryAfterMs, quotaId, raw };
+  }
+
   const perDay =
     /per\s*day|perday|requests per day|generaterequestsperday/i.test(quotaId ?? "") ||
     /perdayper|requests per day|generaterequestsperday/i.test(lower);
@@ -182,17 +199,21 @@ export const PER_MINUTE_MIN_DELAY_MS = 2_000;
  *
  * When Google sends a usable `retryDelay`, that is a hard MINIMUM — jitter is
  * added on top, never subtracted, so we never re-fire before the window Google
- * named, and there is no upper cap (a provider delay above
- * `PER_MINUTE_MAX_DELAY_MS` is honoured in full). Keeping the jitter even past
- * the cap is what stops concurrent workers that got the same `retryDelay` from
- * all re-firing on the same tick.
+ * named. It is clamped to `PER_MINUTE_PROVIDER_DELAY_CAP_MS`; a delay past that
+ * should already have been classified `daily` (rotate key), and this is the
+ * backstop so one function can't schedule an hours-long sleep. Jitter is kept
+ * even at the clamp so concurrent workers that got the same `retryDelay` don't
+ * all re-fire on the same tick.
  *
  * Otherwise: exponential from `PER_MINUTE_BASE_DELAY_MS` with ±15% jitter,
  * always at least `PER_MINUTE_MIN_DELAY_MS`, at most `PER_MINUTE_MAX_DELAY_MS`. */
 export function perMinuteBackoffMs(attempt: number, retryAfterMs?: number): number {
   if (retryAfterMs !== undefined && retryAfterMs > 0) {
-    const floor = Math.max(retryAfterMs, PER_MINUTE_MIN_DELAY_MS);
-    return Math.round(floor * (1 + Math.random() * 0.15));
+    const bounded = Math.min(
+      Math.max(retryAfterMs, PER_MINUTE_MIN_DELAY_MS),
+      PER_MINUTE_PROVIDER_DELAY_CAP_MS
+    );
+    return Math.round(bounded * (1 + Math.random() * 0.15));
   }
   const base = PER_MINUTE_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
   const capped = Math.min(Math.max(base, PER_MINUTE_MIN_DELAY_MS), PER_MINUTE_MAX_DELAY_MS);


### PR DESCRIPTION
Fixes #560

## Root cause

`lib/ai/gemini-errors.ts` → `parseRetryAfterMs` parses `"retryDelay":"86400s"` into `86_400_000` ms. `classifyGeminiError` still returned `per-minute` / `other-429` for such an error, and `perMinuteBackoffMs` honoured that value **in full** in the provider-delay branch — only the fallback (no `retryDelay`) branch was ever bounded by `PER_MINUTE_MAX_DELAY_MS`.

`callGemini` (`lib/ai/ai.ts`) then `interruptibleSleep`s for minutes-to-hours on a single cell (up to `PER_MINUTE_MAX_RETRIES` times). Because no `daily` / `key-invalid` class is thrown, loop mode never rotates keys — the backfill loop stalls (abortable, but stuck).

## Fix (all inside `lib/ai/gemini-errors.ts`, per the "429s classified in exactly one place" rule)

- New `PER_MINUTE_PROVIDER_DELAY_CAP_MS = 120_000`. Free-tier RPM windows reset in ~60 s, so a provider delay past a couple of minutes is not a per-minute window.
- `classifyGeminiError` returns `cls: "daily"` when the parsed `retryDelay` **exceeds** the cap (boundary inclusive: exactly 120 s stays `per-minute`), regardless of quota markers. Loop mode then rotates to the next key (`connection-batch-loop` `case "quota-daily"`) instead of waiting it out.
- `perMinuteBackoffMs` clamps the honoured provider delay to the same cap as a backstop, keeping the +0–15 % jitter so concurrent workers don't re-fire on the same tick.
- Doc comments updated: `perMinuteBackoffMs` (previously "there is no upper cap") and the `classifyGeminiError` rationale (previously argued unconditionally against promoting per-minute → daily).

## Behaviour delta

- A `per-minute` / `other-429` 429 whose `retryDelay` is ≤ 120 s: unchanged (waited + retried on the same key).
- A 429 whose `retryDelay` is > 120 s: now `daily` → immediate `GeminiDailyQuotaError` → key rotation, instead of a multi-minute-to-hours sleep with no rotation.

## Guardrail call-outs

- Touches Gemini 429 classification (`AGENTS.md` single-place rule) and loop-mode key-rotation. No change to `ai.ts` or the batch loop — the magnitude check lives in the classifier.
- **New side effect:** `parseRetryAfterMs` also matches header-style `Retry-After`, so a proxy that injects a generous `Retry-After` (e.g. `300`) on a transient 429 will now rotate that key rather than wait. Accepted — the alternative is the stall this fixes, and the loop rotates rather than stops.
- **Per-cell worst case still bounded per sleep, not per cell:** repeated per-minute 429s with `retryDelay` just under the cap can accumulate ~`PER_MINUTE_MAX_RETRIES` × ~120 s on one cell before `GeminiRateLimitError` (an ordinary cell failure). This shape predates the change and was previously unbounded; the cap makes each individual sleep sane. Cap value (2 min) chosen deliberately.

## Tests

- `__tests__/lib/ai/gemini-errors.test.ts`: `retryDelay` within the cap still classifies `per-minute`; absurd `retryDelay` on a per-minute-shaped 429 and on a bare 429 classify `daily`; **cap boundary is inclusive** (exactly the cap → `per-minute`, just past → `daily`); `perMinuteBackoffMs` honours a delay between `MAX` and the cap (inclusive), and clamps (with jitter) above it. The old "honours a delay above the max in full" test is replaced.
- `__tests__/lib/ai/gemini-retry.test.ts`: a per-minute-shaped 429 carrying `retryDelay:"86400s"` throws `GeminiDailyQuotaError` on the first attempt (no retry, no long sleep) — mirrors the existing per-day case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)