### PR TITLE
fix(connections): filter the insert-conflict re-read to active rows

### DIFF
--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -205,6 +205,23 @@ describe("getConnections", () => {
     expect(mockIncr).toHaveBeenCalledWith("gen_persist_failed");
   });
 
+  it("on an insert conflict, falls back to the freshly generated reason when no ACTIVE row exists for it", async () => {
+    // Simulates a retired row occupying the same (fromRef, toRef, kind, locale)
+    // unique key: onConflictDoNothing() discards the insert (empty `returning`),
+    // and the re-read — correctly filtered to status "active" — finds nothing,
+    // so the result must keep the newly generated reason rather than a retired
+    // row's stale one.
+    mockSelect
+      .mockReturnValueOnce(makeSelectChain([])) // initial cache read: miss
+      .mockReturnValueOnce(makeSelectChain([])); // conflict re-read: no active row
+    mockGenerate.mockResolvedValue([result("2:255")]);
+    mockReturning.mockResolvedValue([]); // insert conflicted, nothing won the race
+
+    const out = await getConnections("1:1", "thematic", source);
+
+    expect(out[0]).toMatchObject({ ref: "2:255", reason: "because" });
+  });
+
   it("on a miss that generates nothing, does not write to the DB", async () => {
     mockSelect.mockReturnValue(makeSelectChain([]));
     mockGenerate.mockResolvedValue([]);

--- a/lib/ai/graph-service.ts
+++ b/lib/ai/graph-service.ts
@@ -494,6 +494,7 @@ export async function generateConnectionsForCell(
               eq(connections.fromRef, fromRef),
               eq(connections.kind, kind),
               eq(connections.locale, "en"),
+              eq(connections.status, "active"),
               inArray(
                 connections.toRef,
                 conflicted.map((g) => g.ref)


### PR DESCRIPTION
## What

\`generateConnectionsForCell\`'s insert-conflict re-read (the block that resolves an \`onConflictDoNothing()\` race) queried by \`fromRef\`/\`kind\`/\`locale\`/\`toRef\` only — no \`status\` filter.

## Why

The unique index backing that conflict, \`connections_from_to_kind_locale_idx\`, is on \`(fromRef, toRef, kind, locale)\` and does **not** include \`status\`. So a row an admin has since retired still occupies that key, and a fresh insert for the same cell gets discarded by \`onConflictDoNothing()\` exactly like a genuine concurrent-insert race. The re-read that resolves that race then had no way to distinguish "a peer legitimately won this row" from "a retired row is squatting on the key" — it could hand back the retired row's stale/rejected reason through \`reasonByRef\`, resurrecting it instead of keeping the freshly generated one.

This mirrors the fix already present in this same file's \`persistTranslatedRows\` (added for the same class of bug on the non-English path) and the primary cache-read query (\`readActiveRows\`), both of which already filter \`eq(connections.status, "active")\`.

## Fix

Add \`eq(connections.status, "active")\` to the conflict re-read's \`where\`. When no active row exists for a conflicted ref, the existing fallback (\`persistedReason !== undefined ? ... : g\`) already keeps the newly generated reason — no other logic changes needed.

## Testing

- Added a regression test asserting that on an insert conflict with no active row backing it, the result uses the freshly generated reason.
- \`bun run test:ci -- graph-service\` — 33/33 passed.
- \`bun run typecheck\`, \`bun run lint\`, \`bun run format:check\` — clean (pre-existing unrelated warnings only).
- \`bun run test:integration\` passed via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh9iePk6q1mKTiZbszHpAi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection generation when an existing matching record is retired or flagged, ensuring it is not incorrectly reused.
  - Preserved the newly generated connection reason when no active matching record is available after an insert conflict.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->