### PR TITLE
fix(i18n): wire next-intl through authed surfaces that bypassed it

### DIFF
--- a/__tests__/components/social/ChallengeList.test.tsx
+++ b/__tests__/components/social/ChallengeList.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ChallengeList, type EnrichedChallenge } from "@/components/social/ChallengeList";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
+import { renderWithIntl as render } from "../../test-utils/render-with-intl";
 
 function challenge(overrides: Partial<EnrichedChallenge> = {}): EnrichedChallenge {
   return {

--- a/__tests__/components/social/ChallengeList.test.tsx
+++ b/__tests__/components/social/ChallengeList.test.tsx
@@ -1,9 +1,12 @@
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor, render as rtlRender } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextIntlClientProvider } from "next-intl";
 import { ChallengeList, type EnrichedChallenge } from "@/components/social/ChallengeList";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
 import { renderWithIntl as render } from "../../test-utils/render-with-intl";
+import en from "@/messages/en.json";
+import tr from "@/messages/tr.json";
 
 function challenge(overrides: Partial<EnrichedChallenge> = {}): EnrichedChallenge {
   return {
@@ -75,5 +78,38 @@ describe("ChallengeCard PATCH error handling", () => {
     await waitFor(() => {
       expect(onUpdate).toHaveBeenCalled();
     });
+  });
+});
+
+describe("ChallengeCard countdown locale", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: "test-token" });
+    useSocialStore.setState({ userId: 1 });
+  });
+
+  it("re-renders the ticking countdown in the new locale after a locale switch, not just on the next endsAt change", () => {
+    const active = challenge({
+      status: "active",
+      endsAt: new Date(Date.now() + 5 * 60_000).toISOString(),
+    });
+
+    const { rerender } = rtlRender(
+      <NextIntlClientProvider locale="en" messages={en}>
+        <ChallengeList challenges={[active]} onUpdate={vi.fn()} />
+      </NextIntlClientProvider>
+    );
+    expect(screen.getByText(/left/)).toBeInTheDocument();
+
+    // Same challenge (same endsAt/id — no remount), locale switched. The
+    // countdown's own effect must re-run on this (see useCountdown's `t` in
+    // its deps) rather than staying frozen in the pre-switch locale.
+    rerender(
+      <NextIntlClientProvider locale="tr" messages={tr}>
+        <ChallengeList challenges={[active]} onUpdate={vi.fn()} />
+      </NextIntlClientProvider>
+    );
+
+    expect(screen.getByText(/kaldı/)).toBeInTheDocument();
+    expect(screen.queryByText(/left/)).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/social/FriendList.test.tsx
+++ b/__tests__/components/social/FriendList.test.tsx
@@ -1,11 +1,12 @@
-import { render as rtlRender, screen, fireEvent, act } from "@testing-library/react";
+import { screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { FriendList } from "@/components/social/FriendList";
 import { TooltipProvider } from "@/components/ui";
 import { useAuthStore } from "@/store/auth";
+import { renderWithIntl } from "../../test-utils/render-with-intl";
 
 function render(ui: React.ReactElement) {
-  return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
+  return renderWithIntl(<TooltipProvider>{ui}</TooltipProvider>);
 }
 
 function friend(overrides: Partial<Parameters<typeof FriendList>[0]["friends"][number]> = {}) {

--- a/app/canvas/CanvasPageClient.tsx
+++ b/app/canvas/CanvasPageClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
+import { useTranslations } from "next-intl";
 import { Header } from "@/components/layout/Header";
 import { MobileNavBar } from "@/components/layout/MobileNavBar";
 import { SearchDialog } from "@/components/search/SearchDialog";
@@ -13,17 +14,25 @@ import { useCanvasStore } from "@/store/canvas";
 import { findFreeSlot } from "@/lib/canvas/canvas-layout";
 import type { Verse } from "@/types/quran";
 
+// `next/dynamic`'s `loading` renders as a component (hooks are legal here),
+// but it's outside CanvasPageClient's own render, so it needs its own
+// useTranslations call rather than sharing one from the parent.
+function CanvasLoadingFallback() {
+  const t = useTranslations("canvas");
+  return (
+    <div className="w-full h-full flex items-center justify-center">
+      <div className="text-xs font-mono tracking-wider uppercase text-text-muted">
+        {t("loadingCanvas")}
+      </div>
+    </div>
+  );
+}
+
 const HikmahCanvas = dynamic(
   () => import("@/components/canvas/HikmahCanvas").then((m) => m.HikmahCanvas),
   {
     ssr: false,
-    loading: () => (
-      <div className="w-full h-full flex items-center justify-center">
-        <div className="text-xs font-mono tracking-wider uppercase text-text-muted">
-          Loading canvas…
-        </div>
-      </div>
-    ),
+    loading: () => <CanvasLoadingFallback />,
   }
 );
 

--- a/app/mentions/page.tsx
+++ b/app/mentions/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { AtSign, Network } from "lucide-react";
+import { useTranslations, useFormatter } from "next-intl";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
 import { AuthShell } from "@/components/layout/AuthShell";
@@ -18,6 +19,8 @@ interface Mention {
 }
 
 export default function MentionsPage() {
+  const t = useTranslations("mentions");
+  const format = useFormatter();
   const accessToken = useAuthStore((s) => s.accessToken);
   const setPendingMentionCount = useSocialStore((s) => s.setPendingMentionCount);
 
@@ -77,7 +80,7 @@ export default function MentionsPage() {
       <div className="mx-auto w-full max-w-2xl">
         <div className="mb-8 flex items-center gap-3">
           <AtSign className="h-5 w-5 text-gold" />
-          <h1 className="text-lg font-semibold text-text-primary">Mentions</h1>
+          <h1 className="text-lg font-semibold text-text-primary">{t("pageTitle")}</h1>
           {mentions.length > 0 && (
             <span className="rounded border border-border px-1.5 py-0.5 font-mono text-xs text-text-muted">
               {mentions.length}
@@ -85,14 +88,10 @@ export default function MentionsPage() {
           )}
         </div>
 
-        {markReadError && (
-          <p className="mb-4 text-xs text-error">
-            Couldn&apos;t mark mentions as read. The unread count may be out of sync.
-          </p>
-        )}
+        {markReadError && <p className="mb-4 text-xs text-error">{t("couldntMarkRead")}</p>}
 
         {error ? (
-          <p className="py-10 text-center text-sm text-error">Couldn&apos;t load mentions.</p>
+          <p className="py-10 text-center text-sm text-error">{t("couldntLoadMentions")}</p>
         ) : loading ? (
           <div className="space-y-3">
             {[0, 1, 2].map((i) => (
@@ -105,10 +104,8 @@ export default function MentionsPage() {
         ) : mentions.length === 0 ? (
           <div className="py-20 text-center">
             <AtSign className="mx-auto mb-4 h-8 w-8 text-text-muted/40" />
-            <p className="text-sm text-text-muted">No mentions yet.</p>
-            <p className="mt-1 text-xs text-text-muted">
-              A friend can tag you with @{"{username}"} in a verse note.
-            </p>
+            <p className="text-sm text-text-muted">{t("noMentionsYet")}</p>
+            <p className="mt-1 text-xs text-text-muted">{t("mentionHint")}</p>
           </div>
         ) : (
           <div className="space-y-3">
@@ -117,15 +114,15 @@ export default function MentionsPage() {
                 <div className="flex items-start justify-between gap-3">
                   <p className="text-sm text-text-secondary">
                     <span className="font-medium text-text-primary">@{m.mentioningUsername}</span>{" "}
-                    mentioned you on{" "}
+                    {t("mentionedYouOn")}{" "}
                     <span className="rounded border border-gold bg-gold/[0.08] px-1.5 py-0.5 font-mono text-xs text-gold">
                       {m.verseRef}
                     </span>
                   </p>
-                  <Tooltip label="Open in canvas">
+                  <Tooltip label={t("openInCanvas")}>
                     <Link
                       href={`/canvas?verse=${m.verseRef}`}
-                      aria-label="Open in canvas"
+                      aria-label={t("openInCanvas")}
                       className={iconButtonVariants({ tone: "teal", size: "xs" })}
                     >
                       <Network />
@@ -133,7 +130,10 @@ export default function MentionsPage() {
                   </Tooltip>
                 </div>
                 <p className="mt-2 text-xs text-text-muted">
-                  {new Date(m.createdAt).toLocaleString()}
+                  {format.dateTime(new Date(m.createdAt), {
+                    dateStyle: "medium",
+                    timeStyle: "short",
+                  })}
                 </p>
               </Card>
             ))}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -18,6 +18,7 @@ export default function OnboardingPage() {
   const { signIn, signingIn } = useSignIn();
   const t = useTranslations("authGate");
   const tCommon = useTranslations("common");
+  const tOnboarding = useTranslations("onboarding");
 
   const [username, setUsername] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -28,7 +29,7 @@ export default function OnboardingPage() {
       <div
         className="flex min-h-screen items-center justify-center bg-bg"
         role="status"
-        aria-label="Loading"
+        aria-label={tCommon("loading")}
       >
         <Loader2 className="h-5 w-5 animate-spin text-teal" />
       </div>
@@ -79,14 +80,14 @@ export default function OnboardingPage() {
       const data = await res.json();
 
       if (!res.ok) {
-        setError(data.error ?? "Could not save username. Try another one.");
+        setError(data.error ?? tOnboarding("couldNotSaveUsername"));
         return;
       }
 
       setProfile({ userId: data.id, username: data.username });
       router.replace("/");
     } catch {
-      setError("Network error. Please try again.");
+      setError(tOnboarding("networkErrorPleaseRetry"));
     } finally {
       setSaving(false);
     }
@@ -100,10 +101,10 @@ export default function OnboardingPage() {
             <BookOpen className="h-5 w-5 text-gold" />
           </div>
           <div className="space-y-1 text-center">
-            <h1 className="text-base font-medium text-text-primary">Choose a username</h1>
-            <p className="text-xs text-text-muted">
-              This is how friends will find you on the leaderboard.
-            </p>
+            <h1 className="text-base font-medium text-text-primary">
+              {tOnboarding("chooseUsername")}
+            </h1>
+            <p className="text-xs text-text-muted">{tOnboarding("usernameHint")}</p>
           </div>
         </div>
 
@@ -116,16 +117,14 @@ export default function OnboardingPage() {
                 setUsername(e.target.value);
                 setError(null);
               }}
-              placeholder="e.g. ahmed_hikmah"
+              placeholder={tOnboarding("usernamePlaceholder")}
               maxLength={20}
               autoFocus
               autoComplete="off"
               spellCheck={false}
               className={cn(error && "border-error")}
             />
-            <p className="text-xs text-text-muted">
-              3–20 characters: letters, numbers, underscores only
-            </p>
+            <p className="text-xs text-text-muted">{tOnboarding("usernameRules")}</p>
             {error && <p className="text-xs text-error">{error}</p>}
           </div>
 
@@ -135,7 +134,7 @@ export default function OnboardingPage() {
             className="flex w-full cursor-pointer items-center justify-center gap-2 rounded bg-teal py-2 text-sm font-medium text-text-primary transition-[filter] duration-[120ms] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-            {saving ? "Saving…" : "Get started"}
+            {saving ? tOnboarding("saving") : tOnboarding("getStarted")}
           </button>
         </form>
       </Card>

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
 import { AddFriendForm } from "@/components/social/AddFriendForm";
@@ -45,6 +46,7 @@ function countIncomingChallenges(list: EnrichedChallenge[], myId: number | null)
 }
 
 export default function SocialPage() {
+  const t = useTranslations("social.page");
   const accessToken = useAuthStore((s) => s.accessToken);
   const userId = useSocialStore((s) => s.userId);
   const username = useSocialStore((s) => s.username);
@@ -197,42 +199,44 @@ export default function SocialPage() {
           </div>
         ) : !userId && profileTimedOut ? (
           <div className="space-y-3 py-20 text-center">
-            <p className="text-sm text-text-secondary">
-              Your profile couldn&apos;t load. Please sign out and try again.
-            </p>
+            <p className="text-sm text-text-secondary">{t("profileLoadFailed")}</p>
             <Link href="/" className="text-xs text-teal underline">
-              Back to home
+              {t("backToHome")}
             </Link>
           </div>
         ) : (
           <>
             {/* Page heading */}
             <div className="mb-6 flex items-center justify-between">
-              <h1 className="text-lg font-medium text-text-primary">Social</h1>
+              <h1 className="text-lg font-medium text-text-primary">{t("pageTitle")}</h1>
               {username && <span className="font-mono text-xs text-text-muted">@{username}</span>}
             </div>
 
             {/* Tab bar */}
             <div className="mb-6 flex divide-x divide-border overflow-hidden rounded-lg border border-border">
-              {(["leaderboard", "friends", "challenges"] as Tab[]).map((t) => (
+              {(["leaderboard", "friends", "challenges"] as Tab[]).map((tabKey) => (
                 <button
-                  key={t}
-                  onClick={() => setTab(t)}
+                  key={tabKey}
+                  onClick={() => setTab(tabKey)}
                   className={`flex min-h-[44px] flex-1 cursor-pointer items-center justify-center gap-1.5 px-1 py-2 text-[13px] font-medium capitalize transition-colors ${
-                    tab === t
+                    tab === tabKey
                       ? "bg-surface-raised text-text-primary"
                       : "text-text-muted hover:text-text-secondary"
                   }`}
                 >
-                  {t === "leaderboard" ? (
+                  {tabKey === "leaderboard" ? (
                     <Trophy className="h-4 w-4" />
-                  ) : t === "friends" ? (
+                  ) : tabKey === "friends" ? (
                     <Users className="h-4 w-4" />
                   ) : (
                     <Swords className="h-4 w-4" />
                   )}
-                  {t === "leaderboard" ? "Leaderboard" : t === "friends" ? "Friends" : "Challenges"}
-                  {t === "challenges" && pendingChallengeCount > 0 && (
+                  {tabKey === "leaderboard"
+                    ? t("tabLeaderboard")
+                    : tabKey === "friends"
+                      ? t("tabFriends")
+                      : t("tabChallenges")}
+                  {tabKey === "challenges" && pendingChallengeCount > 0 && (
                     <span className="ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-gold px-1 text-[10px] font-semibold text-ink">
                       {pendingChallengeCount}
                     </span>
@@ -243,7 +247,7 @@ export default function SocialPage() {
 
             {loadError && !loadingFriends && !loadingLeaderboard && !loadingChallenges && (
               <p className="mb-3 text-center text-xs text-error">
-                Couldn&apos;t load.{" "}
+                {t("couldntLoad")}{" "}
                 <button
                   onClick={() => {
                     fetchFriends();
@@ -253,7 +257,7 @@ export default function SocialPage() {
                   }}
                   className="cursor-pointer underline"
                 >
-                  Retry
+                  {t("retry")}
                 </button>
               </p>
             )}
@@ -286,7 +290,7 @@ export default function SocialPage() {
                           disabled={loadingMoreFriends}
                           className="cursor-pointer text-xs text-teal underline disabled:cursor-wait disabled:opacity-50"
                         >
-                          {loadingMoreFriends ? "Loading…" : "Load more"}
+                          {loadingMoreFriends ? t("loading") : t("loadMore")}
                         </button>
                       </div>
                     )}
@@ -311,7 +315,7 @@ export default function SocialPage() {
                 />
                 <section className="space-y-2">
                   <h3 className="px-0.5 text-[11px] font-medium uppercase tracking-wide text-text-muted">
-                    Your challenges
+                    {t("yourChallenges")}
                   </h3>
                   {loadingChallenges ? (
                     <div className="flex justify-center py-4">
@@ -344,18 +348,18 @@ export default function SocialPage() {
                       disabled={loadingMoreLeaderboard}
                       className="cursor-pointer text-xs text-teal underline disabled:cursor-wait disabled:opacity-50"
                     >
-                      {loadingMoreLeaderboard ? "Loading…" : "Load more"}
+                      {loadingMoreLeaderboard ? t("loading") : t("loadMore")}
                     </button>
                   </div>
                 )}
                 {!loadingLeaderboard && leaderboard.length <= 1 && (
                   <p className="text-center text-xs text-text-muted">
-                    Add friends to see them here.{" "}
+                    {t("addFriendsToSeeThemHere")}{" "}
                     <button
                       onClick={() => setTab("friends")}
                       className="cursor-pointer text-teal underline"
                     >
-                      Go to Friends
+                      {t("goToFriends")}
                     </button>
                   </p>
                 )}

--- a/app/workspaces/page.tsx
+++ b/app/workspaces/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { FolderOpen, Loader2, Trash2, Upload, Network, TriangleAlert } from "lucide-react";
+import { useTranslations, useFormatter } from "next-intl";
 import { useAuthStore } from "@/store/auth";
 import { useCanvasStore, type SavedCanvas } from "@/store/canvas";
 import { Card, IconButton, Tooltip } from "@/components/ui";
@@ -31,6 +32,8 @@ function WorkspaceRow({
   onLoad: (id: number) => void;
   onDelete: (id: number) => void;
 }) {
+  const t = useTranslations("workspaces");
+  const format = useFormatter();
   const { armed: deleteArmed, trigger: triggerDelete } = useArmedConfirm(() => onDelete(ws.id));
 
   return (
@@ -39,14 +42,10 @@ function WorkspaceRow({
         <p className="truncate text-sm font-medium text-text-primary">{ws.name}</p>
         <div className="mt-1 flex items-center gap-3">
           <span className="rounded border border-border px-1.5 py-0.5 font-mono text-xs text-text-muted">
-            {ws.nodeCount} verse{ws.nodeCount === 1 ? "" : "s"}
+            {t("nodeCount", { count: ws.nodeCount })}
           </span>
           <span className="text-xs text-text-muted">
-            {new Date(ws.updatedAt).toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
-            })}
+            {format.dateTime(new Date(ws.updatedAt), { dateStyle: "medium" })}
           </span>
         </div>
       </div>
@@ -62,16 +61,16 @@ function WorkspaceRow({
           ) : (
             <Upload className="h-3.5 w-3.5" />
           )}
-          <span>Load</span>
+          <span>{t("load")}</span>
         </button>
 
-        <Tooltip label={deleteArmed ? "Confirm delete canvas?" : "Delete canvas"}>
+        <Tooltip label={deleteArmed ? t("confirmDeleteCanvas") : t("deleteCanvas")}>
           <IconButton
             tone="danger"
             size="sm"
             onClick={triggerDelete}
             disabled={!!deletingId}
-            aria-label={deleteArmed ? "Confirm delete canvas?" : "Delete canvas"}
+            aria-label={deleteArmed ? t("confirmDeleteCanvas") : t("deleteCanvas")}
           >
             {deletingId === ws.id ? (
               <Loader2 className="animate-spin" />
@@ -88,6 +87,7 @@ function WorkspaceRow({
 }
 
 export default function WorkspacesPage() {
+  const t = useTranslations("workspaces");
   const router = useRouter();
   const accessToken = useAuthStore((s) => s.accessToken);
   const appendWorkspace = useCanvasStore((s) => s.appendWorkspace);
@@ -164,7 +164,7 @@ export default function WorkspacesPage() {
         {/* Page header */}
         <div className="mb-8 flex items-center gap-3">
           <FolderOpen className="h-5 w-5 text-gold" />
-          <h1 className="text-lg font-semibold text-text-primary">Saved Canvases</h1>
+          <h1 className="text-lg font-semibold text-text-primary">{t("pageTitle")}</h1>
           {workspaces.length > 0 && (
             <span className="rounded border border-border px-1.5 py-0.5 font-mono text-xs text-text-muted">
               {workspaces.length}
@@ -179,27 +179,25 @@ export default function WorkspacesPage() {
         ) : loadError ? (
           <div className="py-20 text-center">
             <TriangleAlert className="mx-auto mb-4 h-8 w-8 text-error/60" />
-            <p className="text-sm text-text-muted">Couldn&apos;t load your saved canvases.</p>
+            <p className="text-sm text-text-muted">{t("couldntLoadCanvases")}</p>
             <button
               onClick={() => fetchWorkspaces()}
               className="mt-4 cursor-pointer text-xs text-teal underline"
             >
-              Retry
+              {t("retry")}
             </button>
           </div>
         ) : workspaces.length === 0 ? (
           <div className="py-20 text-center">
             <FolderOpen className="mx-auto mb-4 h-8 w-8 text-text-muted/40" />
-            <p className="text-sm text-text-muted">No saved canvases yet.</p>
-            <p className="mt-1 text-xs text-text-muted">
-              Build a canvas and click the save icon in the header to save it.
-            </p>
+            <p className="text-sm text-text-muted">{t("noSavedCanvasesYet")}</p>
+            <p className="mt-1 text-xs text-text-muted">{t("buildAndSaveHint")}</p>
             <Link
               href="/canvas"
               className="mt-5 inline-flex items-center gap-1.5 rounded-md border border-border px-4 py-2 text-sm text-text-secondary transition-colors hover:border-gold-muted hover:text-gold"
             >
               <Network className="h-3.5 w-3.5" />
-              Open canvas
+              {t("openCanvas")}
             </Link>
           </div>
         ) : (

--- a/components/layout/AuthShell.tsx
+++ b/components/layout/AuthShell.tsx
@@ -21,7 +21,11 @@ export function AuthShell({ children }: { children: React.ReactNode }) {
       {showContent ? (
         children
       ) : isSessionLoading ? (
-        <div className="flex flex-1 items-center justify-center" role="status" aria-label="Loading">
+        <div
+          className="flex flex-1 items-center justify-center"
+          role="status"
+          aria-label={tCommon("loading")}
+        >
           <Loader2 className="h-5 w-5 animate-spin text-teal" />
         </div>
       ) : (

--- a/components/layout/ContextSidebar.tsx
+++ b/components/layout/ContextSidebar.tsx
@@ -3,6 +3,7 @@
 import { motion, AnimatePresence } from "framer-motion";
 import { X, ChevronDown, ChevronRight } from "lucide-react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { useCanvasStore } from "@/store/canvas";
 import { useAuthStore } from "@/store/auth";
 import { useState, useEffect, useRef } from "react";
@@ -13,6 +14,7 @@ import { InteractiveArabic } from "@/components/morphology/InteractiveArabic";
 import type { TafsirBlock } from "@/lib/quran/tafsir";
 
 function TafsirSection({ surah, ayah }: { surah: number; ayah: number }) {
+  const t = useTranslations("canvas.contextSidebar");
   const [open, setOpen] = useState(false);
   const [blocks, setBlocks] = useState<TafsirBlock[] | null>(null);
   const [loading, setLoading] = useState(false);
@@ -42,15 +44,15 @@ function TafsirSection({ surah, ayah }: { surah: number; ayah: number }) {
         onClick={handleOpen}
         className="flex w-full cursor-pointer items-center justify-between px-3 py-2 text-text-secondary"
       >
-        <span className="text-xs font-medium">Ibn Kathir Tafsir</span>
+        <span className="text-xs font-medium">{t("tafsirTitle")}</span>
         {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
       </button>
       {open && (
         <div className="space-y-2 px-3 pb-3">
           {loading ? (
-            <p className="text-xs text-text-muted">Loading…</p>
+            <p className="text-xs text-text-muted">{t("loading")}</p>
           ) : !blocks?.length ? (
-            <p className="text-xs text-text-muted">Tafsir unavailable.</p>
+            <p className="text-xs text-text-muted">{t("tafsirUnavailable")}</p>
           ) : (
             blocks.map((b, i) =>
               b.arabic ? (
@@ -75,6 +77,7 @@ function TafsirSection({ surah, ayah }: { surah: number; ayah: number }) {
 }
 
 function NotesSection({ verseRef }: { verseRef: string }) {
+  const t = useTranslations("canvas.contextSidebar");
   const accessToken = useAuthStore((s) => s.accessToken);
   const [open, setOpen] = useState(false);
   const [notes, setNotes] = useState<{ id: number; note: string; createdAt: string }[]>([]);
@@ -185,25 +188,25 @@ function NotesSection({ verseRef }: { verseRef: string }) {
         onClick={() => setOpen((o) => !o)}
         className="flex w-full cursor-pointer items-center justify-between px-3 py-2 text-text-secondary"
       >
-        <span className="text-xs font-medium">My Notes</span>
+        <span className="text-xs font-medium">{t("myNotes")}</span>
         {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
       </button>
 
       {open && (
         <div className="space-y-2 px-3 pb-3">
           {!accessToken ? (
-            <p className="text-xs text-text-muted">Sign in to add private notes.</p>
+            <p className="text-xs text-text-muted">{t("signInForNotes")}</p>
           ) : (
             <>
               {notes.map((n) => (
                 <div key={n.id} className="flex items-start gap-2 rounded border border-border p-2">
                   <p className="flex-1 text-xs leading-relaxed text-text-secondary">{n.note}</p>
                   {deleteErrorId === n.id && (
-                    <span className="shrink-0 text-xs text-error">Delete failed</span>
+                    <span className="shrink-0 text-xs text-error">{t("deleteFailed")}</span>
                   )}
                   <button
                     onClick={() => remove(n.id)}
-                    aria-label="Delete note"
+                    aria-label={t("deleteNote")}
                     className={`shrink-0 cursor-pointer transition-colors hover:text-text-secondary ${
                       deleteErrorId === n.id ? "text-error" : "text-text-muted"
                     }`}
@@ -215,8 +218,8 @@ function NotesSection({ verseRef }: { verseRef: string }) {
               <textarea
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
-                placeholder="Add a private note…"
-                aria-label="Add a private note"
+                placeholder={t("addNotePlaceholder")}
+                aria-label={t("addNotePlaceholder")}
                 rows={2}
                 className="w-full resize-none rounded border border-border bg-transparent px-2.5 py-2 text-xs text-text-primary transition-colors focus:border-gold-muted"
               />
@@ -227,7 +230,7 @@ function NotesSection({ verseRef }: { verseRef: string }) {
                   saveError ? "border-error text-error" : "border-teal text-teal"
                 }`}
               >
-                {saving ? "Saving…" : saveError ? "Save failed — try again" : "Save"}
+                {saving ? t("saving") : saveError ? t("saveFailedRetry") : t("save")}
               </button>
             </>
           )}
@@ -238,6 +241,7 @@ function NotesSection({ verseRef }: { verseRef: string }) {
 }
 
 function SimilarSection({ surah, ayah }: { surah: number; ayah: number }) {
+  const t = useTranslations("canvas.contextSidebar");
   const [open, setOpen] = useState(false);
   const [refs, setRefs] = useState<string[] | null>(null);
   const [loading, setLoading] = useState(false);
@@ -267,15 +271,15 @@ function SimilarSection({ surah, ayah }: { surah: number; ayah: number }) {
         onClick={handleOpen}
         className="flex w-full cursor-pointer items-center justify-between px-3 py-2 text-text-secondary"
       >
-        <span className="text-xs font-medium">Similar verses</span>
+        <span className="text-xs font-medium">{t("similarVerses")}</span>
         {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
       </button>
       {open && (
         <div className="px-3 pb-3">
           {loading ? (
-            <p className="text-xs text-text-muted">Loading…</p>
+            <p className="text-xs text-text-muted">{t("loading")}</p>
           ) : !refs?.length ? (
-            <p className="text-xs text-text-muted">None found.</p>
+            <p className="text-xs text-text-muted">{t("noneFound")}</p>
           ) : (
             <div className="flex flex-wrap gap-1.5">
               {refs.map((ref) => (
@@ -295,12 +299,6 @@ function SimilarSection({ surah, ayah }: { surah: number; ayah: number }) {
   );
 }
 
-const KIND_LABEL: Record<EdgeKind, string> = {
-  thematic: "Thematic",
-  root: "Root word",
-  contrast: "Contrast",
-};
-
 // Edge-kind accent as palette class sets (teal / gold / contrast), replacing the
 // old inline colour-string + hex-alpha concatenation.
 const KIND_BADGE: Record<EdgeKind, string> = {
@@ -310,6 +308,12 @@ const KIND_BADGE: Record<EdgeKind, string> = {
 };
 
 export function ContextSidebar() {
+  const t = useTranslations("canvas.contextSidebar");
+  const KIND_LABEL: Record<EdgeKind, string> = {
+    thematic: t("edgeKindThematic"),
+    root: t("edgeKindRoot"),
+    contrast: t("edgeKindContrast"),
+  };
   const sidebarContent = useCanvasStore((s) => s.sidebarContent);
   const setSidebarContent = useCanvasStore((s) => s.setSidebarContent);
   const { width, onHandlePointerDown, isResizing } = useSidebarResize();
@@ -340,7 +344,7 @@ export function ContextSidebar() {
             <div
               role="separator"
               aria-orientation="vertical"
-              aria-label="Resize panel"
+              aria-label={t("resizePanel")}
               onPointerDown={onHandlePointerDown}
               className={`absolute left-0 top-0 h-full w-1.5 -translate-x-1/2 cursor-col-resize transition-colors ${
                 isResizing ? "bg-gold-muted/60" : "hover:bg-gold-muted/40"
@@ -350,11 +354,11 @@ export function ContextSidebar() {
           {/* Header */}
           <div className="flex h-10 shrink-0 items-center justify-between border-b border-border px-4">
             <span className="text-xs text-text-muted">
-              {sidebarContent.type === "node" ? "Verse" : "Connection"}
+              {sidebarContent.type === "node" ? t("verseHeader") : t("connectionHeader")}
             </span>
             <button
               onClick={() => setSidebarContent(null)}
-              aria-label="Close panel"
+              aria-label={t("closePanel")}
               className="-mr-1.5 grid h-9 w-9 place-items-center rounded text-text-muted transition-colors hover:bg-white/5 sm:mr-0 sm:h-6 sm:w-6"
             >
               <X className="h-4 w-4 sm:h-3.5 sm:w-3.5" />
@@ -428,7 +432,7 @@ export function ContextSidebar() {
 
                 {/* Reason */}
                 <Card variant="raised" className="rounded-md p-3">
-                  <p className="mb-1.5 text-xs text-text-muted">Why connected</p>
+                  <p className="mb-1.5 text-xs text-text-muted">{t("whyConnected")}</p>
                   <p className="text-xs leading-relaxed text-text-primary">
                     {sidebarContent.reason}
                   </p>

--- a/components/social/AddFriendForm.tsx
+++ b/components/social/AddFriendForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useAuthStore } from "@/store/auth";
 import { Loader2, UserPlus, Check, Clock } from "lucide-react";
 import { Input, Card } from "@/components/ui";
@@ -18,6 +19,7 @@ interface SearchResult {
 }
 
 export function AddFriendForm({ onAdded }: Props) {
+  const t = useTranslations("social.addFriendForm");
   const accessToken = useAuthStore((s) => s.accessToken);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
@@ -64,7 +66,7 @@ export function AddFriendForm({ onAdded }: Props) {
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
-        setError(data.error ?? "Could not send request");
+        setError(data.error ?? t("couldNotSendRequest"));
         return;
       }
       // Reflect the new state locally; mutual requests come back accepted.
@@ -72,7 +74,7 @@ export function AddFriendForm({ onAdded }: Props) {
       setResults((prev) => prev.map((r) => (r.id === user.id ? { ...r, status: newStatus } : r)));
       onAdded();
     } catch {
-      setError("Network error. Try again.");
+      setError(t("networkErrorPeriod"));
     } finally {
       setSendingId(null);
     }
@@ -87,7 +89,7 @@ export function AddFriendForm({ onAdded }: Props) {
           setQuery(e.target.value);
           setError(null);
         }}
-        placeholder="Search by username…"
+        placeholder={t("searchPlaceholder")}
         maxLength={20}
         autoComplete="off"
         spellCheck={false}
@@ -99,9 +101,9 @@ export function AddFriendForm({ onAdded }: Props) {
       {query.trim() && (
         <div className="space-y-1">
           {searching && results.length === 0 ? (
-            <p className="px-1 py-1 text-xs text-text-muted">Searching…</p>
+            <p className="px-1 py-1 text-xs text-text-muted">{t("searching")}</p>
           ) : results.length === 0 ? (
-            <p className="px-1 py-1 text-xs text-text-muted">No users found.</p>
+            <p className="px-1 py-1 text-xs text-text-muted">{t("noUsersFound")}</p>
           ) : (
             results.map((u) => (
               <Card
@@ -133,17 +135,18 @@ function FriendAction({
   sending: boolean;
   onClick: () => void;
 }) {
+  const t = useTranslations("social.addFriendForm");
   if (status === "accepted") {
     return (
       <span className="flex items-center gap-1 text-xs text-text-muted">
-        <Check className="h-3.5 w-3.5" /> Friends
+        <Check className="h-3.5 w-3.5" /> {t("statusFriends")}
       </span>
     );
   }
   if (status === "pending_sent") {
     return (
       <span className="flex items-center gap-1 text-xs text-text-muted">
-        <Clock className="h-3.5 w-3.5" /> Sent
+        <Clock className="h-3.5 w-3.5" /> {t("statusSent")}
       </span>
     );
   }
@@ -160,7 +163,7 @@ function FriendAction({
       ) : (
         <UserPlus className="h-3.5 w-3.5" />
       )}
-      {status === "pending_received" ? "Accept" : "Add"}
+      {status === "pending_received" ? t("accept") : t("add")}
     </button>
   );
 }

--- a/components/social/ChallengeList.tsx
+++ b/components/social/ChallengeList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { useAuthStore } from "@/store/auth";
 import { useSocialStore } from "@/store/social";
 import { Loader2, Trophy, Clock, Minus, Swords } from "lucide-react";
@@ -29,33 +30,35 @@ interface Props {
   layout?: "list" | "grid";
 }
 
-function formatCountdown(endsAt: string): string {
+type CountdownT = (key: string, values?: Record<string, string | number>) => string;
+
+function formatCountdown(endsAt: string, t: CountdownT): string {
   const diff = new Date(endsAt).getTime() - Date.now();
-  if (diff <= 0) return "Ended";
+  if (diff <= 0) return t("ended");
   const totalSec = Math.floor(diff / 1000);
   const d = Math.floor(totalSec / 86_400);
   const h = Math.floor((totalSec % 86_400) / 3600);
   const m = Math.floor((totalSec % 3600) / 60);
   const s = totalSec % 60;
-  if (d > 0) return `${d}d ${h}h left`;
-  if (h > 0) return `${h}h ${m}m left`;
-  return `${m}m ${s}s left`;
+  if (d > 0) return t("daysHoursLeft", { d, h });
+  if (h > 0) return t("hoursMinutesLeft", { h, m });
+  return t("minutesSecondsLeft", { m, s });
 }
 
 /** Self-adjusting countdown: ticks per-second in the final hour, every 30s before. */
-function useCountdown(endsAt: string): string {
-  const [label, setLabel] = useState(() => formatCountdown(endsAt));
+function useCountdown(endsAt: string, t: CountdownT): string {
+  const [label, setLabel] = useState(() => formatCountdown(endsAt, t));
   useEffect(() => {
     // Reflect the new endsAt right away, then schedule subsequent ticks.
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLabel(formatCountdown(endsAt));
+    setLabel(formatCountdown(endsAt, t));
     let timer: ReturnType<typeof setTimeout>;
     const schedule = () => {
       const diff = new Date(endsAt).getTime() - Date.now();
       if (diff <= 0) return;
       timer = setTimeout(
         () => {
-          setLabel(formatCountdown(endsAt));
+          setLabel(formatCountdown(endsAt, t));
           schedule();
         },
         diff < 3_600_000 ? 1000 : 30_000
@@ -63,6 +66,7 @@ function useCountdown(endsAt: string): string {
     };
     schedule();
     return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [endsAt]);
   return label;
 }
@@ -109,10 +113,11 @@ function ChallengeCard({
   myId: number;
   onUpdate: () => void;
 }) {
+  const t = useTranslations("social.challengeList");
   const accessToken = useAuthStore((s) => s.accessToken);
   const [acting, setActing] = useState<"accept" | "decline" | "cancel" | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const countdown = useCountdown(c.endsAt);
+  const countdown = useCountdown(c.endsAt, t);
 
   const isChallenger = c.challengerId === myId;
   const myScore = isChallenger ? c.challengerScore : c.challengedScore;
@@ -141,33 +146,39 @@ function ChallengeCard({
         body: JSON.stringify({ action }),
       });
       if (!res.ok) {
-        setError(`Couldn't ${action} — try again.`);
+        setError(
+          action === "accept"
+            ? t("acceptFailedRetry")
+            : action === "decline"
+              ? t("declineFailedRetry")
+              : t("cancelFailedRetry")
+        );
         return;
       }
       onUpdate();
     } catch {
-      setError("Network error — try again.");
+      setError(t("networkErrorTryAgain"));
     } finally {
       setActing(null);
     }
   };
 
   const statusBadge = isActive ? (
-    <StatusBadge label="Active" tone="teal" />
+    <StatusBadge label={t("statusActive")} tone="teal" />
   ) : incoming ? (
-    <StatusBadge label="Incoming" tone="gold" />
+    <StatusBadge label={t("statusIncoming")} tone="gold" />
   ) : sent ? (
-    <StatusBadge label="Pending" tone="muted" />
+    <StatusBadge label={t("statusPending")} tone="muted" />
   ) : iWon ? (
-    <StatusBadge label="Won" tone="gold" />
+    <StatusBadge label={t("statusWon")} tone="gold" />
   ) : isDraw ? (
-    <StatusBadge label="Draw" tone="draw" />
+    <StatusBadge label={t("statusDraw")} tone="draw" />
   ) : theyWon ? (
-    <StatusBadge label="Lost" tone="muted" />
+    <StatusBadge label={t("statusLost")} tone="muted" />
   ) : c.status === "cancelled" ? (
-    <StatusBadge label="Cancelled" tone="muted" />
+    <StatusBadge label={t("statusCancelled")} tone="muted" />
   ) : (
-    <StatusBadge label="Declined" tone="muted" />
+    <StatusBadge label={t("statusDeclined")} tone="muted" />
   );
 
   return (
@@ -185,9 +196,9 @@ function ChallengeCard({
       {/* Scoreboard */}
       {(isActive || isCompleted) && (
         <div className="flex items-stretch rounded-md border border-border-subtle bg-bg/40">
-          <ScoreCell label="You" score={myScore} lead={myScore >= theirScore} />
+          <ScoreCell label={t("you")} score={myScore} lead={myScore >= theirScore} />
           <div className="flex items-center px-2 font-mono text-[10px] uppercase text-text-muted">
-            vs
+            {t("vs")}
           </div>
           <ScoreCell label={`@${opponentName}`} score={theirScore} lead={theirScore > myScore} />
         </div>
@@ -201,15 +212,19 @@ function ChallengeCard({
       )}
       {iWon && (
         <p className="flex items-center justify-center gap-1.5 text-xs font-medium text-gold">
-          <Trophy className="h-3.5 w-3.5" /> You won
+          <Trophy className="h-3.5 w-3.5" /> {t("youWon")}
         </p>
       )}
       {isDraw && (
         <p className="flex items-center justify-center gap-1.5 text-xs text-text-secondary">
-          <Minus className="h-3.5 w-3.5" /> Draw
+          <Minus className="h-3.5 w-3.5" /> {t("statusDraw")}
         </p>
       )}
-      {theyWon && <p className="text-center text-xs text-text-muted">@{opponentName} won</p>}
+      {theyWon && (
+        <p className="text-center text-xs text-text-muted">
+          {t("theyWonCaption", { name: `@${opponentName}` })}
+        </p>
+      )}
       {error && <p className="text-center text-xs text-error">{error}</p>}
 
       {/* Actions */}
@@ -227,7 +242,7 @@ function ChallengeCard({
             ) : (
               <Swords className="h-3.5 w-3.5" />
             )}
-            Accept
+            {t("accept")}
           </Button>
           <Button
             variant="secondary"
@@ -237,13 +252,15 @@ function ChallengeCard({
             disabled={acting !== null}
           >
             {acting === "decline" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-            Decline
+            {t("decline")}
           </Button>
         </div>
       )}
       {sent && (
         <div className="flex items-center justify-between gap-2 border-t border-border-subtle pt-2.5">
-          <span className="text-xs text-text-muted">Waiting for @{opponentName}…</span>
+          <span className="text-xs text-text-muted">
+            {t("waitingForOpponent", { name: `@${opponentName}` })}
+          </span>
           <Button
             variant="ghost"
             size="sm"
@@ -252,7 +269,7 @@ function ChallengeCard({
             disabled={acting !== null}
           >
             {acting === "cancel" && <Loader2 className="h-3 w-3 animate-spin" />}
-            Cancel
+            {t("cancel")}
           </Button>
         </div>
       )}
@@ -304,6 +321,7 @@ function Group({
 }
 
 export function ChallengeList({ challenges, onUpdate, layout = "list" }: Props) {
+  const t = useTranslations("social.challengeList");
   const myId = useSocialStore((s) => s.userId);
   if (!myId) return null;
 
@@ -311,10 +329,8 @@ export function ChallengeList({ challenges, onUpdate, layout = "list" }: Props) 
     return (
       <div className="rounded-lg border border-dashed border-border p-8 text-center">
         <Swords className="mx-auto mb-2 h-6 w-6 text-text-muted" />
-        <p className="text-sm text-text-secondary">No challenges yet.</p>
-        <p className="mt-0.5 text-xs text-text-muted">
-          Pick a suggestion or challenge a friend above.
-        </p>
+        <p className="text-sm text-text-secondary">{t("noChallengesYet")}</p>
+        <p className="mt-0.5 text-xs text-text-muted">{t("pickSuggestionOrChallenge")}</p>
       </div>
     );
   }
@@ -338,10 +354,10 @@ export function ChallengeList({ challenges, onUpdate, layout = "list" }: Props) 
 
   return (
     <div className="space-y-5">
-      <Group label="Needs your response" items={incoming} myId={myId} onUpdate={onUpdate} />
-      <Group label="Active" items={active} myId={myId} onUpdate={onUpdate} />
-      <Group label="Sent" items={sent} myId={myId} onUpdate={onUpdate} />
-      <Group label="Past" items={past} myId={myId} onUpdate={onUpdate} />
+      <Group label={t("groupNeedsResponse")} items={incoming} myId={myId} onUpdate={onUpdate} />
+      <Group label={t("groupActive")} items={active} myId={myId} onUpdate={onUpdate} />
+      <Group label={t("groupSent")} items={sent} myId={myId} onUpdate={onUpdate} />
+      <Group label={t("groupPast")} items={past} myId={myId} onUpdate={onUpdate} />
     </div>
   );
 }

--- a/components/social/ChallengeList.tsx
+++ b/components/social/ChallengeList.tsx
@@ -66,8 +66,12 @@ function useCountdown(endsAt: string, t: CountdownT): string {
     };
     schedule();
     return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [endsAt]);
+    // `t` is included: next-intl memoizes it on locale, so this only restarts
+    // the schedule on an actual locale switch — without it, a countdown
+    // already ticking would keep rendering in the pre-switch locale (a stale
+    // closure over the old `t`) until endsAt next changed or the component
+    // remounted.
+  }, [endsAt, t]);
   return label;
 }
 

--- a/components/social/ChallengeSuggestions.tsx
+++ b/components/social/ChallengeSuggestions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Sparkles, ArrowRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 export interface Suggestion {
   id: number;
@@ -20,13 +21,14 @@ interface Props {
  * the create form below. Renders nothing when there are no active suggestions.
  */
 export function ChallengeSuggestions({ suggestions, onPick }: Props) {
+  const t = useTranslations("social.challengeSuggestions");
   if (suggestions.length === 0) return null;
 
   return (
     <section className="space-y-2">
       <h3 className="flex items-center gap-1.5 px-0.5 text-[11px] font-medium uppercase tracking-wide text-text-muted">
         <Sparkles className="h-3.5 w-3.5 text-teal" />
-        Suggested
+        {t("suggested")}
       </h3>
       <div className="-mx-1 flex snap-x gap-2 overflow-x-auto px-1 pb-1">
         {suggestions.map((s) => (
@@ -55,7 +57,7 @@ export function ChallengeSuggestions({ suggestions, onPick }: Props) {
                 <span />
               )}
               <span className="flex items-center gap-0.5 text-[11px] font-medium text-text-secondary transition-colors group-hover:text-teal">
-                Use <ArrowRight className="h-3 w-3" />
+                {t("use")} <ArrowRight className="h-3 w-3" />
               </span>
             </div>
           </button>

--- a/components/social/CreateChallengeForm.tsx
+++ b/components/social/CreateChallengeForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { useAuthStore } from "@/store/auth";
 import { Loader2, Swords, X } from "lucide-react";
 import { Button, Input } from "@/components/ui";
@@ -44,6 +45,7 @@ export function CreateChallengeForm({
   onClearPrefill,
   compact,
 }: Props) {
+  const t = useTranslations("social.createChallengeForm");
   const accessToken = useAuthStore((s) => s.accessToken);
   // Initial values seed from a picked suggestion (the form is remounted via `key`
   // when a new suggestion is chosen, so these initializers re-run).
@@ -77,16 +79,16 @@ export function CreateChallengeForm({
       });
       const data = await res.json();
       if (!res.ok) {
-        setError(data.error ?? "Could not send challenge");
+        setError(data.error ?? t("couldNotSendChallenge"));
         return;
       }
-      setSuccess(`Challenge sent to @${selectedFriend}!`);
+      setSuccess(t("challengeSent", { username: selectedFriend }));
       setSelectedFriend("");
       setVerseRef("");
       onClearPrefill?.();
       onCreated();
     } catch {
-      setError("Network error. Try again.");
+      setError(t("networkErrorPeriod"));
     } finally {
       setSending(false);
     }
@@ -103,7 +105,7 @@ export function CreateChallengeForm({
   if (friends.length === 0) {
     return (
       <div className="rounded-lg border border-dashed border-border p-5 text-center text-sm text-text-muted">
-        Add friends first to challenge them.
+        {t("addFriendsFirst")}
       </div>
     );
   }
@@ -111,13 +113,13 @@ export function CreateChallengeForm({
   const prefillChip = prefill?.title && (
     <div className="flex items-center justify-between gap-2 rounded-md border-l-2 border-teal bg-teal/[0.06] px-3 py-1.5">
       <span className="truncate text-xs text-text-secondary">
-        From: <span className="text-teal">{prefill.title}</span>
+        {t("fromLabel")} <span className="text-teal">{prefill.title}</span>
       </span>
       {onClearPrefill && (
         <button
           type="button"
           onClick={onClearPrefill}
-          aria-label="Clear suggestion"
+          aria-label={t("clearSuggestion")}
           className="shrink-0 text-text-muted hover:text-text-primary"
         >
           <X className="h-3.5 w-3.5" />
@@ -147,13 +149,13 @@ export function CreateChallengeForm({
     return (
       <section className="space-y-2">
         <h3 className="px-0.5 text-[11px] font-medium uppercase tracking-wide text-text-muted">
-          New challenge
+          {t("newChallenge")}
         </h3>
         <div className="space-y-2 rounded-lg border border-border bg-surface p-3">
           {prefillChip}
           <form onSubmit={handleSubmit} className="flex flex-wrap items-center gap-2">
             <select
-              aria-label="Choose a friend"
+              aria-label={t("chooseAFriend")}
               value={selectedFriend}
               onChange={(e) => {
                 setSelectedFriend(e.target.value);
@@ -166,7 +168,7 @@ export function CreateChallengeForm({
               )}
             >
               <option value="" disabled className="bg-surface">
-                Choose a friend…
+                {t("chooseAFriendPlaceholder")}
               </option>
               {friends.map((f) => (
                 <option key={f.id} value={f.username} className="bg-surface">
@@ -179,7 +181,7 @@ export function CreateChallengeForm({
               type="text"
               value={verseRef}
               onChange={(e) => setVerseRef(e.target.value)}
-              placeholder="Verse (optional)"
+              placeholder={t("versePlaceholderCompact")}
               maxLength={20}
               autoComplete="off"
               spellCheck={false}
@@ -197,7 +199,7 @@ export function CreateChallengeForm({
               ) : (
                 <Swords className="h-3.5 w-3.5" />
               )}
-              Send
+              {t("send")}
             </Button>
           </form>
           {error && <p className="text-xs text-error">{error}</p>}
@@ -210,7 +212,7 @@ export function CreateChallengeForm({
   return (
     <section className="space-y-2">
       <h3 className="px-0.5 text-[11px] font-medium uppercase tracking-wide text-text-muted">
-        New challenge
+        {t("newChallenge")}
       </h3>
       <form
         onSubmit={handleSubmit}
@@ -219,7 +221,7 @@ export function CreateChallengeForm({
         {prefillChip}
 
         <select
-          aria-label="Choose a friend"
+          aria-label={t("chooseAFriend")}
           value={selectedFriend}
           onChange={(e) => {
             setSelectedFriend(e.target.value);
@@ -232,7 +234,7 @@ export function CreateChallengeForm({
           )}
         >
           <option value="" disabled className="bg-surface">
-            Choose a friend…
+            {t("chooseAFriendPlaceholder")}
           </option>
           {friends.map((f) => (
             <option key={f.id} value={f.username} className="bg-surface">
@@ -243,7 +245,7 @@ export function CreateChallengeForm({
 
         <div className="space-y-1.5">
           <span className="block text-[11px] uppercase tracking-wide text-text-muted">
-            Duration
+            {t("duration")}
           </span>
           <div className="flex gap-2">{durationButtons}</div>
         </div>
@@ -252,7 +254,7 @@ export function CreateChallengeForm({
           type="text"
           value={verseRef}
           onChange={(e) => setVerseRef(e.target.value)}
-          placeholder="Verse context (optional, e.g. 2:255)"
+          placeholder={t("versePlaceholderFull")}
           maxLength={20}
           autoComplete="off"
           spellCheck={false}
@@ -271,7 +273,7 @@ export function CreateChallengeForm({
             ) : (
               <Swords className="h-3.5 w-3.5" />
             )}
-            Send challenge
+            {t("sendChallenge")}
           </Button>
           {error && <p className="text-xs text-error">{error}</p>}
           {success && <p className="text-xs text-teal">{success}</p>}

--- a/components/social/FriendList.tsx
+++ b/components/social/FriendList.tsx
@@ -3,6 +3,7 @@
 import { useAuthStore } from "@/store/auth";
 import { Check, X, UserMinus, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Card, IconButton, Tooltip } from "@/components/ui";
 import { useArmedConfirm } from "@/hooks/useArmedConfirm";
 
@@ -55,6 +56,7 @@ function DestructiveIconButton({
 }
 
 export function FriendList({ friends, onUpdate }: Props) {
+  const t = useTranslations("social.friendList");
   const accessToken = useAuthStore((s) => s.accessToken);
   const [busy, setBusy] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -76,12 +78,12 @@ export function FriendList({ friends, onUpdate }: Props) {
         body: JSON.stringify({ action }),
       });
       if (!res.ok) {
-        setError(`Couldn't ${action} request — try again.`);
+        setError(action === "accept" ? t("acceptRequestFailed") : t("declineRequestFailed"));
         return;
       }
       onUpdate();
     } catch {
-      setError("Network error — try again.");
+      setError(t("networkErrorTryAgain"));
     } finally {
       setBusy(null);
     }
@@ -97,12 +99,12 @@ export function FriendList({ friends, onUpdate }: Props) {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
       if (!res.ok) {
-        setError("Couldn't remove — try again.");
+        setError(t("couldntRemoveTryAgain"));
         return;
       }
       onUpdate();
     } catch {
-      setError("Network error — try again.");
+      setError(t("networkErrorTryAgain"));
     } finally {
       setBusy(null);
     }
@@ -111,9 +113,7 @@ export function FriendList({ friends, onUpdate }: Props) {
   const empty = accepted.length === 0 && pending.length === 0;
 
   if (empty) {
-    return (
-      <p className="py-4 text-sm text-text-muted">No friends yet. Add someone by username above.</p>
-    );
+    return <p className="py-4 text-sm text-text-muted">{t("noFriendsYet")}</p>;
   }
 
   return (
@@ -121,7 +121,7 @@ export function FriendList({ friends, onUpdate }: Props) {
       {error && <p className="text-xs text-error">{error}</p>}
       {pending.length > 0 && (
         <div className="space-y-1">
-          <p className="mb-2 font-mono text-xs text-text-muted">Pending requests</p>
+          <p className="mb-2 font-mono text-xs text-text-muted">{t("pendingRequests")}</p>
           {pending.map((f) => (
             <Card
               key={f.id}
@@ -131,29 +131,29 @@ export function FriendList({ friends, onUpdate }: Props) {
               <div className="flex items-center gap-2">
                 <span className="text-sm text-text-primary">{f.friend?.username ?? "—"}</span>
                 <span className="text-xs text-text-muted">
-                  {f.direction === "sent" ? "sent" : "received"}
+                  {f.direction === "sent" ? t("sentDirection") : t("receivedDirection")}
                 </span>
               </div>
               {f.direction === "received" ? (
                 <div className="flex items-center gap-1">
-                  <Tooltip label="Accept">
+                  <Tooltip label={t("acceptRequestAria")}>
                     <IconButton
                       tone="teal"
                       size="xs"
                       onClick={() => patch(f.id, "accept")}
                       disabled={busy === f.id}
-                      aria-label="Accept request"
+                      aria-label={t("acceptRequestAria")}
                     >
                       {busy === f.id ? <Loader2 className="animate-spin" /> : <Check />}
                     </IconButton>
                   </Tooltip>
-                  <Tooltip label="Decline">
+                  <Tooltip label={t("declineRequestAria")}>
                     <IconButton
                       tone="danger"
                       size="xs"
                       onClick={() => patch(f.id, "decline")}
                       disabled={busy === f.id}
-                      aria-label="Decline request"
+                      aria-label={t("declineRequestAria")}
                     >
                       <X />
                     </IconButton>
@@ -165,8 +165,8 @@ export function FriendList({ friends, onUpdate }: Props) {
                   disabled={busy === f.id}
                   busy={busy === f.id}
                   idleIcon={<X />}
-                  label="Cancel request"
-                  confirmLabel="Click again to confirm"
+                  label={t("cancelRequestAria")}
+                  confirmLabel={t("clickAgainToConfirm")}
                 />
               )}
             </Card>
@@ -176,7 +176,7 @@ export function FriendList({ friends, onUpdate }: Props) {
 
       {accepted.length > 0 && (
         <div className="space-y-1">
-          <p className="mb-2 font-mono text-xs text-text-muted">Friends</p>
+          <p className="mb-2 font-mono text-xs text-text-muted">{t("friendsHeader")}</p>
           {accepted.map((f) => (
             <Card
               key={f.id}
@@ -192,8 +192,8 @@ export function FriendList({ friends, onUpdate }: Props) {
                 disabled={busy === f.id}
                 busy={busy === f.id}
                 idleIcon={<UserMinus />}
-                label="Remove friend"
-                confirmLabel="Click again to confirm"
+                label={t("removeFriendAria")}
+                confirmLabel={t("clickAgainToConfirm")}
               />
             </Card>
           ))}

--- a/components/social/LeaderboardTable.tsx
+++ b/components/social/LeaderboardTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Flame, Crown } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 
 interface LeaderboardEntry {
@@ -18,8 +19,9 @@ interface Props {
 }
 
 export function LeaderboardTable({ entries }: Props) {
+  const t = useTranslations("social.leaderboardTable");
   if (entries.length === 0) {
-    return <p className="py-4 text-sm text-text-muted">Add friends to see the leaderboard.</p>;
+    return <p className="py-4 text-sm text-text-muted">{t("addFriendsToSeeLeaderboard")}</p>;
   }
 
   return (
@@ -54,7 +56,9 @@ export function LeaderboardTable({ entries }: Props) {
             {entry.displayName && (
               <span className="ml-1.5 font-mono text-xs text-text-muted">@{entry.username}</span>
             )}
-            {entry.isYou && <span className="ml-1.5 text-xs text-text-muted">(you)</span>}
+            {entry.isYou && (
+              <span className="ml-1.5 text-xs text-text-muted">{t("youSuffix")}</span>
+            )}
           </div>
 
           {/* Streak */}

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -60,6 +60,23 @@ test.describe("language switching", () => {
     expect(cookies.find((c) => c.name === "oh_locale")?.value).toBe("tr");
     await expect(page.locator("html")).toHaveAttribute("lang", "tr");
   });
+
+  test("an authed surface renders translated copy once the locale is switched (issue #571)", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/search");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: /change language/i }).click();
+    await page.getByRole("button", { name: "Türkçe" }).click();
+    await expect(page.locator("html")).toHaveAttribute("lang", "tr");
+
+    // /workspaces' page title is not gated behind a loading state, unlike
+    // /social's (which only renders its heading once userId resolves) — a
+    // stable target for this check.
+    await page.goto("/workspaces");
+    await expect(page.getByRole("heading", { name: "Kaydedilmiş Kanvaslar" })).toBeVisible();
+  });
 });
 
 test.describe("mobile bottom nav", () => {

--- a/messages/az.json
+++ b/messages/az.json
@@ -7,7 +7,8 @@
     "allSettings": "Bütün tənzimləmələr →",
     "changeLanguage": "Dili dəyiş",
     "removeBookmark": "Əlfəcini sil",
-    "bookmarkVerse": "Ayəni əlfəcinlə"
+    "bookmarkVerse": "Ayəni əlfəcinlə",
+    "loading": "Yüklənir"
   },
   "nav": {
     "canvas": "Lövhə",
@@ -109,7 +110,31 @@
     "saveWorkspace": "İş sahəsini yadda saxla",
     "exportAsPng": "PNG kimi ixrac et",
     "exportAsPdf": "PDF kimi ixrac et",
-    "more": "Daha çox"
+    "more": "Daha çox",
+    "contextSidebar": {
+      "tafsirTitle": "İbn Kəsir Təfsiri",
+      "loading": "Yüklənir…",
+      "tafsirUnavailable": "Təfsir mövcud deyil.",
+      "myNotes": "Qeydlərim",
+      "signInForNotes": "Şəxsi qeyd əlavə etmək üçün daxil olun.",
+      "deleteNote": "Qeydi sil",
+      "deleteFailed": "Silinmə uğursuz oldu",
+      "addNotePlaceholder": "Şəxsi qeyd əlavə edin…",
+      "saving": "Yadda saxlanılır…",
+      "saveFailedRetry": "Yadda saxlama uğursuz oldu — yenidən cəhd edin",
+      "save": "Yadda saxla",
+      "similarVerses": "Oxşar ayələr",
+      "noneFound": "Tapılmadı.",
+      "edgeKindThematic": "Mövzu",
+      "edgeKindRoot": "Kök söz",
+      "edgeKindContrast": "Ziddiyyət",
+      "resizePanel": "Paneli ölçüləndir",
+      "verseHeader": "Ayə",
+      "connectionHeader": "Əlaqə",
+      "closePanel": "Paneli bağla",
+      "whyConnected": "Niyə əlaqəlidir"
+    },
+    "loadingCanvas": "Kanvas yüklənir…"
   },
   "search": {
     "dialogTitle": "Quran Ayələrində Axtar",
@@ -229,5 +254,136 @@
   "authGate": {
     "title": "Davam etmək üçün daxil olun",
     "body": "Bu səhifəyə baxmaq üçün daxil olmalısınız."
+  },
+  "social": {
+    "page": {
+      "pageTitle": "Sosial",
+      "tabLeaderboard": "Reytinq",
+      "tabFriends": "Dostlar",
+      "tabChallenges": "Çağırışlar",
+      "profileLoadFailed": "Profiliniz yüklənmədi. Çıxış edib yenidən cəhd edin.",
+      "backToHome": "Ana səhifəyə qayıt",
+      "couldntLoad": "Yüklənmədi.",
+      "retry": "Yenidən cəhd et",
+      "loadMore": "Daha çox yüklə",
+      "loading": "Yüklənir…",
+      "yourChallenges": "Çağırışlarınız",
+      "addFriendsToSeeThemHere": "Burada görmək üçün dost əlavə edin.",
+      "goToFriends": "Dostlara keç"
+    },
+    "challengeList": {
+      "ended": "Bitdi",
+      "daysHoursLeft": "{d}g {h}s qaldı",
+      "hoursMinutesLeft": "{h}s {m}d qaldı",
+      "minutesSecondsLeft": "{m}d {s}s qaldı",
+      "statusActive": "Aktiv",
+      "statusIncoming": "Gələn",
+      "statusPending": "Gözləmədə",
+      "statusWon": "Qazandı",
+      "statusDraw": "Bərabərə",
+      "statusLost": "Uduzdu",
+      "statusCancelled": "Ləğv edildi",
+      "statusDeclined": "Rədd edildi",
+      "youWon": "Siz qazandınız",
+      "theyWonCaption": "{name} qazandı",
+      "acceptFailedRetry": "Qəbul edilmədi — yenidən cəhd edin.",
+      "declineFailedRetry": "Rədd edilmədi — yenidən cəhd edin.",
+      "cancelFailedRetry": "Ləğv edilmədi — yenidən cəhd edin.",
+      "networkErrorTryAgain": "Şəbəkə xətası — yenidən cəhd edin.",
+      "accept": "Qəbul et",
+      "decline": "Rədd et",
+      "waitingForOpponent": "{name} gözlənilir…",
+      "cancel": "Ləğv et",
+      "noChallengesYet": "Hələ çağırış yoxdur.",
+      "pickSuggestionOrChallenge": "Yuxarıdan bir təklif seçin və ya dostunuza çağırış göndərin.",
+      "groupNeedsResponse": "Cavabınız gözlənilir",
+      "groupActive": "Aktiv",
+      "groupSent": "Göndərilib",
+      "groupPast": "Keçmiş",
+      "you": "Siz",
+      "vs": "vs"
+    },
+    "createChallengeForm": {
+      "newChallenge": "Yeni çağırış",
+      "chooseAFriend": "Dost seçin",
+      "chooseAFriendPlaceholder": "Dost seçin…",
+      "clearSuggestion": "Təklifi təmizlə",
+      "duration": "Müddət",
+      "versePlaceholderCompact": "Ayə (istəyə görə)",
+      "versePlaceholderFull": "Ayə konteksti (istəyə görə, məs. 2:255)",
+      "send": "Göndər",
+      "sendChallenge": "Çağırışı göndər",
+      "couldNotSendChallenge": "Çağırış göndərilmədi",
+      "challengeSent": "Çağırış @{username} istifadəçisinə göndərildi!",
+      "networkErrorPeriod": "Şəbəkə xətası. Yenidən cəhd edin.",
+      "addFriendsFirst": "Çağırış göndərmək üçün əvvəlcə dost əlavə edin.",
+      "fromLabel": "Mənbə:"
+    },
+    "addFriendForm": {
+      "searchPlaceholder": "İstifadəçi adına görə axtar…",
+      "searching": "Axtarılır…",
+      "noUsersFound": "İstifadəçi tapılmadı.",
+      "statusFriends": "Dostlar",
+      "statusSent": "Göndərilib",
+      "add": "Əlavə et",
+      "accept": "Qəbul et",
+      "couldNotSendRequest": "Sorğu göndərilmədi",
+      "networkErrorPeriod": "Şəbəkə xətası. Yenidən cəhd edin."
+    },
+    "challengeSuggestions": {
+      "suggested": "Təklif olunan",
+      "use": "İstifadə et"
+    },
+    "leaderboardTable": {
+      "addFriendsToSeeLeaderboard": "Reytinqi görmək üçün dost əlavə edin.",
+      "youSuffix": "(siz)"
+    },
+    "friendList": {
+      "noFriendsYet": "Hələ dost yoxdur. Yuxarıdan istifadəçi adı ilə kimisə əlavə edin.",
+      "pendingRequests": "Gözləyən sorğular",
+      "friendsHeader": "Dostlar",
+      "sentDirection": "göndərilib",
+      "receivedDirection": "alınıb",
+      "acceptRequestAria": "Sorğunu qəbul et",
+      "declineRequestAria": "Sorğunu rədd et",
+      "cancelRequestAria": "Sorğunu ləğv et",
+      "clickAgainToConfirm": "Təsdiqləmək üçün yenidən klikləyin",
+      "removeFriendAria": "Dostu sil",
+      "acceptRequestFailed": "Sorğu qəbul edilmədi — yenidən cəhd edin.",
+      "declineRequestFailed": "Sorğu rədd edilmədi — yenidən cəhd edin.",
+      "couldntRemoveTryAgain": "Silinmədi — yenidən cəhd edin.",
+      "networkErrorTryAgain": "Şəbəkə xətası — yenidən cəhd edin."
+    }
+  },
+  "mentions": {
+    "pageTitle": "Qeyd edilmələr",
+    "noMentionsYet": "Hələ qeyd edilmə yoxdur.",
+    "mentionHint": "Bir dost ayə qeydində sizi @istifadəçiadınızla qeyd edə bilər.",
+    "couldntMarkRead": "Qeyd edilmələr oxunmuş kimi işarələnmədi. Oxunmamış sayı sinxron olmaya bilər.",
+    "couldntLoadMentions": "Qeyd edilmələr yüklənmədi.",
+    "mentionedYouOn": "sizi qeyd etdi:",
+    "openInCanvas": "Kanvasda aç"
+  },
+  "workspaces": {
+    "pageTitle": "Yadda Saxlanmış Kanvaslar",
+    "noSavedCanvasesYet": "Hələ yadda saxlanmış kanvas yoxdur.",
+    "buildAndSaveHint": "Bir kanvas yaradın və yadda saxlamaq üçün başlıqdakı yadda saxla ikonuna klikləyin.",
+    "openCanvas": "Kanvası aç",
+    "couldntLoadCanvases": "Yadda saxlanmış kanvaslarınız yüklənmədi.",
+    "retry": "Yenidən cəhd et",
+    "load": "Yüklə",
+    "deleteCanvas": "Kanvası sil",
+    "confirmDeleteCanvas": "Kanvası silməyi təsdiqləyirsiniz?",
+    "nodeCount": "{count, plural, other {# ayə}}"
+  },
+  "onboarding": {
+    "chooseUsername": "İstifadəçi adı seçin",
+    "usernameHint": "Dostlarınız sizi reytinqdə belə tapacaq.",
+    "usernamePlaceholder": "məs. ahmed_hikmah",
+    "usernameRules": "3–20 simvol: yalnız hərflər, rəqəmlər, alt xətlər",
+    "couldNotSaveUsername": "İstifadəçi adı yadda saxlanmadı. Başqasını sınayın.",
+    "networkErrorPleaseRetry": "Şəbəkə xətası. Yenidən cəhd edin.",
+    "saving": "Yadda saxlanılır…",
+    "getStarted": "Başla"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,7 +7,8 @@
     "allSettings": "All settings →",
     "changeLanguage": "Change language",
     "removeBookmark": "Remove bookmark",
-    "bookmarkVerse": "Bookmark verse"
+    "bookmarkVerse": "Bookmark verse",
+    "loading": "Loading"
   },
   "nav": {
     "canvas": "Canvas",
@@ -109,7 +110,31 @@
     "saveWorkspace": "Save workspace",
     "exportAsPng": "Export as PNG",
     "exportAsPdf": "Export as PDF",
-    "more": "More"
+    "more": "More",
+    "contextSidebar": {
+      "tafsirTitle": "Ibn Kathir Tafsir",
+      "loading": "Loading…",
+      "tafsirUnavailable": "Tafsir unavailable.",
+      "myNotes": "My Notes",
+      "signInForNotes": "Sign in to add private notes.",
+      "deleteNote": "Delete note",
+      "deleteFailed": "Delete failed",
+      "addNotePlaceholder": "Add a private note…",
+      "saving": "Saving…",
+      "saveFailedRetry": "Save failed — try again",
+      "save": "Save",
+      "similarVerses": "Similar verses",
+      "noneFound": "None found.",
+      "edgeKindThematic": "Thematic",
+      "edgeKindRoot": "Root word",
+      "edgeKindContrast": "Contrast",
+      "resizePanel": "Resize panel",
+      "verseHeader": "Verse",
+      "connectionHeader": "Connection",
+      "closePanel": "Close panel",
+      "whyConnected": "Why connected"
+    },
+    "loadingCanvas": "Loading canvas…"
   },
   "search": {
     "dialogTitle": "Search Quran Verses",
@@ -229,5 +254,136 @@
   "authGate": {
     "title": "Sign in to continue",
     "body": "You need to be signed in to view this page."
+  },
+  "social": {
+    "page": {
+      "pageTitle": "Social",
+      "tabLeaderboard": "Leaderboard",
+      "tabFriends": "Friends",
+      "tabChallenges": "Challenges",
+      "profileLoadFailed": "Your profile couldn't load. Please sign out and try again.",
+      "backToHome": "Back to home",
+      "couldntLoad": "Couldn't load.",
+      "retry": "Retry",
+      "loadMore": "Load more",
+      "loading": "Loading…",
+      "yourChallenges": "Your challenges",
+      "addFriendsToSeeThemHere": "Add friends to see them here.",
+      "goToFriends": "Go to Friends"
+    },
+    "challengeList": {
+      "ended": "Ended",
+      "daysHoursLeft": "{d}d {h}h left",
+      "hoursMinutesLeft": "{h}h {m}m left",
+      "minutesSecondsLeft": "{m}m {s}s left",
+      "statusActive": "Active",
+      "statusIncoming": "Incoming",
+      "statusPending": "Pending",
+      "statusWon": "Won",
+      "statusDraw": "Draw",
+      "statusLost": "Lost",
+      "statusCancelled": "Cancelled",
+      "statusDeclined": "Declined",
+      "youWon": "You won",
+      "theyWonCaption": "{name} won",
+      "acceptFailedRetry": "Couldn't accept — try again.",
+      "declineFailedRetry": "Couldn't decline — try again.",
+      "cancelFailedRetry": "Couldn't cancel — try again.",
+      "networkErrorTryAgain": "Network error — try again.",
+      "accept": "Accept",
+      "decline": "Decline",
+      "waitingForOpponent": "Waiting for {name}…",
+      "cancel": "Cancel",
+      "noChallengesYet": "No challenges yet.",
+      "pickSuggestionOrChallenge": "Pick a suggestion or challenge a friend above.",
+      "groupNeedsResponse": "Needs your response",
+      "groupActive": "Active",
+      "groupSent": "Sent",
+      "groupPast": "Past",
+      "you": "You",
+      "vs": "vs"
+    },
+    "createChallengeForm": {
+      "newChallenge": "New challenge",
+      "chooseAFriend": "Choose a friend",
+      "chooseAFriendPlaceholder": "Choose a friend…",
+      "clearSuggestion": "Clear suggestion",
+      "duration": "Duration",
+      "versePlaceholderCompact": "Verse (optional)",
+      "versePlaceholderFull": "Verse context (optional, e.g. 2:255)",
+      "send": "Send",
+      "sendChallenge": "Send challenge",
+      "couldNotSendChallenge": "Could not send challenge",
+      "challengeSent": "Challenge sent to @{username}!",
+      "networkErrorPeriod": "Network error. Try again.",
+      "addFriendsFirst": "Add friends first to challenge them.",
+      "fromLabel": "From:"
+    },
+    "addFriendForm": {
+      "searchPlaceholder": "Search by username…",
+      "searching": "Searching…",
+      "noUsersFound": "No users found.",
+      "statusFriends": "Friends",
+      "statusSent": "Sent",
+      "add": "Add",
+      "accept": "Accept",
+      "couldNotSendRequest": "Could not send request",
+      "networkErrorPeriod": "Network error. Try again."
+    },
+    "challengeSuggestions": {
+      "suggested": "Suggested",
+      "use": "Use"
+    },
+    "leaderboardTable": {
+      "addFriendsToSeeLeaderboard": "Add friends to see the leaderboard.",
+      "youSuffix": "(you)"
+    },
+    "friendList": {
+      "noFriendsYet": "No friends yet. Add someone by username above.",
+      "pendingRequests": "Pending requests",
+      "friendsHeader": "Friends",
+      "sentDirection": "sent",
+      "receivedDirection": "received",
+      "acceptRequestAria": "Accept request",
+      "declineRequestAria": "Decline request",
+      "cancelRequestAria": "Cancel request",
+      "clickAgainToConfirm": "Click again to confirm",
+      "removeFriendAria": "Remove friend",
+      "acceptRequestFailed": "Couldn't accept request — try again.",
+      "declineRequestFailed": "Couldn't decline request — try again.",
+      "couldntRemoveTryAgain": "Couldn't remove — try again.",
+      "networkErrorTryAgain": "Network error — try again."
+    }
+  },
+  "mentions": {
+    "pageTitle": "Mentions",
+    "noMentionsYet": "No mentions yet.",
+    "mentionHint": "A friend can tag you with your @username in a verse note.",
+    "couldntMarkRead": "Couldn't mark mentions as read. The unread count may be out of sync.",
+    "couldntLoadMentions": "Couldn't load mentions.",
+    "mentionedYouOn": "mentioned you on",
+    "openInCanvas": "Open in canvas"
+  },
+  "workspaces": {
+    "pageTitle": "Saved Canvases",
+    "noSavedCanvasesYet": "No saved canvases yet.",
+    "buildAndSaveHint": "Build a canvas and click the save icon in the header to save it.",
+    "openCanvas": "Open canvas",
+    "couldntLoadCanvases": "Couldn't load your saved canvases.",
+    "retry": "Retry",
+    "load": "Load",
+    "deleteCanvas": "Delete canvas",
+    "confirmDeleteCanvas": "Confirm delete canvas?",
+    "nodeCount": "{count, plural, one {# verse} other {# verses}}"
+  },
+  "onboarding": {
+    "chooseUsername": "Choose a username",
+    "usernameHint": "This is how friends will find you on the leaderboard.",
+    "usernamePlaceholder": "e.g. ahmed_hikmah",
+    "usernameRules": "3–20 characters: letters, numbers, underscores only",
+    "couldNotSaveUsername": "Could not save username. Try another one.",
+    "networkErrorPleaseRetry": "Network error. Please try again.",
+    "saving": "Saving…",
+    "getStarted": "Get started"
   }
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -7,7 +7,8 @@
     "allSettings": "Все настройки →",
     "changeLanguage": "Изменить язык",
     "removeBookmark": "Удалить закладку",
-    "bookmarkVerse": "Добавить в закладки"
+    "bookmarkVerse": "Добавить в закладки",
+    "loading": "Загрузка"
   },
   "nav": {
     "canvas": "Холст",
@@ -109,7 +110,31 @@
     "saveWorkspace": "Сохранить рабочее пространство",
     "exportAsPng": "Экспортировать как PNG",
     "exportAsPdf": "Экспортировать как PDF",
-    "more": "Ещё"
+    "more": "Ещё",
+    "contextSidebar": {
+      "tafsirTitle": "Тафсир Ибн Касира",
+      "loading": "Загрузка…",
+      "tafsirUnavailable": "Тафсир недоступен.",
+      "myNotes": "Мои заметки",
+      "signInForNotes": "Войдите, чтобы добавлять личные заметки.",
+      "deleteNote": "Удалить заметку",
+      "deleteFailed": "Не удалось удалить",
+      "addNotePlaceholder": "Добавьте личную заметку…",
+      "saving": "Сохранение…",
+      "saveFailedRetry": "Не удалось сохранить — повторите попытку",
+      "save": "Сохранить",
+      "similarVerses": "Похожие аяты",
+      "noneFound": "Ничего не найдено.",
+      "edgeKindThematic": "Тема",
+      "edgeKindRoot": "Корень слова",
+      "edgeKindContrast": "Контраст",
+      "resizePanel": "Изменить размер панели",
+      "verseHeader": "Аят",
+      "connectionHeader": "Связь",
+      "closePanel": "Закрыть панель",
+      "whyConnected": "Почему связаны"
+    },
+    "loadingCanvas": "Загрузка холста…"
   },
   "search": {
     "dialogTitle": "Поиск аятов Корана",
@@ -229,5 +254,136 @@
   "authGate": {
     "title": "Войдите, чтобы продолжить",
     "body": "Чтобы просмотреть эту страницу, необходимо войти в систему."
+  },
+  "social": {
+    "page": {
+      "pageTitle": "Сообщество",
+      "tabLeaderboard": "Рейтинг",
+      "tabFriends": "Друзья",
+      "tabChallenges": "Испытания",
+      "profileLoadFailed": "Не удалось загрузить профиль. Выйдите и попробуйте снова.",
+      "backToHome": "На главную",
+      "couldntLoad": "Не удалось загрузить.",
+      "retry": "Повторить",
+      "loadMore": "Загрузить ещё",
+      "loading": "Загрузка…",
+      "yourChallenges": "Ваши испытания",
+      "addFriendsToSeeThemHere": "Добавьте друзей, чтобы увидеть их здесь.",
+      "goToFriends": "К друзьям"
+    },
+    "challengeList": {
+      "ended": "Завершено",
+      "daysHoursLeft": "Осталось {d} дн. {h} ч.",
+      "hoursMinutesLeft": "Осталось {h} ч. {m} мин.",
+      "minutesSecondsLeft": "Осталось {m} мин. {s} сек.",
+      "statusActive": "Активно",
+      "statusIncoming": "Входящее",
+      "statusPending": "Ожидание",
+      "statusWon": "Победа",
+      "statusDraw": "Ничья",
+      "statusLost": "Поражение",
+      "statusCancelled": "Отменено",
+      "statusDeclined": "Отклонено",
+      "youWon": "Вы выиграли",
+      "theyWonCaption": "{name} выиграл(а)",
+      "acceptFailedRetry": "Не удалось принять — попробуйте снова.",
+      "declineFailedRetry": "Не удалось отклонить — попробуйте снова.",
+      "cancelFailedRetry": "Не удалось отменить — попробуйте снова.",
+      "networkErrorTryAgain": "Ошибка сети — попробуйте снова.",
+      "accept": "Принять",
+      "decline": "Отклонить",
+      "waitingForOpponent": "Ожидание {name}…",
+      "cancel": "Отменить",
+      "noChallengesYet": "Пока нет испытаний.",
+      "pickSuggestionOrChallenge": "Выберите предложение или бросьте вызов другу выше.",
+      "groupNeedsResponse": "Требует вашего ответа",
+      "groupActive": "Активные",
+      "groupSent": "Отправленные",
+      "groupPast": "Прошедшие",
+      "you": "Вы",
+      "vs": "vs"
+    },
+    "createChallengeForm": {
+      "newChallenge": "Новое испытание",
+      "chooseAFriend": "Выберите друга",
+      "chooseAFriendPlaceholder": "Выберите друга…",
+      "clearSuggestion": "Очистить предложение",
+      "duration": "Продолжительность",
+      "versePlaceholderCompact": "Аят (необязательно)",
+      "versePlaceholderFull": "Контекст аята (необязательно, напр. 2:255)",
+      "send": "Отправить",
+      "sendChallenge": "Отправить испытание",
+      "couldNotSendChallenge": "Не удалось отправить испытание",
+      "challengeSent": "Испытание отправлено @{username}!",
+      "networkErrorPeriod": "Ошибка сети. Попробуйте снова.",
+      "addFriendsFirst": "Сначала добавьте друзей, чтобы бросить им вызов.",
+      "fromLabel": "Из:"
+    },
+    "addFriendForm": {
+      "searchPlaceholder": "Поиск по имени пользователя…",
+      "searching": "Поиск…",
+      "noUsersFound": "Пользователи не найдены.",
+      "statusFriends": "Друзья",
+      "statusSent": "Отправлено",
+      "add": "Добавить",
+      "accept": "Принять",
+      "couldNotSendRequest": "Не удалось отправить запрос",
+      "networkErrorPeriod": "Ошибка сети. Попробуйте снова."
+    },
+    "challengeSuggestions": {
+      "suggested": "Предложенное",
+      "use": "Использовать"
+    },
+    "leaderboardTable": {
+      "addFriendsToSeeLeaderboard": "Добавьте друзей, чтобы увидеть рейтинг.",
+      "youSuffix": "(вы)"
+    },
+    "friendList": {
+      "noFriendsYet": "Пока нет друзей. Добавьте кого-нибудь по имени пользователя выше.",
+      "pendingRequests": "Ожидающие запросы",
+      "friendsHeader": "Друзья",
+      "sentDirection": "отправлено",
+      "receivedDirection": "получено",
+      "acceptRequestAria": "Принять запрос",
+      "declineRequestAria": "Отклонить запрос",
+      "cancelRequestAria": "Отменить запрос",
+      "clickAgainToConfirm": "Нажмите ещё раз для подтверждения",
+      "removeFriendAria": "Удалить друга",
+      "acceptRequestFailed": "Не удалось принять запрос — попробуйте снова.",
+      "declineRequestFailed": "Не удалось отклонить запрос — попробуйте снова.",
+      "couldntRemoveTryAgain": "Не удалось удалить — попробуйте снова.",
+      "networkErrorTryAgain": "Ошибка сети — попробуйте снова."
+    }
+  },
+  "mentions": {
+    "pageTitle": "Упоминания",
+    "noMentionsYet": "Пока нет упоминаний.",
+    "mentionHint": "Друг может упомянуть вас по @имени_пользователя в заметке к аяту.",
+    "couldntMarkRead": "Не удалось отметить упоминания как прочитанные. Счётчик непрочитанных может быть неточным.",
+    "couldntLoadMentions": "Не удалось загрузить упоминания.",
+    "mentionedYouOn": "упомянул(а) вас в",
+    "openInCanvas": "Открыть на холсте"
+  },
+  "workspaces": {
+    "pageTitle": "Сохранённые холсты",
+    "noSavedCanvasesYet": "Пока нет сохранённых холстов.",
+    "buildAndSaveHint": "Создайте холст и нажмите значок сохранения в шапке, чтобы сохранить его.",
+    "openCanvas": "Открыть холст",
+    "couldntLoadCanvases": "Не удалось загрузить сохранённые холсты.",
+    "retry": "Повторить",
+    "load": "Загрузить",
+    "deleteCanvas": "Удалить холст",
+    "confirmDeleteCanvas": "Подтвердить удаление холста?",
+    "nodeCount": "{count, plural, one {# аят} few {# аята} many {# аятов} other {# аята}}"
+  },
+  "onboarding": {
+    "chooseUsername": "Выберите имя пользователя",
+    "usernameHint": "Так друзья найдут вас в рейтинге.",
+    "usernamePlaceholder": "напр. ahmed_hikmah",
+    "usernameRules": "3–20 символов: только буквы, цифры, подчёркивания",
+    "couldNotSaveUsername": "Не удалось сохранить имя пользователя. Попробуйте другое.",
+    "networkErrorPleaseRetry": "Ошибка сети. Пожалуйста, попробуйте снова.",
+    "saving": "Сохранение…",
+    "getStarted": "Начать"
   }
 }

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -7,7 +7,8 @@
     "allSettings": "Tüm ayarlar →",
     "changeLanguage": "Dili değiştir",
     "removeBookmark": "Yer imini kaldır",
-    "bookmarkVerse": "Ayeti işaretle"
+    "bookmarkVerse": "Ayeti işaretle",
+    "loading": "Yükleniyor"
   },
   "nav": {
     "canvas": "Kanvas",
@@ -109,7 +110,31 @@
     "saveWorkspace": "Çalışma alanını kaydet",
     "exportAsPng": "PNG olarak dışa aktar",
     "exportAsPdf": "PDF olarak dışa aktar",
-    "more": "Diğer"
+    "more": "Diğer",
+    "contextSidebar": {
+      "tafsirTitle": "İbn Kesir Tefsiri",
+      "loading": "Yükleniyor…",
+      "tafsirUnavailable": "Tefsir mevcut değil.",
+      "myNotes": "Notlarım",
+      "signInForNotes": "Özel not eklemek için giriş yapın.",
+      "deleteNote": "Notu sil",
+      "deleteFailed": "Silme başarısız",
+      "addNotePlaceholder": "Özel bir not ekleyin…",
+      "saving": "Kaydediliyor…",
+      "saveFailedRetry": "Kaydetme başarısız — tekrar deneyin",
+      "save": "Kaydet",
+      "similarVerses": "Benzer ayetler",
+      "noneFound": "Bulunamadı.",
+      "edgeKindThematic": "Tema",
+      "edgeKindRoot": "Kök kelime",
+      "edgeKindContrast": "Karşıtlık",
+      "resizePanel": "Paneli yeniden boyutlandır",
+      "verseHeader": "Ayet",
+      "connectionHeader": "Bağlantı",
+      "closePanel": "Paneli kapat",
+      "whyConnected": "Neden bağlantılı"
+    },
+    "loadingCanvas": "Kanvas yükleniyor…"
   },
   "search": {
     "dialogTitle": "Kur'an Ayetlerinde Ara",
@@ -229,5 +254,136 @@
   "authGate": {
     "title": "Devam etmek için giriş yapın",
     "body": "Bu sayfayı görüntülemek için giriş yapmanız gerekiyor."
+  },
+  "social": {
+    "page": {
+      "pageTitle": "Sosyal",
+      "tabLeaderboard": "Lider Tablosu",
+      "tabFriends": "Arkadaşlar",
+      "tabChallenges": "Meydan Okumalar",
+      "profileLoadFailed": "Profiliniz yüklenemedi. Lütfen çıkış yapıp tekrar deneyin.",
+      "backToHome": "Ana sayfaya dön",
+      "couldntLoad": "Yüklenemedi.",
+      "retry": "Tekrar dene",
+      "loadMore": "Daha fazla yükle",
+      "loading": "Yükleniyor…",
+      "yourChallenges": "Meydan okumalarınız",
+      "addFriendsToSeeThemHere": "Burada görmek için arkadaş ekleyin.",
+      "goToFriends": "Arkadaşlara git"
+    },
+    "challengeList": {
+      "ended": "Sona erdi",
+      "daysHoursLeft": "{d}g {h}s kaldı",
+      "hoursMinutesLeft": "{h}s {m}d kaldı",
+      "minutesSecondsLeft": "{m}d {s}s kaldı",
+      "statusActive": "Aktif",
+      "statusIncoming": "Gelen",
+      "statusPending": "Beklemede",
+      "statusWon": "Kazandı",
+      "statusDraw": "Berabere",
+      "statusLost": "Kaybetti",
+      "statusCancelled": "İptal edildi",
+      "statusDeclined": "Reddedildi",
+      "youWon": "Kazandınız",
+      "theyWonCaption": "{name} kazandı",
+      "acceptFailedRetry": "Kabul edilemedi — tekrar deneyin.",
+      "declineFailedRetry": "Reddedilemedi — tekrar deneyin.",
+      "cancelFailedRetry": "İptal edilemedi — tekrar deneyin.",
+      "networkErrorTryAgain": "Ağ hatası — tekrar deneyin.",
+      "accept": "Kabul et",
+      "decline": "Reddet",
+      "waitingForOpponent": "{name} bekleniyor…",
+      "cancel": "İptal et",
+      "noChallengesYet": "Henüz meydan okuma yok.",
+      "pickSuggestionOrChallenge": "Yukarıdan bir öneri seçin veya bir arkadaşınıza meydan okuyun.",
+      "groupNeedsResponse": "Yanıtınız bekleniyor",
+      "groupActive": "Aktif",
+      "groupSent": "Gönderildi",
+      "groupPast": "Geçmiş",
+      "you": "Siz",
+      "vs": "vs"
+    },
+    "createChallengeForm": {
+      "newChallenge": "Yeni meydan okuma",
+      "chooseAFriend": "Bir arkadaş seçin",
+      "chooseAFriendPlaceholder": "Bir arkadaş seçin…",
+      "clearSuggestion": "Öneriyi temizle",
+      "duration": "Süre",
+      "versePlaceholderCompact": "Ayet (isteğe bağlı)",
+      "versePlaceholderFull": "Ayet bağlamı (isteğe bağlı, örn. 2:255)",
+      "send": "Gönder",
+      "sendChallenge": "Meydan okumayı gönder",
+      "couldNotSendChallenge": "Meydan okuma gönderilemedi",
+      "challengeSent": "Meydan okuma @{username} adlı kullanıcıya gönderildi!",
+      "networkErrorPeriod": "Ağ hatası. Tekrar deneyin.",
+      "addFriendsFirst": "Meydan okumadan önce arkadaş ekleyin.",
+      "fromLabel": "Kaynak:"
+    },
+    "addFriendForm": {
+      "searchPlaceholder": "Kullanıcı adına göre ara…",
+      "searching": "Aranıyor…",
+      "noUsersFound": "Kullanıcı bulunamadı.",
+      "statusFriends": "Arkadaş",
+      "statusSent": "Gönderildi",
+      "add": "Ekle",
+      "accept": "Kabul et",
+      "couldNotSendRequest": "İstek gönderilemedi",
+      "networkErrorPeriod": "Ağ hatası. Tekrar deneyin."
+    },
+    "challengeSuggestions": {
+      "suggested": "Önerilen",
+      "use": "Kullan"
+    },
+    "leaderboardTable": {
+      "addFriendsToSeeLeaderboard": "Lider tablosunu görmek için arkadaş ekleyin.",
+      "youSuffix": "(siz)"
+    },
+    "friendList": {
+      "noFriendsYet": "Henüz arkadaş yok. Yukarıdan kullanıcı adıyla birini ekleyin.",
+      "pendingRequests": "Bekleyen istekler",
+      "friendsHeader": "Arkadaşlar",
+      "sentDirection": "gönderildi",
+      "receivedDirection": "alındı",
+      "acceptRequestAria": "İsteği kabul et",
+      "declineRequestAria": "İsteği reddet",
+      "cancelRequestAria": "İsteği iptal et",
+      "clickAgainToConfirm": "Onaylamak için tekrar tıklayın",
+      "removeFriendAria": "Arkadaşı kaldır",
+      "acceptRequestFailed": "İstek kabul edilemedi — tekrar deneyin.",
+      "declineRequestFailed": "İstek reddedilemedi — tekrar deneyin.",
+      "couldntRemoveTryAgain": "Kaldırılamadı — tekrar deneyin.",
+      "networkErrorTryAgain": "Ağ hatası — tekrar deneyin."
+    }
+  },
+  "mentions": {
+    "pageTitle": "Bahsedilmeler",
+    "noMentionsYet": "Henüz bahsedilme yok.",
+    "mentionHint": "Bir arkadaşınız bir ayet notunda @kullaniciadinizla sizden bahsedebilir.",
+    "couldntMarkRead": "Bahsedilmeler okundu olarak işaretlenemedi. Okunmamış sayısı senkronize olmayabilir.",
+    "couldntLoadMentions": "Bahsedilmeler yüklenemedi.",
+    "mentionedYouOn": "sizden bahsetti:",
+    "openInCanvas": "Kanvasta aç"
+  },
+  "workspaces": {
+    "pageTitle": "Kaydedilmiş Kanvaslar",
+    "noSavedCanvasesYet": "Henüz kaydedilmiş kanvas yok.",
+    "buildAndSaveHint": "Bir kanvas oluşturun ve kaydetmek için üst bilgideki kaydet simgesine tıklayın.",
+    "openCanvas": "Kanvası aç",
+    "couldntLoadCanvases": "Kaydedilmiş kanvaslarınız yüklenemedi.",
+    "retry": "Tekrar dene",
+    "load": "Yükle",
+    "deleteCanvas": "Kanvası sil",
+    "confirmDeleteCanvas": "Kanvası silmeyi onaylıyor musunuz?",
+    "nodeCount": "{count, plural, one {# ayet} other {# ayet}}"
+  },
+  "onboarding": {
+    "chooseUsername": "Kullanıcı adı seçin",
+    "usernameHint": "Arkadaşlarınız sizi lider tablosunda böyle bulacak.",
+    "usernamePlaceholder": "örn. ahmed_hikmah",
+    "usernameRules": "3–20 karakter: yalnızca harf, rakam, alt çizgi",
+    "couldNotSaveUsername": "Kullanıcı adı kaydedilemedi. Başka bir tane deneyin.",
+    "networkErrorPleaseRetry": "Ağ hatası. Lütfen tekrar deneyin.",
+    "saving": "Kaydediliyor…",
+    "getStarted": "Başla"
   }
 }


### PR DESCRIPTION
## Summary

- Issue #571: `messages/*.json` key parity across en/tr/ru/az was already clean — the actual gap was **code that bypassed next-intl entirely**, rendering hardcoded English regardless of the selected locale.
- Wires `useTranslations`/`useFormatter` through: the canvas context sidebar (`ContextSidebar.tsx`), the whole social surface (`app/social/page.tsx` + 6 `components/social/*.tsx` files), `app/mentions/page.tsx`, `app/workspaces/page.tsx`, `app/onboarding/page.tsx`'s form, and two stray `aria-label="Loading"` spots.
- Adds `canvas.contextSidebar`, `social`, `mentions`, `workspaces`, `onboarding` namespaces (plus `common.loading` and `canvas.loadingCanvas`) to all 4 locale files with real translated copy, not placeholders.
- Date rendering (`mentions`, `workspaces`) now goes through `useFormatter()` instead of `toLocaleString()`/`toLocaleDateString("en-US", ...)`. `workspaces`' hand-rolled English pluralization is now an ICU plural key, mirroring the existing `canvas.workspaceName` pattern.
- `ChallengeList.tsx`'s countdown formatter is parameterized on a translation function instead of building English day/hour/minute strings directly.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (1615 tests)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (this diff only — pre-existing warnings on unrelated `.superpowers/` files)
- [x] New tests added for new functionality

- `__tests__/components/social/ChallengeList.test.tsx` and `FriendList.test.tsx` switched from plain RTL `render` to `renderWithIntl` (`CreateChallengeForm.test.tsx` already used it) since these components now call `useTranslations`.
- Every existing test's English-copy assertion (`ContextSidebar`, `AuthShell`, onboarding, mentions, workspaces) is preserved verbatim in `messages/en.json` — none needed their assertions changed.
- `__tests__/lib/i18n/messages.test.ts` (key-parity + ICU validity across all 4 locales) needed no changes — it walks the tree generically and covers the new namespaces automatically. Ran and passing.
- `e2e/settings.spec.ts`: added a check that `/workspaces` (title not gated behind a loading state, unlike `/social`'s) renders translated copy once switched to Turkish via the existing header-popover flow.

**Not run in this environment**: the new e2e test and a live non-English browse-through — this session had no local Postgres/dev server available (see integration-test/e2e setup in AGENTS.md). Worth a manual pass before merge alongside the rest of the e2e suite.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A
- [x] `README.md` updated if the feature changes the public interface — N/A

Fixes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRprUveCywFmhoTuFzLBGH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added localized text across social, mentions, onboarding, workspaces, canvas context panels, and loading states.
  - Added Azerbaijani, English, Russian, and Turkish translations for these experiences.
  - Dates and timestamps now follow the selected locale.
  - Canvas loading messages and accessibility labels are translated.

- **Tests**
  - Added end-to-end coverage for Turkish localization on the workspaces page.
  - Added coverage confirming challenge countdowns update when the locale changes.
  - Updated component tests to use internationalized rendering setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->