### PR TITLE
fix(connections): make the live path en-canonical for non-English locales

### DIFF
--- a/__tests__/integration/graph.integration.test.ts
+++ b/__tests__/integration/graph.integration.test.ts
@@ -132,6 +132,55 @@ describe("connection graph (integration, real Postgres)", () => {
     expect(mockCallAI).toHaveBeenCalledTimes(2);
   });
 
+  it("a partial locale cache is repaired on the next request — only the missing ref is re-translated", async () => {
+    await seed("2:255");
+    await seed("3:18");
+    let attemptsForA = 0;
+    let translationCalls = 0;
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      if (prompt.startsWith("Translate the following sentence")) {
+        translationCalls++;
+        if (prompt.includes("reason A")) {
+          // First attempt for A fails (empty → English fallback, not persisted);
+          // a later attempt succeeds.
+          return attemptsForA++ === 0 ? "" : "tr A";
+        }
+        return "tr B";
+      }
+      return JSON.stringify([
+        { ref: "2:255", reason: "reason A" },
+        { ref: "3:18", reason: "reason B" },
+      ]);
+    });
+
+    // Cold tr request: en generated, B translates, A fails → only B persisted for tr.
+    const first = await getConnections("1:1", "thematic", source, { locale: "tr" });
+    expect(first.map((c) => c.reason)).toEqual(["reason A", "tr B"]);
+    let rows = await db.select().from(connections);
+    expect(rows.filter((r) => r.locale === "tr").map((r) => r.toRef)).toEqual(["3:18"]);
+    expect(translationCalls).toBe(2);
+
+    // Next tr request: 1 tr row < 2 en rows → not a hit. It re-translates ONLY A
+    // (B is reused from cache) and does NOT regenerate the English selection.
+    const second = await getConnections("1:1", "thematic", source, { locale: "tr" });
+    expect(second.map((c) => c.reason)).toEqual(["tr A", "tr B"]);
+    expect(translationCalls).toBe(3); // just the one retry for A
+    rows = await db.select().from(connections);
+    expect(
+      rows
+        .filter((r) => r.locale === "tr")
+        .map((r) => r.toRef)
+        .sort()
+    ).toEqual(["2:255", "3:18"]);
+    // One English generation total across both requests.
+    expect(await db.select().from(aiGenerations)).toHaveLength(1);
+
+    // Now complete: a third tr request is a pure cache hit.
+    const third = await getConnections("1:1", "thematic", source, { locale: "tr" });
+    expect(third.map((c) => c.reason)).toEqual(["tr A", "tr B"]);
+    expect(translationCalls).toBe(3);
+  });
+
   it("a cold non-en request generates English first, then translates it", async () => {
     await seed("2:255");
     mockCallAI.mockImplementation(async (prompt: string) => {

--- a/__tests__/integration/graph.integration.test.ts
+++ b/__tests__/integration/graph.integration.test.ts
@@ -6,6 +6,7 @@ import { sql } from "drizzle-orm";
 // count / response body are unchanged.
 const { mockCallAI } = vi.hoisted(() => ({ mockCallAI: vi.fn() }));
 vi.mock("@/lib/ai/ai", () => ({
+  callAI: vi.fn((prompt: string) => mockCallAI(prompt)),
   callAIDetailed: vi.fn(async (prompt: string) => ({
     text: await mockCallAI(prompt),
     usage: { inputTokens: 100, outputTokens: 20 },
@@ -102,26 +103,49 @@ describe("connection graph (integration, real Postgres)", () => {
     expect(await db.select().from(connections)).toHaveLength(1);
   });
 
-  it("caches connections per locale: a hit in one locale still generates for another", async () => {
+  it("a non-en request translates the canonical English selection, never re-derives it", async () => {
     await seed("2:255");
-    mockCallAI
-      .mockResolvedValueOnce(JSON.stringify([{ ref: "2:255", reason: "throne verse" }]))
-      .mockResolvedValueOnce(JSON.stringify([{ ref: "2:255", reason: "ayet-el kursi" }]));
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      if (prompt.startsWith("Translate the following sentence")) return "ayet-el kürsi";
+      return JSON.stringify([{ ref: "2:255", reason: "throne verse" }]);
+    });
 
     const en = await getConnections("1:1", "thematic", source, { locale: "en" });
-    expect(en[0]).toMatchObject({ reason: "throne verse" });
-    expect(mockCallAI).toHaveBeenCalledTimes(1);
+    expect(en[0]).toMatchObject({ ref: "2:255", reason: "throne verse" });
+    expect(mockCallAI).toHaveBeenCalledTimes(1); // one generation
 
-    // Different locale — must NOT hit the English row, generates its own.
+    // Turkish: same verse selection, reason translated — one extra call, NO regeneration.
     const tr = await getConnections("1:1", "thematic", source, { locale: "tr" });
-    expect(tr[0]).toMatchObject({ reason: "ayet-el kursi" });
+    expect(tr[0]).toMatchObject({ ref: "2:255", reason: "ayet-el kürsi" });
     expect(mockCallAI).toHaveBeenCalledTimes(2);
-    expect(await db.select().from(connections)).toHaveLength(2);
+    const rows = await db.select().from(connections);
+    expect(rows).toHaveLength(2); // en + tr, same toRef
+    expect(rows.filter((r) => r.locale === "tr").map((r) => r.toRef)).toEqual(["2:255"]);
 
-    // Re-requesting English now serves from cache, not a third AI call.
-    const enAgain = await getConnections("1:1", "thematic", source, { locale: "en" });
-    expect(enAgain[0]).toMatchObject({ reason: "throne verse" });
+    // Both locales now cached — no further AI calls.
+    expect((await getConnections("1:1", "thematic", source, { locale: "en" }))[0]).toMatchObject({
+      reason: "throne verse",
+    });
+    expect((await getConnections("1:1", "thematic", source, { locale: "tr" }))[0]).toMatchObject({
+      reason: "ayet-el kürsi",
+    });
     expect(mockCallAI).toHaveBeenCalledTimes(2);
+  });
+
+  it("a cold non-en request generates English first, then translates it", async () => {
+    await seed("2:255");
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      if (prompt.startsWith("Translate the following sentence")) return "witness of oneness (ru)";
+      return JSON.stringify([{ ref: "2:255", reason: "witness of oneness" }]);
+    });
+
+    const ru = await getConnections("1:1", "thematic", source, { locale: "ru" });
+
+    expect(ru[0]).toMatchObject({ ref: "2:255", reason: "witness of oneness (ru)" });
+    expect(mockCallAI).toHaveBeenCalledTimes(2); // 1 English generation + 1 translation
+    const rows = await db.select().from(connections);
+    expect(rows.map((r) => r.locale).sort()).toEqual(["en", "ru"]);
+    expect(rows.find((r) => r.locale === "en")?.reason).toBe("witness of oneness");
   });
 
   it("persists a concrete model id even when no provider is passed (resolves the flag)", async () => {

--- a/__tests__/integration/graph.integration.test.ts
+++ b/__tests__/integration/graph.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 // Real Postgres (Testcontainers) — only the AI call is mocked. The generator
 // uses callAIDetailed; mockCallAI stays the text source so assertions on call
@@ -179,6 +179,42 @@ describe("connection graph (integration, real Postgres)", () => {
     const third = await getConnections("1:1", "thematic", source, { locale: "tr" });
     expect(third.map((c) => c.reason)).toEqual(["tr A", "tr B"]);
     expect(translationCalls).toBe(3);
+  });
+
+  it("a retired locale translation is not resurrected — a repair serves the fresh text without reviving the old row", async () => {
+    await seed("2:255");
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      if (prompt.startsWith("Translate the following sentence")) return "old tr";
+      return JSON.stringify([{ ref: "2:255", reason: "reason A" }]);
+    });
+
+    // Cold tr request: generates en, translates, persists one active tr row.
+    await getConnections("1:1", "thematic", source, { locale: "tr" });
+    let rows = await db.select().from(connections).where(eq(connections.locale, "tr"));
+    expect(rows).toMatchObject([{ toRef: "2:255", reason: "old tr", status: "active" }]);
+
+    // An admin retires the (bad) translation — the English row is untouched.
+    await db
+      .update(connections)
+      .set({ status: "retired" })
+      .where(and(eq(connections.locale, "tr"), eq(connections.toRef, "2:255")));
+
+    // The retired row makes the locale incomplete again (no ACTIVE tr row for
+    // the canonical en ref), so the next request repairs it with a fresh
+    // translation — served in the response, but NOT persisted over the
+    // retired row (the unique key is still held by it).
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      if (prompt.startsWith("Translate the following sentence")) return "new tr";
+      return JSON.stringify([{ ref: "2:255", reason: "reason A" }]);
+    });
+    const repaired = await getConnections("1:1", "thematic", source, { locale: "tr" });
+
+    expect(repaired.map((c) => c.reason)).toEqual(["new tr"]); // fresh text served
+    rows = await db.select().from(connections).where(eq(connections.locale, "tr"));
+    expect(rows).toHaveLength(1); // no new row inserted, the retired one still holds the key
+    expect(rows[0]).toMatchObject({ reason: "old tr", status: "retired" }); // untouched, not resurrected
+    // Only ever generated English once across the whole test.
+    expect(await db.select().from(aiGenerations)).toHaveLength(1);
   });
 
   it("a cold non-en request generates English first, then translates it", async () => {

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -487,6 +487,27 @@ describe("getConnections — en-canonical localized reasons", () => {
     expect(mockGenerate).toHaveBeenCalledTimes(1);
     expect(mockTranslateReason).toHaveBeenCalledTimes(1); // only the tr caller translates
   });
+
+  it("spends the client budget per translation and serves English once it is out", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([]));
+    mockGenerate.mockResolvedValue([result("2:255"), result("3:18"), result("59:22")]);
+    mockTranslateReason.mockImplementation(async (r: string) => `TR(${r})`);
+    // Upfront miss consume passes; then the first per-row consume passes and the
+    // rest are over budget.
+    mockConsume.mockResolvedValueOnce(true).mockResolvedValueOnce(true).mockResolvedValue(false);
+
+    const out = await getConnections("1:1", "thematic", source, {
+      locale: "tr",
+      clientKey: "9.9.9.9",
+    });
+
+    expect(mockTranslateReason).toHaveBeenCalledTimes(1); // stopped after the budget ran out
+    expect(out.map((c) => c.reason)).toEqual(["TR(because)", "because", "because"]);
+    // only the one successful translation is persisted
+    const trInsert = mockValues.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>>;
+    expect(trInsert).toHaveLength(1);
+    expect(trInsert[0]).toMatchObject({ toRef: "2:255", locale: "tr" });
+  });
 });
 
 describe("getConnections — single-flight de-duplication", () => {

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -35,6 +35,7 @@ const {
   mockResolveVerse,
   mockConsume,
   mockIncr,
+  mockTranslateReason,
 } = vi.hoisted(() => {
   // Mirrors the real chain: .values(...).onConflictDoNothing().returning(...) —
   // `returning` resolves with the rows actually inserted (empty by default here,
@@ -55,10 +56,12 @@ const {
     mockResolveVerse: vi.fn(),
     mockConsume: vi.fn(),
     mockIncr: vi.fn(),
+    mockTranslateReason: vi.fn(),
   };
 });
 
 vi.mock("@/lib/infra/db", () => ({ db: { select: mockSelect, insert: mockInsert } }));
+vi.mock("@/lib/ai/translate", () => ({ translateReason: mockTranslateReason }));
 const { ConnectionParseError } = vi.hoisted(() => ({
   ConnectionParseError: class ConnectionParseError extends Error {
     constructor(msg = "unparseable") {
@@ -368,7 +371,7 @@ describe("getConnections", () => {
   });
 });
 
-describe("getConnections — per-locale caching", () => {
+describe("getConnections — en-canonical localized reasons", () => {
   beforeEach(() => {
     mockSelect.mockReset();
     mockInsert.mockClear();
@@ -384,36 +387,18 @@ describe("getConnections — per-locale caching", () => {
     mockConsume.mockResolvedValue(true);
     mockDiscover.mockResolvedValue([]);
     mockResolveVerse.mockImplementation(async (ref: string) => verse(ref));
+    mockTranslateReason.mockReset();
   });
 
-  it("persists the reason under the requested locale", async () => {
-    mockSelect.mockReturnValue(makeSelectChain([]));
-    mockGenerate.mockResolvedValue([result("2:255")]);
+  it("on a non-en miss with no en rows, generates the selection in ENGLISH then translates each reason", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // tr read + en read both miss
+    mockGenerate.mockResolvedValue([result("2:255"), result("3:18")]);
+    mockTranslateReason.mockImplementation(async (reason: string) => `TR(${reason})`);
 
-    await getConnections("1:1", "thematic", source, { locale: "tr" });
+    const out = await getConnections("1:1", "thematic", source, { locale: "tr" });
 
-    expect(mockGenerate).toHaveBeenCalledWith(
-      "1:1",
-      SOURCE_ARABIC,
-      "tr",
-      "thematic",
-      "tr",
-      RESOLVED
-    );
-    const persisted = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
-    expect(persisted[0]).toMatchObject({ locale: "tr" });
-  });
-
-  it("does not coalesce concurrent misses for the same verse+kind but different locales", async () => {
-    mockSelect.mockReturnValue(makeSelectChain([]));
-    mockGenerate.mockImplementation(async () => [result("2:255")]);
-
-    await Promise.all([
-      getConnections("1:1", "thematic", source, { locale: "en" }),
-      getConnections("1:1", "thematic", source, { locale: "tr" }),
-    ]);
-
-    expect(mockGenerate).toHaveBeenCalledTimes(2);
+    // selection derived once, in English — never natively per locale
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
     expect(mockGenerate).toHaveBeenCalledWith(
       "1:1",
       SOURCE_ARABIC,
@@ -422,14 +407,85 @@ describe("getConnections — per-locale caching", () => {
       "en",
       RESOLVED
     );
-    expect(mockGenerate).toHaveBeenCalledWith(
-      "1:1",
-      SOURCE_ARABIC,
-      "tr",
-      "thematic",
-      "tr",
-      RESOLVED
+    // each English reason translated for the requested locale
+    expect(mockTranslateReason).toHaveBeenCalledTimes(2);
+    expect(mockTranslateReason).toHaveBeenCalledWith("because", "Turkish", RESOLVED);
+    // the persisted locale rows carry the translated text, tagged tr
+    const trInsert = mockValues.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>>;
+    expect(trInsert).toEqual([
+      expect.objectContaining({
+        toRef: "2:255",
+        kind: "thematic",
+        locale: "tr",
+        reason: "TR(because)",
+      }),
+      expect.objectContaining({ toRef: "3:18", locale: "tr", reason: "TR(because)" }),
+    ]);
+    expect(out.map((c) => c.reason)).toEqual(["TR(because)", "TR(because)"]);
+  });
+
+  it("translates the existing en rows without regenerating when they are already cached", async () => {
+    // First select (tr cache read) misses; second (en cache read) hits.
+    mockSelect.mockReturnValueOnce(makeSelectChain([])).mockReturnValue(
+      makeSelectChain([
+        {
+          fromRef: "1:1",
+          toRef: "2:255",
+          kind: "thematic",
+          reason: "en reason",
+          status: "active",
+        },
+      ])
     );
+    mockReturning.mockResolvedValue([{ toRef: "2:255" }]); // tr insert wins its row, no conflict re-read
+    mockTranslateReason.mockResolvedValue("ru reason");
+
+    const out = await getConnections("1:1", "thematic", source, { locale: "ru" });
+
+    expect(mockGenerate).not.toHaveBeenCalled();
+    expect(mockGenerateGrounded).not.toHaveBeenCalled();
+    expect(mockTranslateReason).toHaveBeenCalledWith("en reason", "Russian", RESOLVED);
+    expect(out[0]).toMatchObject({ ref: "2:255", reason: "ru reason" });
+  });
+
+  it("serves the English reason (and does not persist) when a row's translation fails", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([]));
+    mockGenerate.mockResolvedValue([result("2:255")]);
+    mockTranslateReason.mockResolvedValue(""); // rejected / failed translation
+
+    const out = await getConnections("1:1", "thematic", source, { locale: "tr" });
+
+    expect(out[0].reason).toBe("because"); // English reason served
+    expect(mockIncr).toHaveBeenCalledWith("connections_live_translate_failed");
+    // only the en insert happened — no tr row persisted
+    const insertLocales = mockValues.mock.calls.map(
+      (c) => (c[0] as Array<Record<string, unknown>>)[0]?.locale
+    );
+    expect(insertLocales).not.toContain("tr");
+  });
+
+  it("a concurrent en + tr miss derives the English selection ONCE, then tr translates it", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([]));
+    let releaseGen!: (v: ConnectionResult[]) => void;
+    mockGenerate.mockImplementation(
+      () =>
+        new Promise<ConnectionResult[]>((res) => {
+          releaseGen = res;
+        })
+    );
+    mockTranslateReason.mockImplementation(async (r: string) => `TR(${r})`);
+
+    const all = Promise.all([
+      getConnections("1:1", "thematic", source, { locale: "en" }),
+      getConnections("1:1", "thematic", source, { locale: "tr" }),
+    ]);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockGenerate).toHaveBeenCalledTimes(1); // en generation coalesced across both
+
+    releaseGen([result("2:255")]);
+    await all;
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+    expect(mockTranslateReason).toHaveBeenCalledTimes(1); // only the tr caller translates
   });
 });
 

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -549,6 +549,64 @@ describe("getConnections — en-canonical localized reasons", () => {
     expect(out.map((c) => c.reason)).toEqual(["native tr"]);
   });
 
+  it("does not treat count-matching but ref-divergent locale rows as complete (a retired-and-replaced en edge)", async () => {
+    // en canonical is now {3:18, 59:22} (an old ref was retired, a new one
+    // added); tr still reflects the old canonical set {2:255, 3:18} — same
+    // COUNT (2) but a different ref set.
+    const trRows = [
+      {
+        fromRef: "1:1",
+        toRef: "2:255",
+        kind: "thematic",
+        reason: "tr A (orphan)",
+        status: "active",
+      },
+      { fromRef: "1:1", toRef: "3:18", kind: "thematic", reason: "tr B", status: "active" },
+    ];
+    const enRows = [
+      { fromRef: "1:1", toRef: "3:18", kind: "thematic", reason: "en B", status: "active" },
+      { fromRef: "1:1", toRef: "59:22", kind: "thematic", reason: "en C", status: "active" },
+    ];
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain(trRows))
+      .mockReturnValue(makeSelectChain(enRows));
+    mockTranslateReason.mockImplementation(async (reason: string) => `TR(${reason})`);
+    mockReturning.mockResolvedValue([{ toRef: "59:22" }]);
+
+    const out = await getConnections("1:1", "thematic", source, { locale: "tr" });
+
+    expect(mockGenerate).not.toHaveBeenCalled(); // en selection already exists
+    // only the genuinely missing canonical ref (59:22) is translated
+    expect(mockTranslateReason).toHaveBeenCalledTimes(1);
+    expect(mockTranslateReason).toHaveBeenCalledWith("en C", "Turkish", RESOLVED);
+    // the orphaned ref (2:255, no longer canonical) is dropped from the result
+    expect(out.map((c) => c.ref)).toEqual(["3:18", "59:22"]);
+    expect(out.map((c) => c.reason)).toEqual(["tr B", "TR(en C)"]);
+  });
+
+  it("serves the existing partial locale rows instead of erroring when a repair is rate-limited", async () => {
+    const trRows = [
+      { fromRef: "1:1", toRef: "2:255", kind: "thematic", reason: "tr A", status: "active" },
+    ];
+    const enRows = [
+      { fromRef: "1:1", toRef: "2:255", kind: "thematic", reason: "en A", status: "active" },
+      { fromRef: "1:1", toRef: "3:18", kind: "thematic", reason: "en B", status: "active" },
+    ];
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain(trRows))
+      .mockReturnValue(makeSelectChain(enRows));
+    mockConsume.mockResolvedValue(false); // client is over budget
+
+    const out = await getConnections("1:1", "thematic", source, {
+      locale: "tr",
+      clientKey: "9.9.9.9",
+    });
+
+    expect(out.map((c) => c.reason)).toEqual(["tr A"]); // served what's cached, not an error
+    expect(mockTranslateReason).not.toHaveBeenCalled();
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
   it("spends the client budget per translation and serves English once it is out", async () => {
     mockSelect.mockReturnValue(makeSelectChain([]));
     mockGenerate.mockResolvedValue([result("2:255"), result("3:18"), result("59:22")]);

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -488,6 +488,67 @@ describe("getConnections — en-canonical localized reasons", () => {
     expect(mockTranslateReason).toHaveBeenCalledTimes(1); // only the tr caller translates
   });
 
+  it("a fully-translated locale cell is served from cache without generating or translating", async () => {
+    const trRows = [
+      { fromRef: "1:1", toRef: "2:255", kind: "thematic", reason: "tr A", status: "active" },
+      { fromRef: "1:1", toRef: "3:18", kind: "thematic", reason: "tr B", status: "active" },
+    ];
+    const enRows = [
+      { fromRef: "1:1", toRef: "2:255", kind: "thematic", reason: "en A", status: "active" },
+      { fromRef: "1:1", toRef: "3:18", kind: "thematic", reason: "en B", status: "active" },
+    ];
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain(trRows))
+      .mockReturnValue(makeSelectChain(enRows));
+
+    const out = await getConnections("1:1", "thematic", source, { locale: "tr" });
+
+    expect(mockGenerate).not.toHaveBeenCalled();
+    expect(mockTranslateReason).not.toHaveBeenCalled();
+    expect(out.map((c) => c.reason)).toEqual(["tr A", "tr B"]);
+  });
+
+  it("a PARTIAL locale cell is not a hit — it translates only the refs still missing", async () => {
+    // tr has 1 of the 2 canonical en rows (a prior pass failed or ran out of budget).
+    const trRows = [
+      { fromRef: "1:1", toRef: "2:255", kind: "thematic", reason: "tr A", status: "active" },
+    ];
+    const enRows = [
+      { fromRef: "1:1", toRef: "2:255", kind: "thematic", reason: "en A", status: "active" },
+      { fromRef: "1:1", toRef: "3:18", kind: "thematic", reason: "en B", status: "active" },
+    ];
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain(trRows))
+      .mockReturnValue(makeSelectChain(enRows));
+    mockTranslateReason.mockImplementation(async (reason: string) => `TR(${reason})`);
+    mockReturning.mockResolvedValue([{ toRef: "3:18" }]);
+
+    const out = await getConnections("1:1", "thematic", source, { locale: "tr" });
+
+    expect(mockGenerate).not.toHaveBeenCalled(); // en selection already exists
+    // only the missing ref is translated; the already-translated one is reused
+    expect(mockTranslateReason).toHaveBeenCalledTimes(1);
+    expect(mockTranslateReason).toHaveBeenCalledWith("en B", "Turkish", RESOLVED);
+    const trInsert = mockValues.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>>;
+    expect(trInsert).toEqual([
+      expect.objectContaining({ toRef: "3:18", locale: "tr", reason: "TR(en B)" }),
+    ]);
+    expect(out.map((c) => c.reason)).toEqual(["tr A", "TR(en B)"]);
+  });
+
+  it("serves pre-#594 native locale rows (no en canonical) as a hit, without regenerating", async () => {
+    const trRows = [
+      { fromRef: "1:1", toRef: "2:255", kind: "thematic", reason: "native tr", status: "active" },
+    ];
+    mockSelect.mockReturnValueOnce(makeSelectChain(trRows)).mockReturnValue(makeSelectChain([])); // no en rows to compare against
+
+    const out = await getConnections("1:1", "thematic", source, { locale: "tr" });
+
+    expect(mockGenerate).not.toHaveBeenCalled();
+    expect(mockTranslateReason).not.toHaveBeenCalled();
+    expect(out.map((c) => c.reason)).toEqual(["native tr"]);
+  });
+
   it("spends the client budget per translation and serves English once it is out", async () => {
     mockSelect.mockReturnValue(makeSelectChain([]));
     mockGenerate.mockResolvedValue([result("2:255"), result("3:18"), result("59:22")]);

--- a/lib/ai/connection-batch.ts
+++ b/lib/ai/connection-batch.ts
@@ -26,7 +26,9 @@ import type { EdgeKind } from "@/types/quran";
  *
  * Non-English rows are produced by translating the English reason (mirrors the
  * divine-names name_verse_reasons pattern) — the verse SELECTION is never
- * re-derived per locale.
+ * re-derived per locale. The live path (lib/ai/graph-service.ts
+ * `generateLocalizedCell`) follows the same rule, so both converge on one set
+ * of rows per cell instead of layering mixed-provenance ones.
  *
  * Resumable/idempotent: the work list is recomputed from the DB on every run,
  * and every cell's writes commit as it goes, so a crash or a budget stop loses
@@ -556,7 +558,6 @@ export async function runConnectionBatch(
           cell.kind,
           { arabicText: cell.arabicText, translation: cell.translation },
           excludeRefs,
-          "en",
           opts.provider,
           model,
           { apiKey: opts.apiKey, signal }

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -24,13 +24,13 @@ import type { ConnectionResult, EdgeKind } from "@/types/quran";
  */
 
 /**
- * Single-flight registry: concurrent cache misses for the SAME verse+kind+locale
- * share one in-flight generation instead of each firing its own (expensive) AI
- * call. Per-process — full coverage on the single box; a multi-instance deployment
+ * Single-flight registry: concurrent cache misses for the SAME cell+locale share
+ * one in-flight generation instead of each firing its own (expensive) AI call.
+ * Per-process — full coverage on the single box; a multi-instance deployment
  * would need a Redis lock to coalesce across processes (deferred). Keyed by
  * `${fromRef}:${kind}:${locale}:${provider}:${model}:${excludeRefs}`; entries are
- * removed as soon as the generation settles. A non-`en` miss also joins the `en`
- * key while it ensures the canonical rows.
+ * removed as soon as the work settles. A non-`en` miss also joins the `en` key
+ * while it ensures the canonical rows.
  */
 const inFlight = new Map<string, Promise<CellGenerationResult>>();
 
@@ -81,19 +81,24 @@ function cellKey(
   return `${fromRef}:${kind}:${locale}:${provider}:${model}:${[...excludeRefs].sort().join(",")}`;
 }
 
-/** Join an in-flight identical generation if one is running, otherwise lead it.
- *  The get→set MUST stay synchronous (no await between them) or two concurrent
- *  callers could both become the leader. */
+/**
+ * Join an in-flight identical unit of work if one is running, otherwise lead it.
+ * The get→set MUST stay synchronous (no await between them) or two concurrent
+ * callers could both become the leader. `meterAsGeneration` counts the lead /
+ * coalesce as an AI selection-generation — set only for the `en` generation key,
+ * not the non-`en` wrapper (which is a translation batch, not a generation).
+ */
 async function singleFlight(
   key: string,
-  factory: () => Promise<CellGenerationResult>
+  factory: () => Promise<CellGenerationResult>,
+  meterAsGeneration = false
 ): Promise<CellGenerationResult> {
   const pending = inFlight.get(key);
   if (pending) {
-    incr("gen_coalesced");
+    if (meterAsGeneration) incr("gen_coalesced");
     return pending;
   }
-  incr("gen_started");
+  if (meterAsGeneration) incr("gen_started");
   const work = factory();
   inFlight.set(key, work);
   try {
@@ -104,7 +109,10 @@ async function singleFlight(
 }
 
 /** Hydrate stored edges (which carry only refs + reason) into full results. */
-async function hydrate(rows: Connection[], kind: EdgeKind): Promise<ConnectionResult[]> {
+async function hydrate(
+  rows: Pick<Connection, "toRef" | "reason">[],
+  kind: EdgeKind
+): Promise<ConnectionResult[]> {
   const resolved = await Promise.all(rows.map((r) => resolveVerse(r.toRef)));
   return rows
     .map((r, i) => {
@@ -126,14 +134,20 @@ async function hydrate(rows: Connection[], kind: EdgeKind): Promise<ConnectionRe
     .filter((c): c is ConnectionResult => c !== null);
 }
 
-/** Read the active cached edges for one cell+locale, hydrated. */
-async function readActiveConnections(
+/** Raw active cached edges for one cell+locale (not hydrated — callers decide a
+ *  hit on the ROW count, so a cell whose target verses transiently fail to
+ *  resolve is still a hit, not a re-generation trigger). */
+async function readActiveRows(
   fromRef: string,
   kind: EdgeKind,
   locale: Locale,
   excludeRefs: string[]
-): Promise<ConnectionResult[]> {
-  const rows = await db
+): Promise<Connection[]> {
+  // A single generation inserts ~12 edges (see discoverCandidates), but this has
+  // no upper bound enforced at write time — cap defensively so a future code path
+  // that inserts more edges per source ref can't turn this into an unbounded
+  // per-key list query, the same shape hardened elsewhere.
+  return db
     .select()
     .from(connections)
     .where(
@@ -145,12 +159,7 @@ async function readActiveConnections(
         ...(excludeRefs.length > 0 ? [notInArray(connections.toRef, excludeRefs)] : [])
       )
     )
-    // A single generation inserts ~12 edges (see discoverCandidates), but this
-    // has no upper bound enforced at write time — cap defensively so a future
-    // code path that inserts more edges per source ref can't turn this into an
-    // unbounded per-key list query, the same shape hardened elsewhere.
     .limit(200);
-  return hydrate(rows, kind);
 }
 
 /**
@@ -167,8 +176,8 @@ export async function getConnections(
   const excludeRefs = options.excludeRefs ?? [];
   const locale = options.locale ?? "en";
 
-  const existing = await readActiveConnections(fromRef, kind, locale, excludeRefs);
-  if (existing.length > 0) return existing;
+  const existing = await readActiveRows(fromRef, kind, locale, excludeRefs);
+  if (existing.length > 0) return hydrate(existing, kind);
 
   // Cache miss — this is the expensive path, so rate-limit it (per client, as
   // before: the limiter runs for every caller, so the budget semantics are
@@ -188,10 +197,22 @@ export async function getConnections(
   const model = await resolveModel("connections", provider, options.model);
 
   const key = cellKey(fromRef, kind, locale, provider, model, excludeRefs);
-  const result = await singleFlight(key, () =>
+  const result = await singleFlight(
+    key,
+    () =>
+      locale === "en"
+        ? generateConnectionsForCell(fromRef, kind, source, excludeRefs, provider, model)
+        : generateLocalizedCell(
+            fromRef,
+            kind,
+            source,
+            excludeRefs,
+            locale,
+            provider,
+            model,
+            options.clientKey
+          ),
     locale === "en"
-      ? generateConnectionsForCell(fromRef, kind, source, excludeRefs, provider, model)
-      : generateLocalizedCell(fromRef, kind, source, excludeRefs, locale, provider, model)
   );
   return result.results;
 }
@@ -199,9 +220,14 @@ export async function getConnections(
 /**
  * Non-`en` miss body: ensure the canonical English rows exist (generating them
  * through the same single-flight if not), then translate each English reason
- * into `locale` and cache the translated rows under that locale. A reason whose
- * translation fails is served in English for this response and left unpersisted
- * so a later request or the backfill retries it.
+ * into `locale` and cache the translated rows under that locale.
+ *
+ * A row whose translation fails (empty, rejected, or the provider threw) is
+ * served in English for this response and left unpersisted so a later request or
+ * the backfill retries it. Each translation call also spends the client's
+ * generation budget when `clientKey` is set, so a cold non-`en` cell can't turn
+ * one rate-limit token into a dozen LLM calls; once the budget is out, the
+ * remaining rows are served in English.
  */
 async function generateLocalizedCell(
   fromRef: string,
@@ -210,45 +236,71 @@ async function generateLocalizedCell(
   excludeRefs: string[],
   locale: Locale,
   provider: Provider,
-  model: string
+  model: string,
+  clientKey?: string
 ): Promise<CellGenerationResult> {
-  let enResults = await readActiveConnections(fromRef, kind, "en", excludeRefs);
+  const enRows = await readActiveRows(fromRef, kind, "en", excludeRefs);
+  let enPairs: { ref: string; reason: string }[];
   let calledAI = false;
-  if (enResults.length === 0) {
+  if (enRows.length > 0) {
+    enPairs = enRows.map((r) => ({ ref: r.toRef, reason: r.reason }));
+  } else {
     const enKey = cellKey(fromRef, kind, "en", provider, model, excludeRefs);
-    const gen = await singleFlight(enKey, () =>
-      generateConnectionsForCell(fromRef, kind, source, excludeRefs, provider, model)
+    const gen = await singleFlight(
+      enKey,
+      () => generateConnectionsForCell(fromRef, kind, source, excludeRefs, provider, model),
+      true
     );
-    enResults = gen.results;
+    enPairs = gen.results.map((r) => ({ ref: r.ref, reason: r.reason }));
     calledAI = gen.calledAI;
   }
-  if (enResults.length === 0) return { results: [], calledAI };
+  if (enPairs.length === 0) return { results: [], calledAI };
 
   const toPersist: { toRef: string; reason: string }[] = [];
-  const localized: ConnectionResult[] = [];
-  for (const en of enResults) {
-    const translated = await translateReason(en.reason, LOCALE_LANGUAGE_NAME[locale], {
-      provider,
-      model,
-    });
-    calledAI = true;
-    if (translated === "") {
+  const localized: { toRef: string; reason: string }[] = [];
+  let budgetSpent = false;
+  for (const en of enPairs) {
+    if (budgetSpent) {
+      localized.push({ toRef: en.ref, reason: en.reason });
+      continue;
+    }
+    if (clientKey && !(await consume(`gen:${clientKey}`))) {
+      budgetSpent = true;
+      localized.push({ toRef: en.ref, reason: en.reason });
+      continue;
+    }
+
+    let translated = "";
+    try {
+      translated = await translateReason(en.reason, LOCALE_LANGUAGE_NAME[locale], {
+        provider,
+        model,
+      });
+      calledAI = true;
+    } catch (err) {
+      // Degrade to the canonical English reason for this row rather than 500 the
+      // whole response — logged + metered, not swallowed.
+      console.error(`connections: live translation into ${locale} failed for ${en.ref}:`, err);
+    }
+    if (typeof translated !== "string" || translated.trim() === "") {
       incr("connections_live_translate_failed");
-      localized.push(en);
+      localized.push({ toRef: en.ref, reason: en.reason });
       continue;
     }
     toPersist.push({ toRef: en.ref, reason: translated });
-    localized.push({ ...en, reason: translated });
+    localized.push({ toRef: en.ref, reason: translated });
   }
 
   if (toPersist.length > 0) {
-    const persisted = await persistTranslatedRows(fromRef, kind, locale, model, toPersist);
+    const stored = await persistTranslatedRows(fromRef, kind, locale, model, toPersist);
     for (const row of localized) {
-      const stored = persisted.get(row.ref);
-      if (stored !== undefined && stored !== row.reason) row.reason = stored;
+      const persistedReason = stored.get(row.toRef);
+      if (persistedReason !== undefined && persistedReason !== row.reason) {
+        row.reason = persistedReason;
+      }
     }
   }
-  return { results: localized, calledAI };
+  return { results: await hydrate(localized, kind), calledAI };
 }
 
 /** Insert translated rows; a concurrent writer (another instance, or the batch)

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -3,17 +3,24 @@ import { db } from "@/lib/infra/db";
 import { connections, type Connection } from "@/lib/infra/db/schema";
 import { generateConnections, generateGroundedConnections } from "@/lib/ai/connection-generator";
 import { resolveModel, resolveProvider, type Provider } from "@/lib/ai/ai";
+import { translateReason } from "@/lib/ai/translate";
 import { discoverCandidates } from "@/lib/ai/connection-discovery";
 import { resolveVerse } from "@/lib/quran/verse-resolver";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { incr } from "@/lib/infra/metrics";
-import type { Locale } from "@/lib/i18n/config";
+import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
 import type { ConnectionResult, EdgeKind } from "@/types/quran";
 
 /**
  * The persistent knowledge graph. Reads connections from Postgres; only on a
  * miss does it call the AI, then writes the result back so every later reader
  * gets it for free. This is what makes AI cost trend toward zero.
+ *
+ * English is canonical. A non-`en` cache miss does NOT re-derive the verse
+ * SELECTION in that language — it ensures the `en` rows exist, then translates
+ * their reasons for the requested locale (mirrors lib/ai/connection-batch.ts, so
+ * live traffic and the admin backfill converge on the same rows instead of
+ * layering mixed-provenance ones).
  */
 
 /**
@@ -21,8 +28,9 @@ import type { ConnectionResult, EdgeKind } from "@/types/quran";
  * share one in-flight generation instead of each firing its own (expensive) AI
  * call. Per-process — full coverage on the single box; a multi-instance deployment
  * would need a Redis lock to coalesce across processes (deferred). Keyed by
- * `${fromRef}:${kind}:${locale}:${excludeRefs}`; entries are removed as soon as
- * the generation settles.
+ * `${fromRef}:${kind}:${locale}:${provider}:${model}:${excludeRefs}`; entries are
+ * removed as soon as the generation settles. A non-`en` miss also joins the `en`
+ * key while it ensures the canonical rows.
  */
 const inFlight = new Map<string, Promise<CellGenerationResult>>();
 
@@ -49,9 +57,9 @@ interface GetConnectionsOptions {
    *  both the cache read and any fresh generation, so a repeat "get more"
    *  request surfaces genuinely new connections instead of the same set. */
   excludeRefs?: string[];
-  /** Language the reason text is generated and cached in. Reads and writes are
-   *  both keyed on this, so each locale gets its own cached reason instead of
-   *  sharing whichever locale first triggered generation. Defaults to "en". */
+  /** Language the reason text is served in. The verse selection is always the
+   *  canonical `en` one; a non-`en` value translates each `en` reason and caches
+   *  the result under that locale. Defaults to "en". */
   locale?: Locale;
   /** Forces a specific LLM provider for the miss-path generation (the admin
    *  batch job's per-run pick). Unset for live traffic, which uses the
@@ -60,6 +68,39 @@ interface GetConnectionsOptions {
   /** Forces a specific model for the miss-path generation (applied only when it
    *  belongs to the resolved provider). Batch job's per-run pick. */
   model?: string;
+}
+
+function cellKey(
+  fromRef: string,
+  kind: EdgeKind,
+  locale: Locale,
+  provider: Provider,
+  model: string,
+  excludeRefs: string[]
+): string {
+  return `${fromRef}:${kind}:${locale}:${provider}:${model}:${[...excludeRefs].sort().join(",")}`;
+}
+
+/** Join an in-flight identical generation if one is running, otherwise lead it.
+ *  The get→set MUST stay synchronous (no await between them) or two concurrent
+ *  callers could both become the leader. */
+async function singleFlight(
+  key: string,
+  factory: () => Promise<CellGenerationResult>
+): Promise<CellGenerationResult> {
+  const pending = inFlight.get(key);
+  if (pending) {
+    incr("gen_coalesced");
+    return pending;
+  }
+  incr("gen_started");
+  const work = factory();
+  inFlight.set(key, work);
+  try {
+    return await work;
+  } finally {
+    inFlight.delete(key);
+  }
 }
 
 /** Hydrate stored edges (which carry only refs + reason) into full results. */
@@ -85,21 +126,14 @@ async function hydrate(rows: Connection[], kind: EdgeKind): Promise<ConnectionRe
     .filter((c): c is ConnectionResult => c !== null);
 }
 
-/**
- * Returns connections for a source verse and kind. Served from the DB graph when
- * present; otherwise generated, persisted, and returned. `source` text is only
- * needed for the miss path (it grounds the AI prompt).
- */
-export async function getConnections(
+/** Read the active cached edges for one cell+locale, hydrated. */
+async function readActiveConnections(
   fromRef: string,
   kind: EdgeKind,
-  source: SourceVerse,
-  options: GetConnectionsOptions = {}
+  locale: Locale,
+  excludeRefs: string[]
 ): Promise<ConnectionResult[]> {
-  const excludeRefs = options.excludeRefs ?? [];
-  const locale = options.locale ?? "en";
-
-  const existing = await db
+  const rows = await db
     .select()
     .from(connections)
     .where(
@@ -116,10 +150,25 @@ export async function getConnections(
     // code path that inserts more edges per source ref can't turn this into an
     // unbounded per-key list query, the same shape hardened elsewhere.
     .limit(200);
+  return hydrate(rows, kind);
+}
 
-  if (existing.length > 0) {
-    return hydrate(existing, kind);
-  }
+/**
+ * Returns connections for a source verse and kind. Served from the DB graph when
+ * present; otherwise generated, persisted, and returned. `source` text is only
+ * needed for the miss path (it grounds the AI prompt).
+ */
+export async function getConnections(
+  fromRef: string,
+  kind: EdgeKind,
+  source: SourceVerse,
+  options: GetConnectionsOptions = {}
+): Promise<ConnectionResult[]> {
+  const excludeRefs = options.excludeRefs ?? [];
+  const locale = options.locale ?? "en";
+
+  const existing = await readActiveConnections(fromRef, kind, locale, excludeRefs);
+  if (existing.length > 0) return existing;
 
   // Cache miss — this is the expensive path, so rate-limit it (per client, as
   // before: the limiter runs for every caller, so the budget semantics are
@@ -138,55 +187,135 @@ export async function getConnections(
   const provider = await resolveProvider("connections", options.provider);
   const model = await resolveModel("connections", provider, options.model);
 
-  // Single-flight: if an identical generation is already running, join it rather
-  // than starting a second AI call. The get→set below MUST stay synchronous (no
-  // await between them) or two concurrent callers could both become the leader.
-  // The exclude set, locale, provider, and model are folded into the key so a
-  // "get more" request, a different-locale request, or a request pinned to a
-  // different provider/model never coalesces with an unrelated one.
-  const key = `${fromRef}:${kind}:${locale}:${provider}:${model}:${[...excludeRefs].sort().join(",")}`;
-  const pending = inFlight.get(key);
-  if (pending) {
-    incr("gen_coalesced");
-    return (await pending).results;
+  const key = cellKey(fromRef, kind, locale, provider, model, excludeRefs);
+  const result = await singleFlight(key, () =>
+    locale === "en"
+      ? generateConnectionsForCell(fromRef, kind, source, excludeRefs, provider, model)
+      : generateLocalizedCell(fromRef, kind, source, excludeRefs, locale, provider, model)
+  );
+  return result.results;
+}
+
+/**
+ * Non-`en` miss body: ensure the canonical English rows exist (generating them
+ * through the same single-flight if not), then translate each English reason
+ * into `locale` and cache the translated rows under that locale. A reason whose
+ * translation fails is served in English for this response and left unpersisted
+ * so a later request or the backfill retries it.
+ */
+async function generateLocalizedCell(
+  fromRef: string,
+  kind: EdgeKind,
+  source: SourceVerse,
+  excludeRefs: string[],
+  locale: Locale,
+  provider: Provider,
+  model: string
+): Promise<CellGenerationResult> {
+  let enResults = await readActiveConnections(fromRef, kind, "en", excludeRefs);
+  let calledAI = false;
+  if (enResults.length === 0) {
+    const enKey = cellKey(fromRef, kind, "en", provider, model, excludeRefs);
+    const gen = await singleFlight(enKey, () =>
+      generateConnectionsForCell(fromRef, kind, source, excludeRefs, provider, model)
+    );
+    enResults = gen.results;
+    calledAI = gen.calledAI;
+  }
+  if (enResults.length === 0) return { results: [], calledAI };
+
+  const toPersist: { toRef: string; reason: string }[] = [];
+  const localized: ConnectionResult[] = [];
+  for (const en of enResults) {
+    const translated = await translateReason(en.reason, LOCALE_LANGUAGE_NAME[locale], {
+      provider,
+      model,
+    });
+    calledAI = true;
+    if (translated === "") {
+      incr("connections_live_translate_failed");
+      localized.push(en);
+      continue;
+    }
+    toPersist.push({ toRef: en.ref, reason: translated });
+    localized.push({ ...en, reason: translated });
   }
 
-  incr("gen_started");
-  const work = generateConnectionsForCell(
-    fromRef,
-    kind,
-    source,
-    excludeRefs,
-    locale,
-    provider,
-    model
-  );
-  inFlight.set(key, work);
+  if (toPersist.length > 0) {
+    const persisted = await persistTranslatedRows(fromRef, kind, locale, model, toPersist);
+    for (const row of localized) {
+      const stored = persisted.get(row.ref);
+      if (stored !== undefined && stored !== row.reason) row.reason = stored;
+    }
+  }
+  return { results: localized, calledAI };
+}
+
+/** Insert translated rows; a concurrent writer (another instance, or the batch)
+ *  can win the same (fromRef, toRef, kind, locale) row first, so re-read the
+ *  ones DO NOTHING discarded and return what is actually persisted. */
+async function persistTranslatedRows(
+  fromRef: string,
+  kind: EdgeKind,
+  locale: Locale,
+  model: string,
+  rows: { toRef: string; reason: string }[]
+): Promise<Map<string, string>> {
   try {
-    return (await work).results;
-  } finally {
-    inFlight.delete(key);
+    const inserted = await db
+      .insert(connections)
+      .values(rows.map((r) => ({ fromRef, toRef: r.toRef, kind, reason: r.reason, model, locale })))
+      .onConflictDoNothing()
+      .returning({ toRef: connections.toRef });
+
+    const insertedRefs = new Set(inserted.map((r) => r.toRef));
+    const conflicted = rows.filter((r) => !insertedRefs.has(r.toRef));
+    if (conflicted.length === 0) return new Map();
+
+    const stored = await db
+      .select({ toRef: connections.toRef, reason: connections.reason })
+      .from(connections)
+      .where(
+        and(
+          eq(connections.fromRef, fromRef),
+          eq(connections.kind, kind),
+          eq(connections.locale, locale),
+          inArray(
+            connections.toRef,
+            conflicted.map((r) => r.toRef)
+          )
+        )
+      );
+    return new Map(stored.map((r) => [r.toRef, r.reason]));
+  } catch (err) {
+    // A swallowed persist failure would be invisible: the caller still gets
+    // their connections this request, but nothing is cached, so the same
+    // (costly) translation re-runs on every future request for this verse.
+    // Surface it as a counted metric, not just a log line.
+    console.error("Failed to persist localized connections:", err);
+    incr("gen_persist_failed");
+    return new Map();
   }
 }
 
 /**
- * The cache-miss body: discover candidates, generate connections, persist them.
- * Prefers grounded discovery (data discovers, AI articulates); falls back to
- * legacy memory-based generation only when no grounding data is available for
- * this verse (e.g. corpus not yet seeded).
+ * The cache-miss body: discover candidates, generate connections in English,
+ * persist them. Prefers grounded discovery (data discovers, AI articulates);
+ * falls back to legacy memory-based generation only when no grounding data is
+ * available for this verse (e.g. corpus not yet seeded).
  *
  * Exported so the admin backfill job (lib/ai/connection-batch.ts) can drive it
  * directly — WITHOUT the per-client rate limiter and single-flight map that
  * `getConnections` wraps it in for live traffic. The job is sequential and
  * single-process (one job at a time via lib/admin/job-runner.ts), so neither
- * guard applies.
+ * guard applies. The verse selection is always English; non-`en` rows come from
+ * translating these (see `generateLocalizedCell` / lib/ai/connection-batch.ts).
  */
 export async function generateConnectionsForCell(
   fromRef: string,
   kind: EdgeKind,
   source: SourceVerse,
   excludeRefs: string[] = [],
-  locale: Locale = "en",
   provider: Provider,
   model: string,
   gen: { apiKey?: string; signal?: AbortSignal } = {}
@@ -207,7 +336,7 @@ export async function generateConnectionsForCell(
           source.translation,
           kind,
           candidates,
-          locale,
+          "en",
           ...genOpts
         )
       : excludeRefs.length > 0
@@ -217,7 +346,7 @@ export async function generateConnectionsForCell(
             source.arabicText,
             source.translation,
             kind,
-            locale,
+            "en",
             ...genOpts
           );
 
@@ -235,7 +364,7 @@ export async function generateConnectionsForCell(
             kind,
             reason: g.reason,
             model,
-            locale,
+            locale: "en",
           }))
         )
         .onConflictDoNothing()
@@ -256,7 +385,7 @@ export async function generateConnectionsForCell(
             and(
               eq(connections.fromRef, fromRef),
               eq(connections.kind, kind),
-              eq(connections.locale, locale),
+              eq(connections.locale, "en"),
               inArray(
                 connections.toRef,
                 conflicted.map((g) => g.ref)

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -136,10 +136,10 @@ async function hydrate(
     .filter((c): c is ConnectionResult => c !== null);
 }
 
-/** Raw active cached edges for one cell+locale (not hydrated — callers decide a
- *  hit on the ROW count, so a cell whose target verses transiently fail to
- *  resolve is still a hit, not a re-generation trigger; a non-`en` locale
- *  additionally checks that count against the canonical `en` one). */
+/** Raw active cached edges for one cell+locale (not hydrated — a cell whose
+ *  target verses transiently fail to resolve is still a hit, not a
+ *  re-generation trigger). Ordered by `toRef` so the connection order a reader
+ *  sees is stable across requests and the `en`/locale orderings stay aligned. */
 async function readActiveRows(
   fromRef: string,
   kind: EdgeKind,
@@ -162,6 +162,7 @@ async function readActiveRows(
         ...(excludeRefs.length > 0 ? [notInArray(connections.toRef, excludeRefs)] : [])
       )
     )
+    .orderBy(connections.toRef)
     .limit(200);
 }
 
@@ -180,18 +181,27 @@ export async function getConnections(
   const locale = options.locale ?? "en";
 
   const existing = await readActiveRows(fromRef, kind, locale, excludeRefs);
+  // The canonical `en` rows for the same cell: needed to decide whether a
+  // non-`en` locale is complete, and reused by `generateLocalizedCell` on a
+  // miss so the gate decision and the translation work off one snapshot.
+  const enRows =
+    locale === "en" ? existing : await readActiveRows(fromRef, kind, "en", excludeRefs);
+
   if (locale === "en") {
     if (existing.length > 0) return hydrate(existing, kind);
   } else if (existing.length > 0) {
-    // A non-`en` cell is a hit only when it is as complete as the canonical
-    // English set. A partial locale set — left by a translation that failed or
-    // an exhausted client budget on an earlier request — would otherwise be a
-    // permanent short cache that only the admin backfill could repair; instead
-    // fall through so the miss path translates the rows still missing for this
-    // locale. (`enCount === 0` means there is no canonical set to compare
-    // against — pre-#594 native locale rows — so serve what's there.)
-    const enCount = (await readActiveRows(fromRef, kind, "en", excludeRefs)).length;
-    if (enCount === 0 || existing.length >= enCount) return hydrate(existing, kind);
+    // A non-`en` cell is a hit only when EVERY active canonical `en` ref has an
+    // active row in this locale — ref-by-ref, matching `findTranslationGaps` in
+    // lib/ai/connection-batch.ts. A count compare would let a retired-and-
+    // replaced `en` edge look complete when the ref sets actually differ, and a
+    // partial set (a translation that failed, or an exhausted client budget on
+    // an earlier request) would be a permanent short cache. `enRows` empty means
+    // there is no canonical set to translate against — pre-#594 native locale
+    // rows — so serve what is there.
+    const localeRefs = new Set(existing.map((r) => r.toRef));
+    if (enRows.length === 0 || enRows.every((r) => localeRefs.has(r.toRef))) {
+      return hydrate(existing, kind);
+    }
   }
 
   // Cache miss — this is the expensive path, so rate-limit it (per client, as
@@ -199,7 +209,13 @@ export async function getConnections(
   // unchanged — only the AI call itself is de-duplicated below).
   if (options.clientKey) {
     const allowed = await consume(`gen:${options.clientKey}`);
-    if (!allowed) throw new RateLimitError();
+    if (!allowed) {
+      // An incomplete non-`en` cell we can't repair right now: serve the
+      // (partial) rows we already have rather than erroring — a later request
+      // with budget, or the backfill, finishes the translation.
+      if (locale !== "en" && existing.length > 0) return hydrate(existing, kind);
+      throw new RateLimitError();
+    }
   }
 
   // Resolve the effective provider+model ONCE for this miss (honouring any
@@ -225,6 +241,7 @@ export async function getConnections(
             locale,
             provider,
             model,
+            enRows,
             existing,
             options.clientKey
           ),
@@ -257,12 +274,14 @@ async function generateLocalizedCell(
   locale: Locale,
   provider: Provider,
   model: string,
-  // The rows already active for this locale (read by `getConnections` for its
-  // completeness check) — reused so a repair pass doesn't re-query them.
+  // The canonical `en` rows and the rows already active for this locale — both
+  // already read by `getConnections` for its completeness check — reused here
+  // so the gate decision and the translation work off the same snapshot and a
+  // repair pass doesn't re-query either.
+  enRows: Connection[],
   existingLocaleRows: Connection[],
   clientKey?: string
 ): Promise<CellGenerationResult> {
-  const enRows = await readActiveRows(fromRef, kind, "en", excludeRefs);
   let enPairs: { ref: string; reason: string }[];
   let calledAI = false;
   if (enRows.length > 0) {
@@ -315,7 +334,7 @@ async function generateLocalizedCell(
       // whole response — logged + metered, not swallowed.
       console.error(`connections: live translation into ${locale} failed for ${en.ref}:`, err);
     }
-    if (typeof translated !== "string" || translated.trim() === "") {
+    if (translated.trim() === "") {
       incr("connections_live_translate_failed");
       localized.push({ toRef: en.ref, reason: en.reason });
       continue;
@@ -357,6 +376,9 @@ async function persistTranslatedRows(
     const conflicted = rows.filter((r) => !insertedRefs.has(r.toRef));
     if (conflicted.length === 0) return new Map();
 
+    // Only adopt an ACTIVE conflicting row. A retired/flagged row occupying the
+    // same (fromRef, toRef, kind, locale) key must not be resurrected and served
+    // as if it were the winning translation (matches the admin review status).
     const stored = await db
       .select({ toRef: connections.toRef, reason: connections.reason })
       .from(connections)
@@ -365,6 +387,7 @@ async function persistTranslatedRows(
           eq(connections.fromRef, fromRef),
           eq(connections.kind, kind),
           eq(connections.locale, locale),
+          eq(connections.status, "active"),
           inArray(
             connections.toRef,
             conflicted.map((r) => r.toRef)

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -20,7 +20,9 @@ import type { ConnectionResult, EdgeKind } from "@/types/quran";
  * SELECTION in that language — it ensures the `en` rows exist, then translates
  * their reasons for the requested locale (mirrors lib/ai/connection-batch.ts, so
  * live traffic and the admin backfill converge on the same rows instead of
- * layering mixed-provenance ones).
+ * layering mixed-provenance ones). A non-`en` locale is only served from cache
+ * once it has a translation for every canonical `en` row; an incomplete locale
+ * set re-enters the miss path and translates just the rows still missing.
  */
 
 /**
@@ -136,7 +138,8 @@ async function hydrate(
 
 /** Raw active cached edges for one cell+locale (not hydrated — callers decide a
  *  hit on the ROW count, so a cell whose target verses transiently fail to
- *  resolve is still a hit, not a re-generation trigger). */
+ *  resolve is still a hit, not a re-generation trigger; a non-`en` locale
+ *  additionally checks that count against the canonical `en` one). */
 async function readActiveRows(
   fromRef: string,
   kind: EdgeKind,
@@ -177,7 +180,19 @@ export async function getConnections(
   const locale = options.locale ?? "en";
 
   const existing = await readActiveRows(fromRef, kind, locale, excludeRefs);
-  if (existing.length > 0) return hydrate(existing, kind);
+  if (locale === "en") {
+    if (existing.length > 0) return hydrate(existing, kind);
+  } else if (existing.length > 0) {
+    // A non-`en` cell is a hit only when it is as complete as the canonical
+    // English set. A partial locale set — left by a translation that failed or
+    // an exhausted client budget on an earlier request — would otherwise be a
+    // permanent short cache that only the admin backfill could repair; instead
+    // fall through so the miss path translates the rows still missing for this
+    // locale. (`enCount === 0` means there is no canonical set to compare
+    // against — pre-#594 native locale rows — so serve what's there.)
+    const enCount = (await readActiveRows(fromRef, kind, "en", excludeRefs)).length;
+    if (enCount === 0 || existing.length >= enCount) return hydrate(existing, kind);
+  }
 
   // Cache miss — this is the expensive path, so rate-limit it (per client, as
   // before: the limiter runs for every caller, so the budget semantics are
@@ -210,6 +225,7 @@ export async function getConnections(
             locale,
             provider,
             model,
+            existing,
             options.clientKey
           ),
     locale === "en"
@@ -224,10 +240,14 @@ export async function getConnections(
  *
  * A row whose translation fails (empty, rejected, or the provider threw) is
  * served in English for this response and left unpersisted so a later request or
- * the backfill retries it. Each translation call also spends the client's
- * generation budget when `clientKey` is set, so a cold non-`en` cell can't turn
- * one rate-limit token into a dozen LLM calls; once the budget is out, the
- * remaining rows are served in English.
+ * the backfill retries it — the `getConnections` completeness gate re-enters
+ * this path until every canonical row has a locale translation. Rows already
+ * translated for this locale (by a prior pass or the batch) are reused as-is, so
+ * a repair only translates what is still missing and never duplicates a row.
+ * Each translation call also spends the client's generation budget when
+ * `clientKey` is set, so a cold non-`en` cell can't turn one rate-limit token
+ * into a dozen LLM calls; once the budget is out, the remaining rows are served
+ * in English (and picked up on a later request or by the backfill).
  */
 async function generateLocalizedCell(
   fromRef: string,
@@ -237,6 +257,9 @@ async function generateLocalizedCell(
   locale: Locale,
   provider: Provider,
   model: string,
+  // The rows already active for this locale (read by `getConnections` for its
+  // completeness check) — reused so a repair pass doesn't re-query them.
+  existingLocaleRows: Connection[],
   clientKey?: string
 ): Promise<CellGenerationResult> {
   const enRows = await readActiveRows(fromRef, kind, "en", excludeRefs);
@@ -256,10 +279,20 @@ async function generateLocalizedCell(
   }
   if (enPairs.length === 0) return { results: [], calledAI };
 
+  // Rows already translated for this locale (a prior partial pass, or the
+  // backfill) — reuse verbatim so this repair only pays for the refs still
+  // missing and can't duplicate or re-translate an existing row.
+  const existingLocale = new Map(existingLocaleRows.map((r) => [r.toRef, r.reason]));
+
   const toPersist: { toRef: string; reason: string }[] = [];
   const localized: { toRef: string; reason: string }[] = [];
   let budgetSpent = false;
   for (const en of enPairs) {
+    const already = existingLocale.get(en.ref);
+    if (already !== undefined) {
+      localized.push({ toRef: en.ref, reason: already });
+      continue;
+    }
     if (budgetSpent) {
       localized.push({ toRef: en.ref, reason: en.reason });
       continue;


### PR DESCRIPTION
## Problem

Refs #566 (item **B2** — B1/B3/B4 shipped in #576).

`lib/ai/graph-service.ts` `getConnections` filtered its cache read by `locale` and, on a non-`en` cache miss, ran a fresh **native-language** `generateConnectionsForCell(..., locale, ...)`. That re-derives the verse **selection** in each locale and persists locale-tagged rows — contradicting the backfill invariant that *"the verse SELECTION is never re-derived per locale"* (`lib/ai/connection-batch.ts` header). When `findTranslationGaps` later ran the same cell it layered en-derived translated rows on top, so a shared cell could end up with **>3 mixed-provenance rows** and non-`en` reasons that never passed through the admin-reviewed English text.

The verse selection is provably locale-invariant: `locale` only appends a `languageDirective` in `connection-generator.ts`; candidate discovery, `isValidRef`, and `.slice(0, 3)` are identical across locales.

## Change (Option 1 — en-canonical everywhere)

- **`getConnections`, `locale === "en"` miss** — unchanged.
- **`locale !== "en"` miss** — new `generateLocalizedCell`:
  1. Read the active English rows for the cell. If none, generate them via the existing English path, joined through the **same single-flight** under the `en` key (so a concurrent `en` request and `tr`/`ru` request share one generation).
  2. `translateReason` each English reason into the requested locale (mirrors `translateCellReasons`).
  3. Persist the translated rows tagged with that locale (`onConflictDoNothing` + conflict re-read, same as the English path).
  4. A row whose translation returns `""` (empty or rejected — see #557 / #593) is served in **English** for that response and **not persisted**, so the backfill or a later request retries it. `incr("connections_live_translate_failed")`.
- `generateConnectionsForCell` no longer takes a `locale` param — it always generates English. Its one batch call site is updated.
- `connection-batch.ts` header comment updated to note the live path now follows the same rule.

## Not in this PR

- **Existing native non-`en` rows** written by the old live path are left in place — not a regression; the admin review queue can retire bad ones. A cleanup script could be a follow-up.
- `findTranslationGaps` / `connection-batch.ts` logic — unchanged; its model was already en-canonical.
- The #566 comment item about `resolveAndGenerate` retrying Gemini on a Claude *throw* — separate, not touched here.

## Tests

- `__tests__/lib/ai/graph-service.test.ts` — the old `per-locale caching` block is replaced: a non-`en` miss generates the selection **in English once** then translates each reason; an already-cached English cell is translated without regenerating; a failed row translation serves English and persists nothing; a concurrent `en` + `tr` miss derives English **once**.
- `__tests__/integration/graph.integration.test.ts` (real Postgres) — a non-`en` request translates the canonical English selection (`toRef` set identical, `+1` translation call, no regeneration); a cold non-`en` request generates English first then translates; both locales then serve from cache.

## Verification

`bun run typecheck` · `bun run lint` · `bun run format:check` · `bun run test:ci` (1561) · `bun run test:integration` (graph 8/8, connection-batch) — all green locally.

## AI / Theological changes

- [x] Aligns live verse-connection generation with the backfill's en-canonical model: non-English reasons are now always translations of the admin-reviewable English canonical text, never an independently model-selected native set. No prompt wording changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection results are generated from a consistent English source and translated for non-English requests.
  * Translations are cached separately and reused across requests and locales.
  * Incomplete localized results are repaired by translating only missing entries.
  * Concurrent requests can share a single connection-generation process.
* **Bug Fixes**
  * Improved fallback to English when translation is unavailable or rate limits are reached.
  * Prevented retired translations from being restored during cache repair.
  * Improved handling of partial caches and translation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->