### PR TITLE
fix(bookmarks): don't resurrect bookmarks deleted on another device (#554)

### DIFF
--- a/__tests__/store/auth.test.ts
+++ b/__tests__/store/auth.test.ts
@@ -11,6 +11,7 @@ describe("auth store", () => {
     useAuthStore.setState({
       accessToken: null,
       bookmarks: [],
+      pendingBookmarkAdds: [],
       bookmarksLoadError: false,
       bookmarkBusy: {},
       bookmarkGeneration: 0,
@@ -28,13 +29,14 @@ describe("auth store", () => {
     expect(useAuthStore.getState().accessToken).toBe("access-abc");
   });
 
-  it("clearAuth resets token and bookmarks", () => {
+  it("clearAuth resets token, bookmarks, and the pending-sync set", () => {
     useAuthStore.getState().setTokens("tok");
-    useAuthStore.setState({ bookmarks: ["2:255"] });
+    useAuthStore.setState({ bookmarks: ["2:255"], pendingBookmarkAdds: ["2:255"] });
     useAuthStore.getState().clearAuth();
     const s = useAuthStore.getState();
     expect(s.accessToken).toBeNull();
     expect(s.bookmarks).toEqual([]);
+    expect(s.pendingBookmarkAdds).toEqual([]);
   });
 
   it("isBookmarked returns false when not bookmarked", () => {
@@ -224,6 +226,50 @@ describe("auth store", () => {
     expect(useAuthStore.getState().bookmarks).toEqual(["2:255", "112:1"]);
   });
 
+  it("loadRemoteBookmarks drops a previously-synced ref the server no longer has (issue #554)", async () => {
+    // "2:255" was synced on a prior session (persisted, not pending); it was
+    // deleted on another device, so the server GET no longer returns it.
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ refs: ["1:1"] }) });
+    useAuthStore.setState({
+      accessToken: "tok",
+      bookmarks: ["2:255", "1:1"],
+      pendingBookmarkAdds: [],
+    });
+
+    await useAuthStore.getState().loadRemoteBookmarks();
+
+    expect(useAuthStore.getState().bookmarks).toEqual(["1:1"]);
+    expect(useAuthStore.getState().pendingBookmarkAdds).toEqual([]);
+    // Not re-uploaded.
+    const posts = mockFetch.mock.calls.filter(
+      ([, init]) => (init as RequestInit | undefined)?.method === "POST"
+    );
+    expect(posts).toHaveLength(0);
+  });
+
+  it("a guest add survives login, syncs up, then is not resurrected on a later load", async () => {
+    // Guest bookmarks "7:1" with no token → it's a pending add.
+    useAuthStore.getState().toggleBookmark("7:1");
+    expect(useAuthStore.getState().pendingBookmarkAdds).toEqual(["7:1"]);
+
+    // Log in; server has nothing yet. The pending add is kept and uploaded.
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ refs: [] }) }) // GET
+      .mockResolvedValueOnce({ ok: true }); // sync POST for 7:1
+    useAuthStore.setState({ accessToken: "tok" });
+    await useAuthStore.getState().loadRemoteBookmarks();
+    expect(useAuthStore.getState().bookmarks).toEqual(["7:1"]);
+    await vi.waitFor(() => {
+      expect(useAuthStore.getState().pendingBookmarkAdds).toEqual([]);
+    });
+
+    // A later load where the server still doesn't return it (e.g. deleted
+    // elsewhere) now drops it instead of re-adding.
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ refs: [] }) });
+    await useAuthStore.getState().loadRemoteBookmarks();
+    expect(useAuthStore.getState().bookmarks).toEqual([]);
+  });
+
   it("loadRemoteBookmarks keeps the existing list but sets bookmarksLoadError on a non-OK response", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
@@ -267,7 +313,11 @@ describe("auth store", () => {
         releaseSync = res;
       })
     );
-    useAuthStore.setState({ accessToken: "tok", bookmarks: ["2:255", "1:1"] });
+    useAuthStore.setState({
+      accessToken: "tok",
+      bookmarks: ["2:255", "1:1"],
+      pendingBookmarkAdds: ["1:1"],
+    });
 
     await useAuthStore.getState().loadRemoteBookmarks();
     expect(useAuthStore.getState().bookmarks).toEqual(["2:255", "1:1"]);
@@ -275,16 +325,17 @@ describe("auth store", () => {
     releaseSync({ ok: true }); // avoid an unresolved promise leaking into later tests
   });
 
-  it("loadRemoteBookmarks syncs local-only bookmarks to the server in bounded-size batches", async () => {
+  it("loadRemoteBookmarks syncs still-pending bookmarks to the server in bounded-size batches", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ refs: ["2:255"] }),
     });
-    // 5 local-only refs, plus the initial GET, plus 5 sync POSTs = 6 total calls.
+    // 5 pending refs the server doesn't have, plus the GET, plus 5 sync POSTs.
     for (let i = 0; i < 5; i++) mockFetch.mockResolvedValueOnce({ ok: true });
     useAuthStore.setState({
       accessToken: "tok",
       bookmarks: ["2:255", "1:1", "112:1", "3:18", "5:1", "18:10"],
+      pendingBookmarkAdds: ["2:255", "1:1", "112:1", "3:18", "5:1", "18:10"],
     });
 
     await useAuthStore.getState().loadRemoteBookmarks();
@@ -295,6 +346,11 @@ describe("auth store", () => {
       );
       expect(syncCalls).toHaveLength(5);
     });
+    // "2:255" was on the server → dropped from pending immediately; the other
+    // five clear as their POSTs succeed.
+    await vi.waitFor(() => {
+      expect(useAuthStore.getState().pendingBookmarkAdds).toEqual([]);
+    });
   });
 
   it("loadRemoteBookmarks logs a count of failed syncs without throwing", async () => {
@@ -303,7 +359,11 @@ describe("auth store", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ refs: [] }) })
       .mockResolvedValueOnce({ ok: false, status: 500 })
       .mockResolvedValueOnce({ ok: true });
-    useAuthStore.setState({ accessToken: "tok", bookmarks: ["3:18", "5:1"] });
+    useAuthStore.setState({
+      accessToken: "tok",
+      bookmarks: ["3:18", "5:1"],
+      pendingBookmarkAdds: ["3:18", "5:1"],
+    });
 
     await expect(useAuthStore.getState().loadRemoteBookmarks()).resolves.toBeUndefined();
 
@@ -311,5 +371,16 @@ describe("auth store", () => {
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("failed to sync 1/2"));
     });
     errorSpy.mockRestore();
+  });
+
+  it("persist migrate seeds pendingBookmarkAdds from a pre-v1 persisted bookmark list", async () => {
+    localStorage.setItem(
+      "open-hikmah-auth",
+      JSON.stringify({ state: { bookmarks: ["2:255", "18:10"] }, version: 0 })
+    );
+    await useAuthStore.persist.rehydrate();
+    const s = useAuthStore.getState();
+    expect(s.bookmarks).toEqual(["2:255", "18:10"]);
+    expect(s.pendingBookmarkAdds).toEqual(["2:255", "18:10"]);
   });
 });

--- a/store/auth.ts
+++ b/store/auth.ts
@@ -12,6 +12,13 @@ interface AuthStore {
   isSessionLoading: boolean;
   // Bookmarks are non-sensitive and are persisted for offline use
   bookmarks: string[];
+  // Refs added locally that we don't yet know the server has — a guest add not
+  // yet synced, or a signed-in add whose POST hasn't confirmed. Only these
+  // survive a server omission on the next loadRemoteBookmarks; a ref that was
+  // synced before and is now gone from the server was deleted on another
+  // device, so it must not be resurrected (issue #554). Always a subset of
+  // `bookmarks`.
+  pendingBookmarkAdds: string[];
   // True when the most recent loadRemoteBookmarks call failed (network error
   // or non-OK response) — lets the bookmarks page distinguish "really empty"
   // from "failed to load" instead of rendering both identically.
@@ -41,23 +48,29 @@ const BOOKMARK_SYNC_CONCURRENCY = 3;
 // Fire-and-forget from loadRemoteBookmarks (not awaited) so a large sync
 // doesn't hold up isSessionLoading/AuthShell's spinner — but bounded and with
 // failures logged instead of silently dropped, unlike the old unbounded fan-out.
-async function syncLocalOnlyBookmarks(refs: string[], accessToken: string): Promise<void> {
+// `onSynced` is called per ref whose POST succeeded so the caller can drop it
+// from `pendingBookmarkAdds` (a failed ref stays pending and is retried next load).
+async function syncLocalOnlyBookmarks(
+  refs: string[],
+  accessToken: string,
+  onSynced: (ref: string) => void
+): Promise<void> {
   let failedCount = 0;
   for (let i = 0; i < refs.length; i += BOOKMARK_SYNC_CONCURRENCY) {
     const chunk = refs.slice(i, i + BOOKMARK_SYNC_CONCURRENCY);
     const results = await Promise.allSettled(
-      chunk.map((ref) =>
-        fetch("/api/bookmarks", {
+      chunk.map(async (ref) => {
+        const r = await fetch("/api/bookmarks", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${accessToken}`,
           },
           body: JSON.stringify({ ref }),
-        }).then((r) => {
-          if (!r.ok) throw new Error(`sync POST returned ${r.status}`);
-        })
-      )
+        });
+        if (!r.ok) throw new Error(`sync POST returned ${r.status}`);
+        onSynced(ref);
+      })
     );
     failedCount += results.filter((r) => r.status === "rejected").length;
   }
@@ -74,6 +87,7 @@ export const useAuthStore = create<AuthStore>()(
       accessToken: null,
       isSessionLoading: true,
       bookmarks: [],
+      pendingBookmarkAdds: [],
       bookmarksLoadError: false,
       bookmarkBusy: {},
       bookmarkGeneration: 0,
@@ -85,6 +99,7 @@ export const useAuthStore = create<AuthStore>()(
         set((s) => ({
           accessToken: null,
           bookmarks: [],
+          pendingBookmarkAdds: [],
           bookmarksLoadError: false,
           bookmarkBusy: {},
           bookmarkGeneration: s.bookmarkGeneration + 1,
@@ -102,10 +117,15 @@ export const useAuthStore = create<AuthStore>()(
 
         const wasBookmarked = bookmarks.includes(ref);
 
-        // Optimistic update
+        // Optimistic update. Adding marks the ref pending-sync; removing clears
+        // any pending entry (undoing an add that hadn't synced, or a no-op for
+        // an already-synced ref).
         set((s) => ({
           bookmarks: wasBookmarked ? bookmarks.filter((r) => r !== ref) : [...bookmarks, ref],
           bookmarkBusy: { ...s.bookmarkBusy, [ref]: true },
+          pendingBookmarkAdds: wasBookmarked
+            ? s.pendingBookmarkAdds.filter((r) => r !== ref)
+            : [...new Set([...s.pendingBookmarkAdds, ref])],
         }));
 
         if (!accessToken) {
@@ -129,11 +149,21 @@ export const useAuthStore = create<AuthStore>()(
         const rollback = () =>
           set((s) => {
             if (s.bookmarkGeneration !== generation) return s;
+            if (wasBookmarked) {
+              // Failed DELETE — the ref is still on the server, restore it locally.
+              return { bookmarks: [...s.bookmarks, ref] };
+            }
+            // Failed POST — the add didn't stick anywhere.
             return {
-              bookmarks: wasBookmarked
-                ? [...s.bookmarks, ref]
-                : s.bookmarks.filter((r) => r !== ref),
+              bookmarks: s.bookmarks.filter((r) => r !== ref),
+              pendingBookmarkAdds: s.pendingBookmarkAdds.filter((r) => r !== ref),
             };
+          });
+
+        const markSynced = () =>
+          set((s) => {
+            if (s.bookmarkGeneration !== generation) return s;
+            return { pendingBookmarkAdds: s.pendingBookmarkAdds.filter((r) => r !== ref) };
           });
 
         if (wasBookmarked) {
@@ -156,7 +186,8 @@ export const useAuthStore = create<AuthStore>()(
             body: JSON.stringify({ ref }),
           })
             .then((r) => {
-              if (!r.ok) rollback();
+              if (r.ok) markSynced();
+              else rollback();
             })
             .catch(rollback)
             .finally(clearBusy);
@@ -164,7 +195,7 @@ export const useAuthStore = create<AuthStore>()(
       },
 
       loadRemoteBookmarks: async () => {
-        const { accessToken } = get();
+        const { accessToken, bookmarkGeneration: generation } = get();
         if (!accessToken) return;
         try {
           const res = await fetch("/api/bookmarks", {
@@ -176,11 +207,25 @@ export const useAuthStore = create<AuthStore>()(
             return;
           }
           const { refs } = (await res.json()) as { refs: string[] };
-          // Merge: DB is authoritative, but sync any local-only bookmarks up to DB
-          const local = get().bookmarks;
-          const localOnly = local.filter((r) => !refs.includes(r));
-          set({ bookmarks: [...new Set([...refs, ...localOnly])], bookmarksLoadError: false });
-          if (localOnly.length > 0) void syncLocalOnlyBookmarks(localOnly, accessToken);
+          // The server list is authoritative. A local ref the server doesn't
+          // return is kept (and re-uploaded) ONLY if it's still in
+          // pendingBookmarkAdds — an add we haven't confirmed. A ref that was
+          // synced before and is now missing was deleted on another device, so
+          // it's dropped instead of resurrected (issue #554).
+          const stillPending = get().pendingBookmarkAdds.filter((r) => !refs.includes(r));
+          set({
+            bookmarks: [...new Set([...refs, ...stillPending])],
+            pendingBookmarkAdds: stillPending,
+            bookmarksLoadError: false,
+          });
+          if (stillPending.length > 0) {
+            void syncLocalOnlyBookmarks(stillPending, accessToken, (ref) =>
+              set((s) => {
+                if (s.bookmarkGeneration !== generation) return s;
+                return { pendingBookmarkAdds: s.pendingBookmarkAdds.filter((r) => r !== ref) };
+              })
+            );
+          }
         } catch (err) {
           console.error("loadRemoteBookmarks: failed to load bookmarks", err);
           set({ bookmarksLoadError: true });
@@ -189,8 +234,29 @@ export const useAuthStore = create<AuthStore>()(
     }),
     {
       name: "open-hikmah-auth",
-      // Only persist the bookmark list — tokens stay in memory for security
-      partialize: (s) => ({ bookmarks: s.bookmarks }),
+      version: 1,
+      // Only persist the bookmark list + the pending-sync set — tokens stay in
+      // memory for security.
+      partialize: (s) => ({
+        bookmarks: s.bookmarks,
+        pendingBookmarkAdds: s.pendingBookmarkAdds,
+      }),
+      migrate: (persisted, version) => {
+        const p = (persisted ?? {}) as {
+          bookmarks?: string[];
+          pendingBookmarkAdds?: string[];
+        };
+        if (version < 1) {
+          // Pre-v1 persisted only `bookmarks`, with no way to tell a synced ref
+          // from an unsynced guest add. Seed every persisted ref as pending so
+          // the first authoritative loadRemoteBookmarks re-verifies them:
+          // server-known refs drop out of pending, unknown ones are re-uploaded
+          // (matching the old behaviour for that one load). Correct
+          // delete-propagation kicks in from the next load on.
+          return { bookmarks: p.bookmarks ?? [], pendingBookmarkAdds: p.bookmarks ?? [] };
+        }
+        return { bookmarks: p.bookmarks ?? [], pendingBookmarkAdds: p.pendingBookmarkAdds ?? [] };
+      },
     }
   )
 );


### PR DESCRIPTION
Closes #554. Found during the PR #553 bug sweep (deferred there — needed a sync-token design).

## Problem

`loadRemoteBookmarks` (`store/auth.ts`) merged the persisted local `bookmarks` list with the server's, treated **any** local-only ref as "created offline", re-added it to the UI **and POSTed it back**. With no tombstone / last-sync marker:

> bookmark X on device A (persisted), remove X on device B, reopen device A → X is classified local-only, re-added, and re-synced up, undoing the deletion everywhere.

## Approach (client-only — no DB migration)

New persisted `pendingBookmarkAdds: string[]` — the refs we've added locally but don't yet know the server has (a guest add, or a signed-in add whose `POST` hasn't confirmed). Always a subset of `bookmarks`.

- **`toggleBookmark`** — add ⇒ push to `pendingBookmarkAdds`; remove ⇒ drop from it; `POST` success ⇒ drop (now synced); `POST`/`DELETE` failure ⇒ `rollback` (a failed `POST` also drops from pending, a failed `DELETE` just restores the local ref since it's still on the server).
- **`loadRemoteBookmarks`** — the server list is authoritative. A local ref the server omits is kept + re-uploaded **only if it's still in `pendingBookmarkAdds`**; a ref that was synced before and is now gone was deleted on another device → dropped, not resurrected.
- **`syncLocalOnlyBookmarks`** — now clears each ref from `pendingBookmarkAdds` as its `POST` succeeds (failed ones stay pending, retried next load). Generation-guarded like the rest of the store.
- **`clearAuth`** — resets `pendingBookmarkAdds`.
- **persist** — bumped to `version: 1`; `migrate` seeds `pendingBookmarkAdds` from the pre-v1 `bookmarks` list so a guest's unsynced bookmarks still sync on first login. One-time cost: the *first* authoritative load after upgrade still behaves like the old union for that user (documented in the code comment); correct delete-propagation from the next load on.

The OAuth-callback sync path (`app/callback/CallbackClient.tsx`) needs no change — a guest's pre-login bookmarks are already `pendingBookmarkAdds` via `toggleBookmark`.

## Tests (`__tests__/store/auth.test.ts`)

- **#554 regression** — a previously-synced ref (not pending) the server no longer returns is dropped and not re-POSTed.
- Guest add → login → sync-up → later load: survives login and syncs, then is not resurrected once synced and server-absent.
- `persist` migrate from pre-v1 seeds `pendingBookmarkAdds` from the bookmark list.
- Existing sync/round-trip tests updated to seed `pendingBookmarkAdds` (that's now what drives an up-sync).

## Verification

- `bun run test:ci` — green (pre-commit)

## Note

Branched on #590 (playwright-core dedupe) so the pre-commit `typecheck` step passes locally; GitHub retargets this PR to `main` once #590 merges.