### PR TITLE
fix(names): gate Claude→Gemini fallback on detected refusal

### DIFF
--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -170,6 +170,21 @@ describe("names AI routes — model output validation", () => {
     errorSpy.mockRestore();
   });
 
+  it("verses: a model refusal in the AI-fallback path is not cached and does not retry against Gemini", async () => {
+    mockCallAI.mockResolvedValue("I'm sorry, but I can't help with religious interpretation.");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("returned a refusal"));
+    // A refusal must not be silently backed by a different provider — only
+    // the one (refused) call happens, no Gemini fallback attempt.
+    expect(mockCallAI).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
+
   it("verses: AI fallback refs outside real Quran bounds are dropped (no 500)", async () => {
     mockCallAI.mockResolvedValue(
       JSON.stringify([

--- a/__tests__/api/names-ai-validation.test.ts
+++ b/__tests__/api/names-ai-validation.test.ts
@@ -357,7 +357,7 @@ describe("names AI routes — model output validation", () => {
     expect(body[0].reason).toBe("Ayat al-Kursi."); // canonical reason preserved, not blanked
   });
 
-  it("verses: a non-empty but junk translation (model refusal) also falls back to the English reason", async () => {
+  it("verses: a non-empty but junk translation (model refusal) also falls back to the English reason, without retrying against Gemini", async () => {
     withLocale("az");
     mockVerseFetch();
     mockCallAI
@@ -369,5 +369,38 @@ describe("names AI routes — model output validation", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body[0].reason).toBe("Ayat al-Kursi.");
+    // fallback-verses selection + the one (refused) translation call — a
+    // refusal on translation must not be silently backed by Gemini either.
+    expect(mockCallAI).toHaveBeenCalledTimes(2);
+  });
+
+  it("verses: a model refusal in the per-verse reason builder (search found results) leaves the default reason, without retrying against Gemini", async () => {
+    mockFetch.mockImplementation(async (url: unknown) => {
+      if (typeof url !== "string") return { ok: false };
+      if (url.includes("api.quran.com/api/v4/search")) {
+        return { ok: true, json: async () => ({ search: { results: [{ verse_key: "2:255" }] } }) };
+      }
+      if (url.includes("ar.alafasy"))
+        return { ok: true, json: async () => ({ data: { text: "AR" } }) };
+      if (url.includes("en.sahih"))
+        return { ok: true, json: async () => ({ data: { text: "EN" } }) };
+      return { ok: false };
+    });
+    mockCallAI.mockResolvedValue("I'm sorry, but I can't help with religious interpretation.");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await getVerses(req("ar-rahman", "verses"), params("ar-rahman"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].ref).toBe("2:255");
+    expect(body[0].reason).toMatch(/^Contains a form of/); // buildReasons' refusal degrades to the default reason
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("returned a refusal"));
+    // A refusal here only degrades the per-verse reason (search already found
+    // the verse), so it doesn't gate the overall verses fallback — but it
+    // still shouldn't itself retry the reason-builder call against Gemini.
+    expect(mockCallAI).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
   });
 });

--- a/__tests__/lib/ai/translate.test.ts
+++ b/__tests__/lib/ai/translate.test.ts
@@ -109,4 +109,40 @@ describe("translateReason", () => {
     await expect(translateReason(EN, "Russian")).resolves.toBe("");
     expect(incrSpy).toHaveBeenCalledWith("translation_rejected_english_echo");
   });
+
+  it("calls onRejected with the specific reason on a refusal", async () => {
+    mockCallAI.mockResolvedValue("I'm sorry, but I can't translate religious content.");
+    const onRejected = vi.fn();
+
+    await translateReason(EN, "Turkish", {}, onRejected);
+
+    expect(onRejected).toHaveBeenCalledWith("refusal");
+  });
+
+  it("calls onRejected with a non-refusal reason for an English echo, not 'refusal'", async () => {
+    mockCallAI.mockResolvedValue(EN);
+    const onRejected = vi.fn();
+
+    await translateReason(EN, "Russian", {}, onRejected);
+
+    expect(onRejected).toHaveBeenCalledWith("english_echo");
+  });
+
+  it("does not call onRejected on a clean, accepted translation", async () => {
+    mockCallAI.mockResolvedValue("Mümin kalbini yakine bırakır.");
+    const onRejected = vi.fn();
+
+    await translateReason(EN, "Turkish", {}, onRejected);
+
+    expect(onRejected).not.toHaveBeenCalled();
+  });
+
+  it("does not call onRejected for an empty model result (not a rejection)", async () => {
+    mockCallAI.mockResolvedValue("   ");
+    const onRejected = vi.fn();
+
+    await translateReason(EN, "Turkish", {}, onRejected);
+
+    expect(onRejected).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -90,7 +90,9 @@ describe("getOrGenerateNameContent", () => {
     // The provider+model pair handed to generate() is the one that gets
     // persisted — resolved once, so a config change mid-flight can't split them.
     const passedToGenerate = generate.mock.calls[0][0] as { provider: string; model: string };
-    expect(passedToGenerate).toEqual({ provider: expect.any(String), model: expect.any(String) });
+    expect(passedToGenerate).toEqual(
+      expect.objectContaining({ provider: expect.any(String), model: expect.any(String) })
+    );
     expect(values.model).toBe(passedToGenerate.model);
   });
 
@@ -112,10 +114,12 @@ describe("getOrGenerateNameContent", () => {
     expect(out).toEqual(["gemini", "gemini-3.7-flash"]);
     const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
     expect(values.model).toBe("gemini-3.7-flash");
-    expect(generate.mock.calls[0][0]).toEqual({
-      provider: "gemini",
-      model: "gemini-3.7-flash",
-    });
+    expect(generate.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        provider: "gemini",
+        model: "gemini-3.7-flash",
+      })
+    );
     providerSpy.mockRestore();
     modelSpy.mockRestore();
   });
@@ -193,13 +197,71 @@ describe("getOrGenerateNameContent", () => {
 
     expect(out).toEqual(["a", "b"]);
     expect(generate).toHaveBeenCalledTimes(2);
-    expect(generate.mock.calls[0][0]).toEqual({ provider: "claude", model: "claude-opus-5" });
-    expect(generate.mock.calls[1][0]).toEqual({ provider: "gemini", model: "gemini-3.7-flash" });
+    expect(generate.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ provider: "claude", model: "claude-opus-5" })
+    );
+    expect(generate.mock.calls[1][0]).toEqual(
+      expect.objectContaining({ provider: "gemini", model: "gemini-3.7-flash" })
+    );
     expect(mockInsert).toHaveBeenCalledTimes(1);
     const values = mockValues.mock.calls[0][0] as Record<string, unknown>;
     expect(values.model).toBe("gemini-3.7-flash");
     providerSpy.mockRestore();
     modelSpy.mockRestore();
+  });
+
+  it("logs when falling back to Gemini on an empty (non-thrown) primary result", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const ai = await import("@/lib/ai/ai");
+    const providerSpy = vi.spyOn(ai, "resolveProvider").mockResolvedValue("claude");
+    const modelSpy = vi
+      .spyOn(ai, "resolveModel")
+      .mockImplementation(async (_feature, provider) =>
+        provider === "claude" ? "claude-opus-5" : "gemini-3.7-flash"
+      );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const generate = vi.fn(async (resolved: { provider: string; model: string }) =>
+      resolved.provider === "claude" ? [] : ["a"]
+    );
+
+    await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
+
+    // Previously the empty-but-not-thrown path had no log line at all — only
+    // the incr("names_ai_fallback_used") metric, invisible outside /api/metrics.
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Names: primary (claude) returned empty for al-malik/verses, falling back to Gemini"
+    );
+    providerSpy.mockRestore();
+    modelSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("does not fall back to Gemini when the primary result is a detected refusal", async () => {
+    mockSelect.mockReturnValue(makeSelectChain([])); // miss
+    const ai = await import("@/lib/ai/ai");
+    const providerSpy = vi.spyOn(ai, "resolveProvider").mockResolvedValue("claude");
+    const modelSpy = vi.spyOn(ai, "resolveModel").mockResolvedValue("claude-opus-5");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const generate = vi.fn(async (ctx: { markRefusal: () => void }) => {
+      ctx.markRefusal();
+      return [];
+    });
+
+    const out = await getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr);
+
+    expect(out).toEqual([]);
+    // A refusal must not be silently backed by a different provider — no
+    // second (Gemini) call at all, unlike an ordinary empty result.
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Names: claude refused for al-malik/verses, not falling back to Gemini"
+    );
+    providerSpy.mockRestore();
+    modelSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("does not fall back when the primary provider is already Gemini", async () => {
@@ -239,7 +301,10 @@ describe("getOrGenerateNameContent", () => {
     expect(out).toEqual([]);
     expect(generate).toHaveBeenCalledTimes(2);
     expect(mockInsert).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith("Names: Gemini fallback failed:", expect.any(Error));
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Names: Gemini fallback failed for al-malik/verses:",
+      expect.any(Error)
+    );
     providerSpy.mockRestore();
     modelSpy.mockRestore();
     errorSpy.mockRestore();
@@ -422,7 +487,10 @@ describe("getOrGenerateNameContent", () => {
       getOrGenerateNameContent("al-malik", "verses", "en", 1, generate, isEmptyArr)
     ).rejects.toThrow("boom");
     expect(generate).toHaveBeenCalledTimes(2); // primary + fallback attempt
-    expect(errorSpy).toHaveBeenCalledWith("Names: Gemini fallback failed:", expect.any(Error));
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Names: Gemini fallback failed for al-malik/verses:",
+      expect.any(Error)
+    );
     expect(mockInsert).not.toHaveBeenCalled();
 
     // lock released in finally → fresh call regenerates

--- a/app/api/names/[slug]/pairings/route.ts
+++ b/app/api/names/[slug]/pairings/route.ts
@@ -62,12 +62,13 @@ async function getPairings(
     "pairings",
     locale,
     PAIRINGS_VERSION,
-    async (resolved) => {
+    async (ctx) => {
       let text: string;
       try {
         text = await callAI(buildPrompt(name.transliteration, name.arabic, name.meaning, locale), {
           feature: "names",
-          ...resolved,
+          provider: ctx.provider,
+          model: ctx.model,
         });
       } catch (err) {
         // Not cached (empty result), so the next request retries — mirrors how
@@ -81,8 +82,11 @@ async function getPairings(
       if (looksLikeRefusal(text)) {
         // A soft refusal is not canonical content — treat it like an empty
         // result (not cached, retried), same as the no-JSON-array case below.
+        // markRefusal() also stops resolveAndGenerate from silently backing
+        // this with Gemini.
         console.error(`Pairings: model returned a refusal for ${slug}, not caching`);
         incr("names_ai_refusal");
+        ctx.markRefusal();
         return [];
       }
 

--- a/app/api/names/[slug]/reflection/route.ts
+++ b/app/api/names/[slug]/reflection/route.ts
@@ -55,18 +55,20 @@ async function getReflection(
     "reflection",
     locale,
     REFLECTION_VERSION,
-    async (resolved) => {
+    async (ctx) => {
       try {
         const text = await callAI(
           buildPrompt(name.arabic, name.transliteration, name.meaning, name.description, locale),
-          { feature: "names", ...resolved }
+          { feature: "names", provider: ctx.provider, model: ctx.model }
         );
         if (looksLikeRefusal(text)) {
           // A soft refusal / disclaimer is not canonical theology — treat it
           // like an empty result (not cached, retried) rather than version-pin
-          // it as this name's reflection.
+          // it as this name's reflection. markRefusal() also stops
+          // resolveAndGenerate from silently backing this with Gemini.
           console.error(`Reflection: model returned a refusal for ${slug}, not caching`);
           incr("names_ai_refusal");
+          ctx.markRefusal();
           return "";
         }
         return text;

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -317,11 +317,19 @@ async function getVersesBySlug(
         v.ref,
         locale,
         (ctx) =>
-          translateReason(v.reason, language, {
-            feature: "names",
-            provider: ctx.provider,
-            model: ctx.model,
-          }).catch((err) => {
+          translateReason(
+            v.reason,
+            language,
+            { feature: "names", provider: ctx.provider, model: ctx.model },
+            (reason) => {
+              // A refusal on translating a reason must not be silently backed
+              // by Gemini either — same rationale as reflection/pairings/
+              // fallbackAIVerses above. The other rejection reasons (label
+              // wrapper, English echo, length ratio) are ordinary malformed
+              // output, not a refusal, so they still fall back as before.
+              if (reason === "refusal") ctx.markRefusal();
+            }
+          ).catch((err) => {
             // A provider failure on the translation call must degrade to the
             // English reason (handled just below), never 500 the whole verses
             // response — mirrors the callAI try/catch in reflection/pairings.

--- a/app/api/names/[slug]/verses/route.ts
+++ b/app/api/names/[slug]/verses/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { callAI } from "@/lib/ai/ai";
 import { translateReason } from "@/lib/ai/translate";
+import { looksLikeRefusal } from "@/lib/ai/refusal";
 import { getNameBySlug } from "@/lib/names/divine-names";
 import { isValidRef } from "@/lib/quran/quran-corpus";
 import { resolveVerse } from "@/lib/quran/verse-resolver";
@@ -8,6 +9,7 @@ import {
   getOrGenerateNameContent,
   getOrGenerateVerseReason,
   type ResolvedNamesModel,
+  type GenerationContext,
 } from "@/lib/names/name-content";
 import { consume, RateLimitError } from "@/lib/infra/rate-limit";
 import { clientKey } from "@/lib/infra/http";
@@ -91,7 +93,21 @@ Output format:
 { "surah:ayah": "one sentence", ... }`;
 
   try {
-    const text = await callAI(prompt, { feature: "names", ...resolved });
+    const text = await callAI(prompt, {
+      feature: "names",
+      provider: resolved.provider,
+      model: resolved.model,
+    });
+    if (looksLikeRefusal(text)) {
+      // A refusal here only degrades the per-verse *reason* text (each verse
+      // falls back to its default "Contains a form of ..." reason below) — it
+      // never empties the overall verses result, since the refs themselves
+      // already came from search, not this call. Logged for visibility; not
+      // gated through markRefusal() because there's nothing to gate here.
+      console.error(`Name verses: model returned a refusal for ${transliteration}, not caching`);
+      incr("names_ai_refusal");
+      return new Map();
+    }
     const match = text.match(/\{[\s\S]*\}/);
     if (!match) return new Map();
     const obj: unknown = JSON.parse(match[0]);
@@ -113,7 +129,7 @@ async function fallbackAIVerses(
   transliteration: string,
   meaning: string,
   description: string,
-  resolved: ResolvedNamesModel
+  ctx: GenerationContext
 ): Promise<Array<{ ref: string; reason: string }>> {
   const prompt = `You are a classical Islamic scholar (Maturidi/Hanafi tradition).
 
@@ -126,7 +142,21 @@ Return ONLY a JSON array:
 [{ "ref": "surah:ayah", "reason": "one sentence" }, ...]`;
 
   try {
-    const text = await callAI(prompt, { feature: "names", ...resolved });
+    const text = await callAI(prompt, {
+      feature: "names",
+      provider: ctx.provider,
+      model: ctx.model,
+    });
+    if (looksLikeRefusal(text)) {
+      // Unlike buildReasons above, this IS the sole content generator when
+      // search found nothing — an empty result here does gate the overall
+      // verses fallback, so a detected refusal must call markRefusal() to
+      // stop resolveAndGenerate from silently backing it with Gemini.
+      console.error(`Name verses: model returned a refusal for ${transliteration}, not caching`);
+      incr("names_ai_refusal");
+      ctx.markRefusal();
+      return [];
+    }
     const match = text.match(/\[[\s\S]*\]/);
     if (!match) return [];
     const raw: unknown = JSON.parse(match[0]);
@@ -168,7 +198,7 @@ async function getVersesBySlug(
     // requester's locale — see name_verse_reasons below for why.
     "en",
     VERSES_VERSION,
-    async (resolved): Promise<NameVerse[]> => {
+    async (ctx): Promise<NameVerse[]> => {
       // Try actual quran.com search first
       const refs = await searchVerseRefs(name.arabic);
 
@@ -176,7 +206,7 @@ async function getVersesBySlug(
       if (refs.length > 0) {
         const [verseDataResults, reasonMap] = await Promise.all([
           Promise.all(refs.map((ref) => fetchVerseData(ref))),
-          buildReasons(refs, name.transliteration, name.meaning, resolved),
+          buildReasons(refs, name.transliteration, name.meaning, ctx),
         ]);
 
         const verses: NameVerse[] = refs
@@ -200,7 +230,7 @@ async function getVersesBySlug(
         name.transliteration,
         name.meaning,
         name.description,
-        resolved
+        ctx
       );
       if (aiItems.length === 0) return [];
 
@@ -286,8 +316,12 @@ async function getVersesBySlug(
         slug,
         v.ref,
         locale,
-        (resolved) =>
-          translateReason(v.reason, language, { feature: "names", ...resolved }).catch((err) => {
+        (ctx) =>
+          translateReason(v.reason, language, {
+            feature: "names",
+            provider: ctx.provider,
+            model: ctx.model,
+          }).catch((err) => {
             // A provider failure on the translation call must degrade to the
             // English reason (handled just below), never 500 the whole verses
             // response — mirrors the callAI try/catch in reflection/pairings.

--- a/lib/ai/refusal.ts
+++ b/lib/ai/refusal.ts
@@ -6,10 +6,14 @@
  * content. A "Believer's Reflection" opens with its subject ("The believer's
  * realisation of ..."), never "I'm sorry" or "As an AI". Used so a soft model
  * refusal is treated like an empty result (logged, not cached as canonical,
- * retried) rather than persisted verbatim. See the names reflection/pairings
- * routes and `translateReason` (`lib/ai/translate.ts`). Note the pattern is
- * English-anchored — callers translating into another language get only
- * best-effort refusal detection from it.
+ * not silently backed by a different provider) rather than persisted
+ * verbatim. See the names reflection/pairings/verses routes and
+ * `translateReason` (`lib/ai/translate.ts`) — all of them call
+ * `GenerationContext.markRefusal()` (`lib/names/name-content.ts`) on a hit,
+ * so a detected refusal skips the Claude->Gemini fallback everywhere, not
+ * just the caching decision. Note the pattern is English-anchored — callers
+ * translating into another language get only best-effort refusal detection
+ * from it.
  */
 const REFUSAL_OPENER =
   /^\s*(?:i(?:['’ ]?a?m)? (?:sorry|unable|not able)\b|i can(?:not|['’]t)\b|i (?:can(?:not|['’]t)|won['’]t|will not) (?:help|assist|provide|comply|generate|write)\b|i (?:must|have to) decline\b|i['’]m not (?:going to|able to)\b|as an ai\b|as a language model\b|i (?:apologi[sz]e|cannot in good conscience)\b|unfortunately,?\s+i\b)/i;

--- a/lib/ai/translate.ts
+++ b/lib/ai/translate.ts
@@ -85,12 +85,17 @@ export function validateTranslation(source: string, translated: string): Transla
  *
  * Returns "" when the model output is empty or fails {@link validateTranslation};
  * every caller already treats "" as "skip, keep the English reason, retry later"
- * rather than persisting it.
+ * rather than persisting it. `onRejected` is called with the specific reason
+ * before that "" is returned — used by callers that route through
+ * `resolveAndGenerate` (see lib/names/name-content.ts) to call `markRefusal()`
+ * on a `"refusal"` rejection, so a Claude refusal on translating a reason isn't
+ * silently backed by Gemini the way a genuinely empty/malformed translation is.
  */
 export async function translateReason(
   reason: string,
   language: string,
-  opts: CallAiOptions = {}
+  opts: CallAiOptions = {},
+  onRejected?: (reason: TranslationRejection) => void
 ): Promise<string> {
   const prompt = `Translate the following sentence into ${language}. Preserve its meaning exactly — do not add, remove, or alter any theological claim, and maintain ${TANZIH_CONSTRAINT}. Return ONLY the translated sentence, with no quotation marks, labels, or explanation.
 
@@ -102,6 +107,7 @@ Sentence: "${reason}"`;
   if (!verdict.ok) {
     console.error(`translateReason: rejected translation into ${language} (${verdict.reason})`);
     incr(`translation_rejected_${verdict.reason}`);
+    onRejected?.(verdict.reason);
     return "";
   }
   return verdict.text;

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -11,6 +11,18 @@ export interface ResolvedNamesModel {
   model: string;
 }
 
+/**
+ * Passed into every `generate` callback alongside the resolved provider+model.
+ * `markRefusal()` is the callback's way of telling `resolveAndGenerate` that an
+ * empty/degraded result came from a *detected refusal* (see lib/ai/refusal.ts)
+ * rather than a generic empty response, a parse failure, or a transient search
+ * miss. See `resolveAndGenerate`'s doc comment for why that distinction gates
+ * the Gemini fallback.
+ */
+export interface GenerationContext extends ResolvedNamesModel {
+  markRefusal: () => void;
+}
+
 // Resolved ONCE per generation and passed as a pinned pair into both the
 // `callAI` request (as provider + model overrides) and the persisted `model`
 // column, so a config change (`ai_provider_names` / `ai_model_names`) mid-flight
@@ -48,28 +60,58 @@ const resolveNamesModel = async (): Promise<ResolvedNamesModel> => {
  * degrade to, so the fallback's failure re-raises the original primary error
  * — never silently downgrading a real failure into a fabricated empty success.
  *
+ * EXCEPT for a detected refusal (`ctx.markRefusal()` — see `GenerationContext`):
+ * an empty result from a refusal is NOT retried against Gemini. A refusal on
+ * borderline theological phrasing is Claude declining to answer; silently
+ * answering it with a different provider instead would defeat the point of
+ * the refusal, and previously this path was indistinguishable from any other
+ * empty result. A refusal still degrades to the same empty/uncached result a
+ * non-refusal empty result would, it just skips the fallback attempt — logged
+ * distinctly (`names_ai_refusal_no_fallback`) from the ordinary fallback path
+ * (`names_ai_fallback_used`) so the two are visible separately on /api/metrics.
+ *
+ * `logLabel` identifies the (slug, kind[, ref]) this call is generating, for
+ * the log lines above — every call site already has this in scope.
+ *
  * Returns whichever (result, model) pair actually produced the value, so the
  * persisted `model` column never disagrees with what actually ran.
  */
 async function resolveAndGenerate<T>(
-  generate: (resolved: ResolvedNamesModel) => Promise<T>,
+  logLabel: string,
+  generate: (ctx: GenerationContext) => Promise<T>,
   isEmpty: (value: T) => boolean
 ): Promise<{ result: T; model: string }> {
   const resolved = await resolveNamesModel();
+
+  let refused = false;
+  const primaryCtx: GenerationContext = {
+    ...resolved,
+    markRefusal: () => {
+      refused = true;
+    },
+  };
 
   let result: T | undefined;
   let threw = false;
   let primaryError: unknown;
   try {
-    result = await generate(resolved);
+    result = await generate(primaryCtx);
   } catch (err) {
     threw = true;
     primaryError = err;
     // Logged here (not just on a subsequent fallback failure) so a systematic
     // primary failure that Gemini happens to paper over still surfaces —
     // otherwise it would produce no log line at all.
-    console.error(`Names: primary (${resolved.provider}) generation failed:`, err);
+    console.error(`Names: primary (${resolved.provider}) generation failed for ${logLabel}:`, err);
     incr("names_primary_generation_failed");
+  }
+
+  if (refused) {
+    console.error(
+      `Names: ${resolved.provider} refused for ${logLabel}, not falling back to Gemini`
+    );
+    incr("names_ai_refusal_no_fallback");
+    return { result: result as T, model: resolved.model };
   }
 
   const shouldRetry = resolved.provider === "claude" && (threw || isEmpty(result as T));
@@ -78,13 +120,27 @@ async function resolveAndGenerate<T>(
     return { result: result as T, model: resolved.model };
   }
 
+  if (!threw) {
+    // The throw case already logged above at catch time — this covers the
+    // "returned empty without throwing" path, which previously had no log
+    // line at all (only the incr("names_ai_fallback_used") below, and only
+    // when the fallback itself succeeds).
+    console.error(
+      `Names: primary (${resolved.provider}) returned empty for ${logLabel}, falling back to Gemini`
+    );
+  }
+
   try {
     const fallbackModel = await resolveModel("names", "gemini");
-    const fallbackResult = await generate({ provider: "gemini", model: fallbackModel });
+    const fallbackResult = await generate({
+      provider: "gemini",
+      model: fallbackModel,
+      markRefusal: () => undefined,
+    });
     if (!isEmpty(fallbackResult)) incr("names_ai_fallback_used");
     return { result: fallbackResult, model: fallbackModel };
   } catch (err) {
-    console.error("Names: Gemini fallback failed:", err);
+    console.error(`Names: Gemini fallback failed for ${logLabel}:`, err);
     // The primary threw: there's no valid result to degrade to, so the
     // original failure must surface — swallowing it here would turn a real
     // AI failure into a fabricated empty success.
@@ -137,7 +193,7 @@ export async function getOrGenerateNameContent<T>(
   kind: NameContentKind,
   locale: Locale,
   version: number,
-  generate: (resolved: ResolvedNamesModel) => Promise<T>,
+  generate: (ctx: GenerationContext) => Promise<T>,
   isEmpty: (value: T) => boolean,
   onBeforeGenerate?: () => Promise<void>
 ): Promise<T> {
@@ -223,10 +279,10 @@ async function generateAndPersist<T>(
   kind: NameContentKind,
   locale: Locale,
   version: number,
-  generate: (resolved: ResolvedNamesModel) => Promise<T>,
+  generate: (ctx: GenerationContext) => Promise<T>,
   isEmpty: (value: T) => boolean
 ): Promise<T> {
-  const { result, model } = await resolveAndGenerate(generate, isEmpty);
+  const { result, model } = await resolveAndGenerate(`${slug}/${kind}`, generate, isEmpty);
 
   if (!isEmpty(result)) {
     const data = JSON.stringify(result);
@@ -263,7 +319,7 @@ export async function getOrGenerateVerseReason(
   slug: string,
   ref: string,
   locale: Locale,
-  generate: (resolved: ResolvedNamesModel) => Promise<string>,
+  generate: (ctx: GenerationContext) => Promise<string>,
   onBeforeGenerate?: () => Promise<void>
 ): Promise<string> {
   const [row] = await db
@@ -287,7 +343,11 @@ export async function getOrGenerateVerseReason(
   if (pending) return pending;
 
   const work = (async () => {
-    const { result: reason, model } = await resolveAndGenerate(generate, (r) => r.trim() === "");
+    const { result: reason, model } = await resolveAndGenerate(
+      `${slug}/verse-reason/${ref}`,
+      generate,
+      (r) => r.trim() === ""
+    );
     if (reason.trim() === "") return reason;
 
     try {


### PR DESCRIPTION
## Summary

- `resolveAndGenerate` previously fell back to Gemini on any empty Claude result with only an `incr()` metric — indistinguishable from a Claude refusal on borderline theological phrasing, which also arrives as an empty string/array.
- A detected refusal (`looksLikeRefusal`) now skips the Gemini fallback entirely via a new `GenerationContext.markRefusal()` signal, threaded through `reflection`, `pairings`, and `verses`' `fallbackAIVerses` (the sole AI generator on the search-miss path).
- The ordinary empty-but-not-refused fallback path now logs at error level with slug/kind — previously it was silent beyond the metric.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [ ] No AI or theological changes in this PR
- [x] Changes to theological framing — described below

**Details**: A Claude refusal on borderline theological phrasing (for a name's reflection, pairings, or verses) no longer gets silently answered by Gemini instead. It now degrades to the same empty/uncached result a refusal already produced today, just without the fallback attempt — so the refusal actually holds instead of being papered over by a different provider. No prompt wording changed; only the post-response handling of a detected refusal.

## Testing

- [x] `bun run test:ci` passes locally (1618 tests)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (this file only — pre-existing warnings on unrelated `.superpowers/` files)
- [x] New tests added for new functionality

Added:
- `does not fall back to Gemini when the primary result is a detected refusal` + `logs when falling back to Gemini on an empty (non-thrown) primary result` in `__tests__/lib/names/name-content.test.ts`
- `verses: a model refusal in the AI-fallback path is not cached and does not retry against Gemini` in `__tests__/api/names-ai-validation.test.ts`
- Updated two existing assertions for the new `Names: Gemini fallback failed for <slug>/<kind>:` log message (now includes the slug/kind label).

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A, no new env vars
- [x] `README.md` updated if the feature changes the public interface — N/A, internal behavior only

Fixes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRprUveCywFmhoTuFzLBGH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of AI refusal responses across name content, pairings, reflections, and verses.
  - Prevented refused responses from being silently replaced by secondary AI-generated content.
  - Ensured refused verse generation does not return misleading AI-generated results.
  - Improved handling of refused verse translations, preserving the appropriate default explanation.
  - Improved fallback behavior when generation returns empty content or fails, with clearer diagnostic logging.
- **Tests**
  - Added coverage for refusal handling, fallback suppression, and translation rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->