### PR TITLE
chore: unify naming spellings, fix a stray color token, disable X-Powered-By

### DIFF
--- a/__tests__/app/admin/flags/page.test.tsx
+++ b/__tests__/app/admin/flags/page.test.tsx
@@ -52,7 +52,7 @@ describe("FlagsPage — AI routing grid", () => {
 
     render(<FlagsPage />);
 
-    const namesModel = await screen.findByLabelText("Names (Asma-ul-Husna) model");
+    const namesModel = await screen.findByLabelText("Names (Asmaul Husna) model");
     expect(within(namesModel).queryByText("gemini-3.7-flash")).toBeTruthy();
     expect(within(namesModel).queryByText("claude-opus-4-7")).toBeNull();
 
@@ -80,7 +80,7 @@ describe("FlagsPage — AI routing grid", () => {
     render(<FlagsPage />);
 
     const namesModel = (await screen.findByLabelText(
-      "Names (Asma-ul-Husna) model"
+      "Names (Asmaul Husna) model"
     )) as HTMLSelectElement;
     expect(namesModel.value).toBe("");
     expect(within(namesModel).getByRole("option", { selected: true }).textContent).toContain(

--- a/__tests__/app/stories-opengraph-image.test.tsx
+++ b/__tests__/app/stories-opengraph-image.test.tsx
@@ -40,7 +40,7 @@ describe("Story opengraph-image", () => {
       expect.objectContaining({ eyebrow: "Open Hikmah" })
     );
     expect(mockRenderOgCard).not.toHaveBeenCalledWith(
-      expect.objectContaining({ eyebrow: "Prophetic Stories" })
+      expect.objectContaining({ eyebrow: "Prophetic Narratives" })
     );
   });
 
@@ -54,7 +54,7 @@ describe("Story opengraph-image", () => {
     await Image({ params: Promise.resolve({ slug: "test-story" }) });
 
     expect(mockRenderOgCard).toHaveBeenCalledWith(
-      expect.objectContaining({ eyebrow: "Prophetic Stories", title: "Test Story" })
+      expect.objectContaining({ eyebrow: "Prophetic Narratives", title: "Test Story" })
     );
   });
 });

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -16,7 +16,7 @@ import { SELECTABLE_MODELS } from "@/lib/ai/models";
 const AI_ROUTES = [
   { key: "", label: "Default" },
   { key: "_connections", label: "Connections" },
-  { key: "_names", label: "Names (Asma-ul-Husna)" },
+  { key: "_names", label: "Names (Asmaul Husna)" },
 ] as const;
 
 interface Flag {

--- a/app/names/page.tsx
+++ b/app/names/page.tsx
@@ -10,7 +10,7 @@ import { LandingHeader } from "@/components/layout/LandingHeader";
 import { MobileNavBar } from "@/components/layout/MobileNavBar";
 
 export const metadata = {
-  title: "Asma-ul-Husna — Open Hikmah",
+  title: "Asmaul Husna — Open Hikmah",
   description:
     "The 99 Beautiful Names of Allah with Maturidi taxonomy, root morphology, and verse connections.",
 };

--- a/app/stories/[slug]/opengraph-image.tsx
+++ b/app/stories/[slug]/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from "next/og";
 import { getVisibleStoryBySlug } from "@/lib/stories";
 import { renderOgCard, clampBody, OG_SIZE, OG_CONTENT_TYPE } from "@/lib/og-card";
 
-export const alt = "Prophetic Stories — Open Hikmah";
+export const alt = "Prophetic Narratives — Open Hikmah";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
@@ -31,7 +31,7 @@ export default async function Image({ params }: Props) {
 
   return new ImageResponse(
     renderOgCard({
-      eyebrow: "Prophetic Stories",
+      eyebrow: "Prophetic Narratives",
       title: story.name.en,
       body: clampBody(story.tagline.en),
     }),

--- a/app/stories/page.tsx
+++ b/app/stories/page.tsx
@@ -6,7 +6,7 @@ import { listVisibleStories, resolveLocalized } from "@/lib/stories";
 import { getUiLocale } from "@/lib/i18n/request-prefs";
 
 export const metadata = {
-  title: "Prophetic Stories — Open Hikmah",
+  title: "Prophetic Narratives — Open Hikmah",
   description:
     "Curated stories of the Prophets mentioned in the Quran, with verified verse mappings and a direct path to the connection canvas.",
 };

--- a/components/search/SearchDialog.tsx
+++ b/components/search/SearchDialog.tsx
@@ -373,7 +373,7 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
 
               {selectError && (
                 <div className="px-4 py-3 text-center">
-                  <p className="text-xs text-red-400">{t("somethingWentWrong")}</p>
+                  <p className="text-xs text-error">{t("somethingWentWrong")}</p>
                 </div>
               )}
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -12,8 +12,8 @@
   "nav": {
     "canvas": "Canvas",
     "search": "Search",
-    "stories": "Narratives",
-    "names": "Asma'ul Husna",
+    "stories": "Prophetic Narratives",
+    "names": "Asmaul Husna",
     "bookmarks": "Saved",
     "savedCanvases": "Saved canvases",
     "friendsLeaderboard": "Friends & Leaderboard",

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,8 @@ const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 const nextConfig: NextConfig = {
   reactCompiler: true,
   output: "standalone",
+  // Minor info-disclosure: don't advertise the framework on every response.
+  poweredByHeader: false,
   // The self-hosted Coolify build container has less memory than CI's runner,
   // and OOM-kills during `next build`'s own "Running TypeScript" pass (no
   // output, non-zero exit) once the project grows past its ceiling. Type


### PR DESCRIPTION
## Summary

- Batches the low-priority naming/cosmetic findings from issue #573 (PR #553 bug sweep) that are pure copy/config fixes.
- Standardize on **"Asmaul Husna"** (was split 3 ways across nav/title/eyebrow) and **"Prophetic Narratives"** (was split 3 ways across nav/title/eyebrow) — English only, tr/ru/az were already internally consistent per-language.
- `components/search/SearchDialog.tsx`: the one remaining `text-red-400` literal in the codebase → `text-error` design token.
- `next.config.ts`: `poweredByHeader: false` (minor info-disclosure fix).

**Not included** (per the issue and a follow-up decision with the reporter):
- AI transliteration-scheme mixing — tracked separately if non-trivial, out of scope for a copy-only pass.
- robots.txt/sitemap.xml/manifest.webmanifest — split into **#608**, since it needs a product decision (PWA ambitions or not) rather than being a pure fix.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / chore
- [ ] Documentation
- [ ] Tests

## AI / Theological changes

- [x] No AI or theological changes in this PR

## Testing

- [x] `bun run test:ci` passes locally (1615 tests)
- [x] `bun run typecheck` passes locally
- [x] `bun run lint` passes locally
- [x] `bun run format:check` passes locally (this diff only — pre-existing warnings on unrelated `.superpowers/` files)
- [ ] New tests added for new functionality — N/A, copy/config-only change; existing tests (`__tests__/app/admin/flags/page.test.tsx`, `__tests__/app/stories-opengraph-image.test.tsx`) updated to match the new canonical strings.

## Checklist

- [x] Branch is up to date with `main`
- [x] Conventional commits
- [x] No secrets or real API keys in the diff
- [x] `.env.example` updated if new environment variables were added — N/A
- [x] `README.md` updated if the feature changes the public interface — N/A

Fixes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRprUveCywFmhoTuFzLBGH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updated Labels**
  * Renamed “Prophetic Stories” to “Prophetic Narratives” across navigation, page titles, and social preview cards.
  * Standardized “Asmaul Husna” naming across navigation, page titles, and the admin interface.

* **Visual Improvements**
  * Search dialog errors now use the application’s standard error styling.

* **Privacy and Security**
  * Responses no longer advertise the underlying web framework through the `X-Powered-By` header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->