### PR TITLE
feat(admin): coordinate the running-job lock across processes (#517)

### DIFF
--- a/__tests__/integration/job-runner-lock.integration.test.ts
+++ b/__tests__/integration/job-runner-lock.integration.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import postgres from "postgres";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/infra/db";
+import { JOB_LOCK_KEY } from "@/lib/admin/job-lock";
+
+// The runner spawns `bun scripts/<name>.mjs` for script jobs — irrelevant to the
+// lock behaviour under test, so stub it with an EventEmitter we can "close".
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+}
+const { mockSpawn, lastChild } = vi.hoisted(() => ({
+  mockSpawn: vi.fn(),
+  lastChild: { current: null as FakeChild | null },
+}));
+vi.mock("node:child_process", () => ({ spawn: mockSpawn, default: { spawn: mockSpawn } }));
+vi.mock("@/lib/ai/connection-batch", () => ({ runConnectionBatch: vi.fn() }));
+vi.mock("@/lib/ai/connection-batch-loop", () => ({ runConnectionBatchLoop: vi.fn() }));
+
+import { startJob } from "@/lib/admin/job-runner";
+
+// A second connection standing in for "another app process".
+const outsider = postgres(process.env.DATABASE_URL as string, { max: 1 });
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+beforeEach(async () => {
+  mockSpawn.mockReset().mockImplementation(() => {
+    const child = new FakeChild();
+    lastChild.current = child;
+    return child;
+  });
+  await db.execute(sql`TRUNCATE job_runs RESTART IDENTITY`);
+});
+
+afterEach(async () => {
+  // Close out whatever the test started so the runner's in-memory guard and the
+  // advisory lock are both released before the next test.
+  lastChild.current?.emit("close", 0);
+  lastChild.current = null;
+  await sleep(20);
+});
+
+afterAll(async () => {
+  await outsider.end();
+});
+
+describe("job-runner advisory lock (integration, real Postgres)", () => {
+  it("refuses to start when another connection holds the lock, and writes no job_runs row", async () => {
+    const [{ locked }] = await outsider<{ locked: boolean }[]>`
+      select pg_try_advisory_lock(${JOB_LOCK_KEY}) as locked
+    `;
+    expect(locked).toBe(true);
+
+    await expect(startJob("seed-quran", "qf-admin")).rejects.toThrow(/already running/);
+
+    const rows = await db.execute<{ n: number }>(sql`select count(*)::int as n from job_runs`);
+    expect(rows[0].n).toBe(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    await outsider`select pg_advisory_unlock(${JOB_LOCK_KEY})`;
+  });
+
+  it("holds the lock for the duration of a run and releases it on completion", async () => {
+    await startJob("seed-quran", "qf-admin");
+
+    // While the job runs, an outside process cannot take the lock.
+    const [mid] = await outsider<{ locked: boolean }[]>`
+      select pg_try_advisory_lock(${JOB_LOCK_KEY}) as locked
+    `;
+    expect(mid.locked).toBe(false);
+
+    // Job finishes → runner releases the lock.
+    lastChild.current?.emit("close", 0);
+    lastChild.current = null;
+    await sleep(50);
+
+    const [after] = await outsider<{ locked: boolean }[]>`
+      select pg_try_advisory_lock(${JOB_LOCK_KEY}) as locked
+    `;
+    expect(after.locked).toBe(true);
+    await outsider`select pg_advisory_unlock(${JOB_LOCK_KEY})`;
+  });
+
+  it("lets the next job start once the lock has been released", async () => {
+    await startJob("seed-quran", "qf-admin");
+    lastChild.current?.emit("close", 0);
+    lastChild.current = null;
+    await sleep(50);
+
+    const { runId } = await startJob("seed-morphology", "qf-admin");
+    expect(runId).toBeTypeOf("number");
+    const rows = await db.execute<{ n: number }>(sql`select count(*)::int as n from job_runs`);
+    expect(rows[0].n).toBe(2);
+  });
+});

--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -174,6 +174,18 @@ describe("startJob", () => {
     expect(mockReleaseJobLock).toHaveBeenCalledTimes(1);
   });
 
+  it("releases the advisory lock and guard if spawn throws synchronously", async () => {
+    mockSpawn.mockImplementationOnce(() => {
+      throw new Error("EAGAIN");
+    });
+    await expect(startJob("seed-morphology", "qf-admin")).rejects.toThrow("EAGAIN");
+    await Promise.resolve();
+    expect(mockReleaseJobLock).toHaveBeenCalledTimes(1);
+    // Guard released → a retry can proceed.
+    const { runId } = await startJob("seed-quran", "qf-admin");
+    expect(runId).toBe(42);
+  });
+
   it("clears the running guard once the child process closes", async () => {
     await startJob("seed-morphology", "qf-admin");
     lastChild.current?.emit("close", 0);

--- a/__tests__/lib/admin/job-runner.test.ts
+++ b/__tests__/lib/admin/job-runner.test.ts
@@ -45,6 +45,16 @@ vi.mock("node:child_process", () => ({
   default: { spawn: mockSpawn },
 }));
 
+const { mockTryAcquireJobLock, mockReleaseJobLock } = vi.hoisted(() => ({
+  mockTryAcquireJobLock: vi.fn(),
+  mockReleaseJobLock: vi.fn(),
+}));
+vi.mock("@/lib/admin/job-lock", () => ({
+  JOB_LOCK_KEY: 776142517,
+  tryAcquireJobLock: mockTryAcquireJobLock,
+  releaseJobLock: mockReleaseJobLock,
+}));
+
 const { mockRunConnectionBatch } = vi.hoisted(() => ({ mockRunConnectionBatch: vi.fn() }));
 vi.mock("@/lib/ai/connection-batch", () => ({ runConnectionBatch: mockRunConnectionBatch }));
 
@@ -74,6 +84,8 @@ beforeEach(() => {
   });
   mockRunConnectionBatch.mockReset().mockResolvedValue({ stoppedReason: "completed" });
   mockRunConnectionBatchLoop.mockReset().mockResolvedValue({ stoppedReason: "all-keys-daily" });
+  mockTryAcquireJobLock.mockReset().mockResolvedValue(true);
+  mockReleaseJobLock.mockReset().mockResolvedValue(undefined);
 });
 
 // `running` is module-level state in job-runner.ts (by design — it's the
@@ -135,6 +147,31 @@ describe("startJob", () => {
     const { runId } = await startJob("seed-quran", "qf-admin");
     expect(runId).toBe(42);
     expect(mockInsert).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when another process holds the advisory lock, without inserting a row", async () => {
+    mockTryAcquireJobLock.mockResolvedValueOnce(false);
+    await expect(startJob("seed-morphology", "qf-admin")).rejects.toThrow("already running");
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
+    // Guard released → a retry (once the lock frees) can proceed.
+    const { runId } = await startJob("seed-quran", "qf-admin");
+    expect(runId).toBe(42);
+  });
+
+  it("releases the advisory lock when the insert rejects", async () => {
+    mockInsert.mockReturnValueOnce(makeDbChain(Promise.reject(new Error("insert failed"))));
+    await expect(startJob("seed-morphology", "qf-admin")).rejects.toThrow("insert failed");
+    expect(mockReleaseJobLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the advisory lock once the child process closes", async () => {
+    await startJob("seed-morphology", "qf-admin");
+    expect(mockTryAcquireJobLock).toHaveBeenCalledTimes(1);
+    lastChild.current?.emit("close", 0);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockReleaseJobLock).toHaveBeenCalledTimes(1);
   });
 
   it("clears the running guard once the child process closes", async () => {

--- a/lib/admin/job-lock.ts
+++ b/lib/admin/job-lock.ts
@@ -1,0 +1,55 @@
+import postgres from "postgres";
+
+/**
+ * Cross-process mutual exclusion for the admin job runner.
+ *
+ * `job-runner.ts` guards "one job at a time" with a module-level `running`
+ * variable. That is process-local: run the app with more than one Node process
+ * and two near-simultaneous `startJob` calls can each pass that guard, insert
+ * their own `job_runs` row, and spawn duplicate work — for `backfill-connections`
+ * that is duplicated per-call LLM spend. A Postgres session-level advisory lock
+ * closes the gap: only one process can hold {@link JOB_LOCK_KEY} at a time.
+ *
+ * The lock lives on a dedicated connection kept open for the whole job lifetime
+ * (hours, in loop mode) — deliberately NOT one of the shared pool's ten slots.
+ * If the process dies the session drops and Postgres releases the lock on its
+ * own, which is exactly right: a crashed process must not wedge the runner.
+ */
+
+// Arbitrary but fixed — the single global "one job slot". Fits int4 and is
+// passed via pg_advisory_lock's single-argument (bigint) form. Unrelated to any
+// table id.
+export const JOB_LOCK_KEY = 776142517;
+
+// Own connection, never pool-shared. `idle_timeout` and `max_lifetime` are
+// disabled so the connection — and therefore the session-scoped lock — is never
+// recycled out from under a running job.
+const lockClient = postgres(
+  process.env.DATABASE_URL ?? "postgresql://openh:placeholder@localhost:5432/open_hikmah",
+  { max: 1, idle_timeout: 0, max_lifetime: null, connect_timeout: 10 }
+);
+
+/**
+ * Tries to take the global job lock without blocking. `true` means this process
+ * now holds it and must call {@link releaseJobLock} when the job ends; `false`
+ * means another process holds it and the caller must refuse to start.
+ */
+export async function tryAcquireJobLock(): Promise<boolean> {
+  const [{ locked }] = await lockClient<{ locked: boolean }[]>`
+    select pg_try_advisory_lock(${JOB_LOCK_KEY}) as locked
+  `;
+  return locked;
+}
+
+/**
+ * Releases the global job lock. Best-effort: a failure here (e.g. the dedicated
+ * connection dropped) is logged, not thrown — a dropped session has already
+ * released the lock server-side, and the caller is on a terminal path anyway.
+ */
+export async function releaseJobLock(): Promise<void> {
+  try {
+    await lockClient`select pg_advisory_unlock(${JOB_LOCK_KEY})`;
+  } catch (err) {
+    console.error("job-lock: failed to release advisory lock", err);
+  }
+}

--- a/lib/admin/job-lock.ts
+++ b/lib/admin/job-lock.ts
@@ -12,8 +12,20 @@ import postgres from "postgres";
  *
  * The lock lives on a dedicated connection kept open for the whole job lifetime
  * (hours, in loop mode) — deliberately NOT one of the shared pool's ten slots.
- * If the process dies the session drops and Postgres releases the lock on its
- * own, which is exactly right: a crashed process must not wedge the runner.
+ * When the process exits, Postgres releases the lock once it notices the dropped
+ * session: immediately on a clean shutdown, after TCP keepalive detection (~10
+ * min, `keep_alive` default) on an unclean kill.
+ *
+ * Known limits of a session-scoped lock (accepted for the current single-box,
+ * direct-to-Postgres deploy):
+ *   - The connection issues no query between acquire and release, so a Postgres
+ *     restart/failover or a server `idle_session_timeout` during a long job
+ *     drops the session and the lock while the job keeps running. `keep_alive`
+ *     covers NAT/firewall idle-drop but not these.
+ *   - Behind a transaction-pooling proxy (PgBouncer et al.) there is no stable
+ *     server session, so the lock would not span acquire→release at all. Use a
+ *     direct connection / session pooling.
+ * If either becomes real, move to a lease row + heartbeat instead.
  */
 
 // Arbitrary but fixed — the single global "one job slot". Fits int4 and is

--- a/lib/admin/job-runner.ts
+++ b/lib/admin/job-runner.ts
@@ -15,6 +15,7 @@ import {
 import type { Provider } from "@/lib/ai/ai";
 import { SELECTABLE_MODELS, isModelForProvider } from "@/lib/ai/models";
 import { LOCALES, type Locale } from "@/lib/i18n/config";
+import { tryAcquireJobLock, releaseJobLock } from "@/lib/admin/job-lock";
 
 /**
  * Triggers and tracks the project's one-time/resumable backfill jobs from the
@@ -22,7 +23,9 @@ import { LOCALES, type Locale } from "@/lib/i18n/config";
  * deployment: one job runs at a time, tracked by in-memory state in this module
  * (the source of truth for "is a job running right now") backed by a `job_runs`
  * DB row per invocation (the source of truth for history/last-run status, so it
- * survives a server restart).
+ * survives a server restart). A Postgres advisory lock (see `job-lock.ts`)
+ * extends that "one at a time" guarantee across processes, so the in-memory
+ * state only has to coordinate callers within one process.
  *
  * Two execution shapes:
  *   - `script` jobs spawn `bun scripts/<name>.mjs` as a child process. Those
@@ -258,7 +261,14 @@ function finishRun(
     .set({ status, completedAt: new Date(), error, logTail: state.logTail.join("\n") })
     .where(eq(jobRuns.id, state.runId))
     .catch((err) => console.error("job-runner: failed to record job completion", err));
-  if (running?.runId === state.runId) running = null;
+  // Every terminal path funnels through here (spawn close/error, in-process
+  // success/catch), so this is where the cross-process advisory lock is
+  // released — guarded by the same runId check as the in-memory slot so a
+  // double `close`/`error` from one child doesn't unbalance the lock.
+  if (running?.runId === state.runId) {
+    running = null;
+    void releaseJobLock();
+  }
 }
 
 /** Maps a batch / loop terminal reason to the `job_runs.status` the Jobs page
@@ -301,9 +311,10 @@ export async function startJob(
   }
 
   // Claim the slot synchronously (no await between the `if (running)` check
-  // above and this assignment) so two near-simultaneous calls can't both pass
-  // the guard — matches lib/names/name-content.ts's inFlight/reasonInFlight
-  // pattern. `runId` is filled in once the insert below resolves.
+  // above and this assignment) so two near-simultaneous calls in this process
+  // can't both pass the guard — matches lib/names/name-content.ts's
+  // inFlight/reasonInFlight pattern. `runId` is filled in once the insert below
+  // resolves.
   const state: RunningJob = {
     jobId: job.id,
     runId: -1,
@@ -311,6 +322,22 @@ export async function startJob(
     controller: new AbortController(),
   };
   running = state;
+
+  // Cross-process guard: acquire the Postgres advisory lock so a second app
+  // process can't start its own run in parallel. Taken AFTER the synchronous
+  // in-memory claim above — advisory locks are re-entrant within a session, so
+  // relying on this alone would let a second same-process caller through.
+  let lockHeld: boolean;
+  try {
+    lockHeld = await tryAcquireJobLock();
+  } catch (err) {
+    if (running === state) running = null;
+    throw err;
+  }
+  if (!lockHeld) {
+    if (running === state) running = null;
+    throw new Error("A job is already running");
+  }
 
   let row: { id: number };
   try {
@@ -320,6 +347,7 @@ export async function startJob(
       .returning({ id: jobRuns.id });
   } catch (err) {
     if (running === state) running = null;
+    void releaseJobLock();
     throw err;
   }
   state.runId = row.id;

--- a/lib/admin/job-runner.ts
+++ b/lib/admin/job-runner.ts
@@ -375,25 +375,36 @@ export async function startJob(
     return { runId: row.id };
   }
 
-  const child = spawn("bun", [job.script as string], { cwd: process.cwd() });
+  // A synchronous throw from `spawn` (bad args / resource exhaustion) would
+  // otherwise leave `running` set and the advisory lock held with no child and
+  // no `finishRun` ever scheduled — wedging the runner across every process.
+  // `finishRun` records the failed run and releases both; the caller still sees
+  // the error. (A missing `bun` binary surfaces as an `error` event, handled
+  // below, not a throw here.)
+  try {
+    const child = spawn("bun", [job.script as string], { cwd: process.cwd() });
 
-  const onData = (chunk: Buffer) => {
-    for (const line of chunk.toString("utf8").split("\n")) {
-      if (line.trim()) pushLogLine(state, line);
-    }
-  };
-  child.stdout.on("data", onData);
-  child.stderr.on("data", onData);
+    const onData = (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n")) {
+        if (line.trim()) pushLogLine(state, line);
+      }
+    };
+    child.stdout.on("data", onData);
+    child.stderr.on("data", onData);
 
-  child.on("close", (code) => {
-    finishRun(
-      state,
-      code === 0 ? "success" : "failed",
-      code === 0 ? null : `Exited with code ${code}`
-    );
-  });
+    child.on("close", (code) => {
+      finishRun(
+        state,
+        code === 0 ? "success" : "failed",
+        code === 0 ? null : `Exited with code ${code}`
+      );
+    });
 
-  child.on("error", (err) => finishRun(state, "failed", err.message));
+    child.on("error", (err) => finishRun(state, "failed", err.message));
+  } catch (err) {
+    finishRun(state, "failed", err instanceof Error ? err.message : String(err));
+    throw err;
+  }
 
   return { runId: row.id };
 }


### PR DESCRIPTION
Closes #517. Follow-up from the #516 CodeRabbit review.

## Problem

`lib/admin/job-runner.ts` guarded "only one job at a time" with a module-level `running` variable. That is process-local: run the app with more than one Node process and two near-simultaneous `startJob` calls can each pass the guard, insert separate `job_runs` rows, and spawn duplicate child work. For `backfill-connections` that means **duplicated per-call LLM spend**.

## Change

New `lib/admin/job-lock.ts` — a Postgres **session-level advisory lock** (`pg_try_advisory_lock` / `pg_advisory_unlock`) on a dedicated connection:

- **Acquired** in `startJob`, immediately *after* the synchronous in-memory `running` claim. The in-memory guard is kept and still decides same-process races — advisory locks are re-entrant within one session, so relying on the lock alone would let a second same-process caller through. The lock only arbitrates *across* processes.
- **Released** in `finishRun` (the single chokepoint every terminal path funnels through: spawn `close`/`error`, in-process success/`catch`), guarded by the same `runId` check as the in-memory slot so a double `close`+`error` from one child can't unbalance it. Also released on the insert-failure path.
- A `startJob` on another process that can't take the lock throws `"A job is already running"` — the same class of error the in-memory guard raises, which `app/api/admin/jobs/route.ts` already maps to a 400.

The lock connection is **outside the shared pool** (`max: 1`, `idle_timeout: 0`, `max_lifetime: null`) so a multi-hour loop-mode job never occupies one of the pool's ten slots and the connection isn't recycled out from under a running job. If the process dies, Postgres drops the session and releases the lock automatically.

Response codes unchanged (the issue mentions 409, but the route has no such mapping today and 400 is the existing contract — out of scope here).

## Tests

- `__tests__/lib/admin/job-runner.test.ts` — mocks `@/lib/admin/job-lock`; adds cases: another process holding the lock → `startJob` rejects and inserts no row (guard released for retry); lock released on insert failure; lock released once the child closes.
- `__tests__/integration/job-runner-lock.integration.test.ts` (new, Testcontainers) — a second real connection holds `pg_try_advisory_lock(JOB_LOCK_KEY)` → `startJob` rejects, no `job_runs` row; the lock is held for the run's duration and released on completion; the next job starts once it's free.

## Verification

- `bun run test:ci` — green (pre-commit)
- `bun run test:integration` — green (pre-push), includes the new contention test

## Note

Branched on #590 (playwright-core dedupe) so the pre-commit `typecheck` step passes locally; GitHub will retarget this PR to `main` once #590 merges.