### PR TITLE
fix(auth): surface a failed refresh-outcome publish, don't log raw upstream errors

### DIFF
--- a/__tests__/api/auth-refresh.test.ts
+++ b/__tests__/api/auth-refresh.test.ts
@@ -136,12 +136,19 @@ describe("POST /api/auth/refresh", () => {
     expect(setCookies.some((c) => c.startsWith("qf_has_session=;"))).toBe(true);
   });
 
-  it("returns 503 and keeps the cookie on a transient upstream failure", async () => {
-    mockFetch.mockRejectedValueOnce(new Error("network error"));
+  it("returns 503 and keeps the cookie on a transient upstream failure, logging a fixed message", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValueOnce(new Error("network error: secret-token-in-message"));
 
     const res = await POST(makeReq("refresh-transient-4"));
     expect(res.status).toBe(503);
     expect(res.headers.get("set-cookie")).toBeNull();
+    // A fixed message only — never the raw error, the token, or the URL.
+    expect(errSpy).toHaveBeenCalledWith(
+      "auth/refresh: token endpoint request failed (network error or timeout)"
+    );
+    expect(errSpy.mock.calls.flat().join(" ")).not.toContain("secret-token-in-message");
+    errSpy.mockRestore();
   });
 
   it("returns 503 for a non-invalid_grant error response", async () => {
@@ -405,7 +412,8 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     expect(mockRedis.redisSetNx).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the lock (does not release) when publishing the result fails", async () => {
+  it("keeps the lock (does not release) when publishing the result fails, and surfaces it — not silently", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mockRedis.redisSetGuarded.mockResolvedValue(false); // publish dropped
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -420,6 +428,10 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
       expect.anything()
     );
     expect(redisStore.has(lockKey("tok-nopublish"))).toBe(true); // lock held to TTL
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to publish the refresh outcome")
+    );
+    errSpy.mockRestore();
   });
 
   it("does not delete a lock a successor took while it was publishing (compare-and-delete)", async () => {

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { HAS_SESSION_COOKIE_NAME, hasSessionCookieOptions } from "@/lib/auth/session-cookie";
+import { incr } from "@/lib/infra/metrics";
 import {
   redisDelIfEqual,
   redisEnabled,
@@ -191,6 +192,11 @@ async function callTokenEndpoint(refreshToken: string): Promise<RefreshOutcome> 
     // Re-stamp the existing token if the provider didn't rotate.
     return { kind: "ok", accessToken: data.access_token, refreshToken: refreshTokenOut };
   } catch {
+    // A network error or the AbortSignal.timeout firing — never log the raw
+    // error, the request URL, or anything derived from `refreshToken`/the
+    // Authorization header (a secret-bearing system boundary); a fixed message
+    // is enough for an operator to see the upstream is failing.
+    console.error("auth/refresh: token endpoint request failed (network error or timeout)");
     return { kind: "transient" };
   }
 }
@@ -299,6 +305,19 @@ async function leadRefreshCoordinated(refreshToken: string): Promise<RefreshOutc
         false
       );
       rememberLocally(refreshToken, outcome);
+      if (!published) {
+        // Not necessarily lost: a "false" here can mean our wrapper gave up
+        // waiting while the write was still in flight (ioredis can't cancel an
+        // already-sent command), so it may still land moments later — and
+        // RESULT_TTL_SECONDS outlives LOCK_TTL_SECONDS, so a peer reading after
+        // our lock expires would still see it. This only surfaces the case
+        // where it never lands at all (a genuine Redis failure): a silent
+        // return here would hide it entirely (no counter, no log), so surface
+        // it per the repo's "no silent catch" rule even though the outcome
+        // below is still correct for this request.
+        console.error("auth/refresh: failed to publish the refresh outcome for peers");
+        incr("auth_refresh_publish_failed");
+      }
       // Only release the lock once peers can actually read the result. If the
       // publish didn't land (or didn't land in time), keep the lock until its
       // TTL so peers keep getting a retryable 503 rather than re-leading and


### PR DESCRIPTION
## What

Review follow-up on #595 (Redis-coordinated refresh single-flight). Two silent-failure gaps in \`app/api/auth/refresh/route.ts\`:

1. **\`callTokenEndpoint\`'s catch was fully silent.** A \`fetch\` rejection or an \`AbortSignal.timeout\` firing returned \`{ kind: "transient" }\` with no log at all — an upstream outage was invisible to operators.
2. **A failed \`redisSetGuarded\` publish in \`leadRefreshCoordinated\` was silently swallowed.** No log, no metric — just a comment explaining why the lock is kept.

## Why only this much

I looked at whether an unpublished result could let a *successor* leader re-present the same (already-consumed) refresh token to Ory after the lock's TTL — which would force a needless re-login. In practice this is already narrow:

- \`redisSetGuarded\`'s write is not cancelled by our route-level timeout (ioredis can't cancel an in-flight command) — a "false" from \`withTimeout\` usually just means the write hadn't confirmed within \`PUBLISH_TIMEOUT_MS\` (2s), not that it failed. It typically still lands.
- \`RESULT_TTL_SECONDS\` (30s) outlives \`LOCK_TTL_SECONDS\` (20s), so a peer reading *after* the lock naturally expires still finds the result if it landed at any point before 30s.
- A publish that **never** lands at all implies a genuine Redis outage, in which case a single forced re-login is the same "Redis outage never takes the site down" degrade already used everywhere else in \`lib/infra/redis.ts\`.

So the residual risk is narrow and already an accepted degrade path elsewhere in this codebase. What wasn't acceptable per this repo's "no silent catch" rule is that neither failure mode left any trace for an operator to see. This PR fixes exactly that — logging (a fixed message, never the raw error/URL/token) and a counter — without changing the coordination logic itself.

## Testing

- Extended \`__tests__/api/auth-refresh.test.ts\`:
  - the transient-upstream-failure test now asserts the fixed log message and that no error-message-embedded secret leaks through it,
  - the failed-publish test now asserts the new log line.
- \`bun run test:ci -- auth-refresh\` — 26/26 passed.
- \`bun run typecheck\`, \`bun run lint\`, \`bun run format:check\` — clean (pre-existing unrelated warnings only).
- \`bun run test:integration\` passed via the pre-push hook.

## Auth / security surface

Touches \`app/api/auth/refresh/route.ts\` (high-risk per CODEOWNERS) — flagging explicitly per repo guardrails. No behavior change to the refresh/lock/publish logic itself, only added logging/metrics on paths that were previously silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh9iePk6q1mKTiZbszHpAi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication refresh error handling with sanitized messages that prevent sensitive request and token details from appearing in logs.
  - Added clearer logging when publishing refresh results fails, while preserving the successful refresh response and lock handling.
  - Added monitoring for failed refresh-result publication events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->