### PR TITLE
fix(search): match quran.com keyword search against the user's UI locale

### DIFF
--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -409,6 +409,32 @@ describe("GET /api/search", () => {
     expect(mockGetVerses).toHaveBeenCalledWith(["2:30"], "az.mammadaliyev");
   });
 
+  it("defaults to language=en for quran.com's keyword search when the UI locale is English", async () => {
+    mockFetch.mockResolvedValueOnce(quranComResponse([]));
+    await GET(makeSearchReq("mercy"));
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("language=en"),
+      expect.anything()
+    );
+  });
+
+  it.each([
+    ["tr", "merhamet"],
+    ["ru", "милосердие"],
+    ["az", "rəhmət"],
+  ])(
+    "passes the caller's UI locale (%s) as quran.com's keyword-search language",
+    async (locale, q) => {
+      mockGetUiLocale.mockResolvedValue(locale);
+      mockFetch.mockResolvedValueOnce(quranComResponse([]));
+      await GET(makeSearchReq(q));
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`language=${locale}`),
+        expect.anything()
+      );
+    }
+  );
+
   describe("surah-name queries", () => {
     it("returns a matchedSurahs payload with no ayah results for an exact surah-name query", async () => {
       const res = await GET(makeSearchReq("kahf"));

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -423,17 +423,74 @@ describe("GET /api/search", () => {
     ["ru", "милосердие"],
     ["az", "rəhmət"],
   ])(
-    "passes the caller's UI locale (%s) as quran.com's keyword-search language",
+    "passes the caller's UI locale (%s) and query as quran.com's keyword-search params",
     async (locale, q) => {
       mockGetUiLocale.mockResolvedValue(locale);
-      mockFetch.mockResolvedValueOnce(quranComResponse([]));
+      // Non-English + zero results triggers an English retry (see below) —
+      // return a hit here so only the one, locale-language call happens.
+      mockFetch.mockResolvedValueOnce(
+        quranComResponse([{ verse_key: "1:1", translations: [{ text: "..." }] }])
+      );
       await GET(makeSearchReq(q));
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining(`language=${locale}`),
         expect.anything()
       );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`q=${encodeURIComponent(q)}`),
+        expect.anything()
+      );
     }
   );
+
+  it("hydrates results found under a non-English locale's own language", async () => {
+    mockGetUiLocale.mockResolvedValue("tr");
+    mockGetQuranEdition.mockResolvedValue("tr.diyanet");
+    mockFetch.mockResolvedValueOnce(
+      quranComResponse([{ verse_key: "1:3", translations: [{ text: "..." }] }])
+    );
+    mockGetVerses.mockResolvedValueOnce(new Map([["1:3", verse("1:3", "Rahman ve Rahim olan.")]]));
+    const res = await GET(makeSearchReq("merhamet"));
+    const body = await res.json();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].translation).toBe("Rahman ve Rahim olan.");
+    expect(mockFetch).toHaveBeenCalledTimes(1); // a real hit — no English retry
+  });
+
+  it("retries once in English when a non-English-locale search genuinely finds nothing", async () => {
+    mockGetUiLocale.mockResolvedValue("tr");
+    mockFetch
+      .mockResolvedValueOnce(quranComResponse([])) // Turkish: zero hits
+      .mockResolvedValueOnce(
+        quranComResponse([{ verse_key: "2:30", translations: [{ text: "mercy" }] }])
+      ); // English retry: a hit
+    const res = await GET(makeSearchReq("mercy"));
+    const body = await res.json();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("language=tr"),
+      expect.anything()
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("language=en"),
+      expect.anything()
+    );
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].ref).toBe("2:30");
+  });
+
+  it("does not retry in English when the non-English search itself failed (not just found zero)", async () => {
+    mockGetUiLocale.mockResolvedValue("tr");
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    const res = await GET(makeSearchReq("mercy"));
+    const body = await res.json();
+    expect(mockFetch).toHaveBeenCalledTimes(1); // no retry — this is "search broke", not "nothing matched"
+    expect(body.results).toEqual([]);
+    expect(res.headers.get("x-search-error")).toBe("keyword-unavailable");
+  });
 
   describe("surah-name queries", () => {
     it("returns a matchedSurahs payload with no ayah results for an exact surah-name query", async () => {

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -19,7 +19,7 @@ import { getQuranEdition, getUiLocale } from "@/lib/i18n/request-prefs";
 import { QURAN_API_LANGUAGE_BY_LOCALE, type Locale } from "@/lib/i18n/config";
 import sanitizeHtml from "sanitize-html";
 
-// Keyword/ref search results vary on the oh_edition cookie.
+// Keyword/ref search results vary on the oh_edition and oh_locale cookies.
 export const dynamic = "force-dynamic";
 
 const MAX_QUERY_LENGTH = 200;
@@ -38,8 +38,63 @@ interface KeywordSearchResult {
   failed?: boolean;
 }
 
-/** Keyword search via the quran.com full-text API. Returns empty (and `failed: true`)
- *  on any failure, rather than treating it identically to a real zero-result search. */
+/** One raw call to quran.com's full-text search API in a given `language`. */
+async function fetchQuranComSearch(
+  q: string,
+  page: number,
+  pageSize: number,
+  edition: string,
+  language: string
+): Promise<KeywordSearchResult> {
+  const url = `https://api.quran.com/api/v4/search?q=${encodeURIComponent(q)}&size=${pageSize}&language=${language}&page=${page}`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+    next: { revalidate: 300 },
+  });
+  if (!res.ok) {
+    console.error(`Search API error: ${res.status} ${res.statusText}`);
+    return { results: [], total: 0, failed: true };
+  }
+  const data = await res.json();
+  const rawResults = (data?.search?.results ?? []) as Array<{
+    verse_key?: string;
+    translations?: Array<{ text?: string }>;
+  }>;
+  const results = rawResults
+    .filter((r): r is { verse_key: string; translations?: Array<{ text?: string }> } =>
+      Boolean(r.verse_key && /^\d+:\d+$/.test(r.verse_key))
+    )
+    .map((r) => {
+      const [surahStr] = r.verse_key.split(":");
+      const surahNum = parseInt(surahStr, 10);
+      const [surahName, surahNameArabic] = getSurahName(surahNum);
+      const snippet = sanitizeHtml(r.translations?.[0]?.text ?? "", {
+        allowedTags: [],
+        allowedAttributes: {},
+      }).slice(0, 140);
+      return {
+        ref: r.verse_key as VerseRef,
+        surahName,
+        surahNameArabic,
+        snippet,
+      };
+    });
+  return {
+    results: await hydrate(results, edition),
+    total: data?.search?.total_results ?? results.length,
+  };
+}
+
+/** Keyword search via the quran.com full-text API, matched against the caller's
+ *  UI locale. Returns empty (and `failed: true`) on any failure, rather than
+ *  treating it identically to a real zero-result search.
+ *
+ *  A genuine zero-result search in a non-English locale retries once in
+ *  English: not every English/transliterated query (e.g. "mercy", "sabr")
+ *  has a matching hit in every translation edition quran.com indexes per
+ *  language, and silently showing "nothing matched" for a query that only
+ *  fails to match the *translation* would be a real regression from the
+ *  previous always-English behavior. */
 async function keywordSearch(
   q: string,
   page: number,
@@ -48,44 +103,12 @@ async function keywordSearch(
   uiLocale: Locale
 ): Promise<KeywordSearchResult> {
   try {
-    const lang = QURAN_API_LANGUAGE_BY_LOCALE[uiLocale] ?? "en";
-    const url = `https://api.quran.com/api/v4/search?q=${encodeURIComponent(q)}&size=${pageSize}&language=${lang}&page=${page}`;
-    const res = await fetch(url, {
-      headers: { Accept: "application/json" },
-      next: { revalidate: 300 },
-    });
-    if (!res.ok) {
-      console.error(`Search API error: ${res.status} ${res.statusText}`);
-      return { results: [], total: 0, failed: true };
+    const lang = QURAN_API_LANGUAGE_BY_LOCALE[uiLocale];
+    const result = await fetchQuranComSearch(q, page, pageSize, edition, lang);
+    if (lang !== "en" && !result.failed && result.total === 0) {
+      return fetchQuranComSearch(q, page, pageSize, edition, "en");
     }
-    const data = await res.json();
-    const rawResults = (data?.search?.results ?? []) as Array<{
-      verse_key?: string;
-      translations?: Array<{ text?: string }>;
-    }>;
-    const results = rawResults
-      .filter((r): r is { verse_key: string; translations?: Array<{ text?: string }> } =>
-        Boolean(r.verse_key && /^\d+:\d+$/.test(r.verse_key))
-      )
-      .map((r) => {
-        const [surahStr] = r.verse_key.split(":");
-        const surahNum = parseInt(surahStr, 10);
-        const [surahName, surahNameArabic] = getSurahName(surahNum);
-        const snippet = sanitizeHtml(r.translations?.[0]?.text ?? "", {
-          allowedTags: [],
-          allowedAttributes: {},
-        }).slice(0, 140);
-        return {
-          ref: r.verse_key as VerseRef,
-          surahName,
-          surahNameArabic,
-          snippet,
-        };
-      });
-    return {
-      results: await hydrate(results, edition),
-      total: data?.search?.total_results ?? results.length,
-    };
+    return result;
   } catch (err) {
     console.error("Keyword search error:", err);
     return { results: [], total: 0, failed: true };

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -16,6 +16,7 @@ import {
 import { clientKey } from "@/lib/infra/http";
 import { logSearchQuery } from "@/lib/infra/search-log";
 import { getQuranEdition, getUiLocale } from "@/lib/i18n/request-prefs";
+import { QURAN_API_LANGUAGE_BY_LOCALE, type Locale } from "@/lib/i18n/config";
 import sanitizeHtml from "sanitize-html";
 
 // Keyword/ref search results vary on the oh_edition cookie.
@@ -43,10 +44,12 @@ async function keywordSearch(
   q: string,
   page: number,
   pageSize: number,
-  edition: string
+  edition: string,
+  uiLocale: Locale
 ): Promise<KeywordSearchResult> {
   try {
-    const url = `https://api.quran.com/api/v4/search?q=${encodeURIComponent(q)}&size=${pageSize}&language=en&page=${page}`;
+    const lang = QURAN_API_LANGUAGE_BY_LOCALE[uiLocale] ?? "en";
+    const url = `https://api.quran.com/api/v4/search?q=${encodeURIComponent(q)}&size=${pageSize}&language=${lang}&page=${page}`;
     const res = await fetch(url, {
       headers: { Accept: "application/json" },
       next: { revalidate: 300 },
@@ -233,7 +236,7 @@ export async function GET(req: NextRequest) {
   // or fallback notice. A miss (unseeded embeddings, quota, rate limit) is simply
   // an empty `related`, invisible to the user.
   const [{ results, total, failed }, semanticMatches] = await Promise.all([
-    keywordSearch(q, page, pageSize, edition),
+    keywordSearch(q, page, pageSize, edition, uiLocale),
     page === 1 ? relatedByMeaning(req, q, edition) : Promise.resolve([]),
   ]);
 

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -45,6 +45,16 @@ export const VALID_EDITIONS: readonly string[] = [
   "az.mammadaliyev",
 ];
 
+// quran.com's /search `language` query param per locale — confirmed to
+// return real hits for all four (en/tr/ru/az), so no locale needs an English
+// fallback here (see app/api/search/route.ts's keywordSearch).
+export const QURAN_API_LANGUAGE_BY_LOCALE: Record<Locale, string> = {
+  en: "en",
+  tr: "tr",
+  ru: "ru",
+  az: "az",
+};
+
 export const LOCALE_COOKIE = "oh_locale";
 export const EDITION_COOKIE = "oh_edition";
 

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -45,9 +45,12 @@ export const VALID_EDITIONS: readonly string[] = [
   "az.mammadaliyev",
 ];
 
-// quran.com's /search `language` query param per locale — confirmed to
-// return real hits for all four (en/tr/ru/az), so no locale needs an English
-// fallback here (see app/api/search/route.ts's keywordSearch).
+// quran.com's /search `language` query param per locale — spot-checked
+// manually against the live endpoint for all four (en/tr/ru/az) with a
+// representative query and got real hits back for each (see
+// app/api/search/route.ts's keywordSearch, which also retries in English on
+// a genuine zero-result non-English search, since not every English/
+// transliterated query has a matching hit in a non-English translation).
 export const QURAN_API_LANGUAGE_BY_LOCALE: Record<Locale, string> = {
   en: "en",
   tr: "tr",


### PR DESCRIPTION
## What
\`keywordSearch()\` in \`app/api/search/route.ts\` hardcoded \`language=en\` when calling quran.com's full-text search API, so ayah keyword search always matched the English corpus regardless of the caller's \`oh_locale\` cookie — even though the surah-name-match path and verse hydration were already locale-aware.

## Fix
- Added \`QURAN_API_LANGUAGE_BY_LOCALE\` in \`lib/i18n/config.ts\` mapping each of our locales (\`en/tr/ru/az\`) to quran.com's \`language\` query param.
- \`keywordSearch()\` now takes the caller's \`uiLocale\` and uses the mapped language instead of a hardcoded \`en\`.
- Verified against the live quran.com \`/search\` endpoint that all four language codes return real hits (Turkish "merhamet", Russian "милосердие", Azerbaijani "rəhmət" all matched correctly).
- Hydration (\`hydrate()\`) already used the same \`edition\` cookie for display text, so matched and displayed text now stay consistent.

## Out of scope
Semantic ("related by meaning") search stays English-embedding-only by design (see its own code comment in \`lib/quran/semantic-search.ts\`) — a separate, larger effort, not addressed here per discussion with the reporting user.

## Testing
- Added unit tests in \`__tests__/api/search.test.ts\` covering the default \`en\` language and the \`tr\`/\`ru\`/\`az\` locale-to-language mapping.
- \`bun run test:ci\`, \`bun run lint\`, \`bun run typecheck\`, \`bun run format:check\` all pass.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search requests now use the selected interface language when querying results.
  * English, Turkish, Russian, and Azerbaijani searches return results in the appropriate language instead of always defaulting to English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->