### PR TITLE
fix(docker): TEMP — actually ship the #566 cleanup scripts into the runner image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,5 +16,9 @@ scripts
 !scripts/embed-corpus.mjs
 !scripts/seed-morphology.mjs
 !scripts/seed-translations.mjs
+# TEMPORARY — issue #566 retroactive cleanup (see PR #600). Remove once the
+# one-time cleanup run against production is done.
+!scripts/cleanup-566-ai-content.mjs
+!scripts/audit-566-retroactive.sql
 hosting.md
 plan.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,15 @@ COPY --from=builder --chown=nextjs:nodejs /app/scripts/seed-translations.mjs ./s
 COPY --from=builder --chown=nextjs:nodejs /app/data/morphology ./data/morphology
 COPY --from=deps /app/node_modules/@google/generative-ai ./node_modules/@google/generative-ai
 
+# TEMPORARY — issue #566 retroactive cleanup (see PR #600). cleanup-566-ai-content.mjs
+# only needs `postgres`, already copied above for migrate.mjs. audit-566-retroactive.sql
+# is a plain file (this image has no psql client — install one on the fly with
+# `apk add --no-cache postgresql-client` if you want to run it, or just rely on the
+# .mjs script's own dry-run output). Remove both COPY lines and the scripts themselves
+# once the one-time cleanup run is done.
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/cleanup-566-ai-content.mjs ./scripts/cleanup-566-ai-content.mjs
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/audit-566-retroactive.sql ./scripts/audit-566-retroactive.sql
+
 USER nextjs
 EXPOSE 3000
 # Migrations run as a one-shot step in scripts/deploy.sh before this container


### PR DESCRIPTION
## ⚠️ TEMPORARY — do not leave merged. Will be reverted together with #600 after one production run.

Fixes a gap in #600: that PR added `scripts/cleanup-566-ai-content.mjs` and
`scripts/audit-566-retroactive.sql` but never updated `.dockerignore` or the
`Dockerfile`, so **the files never reached the deployed image** — confirmed
live in production (the app container's shell showed `docker: not found` for
docker-in-docker, and the files were genuinely missing from its filesystem).

## Root cause

Two-deep:
1. `.dockerignore` excludes `scripts/` entirely except an explicit filename
   allowlist. The two new files weren't on it, so `COPY . .` in the Dockerfile's
   `builder` stage never saw them in the build context at all.
2. Even if it had, the `runner` stage's own `COPY` list (which whitelists
   exactly which files make it into the final image) didn't reference them
   either.

This PR adds both new files to the `.dockerignore` allowlist and adds the two
missing `COPY` lines to the `runner` stage, mirroring the existing
`seed-*.mjs` pattern. No new `node_modules` copy needed — `cleanup-566-ai-content.mjs`
only imports `postgres`, already copied in for `migrate.mjs`'s sake.

## Verified before pushing

Actually built this Dockerfile locally (`docker build --target runner`) and
confirmed both files land in the image with correct ownership/permissions.
Then ran the built image's `cleanup-566-ai-content.mjs --apply` against a real
Postgres container over a Docker network (same topology as Coolify: separate
containers, connecting via `DATABASE_URL`) — it correctly retired a planted
bad connection and repaired `connection_coverage`. Not just "the build didn't
error" — the actual script ran and worked from inside the actual image.

## Corrected run sequence (after this merges and redeploys)

From inside the **app** container's shell (no `docker`/`docker compose` needed —
you're already in the container with `DATABASE_URL` set and the scripts now
present):

```bash
# optional read-only preview — needs a psql client in the image, which it
# doesn't have by default: `apk add --no-cache postgresql-client` first if
# you want this step, or just skip straight to the dry run below
psql "$DATABASE_URL" -f scripts/audit-566-retroactive.sql

# dry run — prints exactly what would change, writes nothing
bun scripts/cleanup-566-ai-content.mjs

# apply for real
bun scripts/cleanup-566-ai-content.mjs --apply
```

## Revert sequence (after the apply run above)

Revert both this PR and #600 on GitHub, then redeploy. That removes the
scripts from the image; it does **not** undo the database changes `--apply`
made (those are the intended, permanent fix).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] Actually built the image locally and ran the script inside it against a real Postgres container (see above) — stronger verification than the standard checklist for this one
- [ ] `bun run test:ci` — n/a, Dockerfile/.dockerignore only
- [ ] `bun run typecheck` / `lint` / `format:check` — n/a, no parser for Dockerfile/.dockerignore

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — n/a
- [x] `README.md` updated if the feature changes the public interface — n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added temporary cleanup and audit scripts to the production container for a one-time data maintenance task.
  * Marked the scripts for removal after the cleanup run is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Run sequence (after this merges and deploys)
On the Hetzner box, inside the app container (has DATABASE_URL already set):

# 1. See what's there first (optional, read-only)
docker compose exec -T db psql -U <user> -d <db> < scripts/audit-566-retroactive.sql

# 2. Dry run — prints exactly what would change, writes nothing
docker compose run --rm app bun scripts/cleanup-566-ai-content.mjs

# 3. Apply for real
docker compose run --rm app bun scripts/cleanup-566-ai-content.mjs --apply
Revert sequence (after step 3 above)
git revert -m 1 <this-merge-commit-sha>   # or just revert the squash commit on main
git push origin main
