### PR TITLE
fix(auth,connections): distinguish a timed-out publish from a failed one; guard the conflict-reread status filter

### DIFF
--- a/__tests__/api/auth-refresh.test.ts
+++ b/__tests__/api/auth-refresh.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import { createHash } from "node:crypto";
 import { NextRequest } from "next/server";
+import { counterSnapshot } from "@/lib/infra/metrics";
 
 // A shared in-memory stand-in for the Redis helpers, so two logical "instances"
 // (both driving the one POST handler) see the same result cache + lock. Default
@@ -414,11 +415,12 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
 
   it("keeps the lock (does not release) when publishing the result fails, and surfaces it — not silently", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    mockRedis.redisSetGuarded.mockResolvedValue(false); // publish dropped
+    mockRedis.redisSetGuarded.mockResolvedValue(false); // a genuine, resolved failure
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ access_token: "acc-np", refresh_token: "ref-np" }),
     });
+    const before = counterSnapshot().auth_refresh_publish_failed ?? 0;
 
     const res = await POST(makeReq("tok-nopublish"));
 
@@ -431,6 +433,8 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     expect(errSpy).toHaveBeenCalledWith(
       expect.stringContaining("failed to publish the refresh outcome")
     );
+    // A resolved `false` is a confirmed failure — counted.
+    expect(counterSnapshot().auth_refresh_publish_failed).toBe(before + 1);
     errSpy.mockRestore();
   });
 
@@ -499,16 +503,19 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
     }
   });
 
-  it("treats a publish that stalls past the publish timeout as unpublished and keeps the lock", async () => {
+  it("treats a publish that stalls past the publish timeout as unresolved (not a failure) and keeps the lock", async () => {
     vi.useFakeTimers();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
-      // The publish never settles — withTimeout() must resolve it to `false`
-      // rather than let the leader's critical section run past its lease.
+      // The publish never settles — withTimeout() must resolve the wrapper
+      // promptly without treating that as a confirmed `redisSetGuarded`
+      // failure, since the write may still land after this request returns.
       mockRedis.redisSetGuarded.mockImplementation(() => new Promise<boolean>(() => {}));
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ access_token: "acc-slow", refresh_token: "ref-slow" }),
       });
+      const before = counterSnapshot().auth_refresh_publish_failed ?? 0;
 
       const pending = POST(makeReq("tok-slowpub"));
       await vi.advanceTimersByTimeAsync(2_500); // past PUBLISH_TIMEOUT_MS (2s)
@@ -521,7 +528,14 @@ describe("POST /api/auth/refresh — Redis-coordinated (multi-instance)", () => 
         expect.anything()
       );
       expect(redisStore.has(lockKey("tok-slowpub"))).toBe(true); // held to TTL
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("timed out"));
+      expect(errSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("failed to publish the refresh outcome")
+      );
+      // Unresolved, not a confirmed failure — must not be counted as one.
+      expect(counterSnapshot().auth_refresh_publish_failed ?? 0).toBe(before);
     } finally {
+      errSpy.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/__tests__/lib/ai/graph-service.test.ts
+++ b/__tests__/lib/ai/graph-service.test.ts
@@ -1,8 +1,38 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Column, Param, is } from "drizzle-orm";
 import type { Verse, VerseRef, ConnectionResult } from "@/types/quran";
 
+// Real drizzle SQL objects (eq/and/inArray are NOT mocked — see below), so a
+// where(...) condition can be inspected structurally instead of by string
+// matching. Walks the nested queryChunks that `and(...)`/`eq(...)` build and
+// checks whether a `status` column is compared against the exact value.
+function flattenChunks(node: unknown, out: unknown[] = []): unknown[] {
+  const chunks = (node as { queryChunks?: unknown[] } | null)?.queryChunks;
+  if (!Array.isArray(chunks)) {
+    out.push(node);
+    return out;
+  }
+  for (const chunk of chunks) flattenChunks(chunk, out);
+  return out;
+}
+function whereFilters(condition: unknown, column: string, value: unknown): boolean {
+  const flat = flattenChunks(condition);
+  for (let i = 0; i < flat.length; i++) {
+    const chunk = flat[i];
+    if (is(chunk, Column) && chunk.name === column) {
+      const param = flat.slice(i + 1).find((c) => is(c, Param));
+      if (param && is(param, Param)) return param.value === value;
+    }
+  }
+  return false;
+}
+
 // ── DB mock: select() resolves to a configurable result; insert() is chainable ──
-function makeSelectChain(resolveWith: unknown[]) {
+// `resolveWith` can be a plain array, or a function of the captured where(...)
+// condition — the latter lets a test assert on the predicate actually built,
+// not just stub a fixed response regardless of it.
+function makeSelectChain(resolveWith: unknown[] | ((whereArg: unknown) => unknown[])) {
+  let capturedWhere: unknown;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const chain: any = new Proxy(
     function () {
@@ -11,8 +41,16 @@ function makeSelectChain(resolveWith: unknown[]) {
     {
       get(_t, prop) {
         if (prop === "then")
-          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
-            Promise.resolve(resolveWith).then(res, rej);
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) => {
+            const rows =
+              typeof resolveWith === "function" ? resolveWith(capturedWhere) : resolveWith;
+            return Promise.resolve(rows).then(res, rej);
+          };
+        if (prop === "where")
+          return (arg: unknown) => {
+            capturedWhere = arg;
+            return chain;
+          };
         return () => chain;
       },
       apply() {
@@ -208,18 +246,27 @@ describe("getConnections", () => {
   it("on an insert conflict, falls back to the freshly generated reason when no ACTIVE row exists for it", async () => {
     // Simulates a retired row occupying the same (fromRef, toRef, kind, locale)
     // unique key: onConflictDoNothing() discards the insert (empty `returning`),
-    // and the re-read — correctly filtered to status "active" — finds nothing,
-    // so the result must keep the newly generated reason rather than a retired
-    // row's stale one.
-    mockSelect
-      .mockReturnValueOnce(makeSelectChain([])) // initial cache read: miss
-      .mockReturnValueOnce(makeSelectChain([])); // conflict re-read: no active row
+    // and the re-read must filter on status = "active" so a retired row is
+    // never adopted as if it were the winning generation. The mock actually
+    // inspects the where(...) predicate rather than stubbing a fixed empty
+    // result — so dropping `eq(connections.status, "active")` from the source
+    // re-read would make this test fail, not pass vacuously.
+    const retiredReason = "retired reason — must not be served";
+    mockSelect.mockReturnValueOnce(makeSelectChain([])).mockReturnValue(
+      makeSelectChain(
+        (whereArg) =>
+          whereFilters(whereArg, "status", "active")
+            ? [] // correctly filtered: the retired row is excluded
+            : [{ toRef: "2:255", reason: retiredReason }] // bug: it would be resurrected
+      )
+    );
     mockGenerate.mockResolvedValue([result("2:255")]);
     mockReturning.mockResolvedValue([]); // insert conflicted, nothing won the race
 
     const out = await getConnections("1:1", "thematic", source);
 
     expect(out[0]).toMatchObject({ ref: "2:255", reason: "because" });
+    expect(out[0].reason).not.toBe(retiredReason);
   });
 
   it("on a miss that generates nothing, does not write to the DB", async () => {

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -61,6 +61,10 @@ const UPSTREAM_TIMEOUT_MS = 8_000;
 // nonce, so a late arrival from an expired lease is a no-op once a successor
 // has taken the lock, not an overwrite of whatever the successor published.
 const PUBLISH_TIMEOUT_MS = 2_000;
+// Distinct from `false` — a timed-out publish is unresolved (it may still land
+// per the comment above), not a confirmed `redisSetGuarded` failure. Keeping
+// the two distinguishable in the caller lets it count only genuine failures.
+const PUBLISH_TIMED_OUT = Symbol("publish-timed-out");
 // A crashed leader's lock self-clears after this so the next request can lead.
 // Kept comfortably above the upstream call plus a slow publish/release so a
 // live leader normally finishes inside its own lease — but this is a
@@ -293,7 +297,7 @@ async function leadRefreshCoordinated(refreshToken: string): Promise<RefreshOutc
       // Guarded on the lock still holding OUR nonce (see redisSetGuarded) — a
       // publish that lands after our lease expired and a successor has taken
       // the lock is a no-op, never an overwrite of the successor's result.
-      const published = await withTimeout(
+      const published = await withTimeout<boolean | typeof PUBLISH_TIMED_OUT>(
         redisSetGuarded(
           resultKey(refreshToken),
           JSON.stringify(outcome),
@@ -302,19 +306,23 @@ async function leadRefreshCoordinated(refreshToken: string): Promise<RefreshOutc
           nonce
         ),
         PUBLISH_TIMEOUT_MS,
-        false
+        PUBLISH_TIMED_OUT
       );
       rememberLocally(refreshToken, outcome);
-      if (!published) {
-        // Not necessarily lost: a "false" here can mean our wrapper gave up
-        // waiting while the write was still in flight (ioredis can't cancel an
-        // already-sent command), so it may still land moments later — and
-        // RESULT_TTL_SECONDS outlives LOCK_TTL_SECONDS, so a peer reading after
-        // our lock expires would still see it. This only surfaces the case
-        // where it never lands at all (a genuine Redis failure): a silent
-        // return here would hide it entirely (no counter, no log), so surface
-        // it per the repo's "no silent catch" rule even though the outcome
-        // below is still correct for this request.
+      if (published === PUBLISH_TIMED_OUT) {
+        // Unresolved, not failed: our wrapper gave up waiting while the write
+        // was still in flight (ioredis can't cancel an already-sent command),
+        // so it may still land moments later — and RESULT_TTL_SECONDS outlives
+        // LOCK_TTL_SECONDS, so a peer reading after our lock expires would
+        // still see it. Log it (visibility into publish latency) but don't
+        // count it as a failure — that would misrepresent a call that may yet
+        // succeed as one that definitely didn't.
+        console.error("auth/refresh: publish to Redis timed out (may still land)");
+      } else if (published === false) {
+        // A genuine `redisSetGuarded` failure: it won't land. A silent return
+        // here would hide it entirely (no counter, no log), so surface it per
+        // the repo's "no silent catch" rule even though the outcome below is
+        // still correct for this request.
         console.error("auth/refresh: failed to publish the refresh outcome for peers");
         incr("auth_refresh_publish_failed");
       }
@@ -324,7 +332,7 @@ async function leadRefreshCoordinated(refreshToken: string): Promise<RefreshOutc
       // presenting the (now consumed) token a second time — by then the local
       // `recent` cache and any peer that reads the eventually-written result
       // replay it directly.
-      if (published) await releaseLock(refreshToken, nonce);
+      if (published === true) await releaseLock(refreshToken, nonce);
     } else {
       // transient — the token wasn't successfully consumed, so a retry can lead.
       await releaseLock(refreshToken, nonce);


### PR DESCRIPTION
## What

Two follow-ups against two review comments on this branch's ancestor commits, verified against current `main` (which had already merged #596 and #597 addressing related but not identical concerns while this was in progress):

**`app/api/auth/refresh/route.ts`** — `withTimeout()` was resolving a stalled Redis publish to the same `false` as a confirmed `redisSetGuarded` failure, so `auth_refresh_publish_failed` (added in #597) and its error log fired on both a genuine failure and an unresolved, possibly-still-landing write. Gave the timeout its own sentinel so the counter only increments on a resolved `false`. Lock-release behavior (keep the lock in both cases, since neither means "definitely didn't land") is unchanged.

**`__tests__/lib/ai/graph-service.test.ts`** — `generateConnectionsForCell`'s insert-conflict re-read already filters on `status = "active"` (mirrors `persistTranslatedRows`, fixed in #596), but the test's `makeSelectChain` mock ignored the `where(...)` predicate entirely, so every `select()` call resolved the same fixed rows regardless of what was actually queried — dropping that filter would have passed silently. `makeSelectChain` now also accepts a function of the captured `where(...)` argument, and a small helper walks the real (unmocked) drizzle SQL condition to check which column/value pairs it filters on. The existing conflict-reread test now uses this instead of stubbing a fixed empty result — verified locally that removing the status filter makes it fail.

## Why (per review)

> Update the publish flow... to use a distinct timeout sentinel, so a timeout is not treated as a failed publication when the underlying call later succeeds. Increment auth_refresh_publish_failed only when redisSetGuarded returns false, while handling timeout outcomes separately.

> The conflict re-read mock in the test should inspect the predicate passed through the select chain's where call... Update the mock... so removing eq(connections.status, "active") from generateConnectionsForCell causes the test to fail.

## Testing

- `bun run test:ci` — all unit tests pass (auth-refresh + graph-service suites specifically re-run and verified)
- `bun run typecheck` / `bun run lint` / `bun run format:check` — clean on touched files
- Manually verified the new graph-service test fails when `eq(connections.status, "active")` is removed from the source, and passes when present
- `bun run test:integration` — passed via the pre-push hook (Testcontainers)

No behavior change to the AI prompts, divine-name data, or theological framing.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRprUveCywFmhoTuFzLBGH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication refresh handling when publishing the refresh result times out.
  - Refresh locks are now retained during uncertain publish outcomes, preventing premature release and reducing the risk of conflicting refresh operations.
  - Confirmed publish failures are handled separately from timeouts, improving error reporting and monitoring accuracy.

- **Tests**
  - Added coverage for publish failures, timeouts, lock behavior, and active-record filtering during recovery flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->