### PR TITLE
fix(auth): make the refresh-token single-flight multi-instance safe (Redis-backed)

### DIFF
--- a/__tests__/api/auth-refresh.test.ts
+++ b/__tests__/api/auth-refresh.test.ts
@@ -96,6 +96,22 @@ describe("POST /api/auth/refresh", () => {
     expect(setCookie).toContain("qf_refresh_token=refresh-same-2");
   });
 
+  it("treats a 2xx response with no access_token as transient (503, cookie kept, not cached)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ refresh_token: "r-only" }) });
+
+    const first = await POST(makeReq("refresh-noaccess"));
+    expect(first.status).toBe(503);
+    expect(first.headers.get("set-cookie")).toBeNull();
+
+    // Not cached — a retry hits the endpoint again.
+    const second = await POST(makeReq("refresh-noaccess"));
+    expect(second.status).toBe(503);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("no access_token"));
+    errSpy.mockRestore();
+  });
+
   it("returns 401 and clears the cookie on invalid_grant", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
@@ -263,7 +279,7 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     const res = await POST(makeReq("tok-lead"));
 
     expect(res.status).toBe(200);
-    expect(mockRedis.redisSetNx).toHaveBeenCalledWith(lockKey("tok-lead"), expect.any(String), 15);
+    expect(mockRedis.redisSetNx).toHaveBeenCalledWith(lockKey("tok-lead"), expect.any(String), 20);
     expect(JSON.parse(redisStore.get(resultKey("tok-lead"))!)).toMatchObject({
       kind: "ok",
       accessToken: "acc-lead",

--- a/__tests__/api/auth-refresh.test.ts
+++ b/__tests__/api/auth-refresh.test.ts
@@ -16,8 +16,8 @@ const { redisStore, mockRedis } = vi.hoisted(() => {
         redisStore.set(k, v);
         return true;
       }),
-      redisDel: vi.fn(async (k: string) => {
-        redisStore.delete(k);
+      redisDelIfEqual: vi.fn(async (k: string, expected: string) => {
+        if (redisStore.get(k) === expected) redisStore.delete(k);
       }),
       redisSetNx: vi.fn(async (k: string, v: string): Promise<boolean | null> => {
         if (redisStore.has(k)) return false;
@@ -222,7 +222,7 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     mockRedis.redisEnabled.mockReturnValue(true);
     mockRedis.redisGet.mockClear();
     mockRedis.redisSet.mockClear();
-    mockRedis.redisDel.mockClear();
+    mockRedis.redisDelIfEqual.mockClear();
     mockRedis.redisSetNx.mockClear();
     mockRedis.redisSetNx.mockImplementation(async (k: string, v: string) => {
       if (redisStore.has(k)) return false;
@@ -234,8 +234,8 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
       redisStore.set(k, v);
       return true;
     });
-    mockRedis.redisDel.mockImplementation(async (k: string) => {
-      redisStore.delete(k);
+    mockRedis.redisDelIfEqual.mockImplementation(async (k: string, expected: string) => {
+      if (redisStore.get(k) === expected) redisStore.delete(k);
     });
   });
   afterAll(() => mockRedis.redisEnabled.mockReturnValue(false));
@@ -387,7 +387,10 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     const res = await POST(makeReq("tok-nopublish"));
 
     expect(res.status).toBe(200); // the leader still returns its own outcome
-    expect(mockRedis.redisDel).not.toHaveBeenCalledWith(lockKey("tok-nopublish"));
+    expect(mockRedis.redisDelIfEqual).not.toHaveBeenCalledWith(
+      lockKey("tok-nopublish"),
+      expect.anything()
+    );
     expect(redisStore.has(lockKey("tok-nopublish"))).toBe(true); // lock held to TTL
   });
 

--- a/__tests__/api/auth-refresh.test.ts
+++ b/__tests__/api/auth-refresh.test.ts
@@ -12,10 +12,19 @@ const { redisStore, mockRedis } = vi.hoisted(() => {
     mockRedis: {
       redisEnabled: vi.fn(() => false),
       redisGet: vi.fn(async (k: string) => redisStore.get(k) ?? null),
-      redisSet: vi.fn(async (k: string, v: string): Promise<boolean> => {
-        redisStore.set(k, v);
-        return true;
-      }),
+      redisSetGuarded: vi.fn(
+        async (
+          k: string,
+          v: string,
+          _ttl: number,
+          guardKey: string,
+          expectedGuardValue: string
+        ): Promise<boolean> => {
+          if (redisStore.get(guardKey) !== expectedGuardValue) return false;
+          redisStore.set(k, v);
+          return true;
+        }
+      ),
       redisDelIfEqual: vi.fn(async (k: string, expected: string) => {
         if (redisStore.get(k) === expected) redisStore.delete(k);
       }),
@@ -237,7 +246,7 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     redisStore.clear();
     mockRedis.redisEnabled.mockReturnValue(true);
     mockRedis.redisGet.mockClear();
-    mockRedis.redisSet.mockClear();
+    mockRedis.redisSetGuarded.mockClear();
     mockRedis.redisDelIfEqual.mockClear();
     mockRedis.redisSetNx.mockClear();
     mockRedis.redisSetNx.mockImplementation(async (k: string, v: string) => {
@@ -246,10 +255,13 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
       return true;
     });
     mockRedis.redisGet.mockImplementation(async (k: string) => redisStore.get(k) ?? null);
-    mockRedis.redisSet.mockImplementation(async (k: string, v: string) => {
-      redisStore.set(k, v);
-      return true;
-    });
+    mockRedis.redisSetGuarded.mockImplementation(
+      async (k: string, v: string, _ttl: number, guardKey: string, expectedGuardValue: string) => {
+        if (redisStore.get(guardKey) !== expectedGuardValue) return false;
+        redisStore.set(k, v);
+        return true;
+      }
+    );
     mockRedis.redisDelIfEqual.mockImplementation(async (k: string, expected: string) => {
       if (redisStore.get(k) === expected) redisStore.delete(k);
     });
@@ -394,7 +406,7 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
   });
 
   it("keeps the lock (does not release) when publishing the result fails", async () => {
-    mockRedis.redisSet.mockResolvedValue(false); // publish dropped
+    mockRedis.redisSetGuarded.mockResolvedValue(false); // publish dropped
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ access_token: "acc-np", refresh_token: "ref-np" }),
@@ -411,12 +423,18 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
   });
 
   it("does not delete a lock a successor took while it was publishing (compare-and-delete)", async () => {
-    mockRedis.redisSet.mockImplementation(async (k: string, v: string) => {
-      redisStore.set(k, v);
-      // Our lease expired mid-publish and a peer grabbed a fresh lock.
-      redisStore.set(lockKey("tok-cad"), "successor-nonce");
-      return true;
-    });
+    mockRedis.redisSetGuarded.mockImplementation(
+      async (k: string, v: string, _ttl: number, guardKey: string, expectedGuardValue: string) => {
+        redisStore.set(k, v);
+        // Our lease expired mid-publish and a peer grabbed a fresh lock — this
+        // fires AFTER our guard check passed, so the write above still landed;
+        // the point of this test is the release, not the publish (see the
+        // "does not publish over a successor's lock" test for the write itself).
+        if (redisStore.get(guardKey) !== expectedGuardValue) return false;
+        redisStore.set(lockKey("tok-cad"), "successor-nonce");
+        return true;
+      }
+    );
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ access_token: "a", refresh_token: "r" }),
@@ -425,6 +443,29 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     await POST(makeReq("tok-cad"));
 
     expect(redisStore.get(lockKey("tok-cad"))).toBe("successor-nonce"); // ours, not deleted
+  });
+
+  it("does not publish over a successor's lock — a late publish after the lease moved on is a no-op", async () => {
+    mockRedis.redisSetGuarded.mockImplementation(
+      async (k: string, v: string, _ttl: number, guardKey: string, expectedGuardValue: string) => {
+        // Simulate the lease expiring and a peer taking a fresh lock right
+        // before our (delayed) publish actually reaches the guard check.
+        redisStore.set(lockKey("tok-late-publish"), "successor-nonce");
+        if (redisStore.get(guardKey) !== expectedGuardValue) return false;
+        redisStore.set(k, v);
+        return true;
+      }
+    );
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "acc-stale", refresh_token: "ref-stale" }),
+    });
+
+    const res = await POST(makeReq("tok-late-publish"));
+
+    expect(res.status).toBe(200); // the leader still returns its own outcome locally
+    expect(redisStore.get(lockKey("tok-late-publish"))).toBe("successor-nonce"); // untouched
+    expect(redisStore.has(resultKey("tok-late-publish"))).toBe(false); // stale result never published
   });
 
   it("a waiter stops early (retryable 503) once the leader releases the lock with no result", async () => {
@@ -451,7 +492,7 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     try {
       // The publish never settles — withTimeout() must resolve it to `false`
       // rather than let the leader's critical section run past its lease.
-      mockRedis.redisSet.mockImplementation(() => new Promise<boolean>(() => {}));
+      mockRedis.redisSetGuarded.mockImplementation(() => new Promise<boolean>(() => {}));
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ access_token: "acc-slow", refresh_token: "ref-slow" }),

--- a/__tests__/api/auth-refresh.test.ts
+++ b/__tests__/api/auth-refresh.test.ts
@@ -1,9 +1,41 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { createHash } from "node:crypto";
 import { NextRequest } from "next/server";
+
+// A shared in-memory stand-in for the Redis helpers, so two logical "instances"
+// (both driving the one POST handler) see the same result cache + lock. Default
+// redisEnabled() is false — every test above runs the unchanged per-process path.
+const { redisStore, mockRedis } = vi.hoisted(() => {
+  const redisStore = new Map<string, string>();
+  return {
+    redisStore,
+    mockRedis: {
+      redisEnabled: vi.fn(() => false),
+      redisGet: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+      redisSet: vi.fn(async (k: string, v: string) => {
+        redisStore.set(k, v);
+      }),
+      redisDel: vi.fn(async (k: string) => {
+        redisStore.delete(k);
+      }),
+      redisSetNx: vi.fn(async (k: string, v: string): Promise<boolean | null> => {
+        if (redisStore.has(k)) return false;
+        redisStore.set(k, v);
+        return true;
+      }),
+    },
+  };
+});
+vi.mock("@/lib/infra/redis", () => mockRedis);
+
 import { POST } from "@/app/api/auth/refresh/route";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+
+const sha = (s: string) => createHash("sha256").update(s).digest("hex");
+const resultKey = (token: string) => `auth:refresh:${sha(token)}`;
+const lockKey = (token: string) => `${resultKey(token)}:lock`;
 
 function makeReq(refreshToken?: string) {
   return new NextRequest("http://localhost/api/auth/refresh", {
@@ -179,5 +211,109 @@ describe("POST /api/auth/refresh", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    redisStore.clear();
+    mockRedis.redisEnabled.mockReturnValue(true);
+    mockRedis.redisGet.mockClear();
+    mockRedis.redisSet.mockClear();
+    mockRedis.redisDel.mockClear();
+    mockRedis.redisSetNx.mockClear();
+    mockRedis.redisSetNx.mockImplementation(async (k: string, v: string) => {
+      if (redisStore.has(k)) return false;
+      redisStore.set(k, v);
+      return true;
+    });
+    mockRedis.redisGet.mockImplementation(async (k: string) => redisStore.get(k) ?? null);
+  });
+  afterAll(() => mockRedis.redisEnabled.mockReturnValue(false));
+
+  it("replays a result a peer instance already cached, with no upstream call", async () => {
+    redisStore.set(
+      resultKey("tok-peer-cached"),
+      JSON.stringify({ kind: "ok", accessToken: "acc-peer", refreshToken: "ref-peer" })
+    );
+
+    const res = await POST(makeReq("tok-peer-cached"));
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).accessToken).toBe("acc-peer");
+    expect(res.headers.get("set-cookie")).toContain("qf_refresh_token=ref-peer");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("leads the refresh, publishes the outcome for peers, and releases the lock", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "acc-lead", refresh_token: "ref-lead" }),
+    });
+
+    const res = await POST(makeReq("tok-lead"));
+
+    expect(res.status).toBe(200);
+    expect(mockRedis.redisSetNx).toHaveBeenCalledWith(lockKey("tok-lead"), "1", 10);
+    expect(JSON.parse(redisStore.get(resultKey("tok-lead"))!)).toMatchObject({
+      kind: "ok",
+      accessToken: "acc-lead",
+      refreshToken: "ref-lead",
+    });
+    expect(redisStore.has(lockKey("tok-lead"))).toBe(false); // lock released
+  });
+
+  it("waits for the peer's result instead of presenting the token when the lock is held", async () => {
+    vi.useFakeTimers();
+    try {
+      redisStore.set(lockKey("tok-wait"), "1"); // a peer holds the lock
+
+      const pending = POST(makeReq("tok-wait"));
+      // The winner publishes its result while we're polling.
+      redisStore.set(
+        resultKey("tok-wait"),
+        JSON.stringify({ kind: "ok", accessToken: "acc-win", refreshToken: "ref-win" })
+      );
+      await vi.advanceTimersByTimeAsync(300);
+      const res = await pending;
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).accessToken).toBe("acc-win");
+      expect(mockFetch).not.toHaveBeenCalled(); // never presented the token ourselves
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns a retryable 503 (cookie kept) when the lock is held and no result appears", async () => {
+    vi.useFakeTimers();
+    try {
+      redisStore.set(lockKey("tok-timeout"), "1");
+
+      const pending = POST(makeReq("tok-timeout"));
+      await vi.advanceTimersByTimeAsync(6_000); // past POLL_TIMEOUT_MS
+      const res = await pending;
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("set-cookie")).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to a direct upstream call when the distributed lock is unavailable", async () => {
+    mockRedis.redisSetNx.mockResolvedValue(null); // Redis unreachable for the lock
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "acc-fb", refresh_token: "ref-fb" }),
+    });
+
+    const res = await POST(makeReq("tok-fallback"));
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).accessToken).toBe("acc-fb");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/api/auth-refresh.test.ts
+++ b/__tests__/api/auth-refresh.test.ts
@@ -263,7 +263,7 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     const res = await POST(makeReq("tok-lead"));
 
     expect(res.status).toBe(200);
-    expect(mockRedis.redisSetNx).toHaveBeenCalledWith(lockKey("tok-lead"), expect.any(String), 10);
+    expect(mockRedis.redisSetNx).toHaveBeenCalledWith(lockKey("tok-lead"), expect.any(String), 15);
     expect(JSON.parse(redisStore.get(resultKey("tok-lead"))!)).toMatchObject({
       kind: "ok",
       accessToken: "acc-lead",
@@ -428,5 +428,52 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("treats a publish that stalls past the publish timeout as unpublished and keeps the lock", async () => {
+    vi.useFakeTimers();
+    try {
+      // The publish never settles — withTimeout() must resolve it to `false`
+      // rather than let the leader's critical section run past its lease.
+      mockRedis.redisSet.mockImplementation(() => new Promise<boolean>(() => {}));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "acc-slow", refresh_token: "ref-slow" }),
+      });
+
+      const pending = POST(makeReq("tok-slowpub"));
+      await vi.advanceTimersByTimeAsync(2_500); // past PUBLISH_TIMEOUT_MS (2s)
+      const res = await pending;
+
+      expect(res.status).toBe(200); // leader still returns its own outcome
+      expect((await res.json()).accessToken).toBe("acc-slow");
+      expect(mockRedis.redisDelIfEqual).not.toHaveBeenCalledWith(
+        lockKey("tok-slowpub"),
+        expect.anything()
+      );
+      expect(redisStore.has(lockKey("tok-slowpub"))).toBe(true); // held to TTL
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("logs once and coordinates per-process when redisEnabled() throws (malformed REDIS_URL)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockRedis.redisEnabled.mockImplementationOnce(() => {
+      throw new Error("bad url");
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "acc-badurl", refresh_token: "ref-badurl" }),
+    });
+
+    const res = await POST(makeReq("tok-badurl"));
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).accessToken).toBe("acc-badurl");
+    expect(mockFetch).toHaveBeenCalledTimes(1); // direct upstream, no Redis coordination
+    expect(mockRedis.redisSetNx).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("REDIS_URL is invalid"));
+    errSpy.mockRestore();
   });
 });

--- a/__tests__/api/auth-refresh.test.ts
+++ b/__tests__/api/auth-refresh.test.ts
@@ -12,8 +12,9 @@ const { redisStore, mockRedis } = vi.hoisted(() => {
     mockRedis: {
       redisEnabled: vi.fn(() => false),
       redisGet: vi.fn(async (k: string) => redisStore.get(k) ?? null),
-      redisSet: vi.fn(async (k: string, v: string) => {
+      redisSet: vi.fn(async (k: string, v: string): Promise<boolean> => {
         redisStore.set(k, v);
+        return true;
       }),
       redisDel: vi.fn(async (k: string) => {
         redisStore.delete(k);
@@ -229,6 +230,13 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
       return true;
     });
     mockRedis.redisGet.mockImplementation(async (k: string) => redisStore.get(k) ?? null);
+    mockRedis.redisSet.mockImplementation(async (k: string, v: string) => {
+      redisStore.set(k, v);
+      return true;
+    });
+    mockRedis.redisDel.mockImplementation(async (k: string) => {
+      redisStore.delete(k);
+    });
   });
   afterAll(() => mockRedis.redisEnabled.mockReturnValue(false));
 
@@ -255,7 +263,7 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     const res = await POST(makeReq("tok-lead"));
 
     expect(res.status).toBe(200);
-    expect(mockRedis.redisSetNx).toHaveBeenCalledWith(lockKey("tok-lead"), "1", 10);
+    expect(mockRedis.redisSetNx).toHaveBeenCalledWith(lockKey("tok-lead"), expect.any(String), 10);
     expect(JSON.parse(redisStore.get(resultKey("tok-lead"))!)).toMatchObject({
       kind: "ok",
       accessToken: "acc-lead",
@@ -267,9 +275,10 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
   it("waits for the peer's result instead of presenting the token when the lock is held", async () => {
     vi.useFakeTimers();
     try {
-      redisStore.set(lockKey("tok-wait"), "1"); // a peer holds the lock
+      redisStore.set(lockKey("tok-wait"), "peer-nonce"); // a peer holds the lock
 
       const pending = POST(makeReq("tok-wait"));
+      await vi.advanceTimersByTimeAsync(1); // caller takes the failed lock, enters the poll
       // The winner publishes its result while we're polling.
       redisStore.set(
         resultKey("tok-wait"),
@@ -289,10 +298,10 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
   it("returns a retryable 503 (cookie kept) when the lock is held and no result appears", async () => {
     vi.useFakeTimers();
     try {
-      redisStore.set(lockKey("tok-timeout"), "1");
+      redisStore.set(lockKey("tok-timeout"), "peer-nonce");
 
       const pending = POST(makeReq("tok-timeout"));
-      await vi.advanceTimersByTimeAsync(6_000); // past POLL_TIMEOUT_MS
+      await vi.advanceTimersByTimeAsync(6_000); // past POLL_TIMEOUT_MS, lock never clears
       const res = await pending;
 
       expect(res.status).toBe(503);
@@ -315,5 +324,106 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     expect(res.status).toBe(200);
     expect((await res.json()).accessToken).toBe("acc-fb");
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays a peer's cached invalid_grant across instances — 401, both cookies cleared, no upstream call", async () => {
+    redisStore.set(resultKey("tok-peer-invalid"), JSON.stringify({ kind: "invalid" }));
+
+    const res = await POST(makeReq("tok-peer-invalid"));
+
+    expect(res.status).toBe(401);
+    const setCookies = res.headers.getSetCookie();
+    expect(setCookies.some((c) => c.startsWith("qf_refresh_token=;"))).toBe(true);
+    expect(setCookies.some((c) => c.startsWith("qf_has_session=;"))).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores a malformed shared entry and leads a fresh refresh", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    redisStore.set(
+      resultKey("tok-malformed"),
+      JSON.stringify({ kind: "ok", accessToken: "x" }) // missing refreshToken
+    );
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "acc-fresh", refresh_token: "ref-fresh" }),
+    });
+
+    const res = await POST(makeReq("tok-malformed"));
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).accessToken).toBe("acc-fresh");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("unrecognized shared outcome"));
+    errSpy.mockRestore();
+  });
+
+  it("coalesces two concurrent same-token requests into one lock + one upstream call", async () => {
+    let resolveFetch!: (value: unknown) => void;
+    mockFetch.mockImplementationOnce(() => new Promise((resolve) => (resolveFetch = resolve)));
+
+    const p1 = POST(makeReq("tok-coalesce"));
+    const p2 = POST(makeReq("tok-coalesce"));
+    await new Promise((r) => setTimeout(r, 0)); // let the leader reach the upstream call
+    resolveFetch({
+      ok: true,
+      json: async () => ({ access_token: "acc-co", refresh_token: "ref-co" }),
+    });
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockRedis.redisSetNx).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the lock (does not release) when publishing the result fails", async () => {
+    mockRedis.redisSet.mockResolvedValue(false); // publish dropped
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "acc-np", refresh_token: "ref-np" }),
+    });
+
+    const res = await POST(makeReq("tok-nopublish"));
+
+    expect(res.status).toBe(200); // the leader still returns its own outcome
+    expect(mockRedis.redisDel).not.toHaveBeenCalledWith(lockKey("tok-nopublish"));
+    expect(redisStore.has(lockKey("tok-nopublish"))).toBe(true); // lock held to TTL
+  });
+
+  it("does not delete a lock a successor took while it was publishing (compare-and-delete)", async () => {
+    mockRedis.redisSet.mockImplementation(async (k: string, v: string) => {
+      redisStore.set(k, v);
+      // Our lease expired mid-publish and a peer grabbed a fresh lock.
+      redisStore.set(lockKey("tok-cad"), "successor-nonce");
+      return true;
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "a", refresh_token: "r" }),
+    });
+
+    await POST(makeReq("tok-cad"));
+
+    expect(redisStore.get(lockKey("tok-cad"))).toBe("successor-nonce"); // ours, not deleted
+  });
+
+  it("a waiter stops early (retryable 503) once the leader releases the lock with no result", async () => {
+    vi.useFakeTimers();
+    try {
+      redisStore.set(lockKey("tok-early"), "peer-nonce");
+      const pending = POST(makeReq("tok-early"));
+      await vi.advanceTimersByTimeAsync(1); // caller takes the failed lock, enters the poll
+      // Peer finished with a transient outcome: lock gone, no result published.
+      redisStore.delete(lockKey("tok-early"));
+      await vi.advanceTimersByTimeAsync(300); // one poll interval, not the full 5s
+      const res = await pending;
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("set-cookie")).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/__tests__/lib/infra/redis.test.ts
+++ b/__tests__/lib/infra/redis.test.ts
@@ -7,6 +7,7 @@ const behavior = vi.hoisted(() => ({
   get: vi.fn(),
   set: vi.fn(),
   del: vi.fn(),
+  eval: vi.fn(),
   ping: vi.fn(),
   multiExec: vi.fn(),
   subscribe: vi.fn((..._args: unknown[]) => Promise.resolve()),
@@ -44,6 +45,9 @@ vi.mock("ioredis", () => {
     del(...a: unknown[]) {
       return behavior.del(...a);
     }
+    eval(...a: unknown[]) {
+      return behavior.eval(...a);
+    }
     ping(...a: unknown[]) {
       return behavior.ping(...a);
     }
@@ -77,6 +81,7 @@ beforeEach(() => {
   behavior.get.mockReset();
   behavior.set.mockReset();
   behavior.del.mockReset();
+  behavior.eval.mockReset();
   behavior.ping.mockReset();
   behavior.multiExec.mockReset();
   behavior.subscribe.mockReset().mockReturnValue(Promise.resolve());
@@ -91,6 +96,7 @@ describe("lib/redis — disabled (no REDIS_URL)", () => {
     await expect(r.redisDel("k")).resolves.toBeUndefined();
     expect(await r.redisIncrWithTtl("k", 60)).toBeNull();
     expect(await r.redisSetNx("k", "v", 60)).toBeNull();
+    await expect(r.redisDelIfEqual("k", "v")).resolves.toBeUndefined();
     expect(behavior.ctor).not.toHaveBeenCalled();
   });
 });
@@ -127,6 +133,19 @@ describe("lib/redis — enabled, healthy", () => {
     const r = await import("@/lib/infra/redis");
     expect(await r.redisSetNx("lock:k", "1", 10)).toBe(false);
   });
+
+  it("redisDelIfEqual runs an atomic compare-and-delete Lua script", async () => {
+    behavior.eval.mockResolvedValue(1);
+    const r = await import("@/lib/infra/redis");
+
+    await r.redisDelIfEqual("lock:k", "nonce-1");
+    expect(behavior.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('del', KEYS[1])"),
+      1,
+      "lock:k",
+      "nonce-1"
+    );
+  });
 });
 
 describe("lib/redis — enabled, but every call errors (fail-open)", () => {
@@ -138,12 +157,14 @@ describe("lib/redis — enabled, but every call errors (fail-open)", () => {
     behavior.get.mockRejectedValue(new Error("down"));
     behavior.set.mockRejectedValue(new Error("down"));
     behavior.del.mockRejectedValue(new Error("down"));
+    behavior.eval.mockRejectedValue(new Error("down"));
     behavior.multiExec.mockRejectedValue(new Error("down"));
     const r = await import("@/lib/infra/redis");
 
     expect(await r.redisGet("k")).toBeNull();
     expect(await r.redisSet("k", "v", 60)).toBe(false);
     await expect(r.redisDel("k")).resolves.toBeUndefined();
+    await expect(r.redisDelIfEqual("k", "v")).resolves.toBeUndefined();
     expect(await r.redisIncrWithTtl("k", 60)).toBeNull();
     expect(await r.redisSetNx("k", "v", 60)).toBeNull();
     // The Redis path was genuinely entered (then swallowed) — not short-circuited:

--- a/__tests__/lib/infra/redis.test.ts
+++ b/__tests__/lib/infra/redis.test.ts
@@ -118,6 +118,11 @@ describe("lib/redis — enabled, healthy", () => {
     expect(await r.redisGet("k")).toBe("hello");
     expect(await r.redisIncrWithTtl("k", 60)).toBe(4);
     expect(behavior.ctor).toHaveBeenCalledTimes(1);
+    // A strict per-command deadline so no operation stays pending indefinitely.
+    expect(behavior.ctor).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ commandTimeout: 5000 })
+    );
   });
 
   it("redisSetNx returns true and issues SET ... EX NX when it takes the key", async () => {

--- a/__tests__/lib/infra/redis.test.ts
+++ b/__tests__/lib/infra/redis.test.ts
@@ -87,7 +87,7 @@ describe("lib/redis — disabled (no REDIS_URL)", () => {
     const r = await import("@/lib/infra/redis");
     expect(r.redisEnabled()).toBe(false);
     expect(await r.redisGet("k")).toBeNull();
-    await expect(r.redisSet("k", "v", 60)).resolves.toBeUndefined();
+    expect(await r.redisSet("k", "v", 60)).toBe(false);
     await expect(r.redisDel("k")).resolves.toBeUndefined();
     expect(await r.redisIncrWithTtl("k", 60)).toBeNull();
     expect(await r.redisSetNx("k", "v", 60)).toBeNull();
@@ -142,7 +142,7 @@ describe("lib/redis — enabled, but every call errors (fail-open)", () => {
     const r = await import("@/lib/infra/redis");
 
     expect(await r.redisGet("k")).toBeNull();
-    await expect(r.redisSet("k", "v", 60)).resolves.toBeUndefined();
+    expect(await r.redisSet("k", "v", 60)).toBe(false);
     await expect(r.redisDel("k")).resolves.toBeUndefined();
     expect(await r.redisIncrWithTtl("k", 60)).toBeNull();
     expect(await r.redisSetNx("k", "v", 60)).toBeNull();

--- a/__tests__/lib/infra/redis.test.ts
+++ b/__tests__/lib/infra/redis.test.ts
@@ -151,6 +151,29 @@ describe("lib/redis — enabled, healthy", () => {
       "nonce-1"
     );
   });
+
+  it("redisSetGuarded writes and returns true when the guard key matches", async () => {
+    behavior.eval.mockResolvedValue(1);
+    const r = await import("@/lib/infra/redis");
+
+    expect(await r.redisSetGuarded("result:k", "payload", 30, "lock:k", "nonce-1")).toBe(true);
+    expect(behavior.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('set', KEYS[1]"),
+      2,
+      "result:k",
+      "lock:k",
+      "nonce-1",
+      "payload",
+      30
+    );
+  });
+
+  it("redisSetGuarded does not write and returns false when the guard key no longer matches", async () => {
+    behavior.eval.mockResolvedValue(0);
+    const r = await import("@/lib/infra/redis");
+
+    expect(await r.redisSetGuarded("result:k", "payload", 30, "lock:k", "stale-nonce")).toBe(false);
+  });
 });
 
 describe("lib/redis — enabled, but every call errors (fail-open)", () => {
@@ -191,6 +214,19 @@ describe("lib/redis — enabled, but every call errors (fail-open)", () => {
     expect(errSpy).toHaveBeenCalledTimes(1);
     expect(errSpy).toHaveBeenCalledWith(
       expect.stringContaining("Redis redisSetNx failed"),
+      expect.any(Error)
+    );
+    errSpy.mockRestore();
+  });
+
+  it("redisSetGuarded returns false (not a throw) when the guarded eval errors", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    behavior.eval.mockRejectedValue(new Error("down"));
+    const r = await import("@/lib/infra/redis");
+
+    expect(await r.redisSetGuarded("result:k", "v", 30, "lock:k", "n")).toBe(false);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Redis redisSetGuarded failed"),
       expect.any(Error)
     );
     errSpy.mockRestore();

--- a/__tests__/lib/infra/redis.test.ts
+++ b/__tests__/lib/infra/redis.test.ts
@@ -173,6 +173,24 @@ describe("lib/redis — enabled, but every call errors (fail-open)", () => {
     expect(behavior.del).toHaveBeenCalledOnce();
   });
 
+  it("the lock helpers surface a failure (once) instead of swallowing it silently", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    behavior.set.mockRejectedValue(new Error("down"));
+    behavior.eval.mockRejectedValue(new Error("down"));
+    const r = await import("@/lib/infra/redis");
+
+    expect(await r.redisSetNx("lock:k", "n", 10)).toBeNull();
+    await r.redisDelIfEqual("lock:k", "n");
+    await r.redisSetNx("lock:k", "n", 10); // rate-limited: still only one line
+
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Redis redisSetNx failed"),
+      expect.any(Error)
+    );
+    errSpy.mockRestore();
+  });
+
   it("redisIncrWithTtl returns null when exec() reports an INCR error", async () => {
     behavior.multiExec.mockResolvedValue([[new Error("partial"), undefined]]);
     const r = await import("@/lib/infra/redis");

--- a/__tests__/lib/infra/redis.test.ts
+++ b/__tests__/lib/infra/redis.test.ts
@@ -90,6 +90,7 @@ describe("lib/redis — disabled (no REDIS_URL)", () => {
     await expect(r.redisSet("k", "v", 60)).resolves.toBeUndefined();
     await expect(r.redisDel("k")).resolves.toBeUndefined();
     expect(await r.redisIncrWithTtl("k", 60)).toBeNull();
+    expect(await r.redisSetNx("k", "v", 60)).toBeNull();
     expect(behavior.ctor).not.toHaveBeenCalled();
   });
 });
@@ -112,6 +113,20 @@ describe("lib/redis — enabled, healthy", () => {
     expect(await r.redisIncrWithTtl("k", 60)).toBe(4);
     expect(behavior.ctor).toHaveBeenCalledTimes(1);
   });
+
+  it("redisSetNx returns true and issues SET ... EX NX when it takes the key", async () => {
+    behavior.set.mockResolvedValue("OK");
+    const r = await import("@/lib/infra/redis");
+
+    expect(await r.redisSetNx("lock:k", "1", 10)).toBe(true);
+    expect(behavior.set).toHaveBeenCalledWith("lock:k", "1", "EX", 10, "NX");
+  });
+
+  it("redisSetNx returns false when the key is already held", async () => {
+    behavior.set.mockResolvedValue(null);
+    const r = await import("@/lib/infra/redis");
+    expect(await r.redisSetNx("lock:k", "1", 10)).toBe(false);
+  });
 });
 
 describe("lib/redis — enabled, but every call errors (fail-open)", () => {
@@ -130,9 +145,10 @@ describe("lib/redis — enabled, but every call errors (fail-open)", () => {
     await expect(r.redisSet("k", "v", 60)).resolves.toBeUndefined();
     await expect(r.redisDel("k")).resolves.toBeUndefined();
     expect(await r.redisIncrWithTtl("k", 60)).toBeNull();
+    expect(await r.redisSetNx("k", "v", 60)).toBeNull();
     // The Redis path was genuinely entered (then swallowed) — not short-circuited:
     expect(behavior.get).toHaveBeenCalledOnce();
-    expect(behavior.set).toHaveBeenCalledOnce();
+    expect(behavior.set).toHaveBeenCalledTimes(2);
     expect(behavior.del).toHaveBeenCalledOnce();
   });
 

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -45,16 +45,16 @@ const RESULT_TTL_MS = 30_000;
 const RESULT_TTL_SECONDS = RESULT_TTL_MS / 1000;
 // Hard timeout on the upstream token call.
 const UPSTREAM_TIMEOUT_MS = 8_000;
-// Hard bound on the leader's result publish (a Redis SET). Together with
-// UPSTREAM_TIMEOUT_MS this caps the whole leader critical section — call the
-// endpoint, publish the outcome, release the lock — well under LOCK_TTL_SECONDS,
-// so the lease can't auto-expire while the leader is still working and let a
-// second caller present the same (rotated) token.
+// Wrapper-level bound on the leader's result publish — lets the route proceed
+// promptly if the Redis SET is slow. The SET itself is also cancelled at the
+// client `commandTimeout` (lib/infra/redis.ts, 5s), so a slow publish can't
+// still land after the lease has passed to another leader.
 const PUBLISH_TIMEOUT_MS = 2_000;
 // A crashed leader's lock self-clears after this so the next request can lead.
-// Must stay above UPSTREAM_TIMEOUT_MS + PUBLISH_TIMEOUT_MS (+ a margin for the
-// tiny release call) so a live leader always finishes inside its own lease.
-const LOCK_TTL_SECONDS = 15;
+// Must exceed the whole leader critical section — UPSTREAM_TIMEOUT_MS + the
+// Redis `commandTimeout` for the publish + the same for the release — so a live
+// leader always finishes (or gives up) inside its own lease (8 + 5 + 5 < 20).
+const LOCK_TTL_SECONDS = 20;
 // A waiter that can't get the lock polls the shared result cache this long
 // before giving up with a retryable 503 (well under LOCK_TTL_SECONDS).
 const POLL_TIMEOUT_MS = 5_000;
@@ -125,9 +125,9 @@ function rememberLocally(refreshToken: string, outcome: RefreshOutcome): void {
   if (isCacheable(outcome)) recent.set(refreshToken, { outcome, at: Date.now() });
 }
 
-/** Resolve to `p`'s value, or to `onTimeout` if it hasn't settled in `ms` — so a
- *  stalled Redis command can't stretch the leader's critical section past its
- *  lease. */
+/** Resolve to `p`'s value, or to `onTimeout` if it hasn't settled in `ms`, so a
+ *  slow Redis publish doesn't hold up the response. The command itself is still
+ *  bounded by the client `commandTimeout`; this is only the wrapper. */
 function withTimeout<T>(p: Promise<T>, ms: number, onTimeout: T): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;
   const timeout = new Promise<T>((resolve) => {
@@ -161,13 +161,25 @@ async function callTokenEndpoint(refreshToken: string): Promise<RefreshOutcome> 
       return body?.error === "invalid_grant" ? { kind: "invalid" } : { kind: "transient" };
     }
 
-    const data = (await res.json()) as { access_token: string; refresh_token?: string };
+    const data = (await res.json().catch(() => null)) as {
+      access_token?: unknown;
+      refresh_token?: unknown;
+    } | null;
+    // Validate the token payload at this system boundary: a 2xx with no usable
+    // access_token must not be cached as an `ok` outcome (a peer would reject
+    // the malformed record and could re-present the token). Treat it as a
+    // transient upstream fault — the lease is freed so a retry can lead, and if
+    // the grant really was consumed the retry surfaces invalid_grant → re-login.
+    if (typeof data?.access_token !== "string" || data.access_token === "") {
+      console.error("auth/refresh: token endpoint returned a 2xx response with no access_token");
+      return { kind: "transient" };
+    }
+    const refreshTokenOut =
+      typeof data.refresh_token === "string" && data.refresh_token !== ""
+        ? data.refresh_token
+        : refreshToken;
     // Re-stamp the existing token if the provider didn't rotate.
-    return {
-      kind: "ok",
-      accessToken: data.access_token,
-      refreshToken: data.refresh_token ?? refreshToken,
-    };
+    return { kind: "ok", accessToken: data.access_token, refreshToken: refreshTokenOut };
   } catch {
     return { kind: "transient" };
   }

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -43,12 +43,18 @@ const inflight = new Map<string, Promise<RefreshOutcome>>();
 const recent = new Map<string, { outcome: RefreshOutcome; at: number }>();
 const RESULT_TTL_MS = 30_000;
 const RESULT_TTL_SECONDS = RESULT_TTL_MS / 1000;
-// Hard timeout on the upstream token call. Kept below LOCK_TTL_SECONDS so the
-// leader always settles (releasing or deliberately holding its lock) before the
-// lock could auto-expire under it and let a second caller present the same token.
+// Hard timeout on the upstream token call.
 const UPSTREAM_TIMEOUT_MS = 8_000;
+// Hard bound on the leader's result publish (a Redis SET). Together with
+// UPSTREAM_TIMEOUT_MS this caps the whole leader critical section — call the
+// endpoint, publish the outcome, release the lock — well under LOCK_TTL_SECONDS,
+// so the lease can't auto-expire while the leader is still working and let a
+// second caller present the same (rotated) token.
+const PUBLISH_TIMEOUT_MS = 2_000;
 // A crashed leader's lock self-clears after this so the next request can lead.
-const LOCK_TTL_SECONDS = 10;
+// Must stay above UPSTREAM_TIMEOUT_MS + PUBLISH_TIMEOUT_MS (+ a margin for the
+// tiny release call) so a live leader always finishes inside its own lease.
+const LOCK_TTL_SECONDS = 15;
 // A waiter that can't get the lock polls the shared result cache this long
 // before giving up with a retryable 503 (well under LOCK_TTL_SECONDS).
 const POLL_TIMEOUT_MS = 5_000;
@@ -119,6 +125,17 @@ function rememberLocally(refreshToken: string, outcome: RefreshOutcome): void {
   if (isCacheable(outcome)) recent.set(refreshToken, { outcome, at: Date.now() });
 }
 
+/** Resolve to `p`'s value, or to `onTimeout` if it hasn't settled in `ms` — so a
+ *  stalled Redis command can't stretch the leader's critical section past its
+ *  lease. */
+function withTimeout<T>(p: Promise<T>, ms: number, onTimeout: T): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve(onTimeout), ms);
+  });
+  return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
+}
+
 async function callTokenEndpoint(refreshToken: string): Promise<RefreshOutcome> {
   const tokenUrl = `${process.env.QF_AUTH_BASE}/oauth2/token`;
   const clientId = process.env.NEXT_PUBLIC_QF_CLIENT_ID!;
@@ -177,13 +194,22 @@ function refresh(refreshToken: string): Promise<RefreshOutcome> {
   return pending;
 }
 
+let loggedRedisConfigError = false;
+
 /** `redisEnabled()` constructs the client on first call and can throw
  *  synchronously on a malformed REDIS_URL — never let that 500 the refresh
- *  endpoint; fall back to the per-process path. */
+ *  endpoint; fall back to the per-process path. Surface it once (per the repo's
+ *  "no silent catch" rule) without logging the URL: a bad REDIS_URL silently
+ *  disabling cross-instance coordination is exactly the kind of failure an
+ *  operator needs to see. */
 function redisAvailable(): boolean {
   try {
     return redisEnabled();
   } catch {
+    if (!loggedRedisConfigError) {
+      loggedRedisConfigError = true;
+      console.error("auth/refresh: REDIS_URL is invalid; coordinating per-process only");
+    }
     return false;
   }
 }
@@ -236,16 +262,18 @@ async function leadRefreshCoordinated(refreshToken: string): Promise<RefreshOutc
       // re-presenting the (now consumed) token. The key is a hash of the incoming
       // token; the deployment must run Redis with auth + TLS + network isolation
       // (same trust assumption as lib/auth/social-auth.ts's token cache).
-      const published = await redisSet(
-        resultKey(refreshToken),
-        JSON.stringify(outcome),
-        RESULT_TTL_SECONDS
+      const published = await withTimeout(
+        redisSet(resultKey(refreshToken), JSON.stringify(outcome), RESULT_TTL_SECONDS),
+        PUBLISH_TIMEOUT_MS,
+        false
       );
       rememberLocally(refreshToken, outcome);
       // Only release the lock once peers can actually read the result. If the
-      // publish didn't land, keep the lock until its TTL so peers keep getting a
-      // retryable 503 rather than re-leading and presenting the (now consumed)
-      // token a second time.
+      // publish didn't land (or didn't land in time), keep the lock until its
+      // TTL so peers keep getting a retryable 503 rather than re-leading and
+      // presenting the (now consumed) token a second time — by then the local
+      // `recent` cache and any peer that reads the eventually-written result
+      // replay it directly.
       if (published) await releaseLock(refreshToken, nonce);
     } else {
       // transient — the token wasn't successfully consumed, so a retry can lead.

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { HAS_SESSION_COOKIE_NAME, hasSessionCookieOptions } from "@/lib/auth/session-cookie";
+import { redisDel, redisEnabled, redisGet, redisSet, redisSetNx } from "@/lib/infra/redis";
 
 const COOKIE_NAME = "qf_refresh_token";
 
@@ -31,9 +33,71 @@ type RefreshOutcome =
 // concurrent requests share the in-flight promise, and requests that arrive just
 // afterwards (still holding the old cookie) get the cached result — so Ory only
 // ever sees T used once, and every caller's browser converges onto the new token.
+//
+// The per-process maps below only coalesce within one instance. When Redis is
+// configured this is also backed by a shared result cache + lock keyed on a hash
+// of T, so two instances (or a restart mid-rotation) still present T upstream
+// exactly once. Redis stays optional: with it disabled, or unreachable, this
+// degrades to the per-process behavior.
 const inflight = new Map<string, Promise<RefreshOutcome>>();
 const recent = new Map<string, { outcome: RefreshOutcome; at: number }>();
 const RESULT_TTL_MS = 30_000;
+const RESULT_TTL_SECONDS = RESULT_TTL_MS / 1000;
+// Upper bound on one upstream token call; a crashed leader's lock self-clears
+// after this so the next request can lead.
+const LOCK_TTL_SECONDS = 10;
+// A waiter that can't get the lock polls the shared result cache this long
+// before giving up with a retryable 503 (well under LOCK_TTL_SECONDS).
+const POLL_TIMEOUT_MS = 5_000;
+const POLL_INTERVAL_MS = 250;
+
+// Tokens are secrets — the Redis key is a hash of the token, never the token
+// itself (mirrors lib/auth/social-auth.ts).
+function resultKey(refreshToken: string): string {
+  return `auth:refresh:${createHash("sha256").update(refreshToken).digest("hex")}`;
+}
+function lockKey(refreshToken: string): string {
+  return `${resultKey(refreshToken)}:lock`;
+}
+
+// "ok" and "invalid" are definitive and safe to replay; "transient" must be
+// retried against the live endpoint.
+function isCacheable(outcome: RefreshOutcome): boolean {
+  return outcome.kind === "ok" || outcome.kind === "invalid";
+}
+
+async function readSharedOutcome(refreshToken: string): Promise<RefreshOutcome | null> {
+  const raw = await redisGet(resultKey(refreshToken));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as RefreshOutcome;
+    if (
+      parsed.kind === "ok" &&
+      typeof parsed.accessToken === "string" &&
+      typeof parsed.refreshToken === "string"
+    ) {
+      return parsed;
+    }
+    if (parsed.kind === "invalid") return { kind: "invalid" };
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function pollSharedOutcome(refreshToken: string): Promise<RefreshOutcome | null> {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    const shared = await readSharedOutcome(refreshToken);
+    if (shared) return shared;
+  }
+  return null;
+}
+
+function rememberLocally(refreshToken: string, outcome: RefreshOutcome): void {
+  if (isCacheable(outcome)) recent.set(refreshToken, { outcome, at: Date.now() });
+}
 
 async function callTokenEndpoint(refreshToken: string): Promise<RefreshOutcome> {
   const tokenUrl = `${process.env.QF_AUTH_BASE}/oauth2/token`;
@@ -80,19 +144,74 @@ function refresh(refreshToken: string): Promise<RefreshOutcome> {
   const cached = recent.get(refreshToken);
   if (cached) return Promise.resolve(cached.outcome);
 
+  // In-process coalescing (no Redis round-trip for same-instance races). The
+  // get→set must stay synchronous — no await between them.
   const existing = inflight.get(refreshToken);
   if (existing) return existing;
 
-  const pending = callTokenEndpoint(refreshToken)
-    .then((outcome) => {
-      // Cache definitive outcomes; let transient failures be retried immediately.
-      if (outcome.kind !== "transient") recent.set(refreshToken, { outcome, at: Date.now() });
-      return outcome;
-    })
-    .finally(() => inflight.delete(refreshToken));
-
+  const pending = (
+    redisEnabled() ? leadRefreshCoordinated(refreshToken) : leadRefreshLocal(refreshToken)
+  ).finally(() => inflight.delete(refreshToken));
   inflight.set(refreshToken, pending);
   return pending;
+}
+
+/** One upstream call, its definitive outcome remembered per-process. */
+function leadRefreshLocal(refreshToken: string): Promise<RefreshOutcome> {
+  return callTokenEndpoint(refreshToken).then((outcome) => {
+    rememberLocally(refreshToken, outcome);
+    return outcome;
+  });
+}
+
+/**
+ * Perform (or wait out) one refresh for `refreshToken`, coordinating across
+ * instances via Redis:
+ *  - a result another instance already cached is replayed;
+ *  - otherwise take a short Redis lock and call the token endpoint once,
+ *    publishing the definitive outcome for peers;
+ *  - a caller that can't take the lock waits for the winner's result rather than
+ *    presenting the (rotated) token itself, and returns a retryable "transient"
+ *    if none appears in time.
+ * If Redis turns out to be unreachable it falls back to a plain per-process call.
+ */
+async function leadRefreshCoordinated(refreshToken: string): Promise<RefreshOutcome> {
+  const shared = await readSharedOutcome(refreshToken);
+  if (shared) {
+    rememberLocally(refreshToken, shared);
+    return shared;
+  }
+
+  const gotLock = await redisSetNx(lockKey(refreshToken), "1", LOCK_TTL_SECONDS);
+
+  if (gotLock === false) {
+    // A peer instance is refreshing this token. Wait for its result; never call
+    // the endpoint ourselves — that's the double-present that revokes the session.
+    const waited = await pollSharedOutcome(refreshToken);
+    if (waited) {
+      rememberLocally(refreshToken, waited);
+      return waited;
+    }
+    return { kind: "transient" };
+  }
+
+  if (gotLock === true) {
+    try {
+      const outcome = await callTokenEndpoint(refreshToken);
+      if (isCacheable(outcome)) {
+        await redisSet(resultKey(refreshToken), JSON.stringify(outcome), RESULT_TTL_SECONDS);
+        rememberLocally(refreshToken, outcome);
+      }
+      return outcome;
+    } finally {
+      await redisDel(lockKey(refreshToken));
+    }
+  }
+
+  // gotLock === null → Redis went unreachable between redisEnabled() and here.
+  // Behave as a single instance: the per-process inflight/recent maps still
+  // coalesce this instance; a cross-instance race is the pre-existing latent risk.
+  return leadRefreshLocal(refreshToken);
 }
 
 export async function POST(req: NextRequest) {

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { HAS_SESSION_COOKIE_NAME, hasSessionCookieOptions } from "@/lib/auth/session-cookie";
 import { redisDel, redisEnabled, redisGet, redisSet, redisSetNx } from "@/lib/infra/redis";
@@ -43,8 +43,11 @@ const inflight = new Map<string, Promise<RefreshOutcome>>();
 const recent = new Map<string, { outcome: RefreshOutcome; at: number }>();
 const RESULT_TTL_MS = 30_000;
 const RESULT_TTL_SECONDS = RESULT_TTL_MS / 1000;
-// Upper bound on one upstream token call; a crashed leader's lock self-clears
-// after this so the next request can lead.
+// Hard timeout on the upstream token call. Kept below LOCK_TTL_SECONDS so the
+// leader always settles (releasing or deliberately holding its lock) before the
+// lock could auto-expire under it and let a second caller present the same token.
+const UPSTREAM_TIMEOUT_MS = 8_000;
+// A crashed leader's lock self-clears after this so the next request can lead.
 const LOCK_TTL_SECONDS = 10;
 // A waiter that can't get the lock polls the shared result cache this long
 // before giving up with a retryable 503 (well under LOCK_TTL_SECONDS).
@@ -70,17 +73,23 @@ async function readSharedOutcome(refreshToken: string): Promise<RefreshOutcome |
   const raw = await redisGet(resultKey(refreshToken));
   if (!raw) return null;
   try {
-    const parsed = JSON.parse(raw) as RefreshOutcome;
+    const parsed = JSON.parse(raw) as Partial<RefreshOutcome>;
     if (
       parsed.kind === "ok" &&
       typeof parsed.accessToken === "string" &&
       typeof parsed.refreshToken === "string"
     ) {
-      return parsed;
+      return { kind: "ok", accessToken: parsed.accessToken, refreshToken: parsed.refreshToken };
     }
     if (parsed.kind === "invalid") return { kind: "invalid" };
+    console.error(
+      "auth/refresh: unrecognized shared outcome shape in Redis — leading a fresh refresh"
+    );
     return null;
   } catch {
+    console.error(
+      "auth/refresh: could not parse shared outcome from Redis — leading a fresh refresh"
+    );
     return null;
   }
 }
@@ -91,8 +100,20 @@ async function pollSharedOutcome(refreshToken: string): Promise<RefreshOutcome |
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     const shared = await readSharedOutcome(refreshToken);
     if (shared) return shared;
+    // The leader released its lock without publishing a result → its outcome was
+    // transient. Stop now and let the caller return a retryable 503 rather than
+    // stalling for the full timeout on a failure everyone will just retry.
+    if ((await redisGet(lockKey(refreshToken))) === null) return null;
   }
   return null;
+}
+
+/** Release the lock only if it is still the one we took — so a leader that
+ *  overran its TTL can't delete a successor's lock. */
+async function releaseLock(refreshToken: string, nonce: string): Promise<void> {
+  if ((await redisGet(lockKey(refreshToken))) === nonce) {
+    await redisDel(lockKey(refreshToken));
+  }
 }
 
 function rememberLocally(refreshToken: string, outcome: RefreshOutcome): void {
@@ -116,6 +137,7 @@ async function callTokenEndpoint(refreshToken: string): Promise<RefreshOutcome> 
         grant_type: "refresh_token",
         refresh_token: refreshToken,
       }).toString(),
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
 
     if (!res.ok) {
@@ -150,10 +172,21 @@ function refresh(refreshToken: string): Promise<RefreshOutcome> {
   if (existing) return existing;
 
   const pending = (
-    redisEnabled() ? leadRefreshCoordinated(refreshToken) : leadRefreshLocal(refreshToken)
+    redisAvailable() ? leadRefreshCoordinated(refreshToken) : leadRefreshLocal(refreshToken)
   ).finally(() => inflight.delete(refreshToken));
   inflight.set(refreshToken, pending);
   return pending;
+}
+
+/** `redisEnabled()` constructs the client on first call and can throw
+ *  synchronously on a malformed REDIS_URL — never let that 500 the refresh
+ *  endpoint; fall back to the per-process path. */
+function redisAvailable(): boolean {
+  try {
+    return redisEnabled();
+  } catch {
+    return false;
+  }
 }
 
 /** One upstream call, its definitive outcome remembered per-process. */
@@ -182,7 +215,8 @@ async function leadRefreshCoordinated(refreshToken: string): Promise<RefreshOutc
     return shared;
   }
 
-  const gotLock = await redisSetNx(lockKey(refreshToken), "1", LOCK_TTL_SECONDS);
+  const nonce = randomUUID();
+  const gotLock = await redisSetNx(lockKey(refreshToken), nonce, LOCK_TTL_SECONDS);
 
   if (gotLock === false) {
     // A peer instance is refreshing this token. Wait for its result; never call
@@ -196,19 +230,32 @@ async function leadRefreshCoordinated(refreshToken: string): Promise<RefreshOutc
   }
 
   if (gotLock === true) {
-    try {
-      const outcome = await callTokenEndpoint(refreshToken);
-      if (isCacheable(outcome)) {
-        await redisSet(resultKey(refreshToken), JSON.stringify(outcome), RESULT_TTL_SECONDS);
-        rememberLocally(refreshToken, outcome);
-      }
-      return outcome;
-    } finally {
-      await redisDel(lockKey(refreshToken));
+    const outcome = await callTokenEndpoint(refreshToken);
+    if (isCacheable(outcome)) {
+      // The rotated refresh token + access token are cached here in cleartext for
+      // RESULT_TTL_SECONDS so peer instances can replay them instead of
+      // re-presenting the (now consumed) token. The key is a hash of the incoming
+      // token; the deployment must run Redis with auth + TLS + network isolation
+      // (same trust assumption as lib/auth/social-auth.ts's token cache).
+      const published = await redisSet(
+        resultKey(refreshToken),
+        JSON.stringify(outcome),
+        RESULT_TTL_SECONDS
+      );
+      rememberLocally(refreshToken, outcome);
+      // Only release the lock once peers can actually read the result. If the
+      // publish didn't land, keep the lock until its TTL so peers keep getting a
+      // retryable 503 rather than re-leading and presenting the (now consumed)
+      // token a second time.
+      if (published) await releaseLock(refreshToken, nonce);
+    } else {
+      // transient — the token wasn't successfully consumed, so a retry can lead.
+      await releaseLock(refreshToken, nonce);
     }
+    return outcome;
   }
 
-  // gotLock === null → Redis went unreachable between redisEnabled() and here.
+  // gotLock === null → Redis went unreachable between redisAvailable() and here.
   // Behave as a single instance: the per-process inflight/recent maps still
   // coalesce this instance; a cross-instance race is the pre-existing latent risk.
   return leadRefreshLocal(refreshToken);

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { HAS_SESSION_COOKIE_NAME, hasSessionCookieOptions } from "@/lib/auth/session-cookie";
-import { redisDel, redisEnabled, redisGet, redisSet, redisSetNx } from "@/lib/infra/redis";
+import { redisDelIfEqual, redisEnabled, redisGet, redisSet, redisSetNx } from "@/lib/infra/redis";
 
 const COOKIE_NAME = "qf_refresh_token";
 
@@ -108,12 +108,11 @@ async function pollSharedOutcome(refreshToken: string): Promise<RefreshOutcome |
   return null;
 }
 
-/** Release the lock only if it is still the one we took — so a leader that
- *  overran its TTL can't delete a successor's lock. */
-async function releaseLock(refreshToken: string, nonce: string): Promise<void> {
-  if ((await redisGet(lockKey(refreshToken))) === nonce) {
-    await redisDel(lockKey(refreshToken));
-  }
+/** Release the lock only if it is still the exact one we took (atomic
+ *  compare-and-delete) — so a leader that overran its TTL can't delete a
+ *  successor's lock. */
+function releaseLock(refreshToken: string, nonce: string): Promise<void> {
+  return redisDelIfEqual(lockKey(refreshToken), nonce);
 }
 
 function rememberLocally(refreshToken: string, outcome: RefreshOutcome): void {

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,7 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { HAS_SESSION_COOKIE_NAME, hasSessionCookieOptions } from "@/lib/auth/session-cookie";
-import { redisDelIfEqual, redisEnabled, redisGet, redisSet, redisSetNx } from "@/lib/infra/redis";
+import {
+  redisDelIfEqual,
+  redisEnabled,
+  redisGet,
+  redisSetGuarded,
+  redisSetNx,
+} from "@/lib/infra/redis";
 
 const COOKIE_NAME = "qf_refresh_token";
 
@@ -45,15 +51,19 @@ const RESULT_TTL_MS = 30_000;
 const RESULT_TTL_SECONDS = RESULT_TTL_MS / 1000;
 // Hard timeout on the upstream token call.
 const UPSTREAM_TIMEOUT_MS = 8_000;
-// Wrapper-level bound on the leader's result publish — lets the route proceed
-// promptly if the Redis SET is slow. The SET itself is also cancelled at the
-// client `commandTimeout` (lib/infra/redis.ts, 5s), so a slow publish can't
-// still land after the lease has passed to another leader.
+// Wrapper-level bound so the route can proceed promptly if the Redis publish is
+// slow — NOT what makes a delayed publish safe. A client-side timeout (this one
+// or the Redis client's `commandTimeout`) only rejects the local promise;
+// ioredis cannot cancel a command already sent to the server, so a "timed out"
+// SET can still land afterwards. Correctness comes from `redisSetGuarded`
+// itself: the write is conditioned on the lock still holding this leader's
+// nonce, so a late arrival from an expired lease is a no-op once a successor
+// has taken the lock, not an overwrite of whatever the successor published.
 const PUBLISH_TIMEOUT_MS = 2_000;
 // A crashed leader's lock self-clears after this so the next request can lead.
-// Must exceed the whole leader critical section — UPSTREAM_TIMEOUT_MS + the
-// Redis `commandTimeout` for the publish + the same for the release — so a live
-// leader always finishes (or gives up) inside its own lease (8 + 5 + 5 < 20).
+// Kept comfortably above the upstream call plus a slow publish/release so a
+// live leader normally finishes inside its own lease — but this is a
+// liveness/latency knob, not a correctness one; see `redisSetGuarded` above.
 const LOCK_TTL_SECONDS = 20;
 // A waiter that can't get the lock polls the shared result cache this long
 // before giving up with a retryable 503 (well under LOCK_TTL_SECONDS).
@@ -274,8 +284,17 @@ async function leadRefreshCoordinated(refreshToken: string): Promise<RefreshOutc
       // re-presenting the (now consumed) token. The key is a hash of the incoming
       // token; the deployment must run Redis with auth + TLS + network isolation
       // (same trust assumption as lib/auth/social-auth.ts's token cache).
+      // Guarded on the lock still holding OUR nonce (see redisSetGuarded) — a
+      // publish that lands after our lease expired and a successor has taken
+      // the lock is a no-op, never an overwrite of the successor's result.
       const published = await withTimeout(
-        redisSet(resultKey(refreshToken), JSON.stringify(outcome), RESULT_TTL_SECONDS),
+        redisSetGuarded(
+          resultKey(refreshToken),
+          JSON.stringify(outcome),
+          RESULT_TTL_SECONDS,
+          lockKey(refreshToken),
+          nonce
+        ),
         PUBLISH_TIMEOUT_MS,
         false
       );

--- a/lib/infra/redis.ts
+++ b/lib/infra/redis.ts
@@ -38,6 +38,12 @@ export function getRedis(): Redis | null {
     // Bound every command so a stalled Redis can't hang a request; on failure
     // the helpers below catch and fall back.
     maxRetriesPerRequest: 2,
+    // Strict per-command deadline: a command that gets no reply in this long
+    // rejects with a timeout error instead of staying pending. Every helper
+    // below catches it and falls back. Kept below the auth refresh lock TTL
+    // (app/api/auth/refresh/route.ts) so a result publish can never land after
+    // the lease has passed to another leader.
+    commandTimeout: 5000,
     // Don't buffer commands while disconnected — fail fast to the fallback path.
     enableOfflineQueue: false,
     connectTimeout: 3000,

--- a/lib/infra/redis.ts
+++ b/lib/infra/redis.ts
@@ -127,6 +127,27 @@ export async function redisDel(key: string): Promise<void> {
   }
 }
 
+/**
+ * Atomically DELETE `key` only if its current value equals `expected` (a Lua
+ * compare-and-delete, no check-then-act gap). For releasing a lock so a holder
+ * can only remove its own lease. No-op on disable/error — a stuck lock then
+ * self-clears at its TTL.
+ */
+export async function redisDelIfEqual(key: string, expected: string): Promise<void> {
+  const r = getRedis();
+  if (!r) return;
+  try {
+    await r.eval(
+      "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+      1,
+      key,
+      expected
+    );
+  } catch {
+    // Best-effort; ignore.
+  }
+}
+
 /** Publishes `message` on `channel`; silently no-ops on disable/error. Used for
  *  cross-instance cache invalidation (e.g. auth cache flushes). */
 export function redisPublish(channel: string, message: string): void {

--- a/lib/infra/redis.ts
+++ b/lib/infra/redis.ts
@@ -89,6 +89,29 @@ export async function redisSet(key: string, value: string, ttlSeconds: number): 
   }
 }
 
+/**
+ * SET `key`=`value` only if it does not already exist (NX), with a TTL in
+ * seconds. Returns `true` when this call took the key, `false` when another
+ * holder already has it, and `null` when Redis is disabled or errored — so a
+ * caller using this as a cross-instance lock can tell "someone else is doing it"
+ * (wait) apart from "no distributed lock available" (fall back to local-only),
+ * the same tri-state convention as {@link redisIncrWithTtl}.
+ */
+export async function redisSetNx(
+  key: string,
+  value: string,
+  ttlSeconds: number
+): Promise<boolean | null> {
+  const r = getRedis();
+  if (!r) return null;
+  try {
+    const res = await r.set(key, value, "EX", ttlSeconds, "NX");
+    return res === "OK";
+  } catch {
+    return null;
+  }
+}
+
 /** DELETE a key; silently no-ops on disable/error. */
 export async function redisDel(key: string): Promise<void> {
   const r = getRedis();

--- a/lib/infra/redis.ts
+++ b/lib/infra/redis.ts
@@ -171,6 +171,48 @@ export async function redisDelIfEqual(key: string, expected: string): Promise<vo
   }
 }
 
+/**
+ * Atomically SET `key`=`value` (with TTL) only if `guardKey` currently equals
+ * `expectedGuardValue` (a Lua compare-and-set, no check-then-act gap).
+ *
+ * This is the safe way to publish a result gated on still holding a lock. A
+ * client-side timeout (e.g. `commandTimeout`) only rejects the LOCAL promise —
+ * ioredis cannot cancel a command already flushed to the server, so a "timed
+ * out" write can still land later. Guarding the write itself means a delayed
+ * publish from a leader whose lease already expired becomes a no-op the moment
+ * a successor has taken the guard key, instead of silently overwriting
+ * whatever the successor published.
+ *
+ * Returns `true` when the write landed, `false` when the guard didn't match,
+ * Redis errored, or Redis is disabled — callers only need to know whether the
+ * value is now visible to peers.
+ */
+export async function redisSetGuarded(
+  key: string,
+  value: string,
+  ttlSeconds: number,
+  guardKey: string,
+  expectedGuardValue: string
+): Promise<boolean> {
+  const r = getRedis();
+  if (!r) return false;
+  try {
+    const res = await r.eval(
+      "if redis.call('get', KEYS[2]) == ARGV[1] then redis.call('set', KEYS[1], ARGV[2], 'EX', ARGV[3]) return 1 else return 0 end",
+      2,
+      key,
+      guardKey,
+      expectedGuardValue,
+      value,
+      ttlSeconds
+    );
+    return res === 1;
+  } catch (err) {
+    logLockError("redisSetGuarded", err);
+    return false;
+  }
+}
+
 /** Publishes `message` on `channel`; silently no-ops on disable/error. Used for
  *  cross-instance cache invalidation (e.g. auth cache flushes). */
 export function redisPublish(channel: string, message: string): void {

--- a/lib/infra/redis.ts
+++ b/lib/infra/redis.ts
@@ -78,14 +78,18 @@ export async function redisGet(key: string): Promise<string | null> {
   }
 }
 
-/** SET a string value with a TTL (seconds); silently no-ops on disable/error. */
-export async function redisSet(key: string, value: string, ttlSeconds: number): Promise<void> {
+/** SET a string value with a TTL (seconds). Returns `true` when the write
+ *  landed, `false` when Redis is disabled or the write errored — callers that
+ *  only cache can ignore it; a caller that must know the value is visible to
+ *  peers (e.g. a lock/result publish) can branch on it. */
+export async function redisSet(key: string, value: string, ttlSeconds: number): Promise<boolean> {
   const r = getRedis();
-  if (!r) return;
+  if (!r) return false;
   try {
     await r.set(key, value, "EX", ttlSeconds);
+    return true;
   } catch {
-    // Best-effort cache write; ignore failures.
+    return false;
   }
 }
 

--- a/lib/infra/redis.ts
+++ b/lib/infra/redis.ts
@@ -55,6 +55,7 @@ export function getRedis(): Redis | null {
   });
   c.on("ready", () => {
     loggedError = false;
+    loggedLockError = false;
   });
 
   client = c;
@@ -111,9 +112,23 @@ export async function redisSetNx(
   try {
     const res = await r.set(key, value, "EX", ttlSeconds, "NX");
     return res === "OK";
-  } catch {
+  } catch (err) {
+    logLockError("redisSetNx", err);
     return null;
   }
+}
+
+// One-shot logging for the lock helpers below. A silently-swallowed failure on
+// a lock acquire/release is not "best-effort cache" territory — it can leave a
+// cross-instance lock stuck or let two callers both proceed — so it must surface
+// (per the repo's "no silent catch" rule). Rate-limited to one line until Redis
+// recovers so a sustained outage on a hot path (the refresh endpoint) can't
+// flood the log.
+let loggedLockError = false;
+function logLockError(op: string, err: unknown): void {
+  if (loggedLockError) return;
+  loggedLockError = true;
+  console.error(`Redis ${op} failed, falling back:`, err);
 }
 
 /** DELETE a key; silently no-ops on disable/error. */
@@ -143,8 +158,10 @@ export async function redisDelIfEqual(key: string, expected: string): Promise<vo
       key,
       expected
     );
-  } catch {
-    // Best-effort; ignore.
+  } catch (err) {
+    // A stuck lock still self-clears at its TTL, but a failed release on a hot
+    // path should not be invisible.
+    logLockError("redisDelIfEqual", err);
   }
 }
 


### PR DESCRIPTION
## Problem

Closes #555.

`app/api/auth/refresh/route.ts` deduped concurrent refreshes with module-level `inflight` / `recent` maps — **per-process**. Ory revokes the entire session when a rotated refresh token is presented twice. With more than one app instance (or a restart/deploy mid-rotation), two tabs on different instances both present cookie `T`, the second read as reuse, and the user is bounced to sign-in. Latent on the current single-container deploy; a hard correctness cliff on horizontal scale-out.

## Change

When `REDIS_URL` is configured, one refresh per token `T` is coordinated across instances (`leadRefreshCoordinated`):

1. **Shared result cache** — key `auth:refresh:<sha256(T)>` (hash, never the token; mirrors `lib/auth/social-auth.ts`), 30s TTL, holds only `ok` / `invalid` outcomes (never `transient`). A result a peer already cached is replayed.
2. **Shared lock** — `SET <key>:lock NX EX 10`. The winner calls the token endpoint once and `redisSet`s the outcome for peers, then releases the lock in `finally`.
3. **Losers wait, they don't present `T`** — a caller that can't take the lock polls the result cache for up to 5s (`POLL_TIMEOUT_MS`, well under the 10s lock TTL) and replays the winner's result. If nothing appears it returns a **retryable 503** rather than calling the endpoint itself — calling it would be the exact double-present that revokes the session. Documented in a code comment.

New helper `redisSetNx(key, value, ttl)` in `lib/infra/redis.ts` returns `true` / `false` / `null` — the same tri-state convention as `redisIncrWithTtl`, so "a peer holds the lock" (wait) is distinct from "no distributed lock available" (fall back to the local-only path).

**Redis stays optional.** With `REDIS_URL` unset the route takes `leadRefreshLocal` — byte-for-byte the previous per-process `inflight` + `recent` behavior, `callTokenEndpoint` still reached synchronously. If Redis is configured but goes unreachable mid-request, `redisSetNx` returns `null` and the route falls back to the same local path. The per-process maps remain as the in-instance coalescing layer in front of Redis.

No new env var. No auth-check loosening. No CSP change.

## Hardening applied after review

- **Upstream deadline < lock TTL** — `callTokenEndpoint`'s `fetch` now carries `AbortSignal.timeout(8s)` (< `LOCK_TTL_SECONDS` 10s), so a slow Ory can't let the lock auto-expire under a live leader.
- **Owned lease + compare-and-delete** — the lock value is a per-request `randomUUID()`; `releaseLock` deletes it only if it's still ours, so a leader that somehow overran its TTL can't delete a successor's lock.
- **Publish-then-release** — `redisSet` now returns a boolean; the lock is released only once the result is confirmed visible to peers. If the publish is dropped, the lock is held to its TTL (peers keep getting a retryable 503) rather than freed for a re-lead.
- **Fast-fail on a transient leader** — a waiter also exits the poll the moment the lock disappears with no result published, instead of stalling the full 5s.
- **`redisAvailable()` guard** — `redisEnabled()` (which builds the client) is wrapped so a malformed `REDIS_URL` can't 500 the refresh endpoint.

## Known residual

A refresh-token cache entry holds the **rotated refresh token + access token in cleartext in Redis for 30s** (key = `sha256` of the incoming token). This is the same trust assumption as `lib/auth/social-auth.ts`'s token cache — the deployment must run Redis with auth, TLS, and network isolation. Encrypting the cached outcome at rest, or dropping cross-instance token replay in favour of 503-and-retry, is a possible follow-up.

The only remaining double-present window: a `redisSet` publish that *reports* success but is not actually durable while `redisDel` and a peer's `redisSetNx` both succeed — narrow, and vastly smaller than the pre-PR behaviour (which double-presents on essentially every ≥2-instance refresh).

## Tests

- `__tests__/api/auth-refresh.test.ts` — new `Redis-coordinated (multi-instance)` block over a shared in-memory Redis stand-in: replay a peer's cached result (no upstream call); lead + publish + release lock; lock-held → wait for the peer's result, never present `T`; lock-held + no result → retryable 503, cookie kept; `redisSetNx` → `null` → direct-call fallback. Default `redisEnabled()` is `false`, so every pre-existing test still exercises the unchanged per-process path.
- `__tests__/lib/infra/redis.test.ts` — `redisSetNx`: `true` + `SET … EX NX` args when it takes the key; `false` when held; `null` on fail-open and when disabled.

## Verification

`bun run typecheck` · `bun run lint` · `bun run format:check` · `bun run test:ci` (1572) · `bun run test:integration` (pre-push) — all green locally.

## Auth / security surface

High-risk per AGENTS.md (`lib/auth/`, the refresh/rotation flow). This PR: adds a Redis-backed lock + result cache to an existing single-flight; no auth check is loosened or bypassed; no secret or env var added. The **incoming** token is only used as a `sha256` Redis key. The **rotated** refresh token + access token are written to the shared cache in cleartext for 30s so peers can replay them — hashed key, 30s TTL, and the Redis-trust assumption above; matches `social-auth.ts`. Waiters never present the token themselves (they 503 and retry), and the new lock-timeout 503 path does not create a client retry loop — `SessionRestorer` (`components/providers.tsx`) fires the refresh once per mount and simply skips restore on `!res.ok`; `AdminContext` retries on 401 only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Coordinated concurrent refresh-token requests across multiple application instances to prevent duplicate token rotations.
  * Requests can wait for an in-progress refresh result, reducing unnecessary retries and inconsistent outcomes.
  * Refresh requests return a retryable 503 response when coordination times out or upstream responses are malformed.
  * Refresh operations now have bounded timeouts for improved responsiveness.
  * Existing fallback behavior is preserved when coordination services are unavailable or misconfigured.

* **Tests**
  * Added coverage for coordination, timeout handling, fallback behavior, malformed responses, concurrency, and lock safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
