### PR TITLE
fix(bookmarks): normalize verse ref on DELETE to match POST

### DIFF
--- a/__tests__/api/bookmarks.test.ts
+++ b/__tests__/api/bookmarks.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
-import type { User } from "@/lib/infra/db/schema";
+import { and, eq, inArray } from "drizzle-orm";
+import { bookmarks, type User } from "@/lib/infra/db/schema";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
@@ -251,22 +252,55 @@ describe("DELETE /api/bookmarks/[ref]", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 200 ok when bookmark is deleted", async () => {
+  it("deletes the canonical ref, scoped to the user", async () => {
     authedUser();
+    const calls: Record<string, unknown[][]> = {};
+    mockDelete.mockReturnValue(makeRecordingChain([], calls));
+    // Next.js hands the route a URL-decoded param, i.e. the canonical ref.
     const res = await DELETE(deleteReq(), {
-      params: Promise.resolve({ ref: "2%3A255" }),
+      params: Promise.resolve({ ref: "2:255" }),
     });
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.ok).toBe(true);
+    expect((await res.json()).ok).toBe(true);
+    expect(calls.where?.[0]?.[0]).toEqual(
+      and(eq(bookmarks.userId, 1), inArray(bookmarks.verseRef, ["2:255"]))
+    );
   });
 
-  it("returns 400 for invalid id", async () => {
+  it("returns 400 for a blank ref, without touching the DB", async () => {
     authedUser();
     const res = await DELETE(deleteReq(), {
-      params: Promise.resolve({ ref: "" }),
+      params: Promise.resolve({ ref: "   " }),
     });
-    // empty ref decodes to "" — still valid for delete (just won't match rows)
-    expect([200, 400]).toContain(res.status);
+    expect(res.status).toBe(400);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("matches both the raw param and its trimmed form so a padded ref still deletes", async () => {
+    authedUser();
+    const calls: Record<string, unknown[][]> = {};
+    mockDelete.mockReturnValue(makeRecordingChain([], calls));
+    const res = await DELETE(deleteReq(), {
+      params: Promise.resolve({ ref: " 2:255 " }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls.where?.[0]?.[0]).toEqual(
+      and(eq(bookmarks.userId, 1), inArray(bookmarks.verseRef, [" 2:255 ", "2:255"]))
+    );
+  });
+
+  it("still deletes a legacy row stored under a non-canonical key", async () => {
+    authedUser();
+    const calls: Record<string, unknown[][]> = {};
+    mockDelete.mockReturnValue(makeRecordingChain([], calls));
+    // "02:255" was writable via POST before isValidRef rejected zero-padding;
+    // DELETE must not strand such rows behind a 400.
+    const res = await DELETE(deleteReq(), {
+      params: Promise.resolve({ ref: "02:255" }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls.where?.[0]?.[0]).toEqual(
+      and(eq(bookmarks.userId, 1), inArray(bookmarks.verseRef, ["02:255"]))
+    );
   });
 });

--- a/app/api/bookmarks/[ref]/route.ts
+++ b/app/api/bookmarks/[ref]/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { bookmarks } from "@/lib/infra/db/schema";
 import { requireUser } from "@/lib/auth/social-auth";
+import { jsonError } from "@/lib/infra/http";
 import { rateLimitOrNull } from "@/lib/infra/rate-limit";
 
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ ref: string }> }) {
@@ -13,16 +14,27 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ r
   if (limited) return limited;
 
   const { ref } = await params;
-  const verseRef = ref;
+  const verseRef = ref.trim();
+  if (!verseRef) return jsonError("Invalid verse ref", 400);
 
   try {
+    // Match both the raw param and its trimmed form. POST trims on write, so a
+    // bookmark saved as "2:255" must be removable by a client that sent
+    // " 2:255 "; matching the raw value too keeps a legacy row stored under a
+    // non-canonical key (writable before isValidRef was tightened) deletable.
+    // Query is userId-scoped and parameterized, so no validation is needed here.
     await db
       .delete(bookmarks)
-      .where(and(eq(bookmarks.userId, authed.userId), eq(bookmarks.verseRef, verseRef)));
+      .where(
+        and(
+          eq(bookmarks.userId, authed.userId),
+          inArray(bookmarks.verseRef, [...new Set([ref, verseRef])])
+        )
+      );
 
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("bookmarks DELETE db error:", err);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return jsonError("Internal server error", 500);
   }
 }


### PR DESCRIPTION
Fixes #562

## Root cause

`app/api/bookmarks/[ref]/route.ts` deleted on `verseRef = ref` verbatim — no `.trim()` — whereas POST (`app/api/bookmarks/route.ts:41-44`) trims on write. A bookmark stored with surrounding whitespace via an older write path could not be deleted: POST wrote `"2:255"`, DELETE looked for `" 2:255 "` → key mismatch → un-removable bookmark, with the handler still returning `{ ok: true }`.

## Fix

DELETE now trims the param, rejects only a **blank** ref (`400`), and deletes rows matching **either** the raw value or its trimmed form:

```ts
const verseRef = ref.trim();
if (!verseRef) return jsonError("Invalid verse ref", 400);

await db.delete(bookmarks).where(and(
  eq(bookmarks.userId, authed.userId),
  inArray(bookmarks.verseRef, [...new Set([ref, verseRef])]),
));
```

### Why not `trim()` + `isValidRef()` + 400 (literal "mirror POST")

POST and DELETE aren't symmetric: POST *creates* (rejecting junk is correct), DELETE *removes*. A hard `isValidRef` 400 on DELETE would strand a class of legacy rows — `"02:255"` was writable via POST before #575 tightened `isValidRef` to reject zero-padding, and `store/auth.ts` `toggleBookmark` rolls back the optimistic removal on any non-`ok` response, so those rows would become **permanently** un-removable. That is exactly #562's symptom, just for a different set of rows. Matching the raw value keeps them deletable. The query is `userId`-scoped and parameterized, so dropping ref validation here costs nothing security-wise.

## Auth/security surface

Touches `app/api/bookmarks/[ref]/` (authed endpoint). No auth check loosened; delete stays `userId`-scoped and parameterized; no new env/secrets. Net effect is a robustness fix.

## Behaviour delta

| Input | Before | After |
|---|---|---|
| Canonical ref (`"2:255"`) | 200, deletes | 200, deletes (unchanged) |
| Whitespace-padded (`" 2:255 "`) | 200 + silent no-op | 200, deletes the `"2:255"` row |
| Legacy non-canonical (`"02:255"`) | 200, deletes | 200, deletes (unchanged) |
| Blank / whitespace-only | 200 + no-op | `400`, no DB call |

## Tests — `__tests__/api/bookmarks.test.ts`

- Canonical ref: asserts the delete's `where` is `and(eq(userId,1), inArray(verseRef, ["2:255"]))` via `makeRecordingChain` — proves it targets the right row, not just that it returns 200.
- Padded ref `" 2:255 "`: asserts `inArray(verseRef, [" 2:255 ", "2:255"])`.
- Legacy `"02:255"`: asserts it still reaches the delete (`inArray(verseRef, ["02:255"])`), not a 400.
- Blank ref `"   "`: `400`, `mockDelete` not called.
- Updated the existing 200 case to pass the URL-decoded param Next.js actually delivers (`"2:255"`, not `"2%3A255"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bookmark deletion now rejects blank or whitespace-only references with a clear error.
  - References with extra spaces are handled correctly during deletion.
  - Deletion remains limited to the current user’s bookmarks.
  - Legacy bookmark references continue to be removable.
  - Server errors now use consistent error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->