### PR TITLE
fix(names): retry on Gemini when the primary generation throws

### DIFF
--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -367,17 +367,69 @@ describe("getOrGenerateNameContent", () => {
     expect(out).toEqual(["ok"]);
   });
 
-  it("surfaces a generate() rejection and clears the lock so the next call retries", async () => {
+  it("retries on Gemini when the primary throws, and caches the fallback's result", async () => {
     mockSelect.mockReturnValue(makeSelectChain([])); // miss
-    const generate = vi.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValue(["ok"]);
+    const ai = await import("@/lib/ai/ai");
+    const providerSpy = vi.spyOn(ai, "resolveProvider").mockResolvedValue("claude");
+    const modelSpy = vi
+      .spyOn(ai, "resolveModel")
+      .mockImplementation(async (_feature, provider) =>
+        provider === "claude" ? "claude-opus-5" : "gemini-3.7-flash"
+      );
+
+    const generate = vi.fn(async (resolved: { provider: string; model: string }) => {
+      if (resolved.provider === "claude") throw new Error("claude overloaded");
+      return ["ok"];
+    });
+
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
+
+    expect(out).toEqual(["ok"]);
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
+    expect(values.model).toBe("gemini-3.7-flash");
+    providerSpy.mockRestore();
+    modelSpy.mockRestore();
+  });
+
+  it("does not retry on Gemini when a throwing primary is already Gemini", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const ai = await import("@/lib/ai/ai");
+    const providerSpy = vi.spyOn(ai, "resolveProvider").mockResolvedValue("gemini");
+    const modelSpy = vi.spyOn(ai, "resolveModel").mockResolvedValue("gemini-3.7-flash");
+    const generate = vi.fn().mockRejectedValue(new Error("gemini down"));
+
+    await expect(
+      getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr)
+    ).rejects.toThrow("gemini down");
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(mockInsert).not.toHaveBeenCalled();
+    providerSpy.mockRestore();
+    modelSpy.mockRestore();
+  });
+
+  it("surfaces the original error when the primary throws AND the Gemini retry also fails, and clears the lock so the next call retries", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const generate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockRejectedValueOnce(new Error("gemini down"))
+      .mockResolvedValue(["ok"]);
 
     await expect(
       getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr)
     ).rejects.toThrow("boom");
+    expect(generate).toHaveBeenCalledTimes(2); // primary + fallback attempt
+    expect(errorSpy).toHaveBeenCalledWith("Names: Gemini fallback failed:", expect.any(Error));
+    expect(mockInsert).not.toHaveBeenCalled();
+
     // lock released in finally → fresh call regenerates
     const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
     expect(out).toEqual(["ok"]);
-    expect(generate).toHaveBeenCalledTimes(2);
+    expect(generate).toHaveBeenCalledTimes(3);
+    errorSpy.mockRestore();
   });
 });
 

--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -581,6 +581,32 @@ describe("getOrGenerateVerseReason", () => {
     modelSpy.mockRestore();
   });
 
+  it("retries on Gemini when the primary translation call throws, and persists the fallback's string result", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const ai = await import("@/lib/ai/ai");
+    const providerSpy = vi.spyOn(ai, "resolveProvider").mockResolvedValue("claude");
+    const modelSpy = vi
+      .spyOn(ai, "resolveModel")
+      .mockImplementation(async (_feature, provider) =>
+        provider === "claude" ? "claude-opus-5" : "gemini-3.7-flash"
+      );
+
+    const generate = vi.fn(async (resolved: { provider: string; model: string }) => {
+      if (resolved.provider === "claude") throw new Error("claude overloaded");
+      return "çeviri";
+    });
+
+    const out = await getOrGenerateVerseReason("ar-rahman", "2:255", "tr", generate);
+
+    expect(out).toBe("çeviri");
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
+    expect(values.model).toBe("gemini-3.7-flash");
+    providerSpy.mockRestore();
+    modelSpy.mockRestore();
+  });
+
   it("when another process wins the insert race, returns the persisted (stored) translation, not the local one", async () => {
     // First select (cache check): miss. Second select (post-conflict re-read,
     // triggered by an empty .returning()): the other writer's stored value.

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -24,12 +24,20 @@ const resolveNamesModel = async (): Promise<ResolvedNamesModel> => {
 
 /**
  * Resolves the primary provider+model, generates once, and — only when the
- * primary is Claude and the result comes back empty (the shape a route's own
- * caught AI failure already takes, see reflection/pairings/verses routes) —
- * retries once against Gemini, whose API key is already provisioned in every
- * deployment (see .env.example) and whose free tier easily absorbs an
- * occasional retry. One-directional (Claude -> Gemini only): a deployment
- * already pointed at Gemini for "names" has nothing to fall back to.
+ * primary is Claude and either the result comes back empty (the shape a
+ * route's own caught AI failure already takes, see reflection/pairings/verses
+ * routes) OR the call throws — retries once against Gemini, whose API key is
+ * already provisioned in every deployment (see .env.example) and whose free
+ * tier easily absorbs an occasional retry. One-directional (Claude -> Gemini
+ * only): a deployment already pointed at Gemini for "names" has nothing to
+ * fall back to, so a throw there re-raises immediately.
+ *
+ * A throw and an empty result are treated the same for *retry* purposes, but
+ * differ in what happens when the retry ALSO fails: an empty primary result
+ * degrades to that (still-valid, just uncached) empty result, same as before
+ * this retry existed. A primary *throw* means there is no valid result to
+ * degrade to, so the fallback's failure re-raises the original primary error
+ * — never silently downgrading a real failure into a fabricated empty success.
  *
  * Returns whichever (result, model) pair actually produced the value, so the
  * persisted `model` column never disagrees with what actually ran.
@@ -39,9 +47,21 @@ async function resolveAndGenerate<T>(
   isEmpty: (value: T) => boolean
 ): Promise<{ result: T; model: string }> {
   const resolved = await resolveNamesModel();
-  const result = await generate(resolved);
-  if (!isEmpty(result) || resolved.provider !== "claude") {
+
+  let result: T;
+  let primaryError: unknown;
+  try {
+    result = await generate(resolved);
+  } catch (err) {
+    primaryError = err;
+    result = undefined as T;
+  }
+
+  if (primaryError === undefined && (!isEmpty(result) || resolved.provider !== "claude")) {
     return { result, model: resolved.model };
+  }
+  if (primaryError !== undefined && resolved.provider !== "claude") {
+    throw primaryError;
   }
 
   try {
@@ -50,10 +70,15 @@ async function resolveAndGenerate<T>(
     if (!isEmpty(fallbackResult)) incr("names_ai_fallback_used");
     return { result: fallbackResult, model: fallbackModel };
   } catch (err) {
-    // A fallback-attempt failure must degrade to the primary's (empty)
-    // result — same as a primary failure already does — never let the retry
-    // surface as an unhandled rejection callers didn't have to handle before.
     console.error("Names: Gemini fallback failed:", err);
+    // The primary threw: there's no valid result to degrade to, so the
+    // original failure must surface — swallowing it here would turn a real
+    // AI failure into a fabricated empty success.
+    if (primaryError !== undefined) throw primaryError;
+    // The primary just returned empty: degrade to that (still-valid, just
+    // uncached) result, same as before this retry existed — never let a
+    // fallback-attempt failure surface as an unhandled rejection callers
+    // didn't have to handle before.
     return { result, model: resolved.model };
   }
 }

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -32,6 +32,15 @@ const resolveNamesModel = async (): Promise<ResolvedNamesModel> => {
  * only): a deployment already pointed at Gemini for "names" has nothing to
  * fall back to, so a throw there re-raises immediately.
  *
+ * Every current `generate` callback already catches its own `callAI` failure
+ * and returns an empty result rather than throwing, so a throw reaching here
+ * today is never itself a provider error — it's something upstream of the AI
+ * call (e.g. a verse-search/fetch failure in the "verses" generator). Gemini
+ * can't fix that, so the retry there just re-runs the whole callback once
+ * more before re-raising the same error. That's accepted as the cost of one
+ * uniform contract: any future `generate` that lets a genuine provider error
+ * propagate gets the retry it needs, without every callback having to opt in.
+ *
  * A throw and an empty result are treated the same for *retry* purposes, but
  * differ in what happens when the retry ALSO fails: an empty primary result
  * degrades to that (still-valid, just uncached) empty result, same as before
@@ -48,20 +57,25 @@ async function resolveAndGenerate<T>(
 ): Promise<{ result: T; model: string }> {
   const resolved = await resolveNamesModel();
 
-  let result: T;
+  let result: T | undefined;
+  let threw = false;
   let primaryError: unknown;
   try {
     result = await generate(resolved);
   } catch (err) {
+    threw = true;
     primaryError = err;
-    result = undefined as T;
+    // Logged here (not just on a subsequent fallback failure) so a systematic
+    // primary failure that Gemini happens to paper over still surfaces —
+    // otherwise it would produce no log line at all.
+    console.error(`Names: primary (${resolved.provider}) generation failed:`, err);
+    incr("names_primary_generation_failed");
   }
 
-  if (primaryError === undefined && (!isEmpty(result) || resolved.provider !== "claude")) {
-    return { result, model: resolved.model };
-  }
-  if (primaryError !== undefined && resolved.provider !== "claude") {
-    throw primaryError;
+  const shouldRetry = resolved.provider === "claude" && (threw || isEmpty(result as T));
+  if (!shouldRetry) {
+    if (threw) throw primaryError;
+    return { result: result as T, model: resolved.model };
   }
 
   try {
@@ -74,12 +88,12 @@ async function resolveAndGenerate<T>(
     // The primary threw: there's no valid result to degrade to, so the
     // original failure must surface — swallowing it here would turn a real
     // AI failure into a fabricated empty success.
-    if (primaryError !== undefined) throw primaryError;
+    if (threw) throw primaryError;
     // The primary just returned empty: degrade to that (still-valid, just
     // uncached) result, same as before this retry existed — never let a
     // fallback-attempt failure surface as an unhandled rejection callers
     // didn't have to handle before.
-    return { result, model: resolved.model };
+    return { result: result as T, model: resolved.model };
   }
 }
 


### PR DESCRIPTION
## Summary

- `lib/names/name-content.ts`'s `resolveAndGenerate()` retried the Claude→Gemini fallback only when the primary call resolved to an *empty* result — a primary call that **threw** propagated immediately with no retry, unlike every other write path in this area.
- Makes the two failure shapes symmetric: a throw now gets the same Gemini retry an empty result already gets. If the retry also fails, the **original primary error** is re-raised (not swallowed into a fabricated empty success) — only an empty-result primary still degrades to that empty result on a failed retry, since there's an actual valid value to fall back to in that case.

Closes #566. The issue's other three findings (B1 blank-reason connections, B2 native per-locale vs. en-canonical connections, B3 no refusal screening on reflection/pairings, B4 unresolved-name pairings cached) were already fixed by earlier PRs (#557 series, #562, #594). This ships the one remaining item, explicitly deferred in the issue's own comments pending this exact design ("assert: primary throw → Gemini retry attempted → original error re-raised only if retry also fails").

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [ ] No AI or theological changes in this PR
- [ ] Claude prompt modified — described below
- [ ] New/updated divine name descriptions — verified against Maturidi/Hanafi sources
- [ ] Changes to theological framing — described below
- [x] Contains AI-generated file(s)/block(s) with minimal human review — `Generated-By` trailer added per [AGENTS.md](../AGENTS.md#ai-attribution-policy)

**Details**: No prompt text or theological framing changed. This is purely retry/fallback plumbing around the existing "names" AI generation call (reflection/pairings/verses/verse-reason translation) — same prompts, same output validation, same Tanzih/refusal screening as before.

## Testing

- [x] `bun run test:ci` passes locally
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally
- [x] New tests added for new functionality

_e2e, accessibility (axe), and bundle-size checks now run automatically in CI — no need to re-verify these by hand._

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added (n/a — none added)
- [x] `README.md` updated if the feature changes the public interface (n/a — internal retry behavior)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for name content and verse-reason generation when the primary provider encounters an error.
  - Generation now retries with a fallback provider when appropriate and preserves the fallback result if successful.
  - Clearer error handling ensures the original failure is surfaced when all retry attempts fail.
  - Prevented unnecessary retries when the configured provider is already the fallback provider.
  - Generation locks are cleared when retries cannot recover from an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->