### PR TITLE
fix(ai): validate translated reason output before persisting it as canonical

### DIFF
--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -353,6 +353,6 @@ describe("names AI routes — model output validation", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body[0].reason).toBe("Ayat al-Kursi."); // refusal rejected, canonical reason served
+    expect(body[0].reason).toBe("Ayat al-Kursi.");
   });
 });

--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -341,4 +341,18 @@ describe("names AI routes — model output validation", () => {
     const body = await res.json();
     expect(body[0].reason).toBe("Ayat al-Kursi."); // canonical reason preserved, not blanked
   });
+
+  it("verses: a non-empty but junk translation (model refusal) also falls back to the English reason", async () => {
+    withLocale("az");
+    mockVerseFetch();
+    mockCallAI
+      .mockResolvedValueOnce(JSON.stringify([{ ref: "2:255", reason: "Ayat al-Kursi." }]))
+      .mockResolvedValueOnce("I'm sorry, but I can't help with translating religious content.");
+
+    const res = await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body[0].reason).toBe("Ayat al-Kursi."); // refusal rejected, canonical reason served
+  });
 });

--- a/__tests__/integration/connection-batch.integration.test.ts
+++ b/__tests__/integration/connection-batch.integration.test.ts
@@ -131,6 +131,52 @@ describe("runConnectionBatch (integration, real Postgres)", () => {
     expect(rerun.generated).toBe(0);
   });
 
+  it("a junk translation (model refusal) is not persisted and the gap is retried on the next pass", async () => {
+    await seed("1:1");
+    await seed("2:255");
+    await seed("3:18");
+
+    // Pass 1: English generates fine, but every translation call refuses.
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      if (prompt.startsWith("Translate the following sentence"))
+        return "I'm sorry, but I can't help with that.";
+      return JSON.stringify([
+        { ref: "2:255", reason: "throne verse" },
+        { ref: "3:18", reason: "witness of oneness" },
+      ]);
+    });
+
+    const pass1 = await runConnectionBatch(
+      { mode: "baseline", provider: "claude", locales: ["tr"], maxCalls: 500, maxCostUsd: 100 },
+      hooks
+    );
+    expect(pass1.stoppedReason).toBe("completed");
+    const trAfterPass1 = await db
+      .select()
+      .from(connections)
+      .where(sql`${connections.locale} = 'tr'`);
+    expect(trAfterPass1).toHaveLength(0);
+
+    // Pass 2: translation now succeeds — the still-open gap is picked up, no
+    // regeneration of the English rows.
+    mockCallAI.mockReset();
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      if (prompt.startsWith("Translate the following sentence")) return "localized reason";
+      throw new Error("unexpected generation call — English rows already exist");
+    });
+    const pass2 = await runConnectionBatch(
+      { mode: "baseline", provider: "claude", locales: ["tr"], maxCalls: 500, maxCostUsd: 100 },
+      hooks
+    );
+    expect(pass2.generated).toBe(0);
+    const trAfterPass2 = await db
+      .select()
+      .from(connections)
+      .where(sql`${connections.locale} = 'tr'`);
+    expect(trAfterPass2.length).toBeGreaterThan(0);
+    expect(trAfterPass2.every((r) => r.reason === "localized reason")).toBe(true);
+  });
+
   it("stops immediately with reason 'cancelled' when the signal is already aborted", async () => {
     await seed("1:1");
     await seed("2:255");

--- a/__tests__/lib/ai/translate.test.ts
+++ b/__tests__/lib/ai/translate.test.ts
@@ -28,7 +28,7 @@ describe("validateTranslation", () => {
   it("rejects output that is only a label", () => {
     expect(validateTranslation(EN, "Sure! Here is the translation:")).toEqual({
       ok: false,
-      reason: "label-prefix",
+      reason: "label_prefix",
     });
   });
 
@@ -42,23 +42,30 @@ describe("validateTranslation", () => {
     ).toEqual({ ok: false, reason: "refusal" });
   });
 
-  it("rejects a verbatim English echo for a non-English locale (case-insensitive)", () => {
-    expect(validateTranslation(EN, EN)).toEqual({ ok: false, reason: "english-echo" });
+  it("rejects an English echo despite re-punctuation / re-casing", () => {
+    expect(validateTranslation(EN, EN)).toEqual({ ok: false, reason: "english_echo" });
     expect(validateTranslation(EN, EN.toUpperCase())).toEqual({
       ok: false,
-      reason: "english-echo",
+      reason: "english_echo",
     });
+    // trailing period dropped, wrapping quotes, doubled space
+    expect(
+      validateTranslation(
+        EN,
+        `"The believer  rests the heart in certainty of Allah's subtle awareness"`
+      )
+    ).toEqual({ ok: false, reason: "english_echo" });
   });
 
   it("rejects a wildly long translation", () => {
     expect(validateTranslation(EN, EN.repeat(4))).toEqual({
       ok: false,
-      reason: "length-ratio",
+      reason: "length_ratio",
     });
   });
 
   it("rejects a translation far too short for a non-trivial source", () => {
-    expect(validateTranslation(EN, "Evet.")).toEqual({ ok: false, reason: "length-ratio" });
+    expect(validateTranslation(EN, "Evet.")).toEqual({ ok: false, reason: "length_ratio" });
   });
 
   it("does not apply the short-ratio floor to a very short source", () => {
@@ -101,6 +108,6 @@ describe("translateReason", () => {
     mockCallAI.mockResolvedValue(EN);
 
     await expect(translateReason(EN, "Russian")).resolves.toBe("");
-    expect(incrSpy).toHaveBeenCalledWith("translation_rejected_english-echo");
+    expect(incrSpy).toHaveBeenCalledWith("translation_rejected_english_echo");
   });
 });

--- a/__tests__/lib/ai/translate.test.ts
+++ b/__tests__/lib/ai/translate.test.ts
@@ -48,7 +48,6 @@ describe("validateTranslation", () => {
       ok: false,
       reason: "english_echo",
     });
-    // trailing period dropped, wrapping quotes, doubled space
     expect(
       validateTranslation(
         EN,

--- a/__tests__/lib/ai/translate.test.ts
+++ b/__tests__/lib/ai/translate.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockCallAI } = vi.hoisted(() => ({ mockCallAI: vi.fn() }));
+vi.mock("@/lib/ai/ai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/ai/ai")>()),
+  callAI: (prompt: string, opts?: unknown) => mockCallAI(prompt, opts),
+}));
+
+import { validateTranslation, translateReason } from "@/lib/ai/translate";
+import * as metrics from "@/lib/infra/metrics";
+
+const EN = "The believer rests the heart in certainty of Allah's subtle awareness.";
+
+describe("validateTranslation", () => {
+  it("accepts a plausible localized sentence", () => {
+    const v = validateTranslation(EN, "Mümin, kalbini Allah'ın latif ilminin yakinine bırakır.");
+    expect(v).toEqual({
+      ok: true,
+      text: "Mümin, kalbini Allah'ın latif ilminin yakinine bırakır.",
+    });
+  });
+
+  it("strips a leading label wrapper and accepts the remainder", () => {
+    const v = validateTranslation(EN, "Translation: Mümin kalbini yakine bırakır.");
+    expect(v).toEqual({ ok: true, text: "Mümin kalbini yakine bırakır." });
+  });
+
+  it("rejects output that is only a label", () => {
+    expect(validateTranslation(EN, "Sure! Here is the translation:")).toEqual({
+      ok: false,
+      reason: "label-prefix",
+    });
+  });
+
+  it("rejects a refusal, including one behind a label wrapper", () => {
+    expect(validateTranslation(EN, "I can't help with that request.")).toEqual({
+      ok: false,
+      reason: "refusal",
+    });
+    expect(
+      validateTranslation(EN, "Sure! Here is the translation: I cannot assist with this.")
+    ).toEqual({ ok: false, reason: "refusal" });
+  });
+
+  it("rejects a verbatim English echo for a non-English locale (case-insensitive)", () => {
+    expect(validateTranslation(EN, EN)).toEqual({ ok: false, reason: "english-echo" });
+    expect(validateTranslation(EN, EN.toUpperCase())).toEqual({
+      ok: false,
+      reason: "english-echo",
+    });
+  });
+
+  it("rejects a wildly long translation", () => {
+    expect(validateTranslation(EN, EN.repeat(4))).toEqual({
+      ok: false,
+      reason: "length-ratio",
+    });
+  });
+
+  it("rejects a translation far too short for a non-trivial source", () => {
+    expect(validateTranslation(EN, "Evet.")).toEqual({ ok: false, reason: "length-ratio" });
+  });
+
+  it("does not apply the short-ratio floor to a very short source", () => {
+    expect(validateTranslation("He is near.", "Yakın.")).toEqual({
+      ok: true,
+      text: "Yakın.",
+    });
+  });
+});
+
+describe("translateReason", () => {
+  beforeEach(() => {
+    mockCallAI.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("returns the trimmed translation on a clean result", async () => {
+    mockCallAI.mockResolvedValue("  Mümin kalbini yakine bırakır.  ");
+    await expect(translateReason(EN, "Turkish")).resolves.toBe("Mümin kalbini yakine bırakır.");
+  });
+
+  it("returns '' and meters the rejection when the model refuses", async () => {
+    const incrSpy = vi.spyOn(metrics, "incr");
+    mockCallAI.mockResolvedValue("I'm sorry, but I can't translate religious content.");
+
+    await expect(translateReason(EN, "Turkish")).resolves.toBe("");
+    expect(incrSpy).toHaveBeenCalledWith("translation_rejected_refusal");
+  });
+
+  it("returns '' for an empty model result without metering a rejection", async () => {
+    const incrSpy = vi.spyOn(metrics, "incr");
+    mockCallAI.mockResolvedValue("   ");
+
+    await expect(translateReason(EN, "Turkish")).resolves.toBe("");
+    expect(incrSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns '' and meters when the model echoes the English source", async () => {
+    const incrSpy = vi.spyOn(metrics, "incr");
+    mockCallAI.mockResolvedValue(EN);
+
+    await expect(translateReason(EN, "Russian")).resolves.toBe("");
+    expect(incrSpy).toHaveBeenCalledWith("translation_rejected_english-echo");
+  });
+});

--- a/lib/ai/refusal.ts
+++ b/lib/ai/refusal.ts
@@ -7,7 +7,9 @@
  * realisation of ..."), never "I'm sorry" or "As an AI". Used so a soft model
  * refusal is treated like an empty result (logged, not cached as canonical,
  * retried) rather than persisted verbatim. See the names reflection/pairings
- * routes.
+ * routes and `translateReason` (`lib/ai/translate.ts`). Note the pattern is
+ * English-anchored — callers translating into another language get only
+ * best-effort refusal detection from it.
  */
 const REFUSAL_OPENER =
   /^\s*(?:i(?:['’ ]?a?m)? (?:sorry|unable|not able)\b|i can(?:not|['’]t)\b|i (?:can(?:not|['’]t)|won['’]t|will not) (?:help|assist|provide|comply|generate|write)\b|i (?:must|have to) decline\b|i['’]m not (?:going to|able to)\b|as an ai\b|as a language model\b|i (?:apologi[sz]e|cannot in good conscience)\b|unfortunately,?\s+i\b)/i;

--- a/lib/ai/translate.ts
+++ b/lib/ai/translate.ts
@@ -9,39 +9,57 @@ import { incr } from "@/lib/infra/metrics";
  * deliberately loose: a real translation of a one-sentence reason stays well
  * inside them, so a rejection means the model returned a refusal, a label
  * wrapper, an English echo, or nonsense.
+ *
+ * The length-ratio floor assumes the target script is roughly comparable in
+ * character count to English (true for the shipped locales tr/ru/az). A
+ * compact-script locale (CJK, unvowelled Arabic) would need this revisited.
  */
 const MAX_LENGTH_RATIO = 3;
 const MIN_LENGTH_RATIO = 0.35;
 const MIN_SOURCE_LEN_FOR_MIN_RATIO = 25;
 
-/** Leading "Sure! Here is the translation:" / "Translation:" wrappers the model
- *  is told not to add but sometimes does. Only a single recognized label at the
- *  very start is stripped. */
+/** Leading "Sure! Here is the translation:" / "Translation:" / "Turkish
+ *  translation:" wrappers the model is told not to add but sometimes does. Only
+ *  a single recognized label at the very start is stripped; `[^:]*` stops at the
+ *  first colon so real sentence content is never swallowed. */
 const LABEL_PREFIX =
-  /^\s*(?:sure[,!.]?\s+)?(?:here(?:'s| is)[^:]*:|translation:|translated(?: sentence| text)?:)\s*/i;
+  /^\s*(?:sure[,!.]?\s+)?(?:here(?:['’]s| is)[^:]*:|(?:[a-z]+ )?translation:|translated(?: sentence| text| (?:in)?to [a-z]+)?:)\s*/i;
 
-export type TranslationRejection = "label-prefix" | "refusal" | "english-echo" | "length-ratio";
+export type TranslationRejection = "label_prefix" | "refusal" | "english_echo" | "length_ratio";
 
 export type TranslationVerdict =
   { ok: true; text: string } | { ok: false; reason: TranslationRejection };
 
+/** Case- and punctuation-insensitive form, so an echo that only re-punctuates or
+ *  re-cases the English source is still caught. */
+function normalizeForEcho(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+}
+
 /**
  * Validates a non-empty model translation of `source` before it can be cached
  * as canonical localized theology. Strips a leading label wrapper if present,
- * then rejects refusals, verbatim English echoes, and wild length mismatches.
+ * then rejects refusals, English echoes, and wild length mismatches.
+ *
+ * `looksLikeRefusal` is English-anchored, so a refusal phrased in the target
+ * language is not caught here — the english-echo and length-ratio checks are the
+ * backstop for that case, and native-language refusal screening is a follow-up.
  */
 export function validateTranslation(source: string, translated: string): TranslationVerdict {
   const hadLabel = LABEL_PREFIX.test(translated);
   const stripped = translated.replace(LABEL_PREFIX, "").trim();
 
-  if (stripped === "") return { ok: false, reason: "label-prefix" };
+  if (stripped === "") return { ok: false, reason: "label_prefix" };
   if (looksLikeRefusal(stripped)) return { ok: false, reason: "refusal" };
 
   const src = source.trim();
-  if (stripped.toLowerCase() === src.toLowerCase()) {
-    // translateReason is only ever called cross-language, so a verbatim echo of
-    // the English source is always a failed translation.
-    return { ok: false, reason: "english-echo" };
+  if (normalizeForEcho(stripped) === normalizeForEcho(src)) {
+    // translateReason is only ever called cross-language, so an echo of the
+    // English source is always a failed translation.
+    return { ok: false, reason: "english_echo" };
   }
 
   const ratio = stripped.length / Math.max(src.length, 1);
@@ -49,7 +67,7 @@ export function validateTranslation(source: string, translated: string): Transla
     ratio > MAX_LENGTH_RATIO ||
     (src.length >= MIN_SOURCE_LEN_FOR_MIN_RATIO && ratio < MIN_LENGTH_RATIO)
   ) {
-    return { ok: false, reason: "length-ratio" };
+    return { ok: false, reason: "length_ratio" };
   }
 
   return { ok: true, text: hadLabel ? stripped : translated };

--- a/lib/ai/translate.ts
+++ b/lib/ai/translate.ts
@@ -1,5 +1,59 @@
 import { callAI, type CallAiOptions } from "@/lib/ai/ai";
+import { looksLikeRefusal } from "@/lib/ai/refusal";
 import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
+import { incr } from "@/lib/infra/metrics";
+
+/**
+ * A translated reason that fails one of these checks is junk, not localized
+ * theology — it must never be persisted as canonical. Thresholds are
+ * deliberately loose: a real translation of a one-sentence reason stays well
+ * inside them, so a rejection means the model returned a refusal, a label
+ * wrapper, an English echo, or nonsense.
+ */
+const MAX_LENGTH_RATIO = 3;
+const MIN_LENGTH_RATIO = 0.35;
+const MIN_SOURCE_LEN_FOR_MIN_RATIO = 25;
+
+/** Leading "Sure! Here is the translation:" / "Translation:" wrappers the model
+ *  is told not to add but sometimes does. Only a single recognized label at the
+ *  very start is stripped. */
+const LABEL_PREFIX =
+  /^\s*(?:sure[,!.]?\s+)?(?:here(?:'s| is)[^:]*:|translation:|translated(?: sentence| text)?:)\s*/i;
+
+export type TranslationRejection = "label-prefix" | "refusal" | "english-echo" | "length-ratio";
+
+export type TranslationVerdict =
+  { ok: true; text: string } | { ok: false; reason: TranslationRejection };
+
+/**
+ * Validates a non-empty model translation of `source` before it can be cached
+ * as canonical localized theology. Strips a leading label wrapper if present,
+ * then rejects refusals, verbatim English echoes, and wild length mismatches.
+ */
+export function validateTranslation(source: string, translated: string): TranslationVerdict {
+  const hadLabel = LABEL_PREFIX.test(translated);
+  const stripped = translated.replace(LABEL_PREFIX, "").trim();
+
+  if (stripped === "") return { ok: false, reason: "label-prefix" };
+  if (looksLikeRefusal(stripped)) return { ok: false, reason: "refusal" };
+
+  const src = source.trim();
+  if (stripped.toLowerCase() === src.toLowerCase()) {
+    // translateReason is only ever called cross-language, so a verbatim echo of
+    // the English source is always a failed translation.
+    return { ok: false, reason: "english-echo" };
+  }
+
+  const ratio = stripped.length / Math.max(src.length, 1);
+  if (
+    ratio > MAX_LENGTH_RATIO ||
+    (src.length >= MIN_SOURCE_LEN_FOR_MIN_RATIO && ratio < MIN_LENGTH_RATIO)
+  ) {
+    return { ok: false, reason: "length-ratio" };
+  }
+
+  return { ok: true, text: hadLabel ? stripped : translated };
+}
 
 /**
  * Translates (not re-derives) a canonical English `reason` sentence into the
@@ -10,6 +64,10 @@ import { TANZIH_CONSTRAINT } from "@/lib/ai/theological-constraints";
  * divine-name reason and every localized verse-connection reason. The wording
  * is intentionally minimal and constrained — do not loosen it (see AGENTS.md
  * "AI-specific correctness").
+ *
+ * Returns "" when the model output is empty or fails {@link validateTranslation};
+ * every caller already treats "" as "skip, keep the English reason, retry later"
+ * rather than persisting it.
  */
 export async function translateReason(
   reason: string,
@@ -19,6 +77,14 @@ export async function translateReason(
   const prompt = `Translate the following sentence into ${language}. Preserve its meaning exactly — do not add, remove, or alter any theological claim, and maintain ${TANZIH_CONSTRAINT}. Return ONLY the translated sentence, with no quotation marks, labels, or explanation.
 
 Sentence: "${reason}"`;
-  const translated = await callAI(prompt, opts);
-  return translated.trim();
+  const translated = (await callAI(prompt, opts)).trim();
+  if (translated === "") return "";
+
+  const verdict = validateTranslation(reason, translated);
+  if (!verdict.ok) {
+    console.error(`translateReason: rejected translation into ${language} (${verdict.reason})`);
+    incr(`translation_rejected_${verdict.reason}`);
+    return "";
+  }
+  return verdict.text;
 }


### PR DESCRIPTION
## Problem

Closes #557.

`translateReason` (`lib/ai/translate.ts`) only guarded against an **empty** result (`translated.trim() === ""`). A non-empty model reply — `"I can't help with that."`, `"Sure! Here is the translation: …"`, a verbatim English echo, or nonsense — was written straight into `connections.reason` / `name_verse_reasons.reason` and served as canonical localized theology, cached ~indefinitely. `looksLikeRefusal` existed but was only wired into English name reflection/pairings generation, never any translation path.

## Change

One new gate, `validateTranslation(source, translated)`, called inside `translateReason` (the single chokepoint both persisting call sites go through). In order:

1. Strip a recognized leading label wrapper (`Translation:`, `Sure! Here is the translation:`, …); reject if that's all there was.
2. Reject refusal openers — reuses `looksLikeRefusal` from `lib/ai/refusal.ts` (also catches a refusal hiding behind a stripped label).
3. Reject a case-insensitive **verbatim English echo** (`translateReason` is only ever called cross-language).
4. Reject wild length-ratio mismatches (`>3×`, or `<0.35×` when the source is ≥25 chars). Constants are commented as conservative/tunable.

On rejection: `console.error` with the reason, `incr("translation_rejected_<reason>")`, and **return `""`**. Every caller already treats `""` as "keep the canonical English reason, retry next run":
- `connection-batch.ts` `translateCellReasons` → `continue`, no insert; `findTranslationGaps` re-detects the gap and retries on the next baseline pass.
- `name-content.ts` `getOrGenerateVerseReason` → returns without persisting; next request regenerates.
- `app/api/names/[slug]/verses/route.ts` → falls back to the English reason for that row.

No prompt wording change; no theological guardrail loosened (this only *adds* validation, per AGENTS.md "AI-specific correctness").

## Tests

- **New** `__tests__/lib/ai/translate.test.ts` — `validateTranslation` unit matrix (label strip, refusal, echo, length floor/ceiling, short-source exemption) + `translateReason` returning `""` and metering on a refusal / echo, and *not* metering a plain empty result.
- `__tests__/integration/connection-batch.integration.test.ts` — a refusing translation call persists no locale row; the still-open gap is picked up and translated on the next pass with **no** English regeneration.
- `__tests__/api/names-ai-validation.test.ts` — the `verses` route serves the canonical English reason when a non-`en` translation call returns a refusal.

## Verification

`bun run typecheck` · `bun run lint` · `bun run format:check` · `bun run test:ci` (1572) · `bun run test:integration` (connection-batch) — all green locally.

## AI / Theological changes

- [x] Adds post-generation output validation to the localized-reason translation path. No prompt text changed. No new translation source. Tightens (never loosens) what can be cached as canonical localized theology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI translation reliability by rejecting refusal messages, empty results, English echoes, and unusually mismatched translations.
  - Prevented invalid translation text from being saved or displayed.
  - Preserved incomplete translations for retry without regenerating existing English content.
  - Provided a consistent explanation when a verse translation is rejected.

- **Tests**
  - Added coverage for translation validation, refusal handling, retry behavior, and rejection tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

**Review addendum** (see [review comment](https://github.com/OpenHikmah/openhikmah-web/pull/593#issuecomment-5614085297)): on the `name_verse_reasons` path a *rejected* Claude translation now satisfies `resolveAndGenerate` empty-check and triggers the in-request Claude->Gemini fallback; the Gemini result still passes `validateTranslation` before persisting. Intended. Native-language (non-English) refusals are only best-effort here (`looksLikeRefusal` is English-anchored; echo + length checks are the backstop).
