### PR TITLE
fix(names): translate the 99-Names meaning/description per UI locale

### DIFF
--- a/__tests__/api/names/meta.test.ts
+++ b/__tests__/api/names/meta.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Chainable + thenable DB proxy (mirrors __tests__/lib/names/name-content.test.ts) ──
+function makeSelectChain(resolveWith: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = new Proxy(
+    function () {
+      return chain;
+    },
+    {
+      get(_t, prop) {
+        if (prop === "then")
+          return (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+            Promise.resolve(resolveWith).then(res, rej);
+        return () => chain;
+      },
+      apply() {
+        return chain;
+      },
+    }
+  );
+  return chain;
+}
+
+const { mockConsume, mockCallAI, mockCookies } = vi.hoisted(() => ({
+  mockConsume: vi.fn(),
+  mockCallAI: vi.fn(),
+  mockCookies: vi.fn(async () => ({
+    get: (_name: string) => undefined as { value: string } | undefined,
+  })),
+}));
+
+vi.mock("next/headers", () => ({ cookies: mockCookies }));
+
+vi.mock("@/lib/infra/db", () => ({
+  db: {
+    select: () => makeSelectChain([]), // durable cache always misses
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: async () => undefined,
+        onConflictDoNothing: () => ({ returning: async () => [{ reason: "unused" }] }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/infra/rate-limit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/infra/rate-limit")>();
+  return { ...actual, consume: mockConsume };
+});
+
+vi.mock("@/lib/ai/ai", () => ({
+  callAI: mockCallAI,
+  resolveProvider: vi.fn(async () => "claude" as const),
+  resolveModel: vi.fn(async () => "claude-opus-4-7"),
+  defaultModelFor: () => "claude-opus-4-7",
+}));
+
+import { GET as getMeta } from "@/app/api/names/[slug]/meta/route";
+
+function req(slug: string) {
+  return new NextRequest(`http://localhost/api/names/${slug}/meta`);
+}
+function params(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+function withLocale(locale: string) {
+  mockCookies.mockResolvedValue({
+    get: (name: string) => (name === "oh_locale" ? { value: locale } : undefined),
+  });
+}
+
+describe("GET /api/names/[slug]/meta", () => {
+  beforeEach(() => {
+    mockConsume.mockReset().mockResolvedValue(true);
+    mockCallAI.mockReset();
+    mockCookies.mockReset().mockResolvedValue({ get: () => undefined }); // "en" default
+  });
+
+  it("returns 404 for an unknown slug", async () => {
+    const res = await getMeta(req("not-a-name"), params("not-a-name"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the canonical English text untranslated, with no AI call", async () => {
+    const res = await getMeta(req("al-malik"), params("al-malik"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meaning).toBe("The Sovereign");
+    expect(body.description).toMatch(/Absolute dominion/);
+    expect(mockCallAI).not.toHaveBeenCalled();
+  });
+
+  // meaning and description translate concurrently (Promise.all in the route),
+  // so which one reaches the mocked callAI first isn't guaranteed — key the
+  // mock off which canonical sentence is being translated instead of call order.
+  function mockTranslationsBySource(bySource: Record<string, string | Error>) {
+    mockCallAI.mockImplementation(async (prompt: string) => {
+      const match = Object.entries(bySource).find(([source]) => prompt.includes(source));
+      if (!match) throw new Error(`unexpected prompt: ${prompt}`);
+      const [, result] = match;
+      if (result instanceof Error) throw result;
+      return result;
+    });
+  }
+
+  // translateReason's length-ratio guard (lib/ai/translate.ts) rejects a
+  // translation whose length strays too far from the source's — the
+  // description canonical text is long, so its mocked "translation" has to
+  // be long enough too, or the guard (correctly) rejects it as junk.
+  const TR_DESCRIPTION =
+    "Var olan her şey üzerinde, hiçbir ortağı, öncülü veya sınırlaması olmaksızın mutlak bir egemenlik; bu hükümranlık yalnızca Zâtın kendisine aittir.";
+  const RU_DESCRIPTION =
+    "Абсолютное владычество над всем сущим, не имеющее ни партнёра, ни предшественника, ни ограничения — суверенитет, который принадлежит самой Сущности.";
+
+  it("translates both fields for a non-English locale", async () => {
+    withLocale("tr");
+    mockTranslationsBySource({
+      "The Sovereign": "Hükümdar",
+      "Absolute dominion": TR_DESCRIPTION,
+    });
+
+    const res = await getMeta(req("al-malik"), params("al-malik"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meaning).toBe("Hükümdar");
+    expect(body.description).toBe(TR_DESCRIPTION);
+    expect(mockCallAI).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the canonical English field when its translation call fails, without failing the request", async () => {
+    withLocale("ru");
+    mockTranslationsBySource({
+      "The Sovereign": new Error("provider down"),
+      "Absolute dominion": RU_DESCRIPTION,
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await getMeta(req("al-malik"), params("al-malik"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meaning).toBe("The Sovereign"); // failed translation → English fallback
+    expect(body.description).toBe(RU_DESCRIPTION);
+    errorSpy.mockRestore();
+  });
+
+  it("falls back to English when the model returns a refusal, without a 500", async () => {
+    withLocale("az");
+    mockCallAI.mockResolvedValue("I'm sorry, but I can't help with translating religious content.");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await getMeta(req("al-malik"), params("al-malik"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meaning).toBe("The Sovereign");
+    expect(body.description).toMatch(/Absolute dominion/);
+    errorSpy.mockRestore();
+  });
+
+  it("charges the rate limit once per request, not once per field", async () => {
+    withLocale("tr");
+    mockCallAI.mockResolvedValue("çeviri");
+    await getMeta(req("al-malik"), params("al-malik"));
+    const genCalls = mockConsume.mock.calls.filter(([key]) => String(key).startsWith("names-gen:"));
+    expect(genCalls).toHaveLength(1);
+  });
+
+  it("never consumes the rate limit for the English locale (no AI call at all)", async () => {
+    await getMeta(req("al-malik"), params("al-malik"));
+    expect(mockConsume).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when the rate limit is exhausted", async () => {
+    withLocale("tr");
+    mockConsume.mockResolvedValue(false);
+    const res = await getMeta(req("al-malik"), params("al-malik"));
+    expect(res.status).toBe(429);
+  });
+});

--- a/__tests__/lib/names/name-content.test.ts
+++ b/__tests__/lib/names/name-content.test.ts
@@ -51,6 +51,7 @@ import {
   getOrGenerateNameContent,
   getOrGenerateVerseReason,
   getCachedNameContent,
+  getCachedNameContentBulk,
 } from "@/lib/names/name-content";
 
 const isEmptyArr = (v: unknown[]) => v.length === 0;
@@ -569,6 +570,85 @@ describe("getCachedNameContent", () => {
     expect(out).toBeNull();
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
+  });
+});
+
+describe("getCachedNameContentBulk", () => {
+  beforeEach(() => {
+    mockSelect.mockReset();
+    mockInsert.mockClear();
+  });
+
+  it("returns an empty map without querying when given no slugs", async () => {
+    const out = await getCachedNameContentBulk<string>([], "meaning", "tr", 1);
+    expect(out.size).toBe(0);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns a map keyed by slug for every cache hit at the current version", async () => {
+    mockSelect.mockReturnValue(
+      makeSelectChain([
+        { slug: "al-malik", data: JSON.stringify("Hükümdar"), version: 1 },
+        { slug: "ar-rahman", data: JSON.stringify("Rahman"), version: 1 },
+      ])
+    );
+
+    const out = await getCachedNameContentBulk<string>(
+      ["al-malik", "ar-rahman", "as-salam"],
+      "meaning",
+      "tr",
+      1
+    );
+
+    expect(out.get("al-malik")).toBe("Hükümdar");
+    expect(out.get("ar-rahman")).toBe("Rahman");
+    expect(out.has("as-salam")).toBe(false); // no row for this slug — a plain miss
+  });
+
+  it("excludes a row whose stored version is older than requested", async () => {
+    mockSelect.mockReturnValue(
+      makeSelectChain([{ slug: "al-malik", data: JSON.stringify("stale"), version: 1 }])
+    );
+
+    const out = await getCachedNameContentBulk<string>(["al-malik"], "meaning", "tr", 2);
+
+    expect(out.has("al-malik")).toBe(false);
+  });
+
+  it("skips a corrupt row and logs, without throwing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockSelect.mockReturnValue(
+      makeSelectChain([{ slug: "al-malik", data: "{not json", version: 1 }])
+    );
+
+    const out = await getCachedNameContentBulk<string>(["al-malik"], "meaning", "tr", 1);
+
+    expect(out.has("al-malik")).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("returns an empty map and logs (instead of throwing) when the query itself rejects", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockSelect.mockReturnValue({
+      from: () => ({
+        where: () => Promise.reject(new Error("connection refused")),
+      }),
+    });
+
+    const out = await getCachedNameContentBulk<string>(["al-malik"], "meaning", "tr", 1);
+
+    expect(out.size).toBe(0);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("never calls generate/insert — it is read-only", async () => {
+    mockSelect.mockReturnValue(
+      makeSelectChain([{ slug: "al-malik", data: JSON.stringify("Hükümdar"), version: 1 }])
+    );
+    await getCachedNameContentBulk<string>(["al-malik"], "meaning", "tr", 1);
+    expect(mockInsert).not.toHaveBeenCalled();
   });
 });
 

--- a/app/api/names/[slug]/meta/route.ts
+++ b/app/api/names/[slug]/meta/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getNameBySlug } from "@/lib/names/divine-names";
+import { getLocalizedNameField, META_VERSION } from "@/lib/names/name-meta";
+import { consume, RateLimitError } from "@/lib/infra/rate-limit";
+import { clientKey } from "@/lib/infra/http";
+import { getUiLocale } from "@/lib/i18n/request-prefs";
+
+export { META_VERSION };
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const name = getNameBySlug(slug);
+  if (!name) {
+    return NextResponse.json({ error: "Name not found" }, { status: 404 });
+  }
+
+  try {
+    const locale = await getUiLocale();
+
+    // One shared rate-limit charge for both fields, not one per field —
+    // mirrors the verses route's shared per-request translation charge.
+    let rateLimitChecked = false;
+    const onBeforeGenerateOnce = async () => {
+      if (rateLimitChecked) return;
+      rateLimitChecked = true;
+      if (!(await consume(`names-gen:${clientKey(req)}`))) throw new RateLimitError();
+    };
+
+    const [meaning, description] = await Promise.all([
+      getLocalizedNameField(slug, "meaning", name.meaning, locale, onBeforeGenerateOnce),
+      getLocalizedNameField(slug, "description", name.description, locale, onBeforeGenerateOnce),
+    ]);
+    return NextResponse.json({ meaning, description });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return NextResponse.json({ error: "Too many requests — please slow down." }, { status: 429 });
+    }
+    console.error("Name meta error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/names/[slug]/NameMeta.tsx
+++ b/app/names/[slug]/NameMeta.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Meta {
+  meaning: string;
+  description: string;
+}
+
+interface Props {
+  slug: string;
+  locale: string;
+  /** Canonical English text, shown immediately and kept on any fetch failure. */
+  fallback: Meta;
+  /** Server-prefetched translation, or `null`/`undefined` on a cache miss (the
+   *  component then falls back to its own fetch, unchanged). Never fetched at
+   *  all when `locale === "en"` — the fallback IS the canonical text. */
+  initialMeta?: Meta | null;
+  /** Rendered between the meaning and description text, e.g. the category/root
+   *  badges — kept in the caller's server-rendered markup rather than
+   *  duplicated here. */
+  children?: React.ReactNode;
+}
+
+export function NameMeta({ slug, locale, fallback, initialMeta, children }: Props) {
+  const [meta, setMeta] = useState<Meta | null>(initialMeta ?? null);
+
+  useEffect(() => {
+    if (locale === "en" || initialMeta != null) return; // already have it
+    let cancelled = false;
+    fetch(`/api/names/${slug}/meta`)
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((data: Meta) => {
+        if (!cancelled && data.meaning && data.description) setMeta(data);
+      })
+      .catch(() => {
+        // Silent — the canonical English fallback below is already showing.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, locale, initialMeta]);
+
+  const meaning = meta?.meaning || fallback.meaning;
+  const description = meta?.description || fallback.description;
+
+  return (
+    <>
+      <p className="mb-6 text-lg text-text-secondary">{meaning}</p>
+      {children}
+      <p className="mx-auto max-w-xl text-sm leading-relaxed text-text-secondary">{description}</p>
+    </>
+  );
+}

--- a/app/names/[slug]/page.tsx
+++ b/app/names/[slug]/page.tsx
@@ -13,10 +13,12 @@ import { MobileNavBar } from "@/components/layout/MobileNavBar";
 import { NameVerses } from "./NameVerses";
 import { NameReflection } from "./NameReflection";
 import { NamePairings, type Pairing } from "./NamePairings";
+import { NameMeta } from "./NameMeta";
 import { getCachedNameContent } from "@/lib/names/name-content";
 import { getUiLocale } from "@/lib/i18n/request-prefs";
 import { REFLECTION_VERSION } from "@/app/api/names/[slug]/reflection/route";
 import { PAIRINGS_VERSION } from "@/app/api/names/[slug]/pairings/route";
+import { META_VERSION } from "@/app/api/names/[slug]/meta/route";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -26,9 +28,17 @@ export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
   const name = getNameBySlug(slug);
   if (!name) return {};
+  const locale = await getUiLocale();
+  // Cache-only lookup (never generates) — a miss just falls back to the
+  // canonical English description, same as the page body's own fallback.
+  const description =
+    locale === "en"
+      ? name.description
+      : ((await getCachedNameContent<string>(slug, "description", locale, META_VERSION)) ??
+        name.description);
   return {
     title: `${name.transliteration} — Open Hikmah`,
-    description: name.description,
+    description,
   };
 }
 
@@ -63,10 +73,23 @@ export default async function NameDetailPage({ params }: Props) {
   // miss leaves the value undefined and the client components fall back to
   // their existing fetch-and-generate behavior unchanged.
   const locale = await getUiLocale();
-  const [initialReflection, initialPairings] = await Promise.all([
-    getCachedNameContent<string>(slug, "reflection", locale, REFLECTION_VERSION),
-    getCachedNameContent<Pairing[]>(slug, "pairings", locale, PAIRINGS_VERSION),
-  ]);
+  const [initialReflection, initialPairings, initialMeaning, initialDescription] =
+    await Promise.all([
+      getCachedNameContent<string>(slug, "reflection", locale, REFLECTION_VERSION),
+      getCachedNameContent<Pairing[]>(slug, "pairings", locale, PAIRINGS_VERSION),
+      locale === "en"
+        ? Promise.resolve(null)
+        : getCachedNameContent<string>(slug, "meaning", locale, META_VERSION),
+      locale === "en"
+        ? Promise.resolve(null)
+        : getCachedNameContent<string>(slug, "description", locale, META_VERSION),
+    ]);
+  // Only trust the pair when BOTH fields hit the cache — a lone hit would
+  // otherwise render one translated field next to a stale/English other one.
+  const initialMeta =
+    initialMeaning != null && initialDescription != null
+      ? { meaning: initialMeaning, description: initialDescription }
+      : null;
 
   const prevName = DIVINE_NAMES.find((n) => n.id === name.id - 1);
   const nextName = DIVINE_NAMES.find((n) => n.id === name.id + 1);
@@ -96,20 +119,21 @@ export default async function NameDetailPage({ params }: Props) {
 
           <p className="mb-2 font-mono text-xl text-text-primary">{name.transliteration}</p>
 
-          <p className="mb-6 text-lg text-text-secondary">{name.meaning}</p>
-
-          <div className="mb-6 flex flex-wrap items-center justify-center gap-3">
-            <span className={`rounded px-2.5 py-1 text-xs font-medium ${styles.badge}`}>
-              {t(categoryLabelKey)}
-            </span>
-            <span className="rounded border border-border bg-surface-raised px-2.5 py-1 font-mono text-xs text-text-secondary">
-              {t("root", { root: name.root })}
-            </span>
-          </div>
-
-          <p className="mx-auto max-w-xl text-sm leading-relaxed text-text-secondary">
-            {name.description}
-          </p>
+          <NameMeta
+            slug={slug}
+            locale={locale}
+            fallback={{ meaning: name.meaning, description: name.description }}
+            initialMeta={initialMeta}
+          >
+            <div className="mb-6 flex flex-wrap items-center justify-center gap-3">
+              <span className={`rounded px-2.5 py-1 text-xs font-medium ${styles.badge}`}>
+                {t(categoryLabelKey)}
+              </span>
+              <span className="rounded border border-border bg-surface-raised px-2.5 py-1 font-mono text-xs text-text-secondary">
+                {t("root", { root: name.root })}
+              </span>
+            </div>
+          </NameMeta>
         </div>
 
         {/* Reflection + Pairings + Verses.

--- a/app/names/page.tsx
+++ b/app/names/page.tsx
@@ -8,6 +8,9 @@ import {
 } from "@/lib/names/divine-names";
 import { LandingHeader } from "@/components/layout/LandingHeader";
 import { MobileNavBar } from "@/components/layout/MobileNavBar";
+import { getCachedNameContentBulk } from "@/lib/names/name-content";
+import { getUiLocale } from "@/lib/i18n/request-prefs";
+import { META_VERSION } from "@/app/api/names/[slug]/meta/route";
 
 export const metadata = {
   title: "Asmaul Husna — Open Hikmah",
@@ -41,6 +44,22 @@ export default async function NamesPage() {
     cat,
     names: DIVINE_NAMES.filter((n) => n.category === cat),
   }));
+
+  // Read-only, cache-only lookup (never generates) for all 99 names in one
+  // query — a miss per name just falls back to the canonical English meaning
+  // below. Rendering all 99 names at once must not trigger up to 99 AI
+  // generations; translations are populated ahead of time by
+  // scripts/backfill-name-meta.ts or by visiting each name's detail page.
+  const locale = await getUiLocale();
+  const localizedMeanings =
+    locale === "en"
+      ? null
+      : await getCachedNameContentBulk<string>(
+          DIVINE_NAMES.map((n) => n.slug),
+          "meaning",
+          locale,
+          META_VERSION
+        );
 
   return (
     <div className="min-h-screen bg-bg pb-[calc(72px+env(safe-area-inset-bottom))] text-text-primary md:pb-0">
@@ -108,7 +127,9 @@ export default async function NamesPage() {
                       <div className="text-xs text-center font-mono mb-1 text-text-secondary">
                         {name.transliteration}
                       </div>
-                      <div className="text-xs text-center text-text-muted">{name.meaning}</div>
+                      <div className="text-xs text-center text-text-muted">
+                        {localizedMeanings?.get(name.slug) ?? name.meaning}
+                      </div>
                       <div className="mt-2 flex justify-center">
                         <span
                           className={`text-[10px] px-1.5 py-0.5 rounded font-mono ${colors.badge}`}

--- a/lib/infra/db/schema.ts
+++ b/lib/infra/db/schema.ts
@@ -439,8 +439,11 @@ export const wordMorphology = pgTable(
 // prompt change force regeneration by bumping the per-kind constant in code.
 
 /** The kinds of AI content cached per name. Single source of truth for the
- *  `name_content.kind` column and the `lib/name-content.ts` helper. */
-export type NameContentKind = "verses" | "reflection" | "pairings";
+ *  `name_content.kind` column and the `lib/name-content.ts` helper.
+ *  "meaning"/"description" are locale-specific *translations* of the
+ *  canonical English `DivineName.meaning`/`.description` (lib/names/divine-names/types.ts)
+ *  — see lib/names/name-meta.ts — never a fresh generation like the other kinds. */
+export type NameContentKind = "verses" | "reflection" | "pairings" | "meaning" | "description";
 
 export const nameContent = pgTable(
   "name_content",

--- a/lib/names/name-content.ts
+++ b/lib/names/name-content.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/infra/db";
 import { nameContent, nameVerseReasons, type NameContentKind } from "@/lib/infra/db/schema";
 import { resolveModel, resolveProvider, type Provider } from "@/lib/ai/ai";
@@ -272,6 +272,51 @@ export async function getCachedNameContent<T>(
     console.error(`Corrupt name_content row for ${slug}/${kind}/${locale}:`, err);
     return null;
   }
+}
+
+/**
+ * Read-only, read-many cache lookup across `slugs` for one `(kind, locale)` at
+ * the current `version` — one query instead of one per slug. Used by the
+ * /names grid, which needs a translated `meaning` for up to all 99 names on a
+ * single render and must never trigger 99 AI generations to do it (a miss is
+ * just absent from the returned map; callers fall back to the canonical
+ * English string, same as `getCachedNameContent`'s single-slug contract).
+ */
+export async function getCachedNameContentBulk<T>(
+  slugs: string[],
+  kind: NameContentKind,
+  locale: Locale,
+  version: number
+): Promise<Map<string, T>> {
+  const out = new Map<string, T>();
+  if (slugs.length === 0) return out;
+
+  let rows: Array<{ slug: string; data: string; version: number }>;
+  try {
+    rows = await db
+      .select({ slug: nameContent.slug, data: nameContent.data, version: nameContent.version })
+      .from(nameContent)
+      .where(
+        and(
+          inArray(nameContent.slug, slugs),
+          eq(nameContent.kind, kind),
+          eq(nameContent.locale, locale)
+        )
+      );
+  } catch (err) {
+    console.error(`Failed to bulk-read name_content for ${kind}/${locale}:`, err);
+    return out;
+  }
+
+  for (const row of rows) {
+    if (row.version !== version) continue;
+    try {
+      out.set(row.slug, JSON.parse(row.data) as T);
+    } catch (err) {
+      console.error(`Corrupt name_content row for ${row.slug}/${kind}/${locale}:`, err);
+    }
+  }
+  return out;
 }
 
 async function generateAndPersist<T>(

--- a/lib/names/name-meta.ts
+++ b/lib/names/name-meta.ts
@@ -1,0 +1,69 @@
+import { translateReason } from "@/lib/ai/translate";
+import { getOrGenerateNameContent, type GenerationContext } from "@/lib/names/name-content";
+import { LOCALE_LANGUAGE_NAME, type Locale } from "@/lib/i18n/config";
+import { incr } from "@/lib/infra/metrics";
+
+// Bump to force regeneration after a prompt change (see translateReason).
+export const META_VERSION = 1;
+
+export type NameMetaField = "meaning" | "description";
+
+/**
+ * Returns the localized text for a divine name's `meaning` or `description`
+ * (lib/names/divine-names/types.ts), translating — never re-deriving — the
+ * canonical English string on first request per `(slug, field, locale)` and
+ * caching it durably in `name_content`. Same shape as
+ * `getOrGenerateVerseReason`'s per-verse-reason translation, just keyed by
+ * field instead of verse ref.
+ *
+ * `locale === "en"` short-circuits to `canonical` with no DB or AI round
+ * trip, so the English path stays byte-identical to before this existed.
+ *
+ * Shared by the `/api/names/[slug]/meta` route (per-request, rate-limited via
+ * `onBeforeGenerate`) and `scripts/backfill-name-meta.ts` (offline, no rate
+ * limit) — both must translate through this one path so a prompt change only
+ * needs to bump `META_VERSION` once.
+ */
+export async function getLocalizedNameField(
+  slug: string,
+  field: NameMetaField,
+  canonical: string,
+  locale: Locale,
+  onBeforeGenerate?: () => Promise<void>
+): Promise<string> {
+  if (locale === "en") return canonical;
+
+  const language = LOCALE_LANGUAGE_NAME[locale];
+  const translated = await getOrGenerateNameContent<string>(
+    slug,
+    field,
+    locale,
+    META_VERSION,
+    (ctx: GenerationContext) =>
+      translateReason(
+        canonical,
+        language,
+        { feature: "names", provider: ctx.provider, model: ctx.model },
+        (reason) => {
+          // A refusal must not be silently backed by Gemini either — same
+          // rationale as the verses route's per-verse reason translation.
+          if (reason === "refusal") ctx.markRefusal();
+        }
+      ).catch((err) => {
+        console.error(`Name meta: translation call failed for ${slug}/${field}/${locale}:`, err);
+        incr("names_ai_call_error");
+        return "";
+      }),
+    (s) => s.trim() === "",
+    onBeforeGenerate
+  );
+
+  // A blank/failed translation must never silently replace an already-vetted
+  // canonical string — fall back to it (and log) rather than serve/cache
+  // empty text. Not persisted as a substitute, so the next request retries.
+  if (translated.trim() === "") {
+    console.error(`Name meta: empty translation for ${slug}/${field}/${locale}`);
+    return canonical;
+  }
+  return translated;
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "embed": "bun scripts/embed-corpus.mjs",
     "prewarm": "bun scripts/prewarm-graph.mjs",
     "backfill:connections": "bun scripts/backfill-connections.ts",
+    "backfill:name-meta": "bun scripts/backfill-name-meta.ts",
     "db:migrate": "bun scripts/migrate.mjs",
     "db:migrate:concurrent-indexes": "bun scripts/migrate-concurrent-indexes.mjs",
     "prepare": "husky"

--- a/scripts/backfill-name-meta.ts
+++ b/scripts/backfill-name-meta.ts
@@ -1,0 +1,55 @@
+/**
+ * Pre-translates every divine name's `meaning` and `description` into each
+ * non-English locale, so /names and /names/[slug] show translated text from
+ * the start instead of slowly warming via individual page visits (the /names
+ * grid never triggers AI generation itself — see getCachedNameContentBulk in
+ * lib/names/name-content.ts).
+ *
+ * Calls the same in-process path the /api/names/[slug]/meta route uses
+ * (getLocalizedNameField), so a result lands in the exact same durable
+ * name_content cache a real request would populate — idempotent and
+ * resumable: an already-translated (slug, field, locale) is a cheap cache
+ * hit, not a re-translation, so it's safe to re-run.
+ *
+ *   ANTHROPIC_API_KEY=... DATABASE_URL=... bun scripts/backfill-name-meta.ts
+ */
+import { DIVINE_NAMES } from "@/lib/names/divine-names";
+import { getLocalizedNameField, type NameMetaField } from "@/lib/names/name-meta";
+import { LOCALES, type Locale } from "@/lib/i18n/config";
+
+const DELAY_MS = Number(process.env.BACKFILL_DELAY_MS ?? 1500);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const targetLocales = LOCALES.filter((l): l is Locale => l !== "en");
+
+let translated = 0;
+let fellBack = 0;
+let errored = 0;
+
+for (const locale of targetLocales) {
+  for (const name of DIVINE_NAMES) {
+    const fields: Array<[NameMetaField, string]> = [
+      ["meaning", name.meaning],
+      ["description", name.description],
+    ];
+    for (const [field, canonical] of fields) {
+      try {
+        const text = await getLocalizedNameField(name.slug, field, canonical, locale);
+        if (text === canonical) {
+          console.error(`  ✗ ${locale}/${name.slug}/${field} → empty translation, kept English`);
+          fellBack++;
+        } else {
+          console.error(`  ✓ ${locale}/${name.slug}/${field}`);
+          translated++;
+        }
+      } catch (err) {
+        errored++;
+        console.error(`  ✗ ${locale}/${name.slug}/${field} →`, err);
+      }
+      await sleep(DELAY_MS);
+    }
+  }
+}
+
+console.error(`Done. translated=${translated} fellBack=${fellBack} errored=${errored}`);
+process.exit(errored > 0 && translated === 0 ? 1 : 0);


### PR DESCRIPTION
## What
\`DivineName.meaning\` and \`.description\` (\`lib/names/divine-names/types.ts\`) were single hardcoded English strings with no locale dimension — unlike the category labels right next to them (already routed through next-intl via \`CATEGORY_LABEL_KEYS\`), \`/names\` and \`/names/[slug]\` always showed the short meaning and longer description in English, regardless of the user's \`oh_locale\` cookie.

## Fix
- New \`lib/names/name-meta.ts\` (\`getLocalizedNameField\`): translates (never re-derives) the canonical English text via the existing, already-reviewed \`translateReason\` helper (\`lib/ai/translate.ts\`) — Tanzih-constrained, with refusal/echo/length-ratio validation — the same helper already used for localized verse-connection reasons. \`locale === "en"\` short-circuits to the canonical text with no DB/AI round trip.
- Extends \`NameContentKind\` with two new kinds, \`"meaning"\` and \`"description"\`, reusing the existing \`name_content\` durable cache table (same one reflection/pairings already use) — no new table.
- New \`/api/names/[slug]/meta\` route + \`NameMeta\` client component, following the existing \`NameReflection\`/\`NamePairings\` lazy-fetch-with-server-prefetch pattern (server-side cache hit → instant SSR; miss → client fetch, one shared rate-limit charge for both fields).
- The \`/names\` grid renders all 99 names on one page, so it must never trigger up to 99 AI generations — it uses a new **read-only** bulk cache lookup, \`getCachedNameContentBulk\` (one query for all 99 slugs), falling back to the canonical English meaning per-name on a cache miss.
- \`scripts/backfill-name-meta.ts\` (\`bun run backfill:name-meta\`) pre-populates the cache for tr/ru/az ahead of user traffic, mirroring \`scripts/backfill-connections.ts\`'s local-dev-wrapper convention.

## Theological / AI disclosure
Per AGENTS.md: this adds a new AI-translation path for divine-name content. It reuses the already-reviewed, Tanzih-constrained \`translateReason\` prompt (no new prompt wording) — same theological guardrails already governing verse-connection-reason translation.

## Testing
- New tests: \`__tests__/api/names/meta.test.ts\` (route: English short-circuit/no AI call, translation of both fields, per-field fallback on a failed/refused translation, shared rate-limit charge), \`getCachedNameContentBulk\` cases added to \`__tests__/lib/names/name-content.test.ts\`.
- Full suite: \`bun run test:ci\` (1643 tests), \`bun run lint\`, \`bun run typecheck\`, \`bun run format:check\` all pass.
- Manual follow-up recommended: run \`bun run backfill:name-meta\` against staging, then spot-check \`/names\` and a few \`/names/[slug]\` pages in tr/ru/az.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMeofkA8KhGrBTJovz5k1N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized meanings and descriptions for divine names in supported non-English locales.
  * Name pages now display translated metadata when available, with immediate English fallback while translations load.
  * Names listings now show cached localized meanings where available.

* **Bug Fixes**
  * Improved resilience when translations are unavailable, refused, or fail by retaining canonical English content.
  * Added request rate limiting to support reliable metadata translation performance.
  * Improved handling of stale or invalid cached translation data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->