### PR TITLE
docs(auth): document JWT aud-absent acceptance as accepted risk

### DIFF
--- a/__tests__/lib/auth/social-auth.test.ts
+++ b/__tests__/lib/auth/social-auth.test.ts
@@ -90,6 +90,11 @@ describe("requireUser — JWT signature verification", () => {
     expect("userId" in res && res.userId).toBe(7);
   });
 
+  // These two pin the accepted-risk decision documented in social-auth.ts next
+  // to the aud check (see issue #569): an absent aud is accepted (QF's own
+  // OIDC discovery doc doesn't support aud at all), a present-but-wrong aud
+  // is still rejected. Do not "fix" the first of these by requiring aud — see
+  // the code comment for what would need to be true first.
   it("accepts a token with no aud claim at all (QF's real tokens never carry one)", async () => {
     mockLimit.mockResolvedValue([user]);
     const token = makeJwt({ sub: "qf-sub-123", exp: farFuture }, { noAud: true });

--- a/lib/auth/social-auth.ts
+++ b/lib/auth/social-auth.ts
@@ -255,11 +255,29 @@ async function verifiedJwtSub(token: string): Promise<string | null> {
   // Validate audience (aud) — reject cross-client token replay, when the token
   // actually carries an audience claim. QF's Hydra instance does NOT populate
   // `aud` on access tokens (confirmed: claims_supported is just ["sub"] in its
-  // OIDC discovery doc, and real production tokens arrive with no aud claim at
-  // all) — so a claim that's entirely ABSENT can't be evidence of anything and
-  // must not be treated as a rejection. A claim that IS present but doesn't
-  // include our client ID is still rejected: that's the actual cross-client
-  // replay case this check exists for.
+  // OIDC discovery doc — https://oauth2.quran.foundation/.well-known/openid-configuration
+  // — and real production tokens arrive with no aud claim at all) — so a claim
+  // that's entirely ABSENT can't be evidence of anything and must not be
+  // treated as a rejection. A claim that IS present but doesn't include our
+  // client ID is still rejected: that's the actual cross-client replay case
+  // this check exists for.
+  //
+  // ACCEPTED RISK (see issue #569): if QF's Hydra ever mints access tokens for
+  // more than one OAuth client_id off this same issuer, and those tokens
+  // carry no `aud` (as today's do), a token issued to a *different* client
+  // would still pass this check — its RS256 signature verifies against QF's
+  // JWKS and `iss` matches, and an absent `aud` isn't rejected. `sub` from
+  // such a token is only looked up against our `users.qfId` column below
+  // (see requireUser's Stage 1) — `resolveQfIdFromUserinfo` is NOT called as
+  // a secondary check once Stage 1 finds a matching row, so there is no
+  // additional per-request audience validation beyond this one. This is
+  // accepted as the current tradeoff because QF's own discovery doc doesn't
+  // support `aud` at all (not just "sometimes omits" it), so requiring it
+  // would break every login; tightening this would need QF to confirm (a)
+  // whether they ever issue tokens for multiple client_ids from one issuer,
+  // and (b) whether `/userinfo` itself rejects a foreign-client token. Until
+  // then, don't require `aud` here — see __tests__/lib/auth/social-auth.test.ts
+  // for the regression tests pinning this decision.
   const qfClientId = process.env.NEXT_PUBLIC_QF_CLIENT_ID;
   if (qfClientId && payload.aud !== undefined) {
     const audiences: unknown[] = Array.isArray(payload.aud) ? payload.aud : [payload.aud];


### PR DESCRIPTION
## Summary

- Documentation/regression-test PR only — **no change to `verifiedJwtSub`'s `aud`-check logic**, per issue #569's explicit instruction not to change auth code before Quran Foundation confirms their token behavior.
- Verified directly against QF's own OIDC discovery document (`https://oauth2.quran.foundation/.well-known/openid-configuration`): `claims_supported` is exactly `["sub"]` — QF's tokens don't support an `aud` claim at all, not just "sometimes omit" it. This matches and strengthens the existing in-code assumption.
- Expanded the code comment above the `aud` check to explicitly frame this as an accepted risk pending QF confirmation, and corrected the "existing mitigation" framing to match actual runtime behavior: `resolveQfIdFromUserinfo` only runs in `requireUser`'s Stage 2 (when the JWT `sub` finds no matching `users` row) — it is **not** a secondary check layered on top of a successful Stage 1 JWT match, so there's no additional per-request audience validation beyond the `aud` check itself today.
- Added a comment above the two existing pinning tests in `__tests__/lib/auth/social-auth.test.ts` making explicit that they encode this accepted-risk decision.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [x] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (1615 tests, no new tests added — see below)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (this file only — pre-existing warnings on unrelated `.superpowers/` files)
- [ ] New tests added for new functionality — N/A, no functional change; the two tests that already pin this exact behavior (`accepts a token with no aud claim at all`, `rejects a token whose aud claim is present but doesn't include our client id`) predate this PR and were only given an explanatory comment.

## Open questions from issue #569 (not resolved by this PR)

1. Does QF's Hydra deployment ever mint access tokens for more than one OAuth `client_id` off the same issuer?
2. Do access tokens ever carry an `aud` claim in practice (their discovery doc says no, but worth confirming with QF support directly)?
3. Would QF's `/userinfo` endpoint itself reject a foreign-client token?

These need a response from Quran Foundation directly (not just their public docs) — I don't have a channel to their support team, so this PR only documents the current accepted-risk state rather than resolving it. If/when QF confirms `aud` is populated, the fix is a one-line tightening of `verifiedJwtSub` (require `aud` to be present) plus updating the two pinning tests referenced above.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A
- [x] `README.md` updated if the feature changes the public interface — N/A, no interface change

Related to #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRprUveCywFmhoTuFzLBGH
